### PR TITLE
[PoC] Initial support for Optane PM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(MSVC)
 	set(CMAKE_CXX_COMPILER $ENV{VCToolsInstallDir}/bin/Hostx64/x64/cl.exe)
 	set(CMAKE_CXX_LINK_EXECUTABLE $ENV{VCToolsInstallDir}/bin/Hostx64/x64/link.exe)
 else()
-	set(CMAKE_CXX_COMPILER g++)
+	set(CMAKE_CXX_COMPILER clang++)
 endif()
 
 project(diskann)
@@ -43,7 +43,7 @@ function(checkEnvAndSetLocalVar env_var msg local_var)
 	endif()
 endfunction()
 
-	
+
 
 #MKL Config
 if (MSVC)
@@ -56,19 +56,22 @@ if (MSVC)
 else()
 	set(INTEL_ROOT /opt/intel/compilers_and_libraries/linux)
 	set(MKL_ROOT ${INTEL_ROOT}/mkl)
-        add_compile_options(-m64 -Wl,--no-as-needed) 
+        add_compile_options(-m64 -Wl,--no-as-needed)
 	link_libraries(mkl_intel_ilp64 mkl_intel_thread mkl_core iomp5 pthread m dl)
 	link_directories(${INTEL_ROOT}/lib/intel64 ${MKL_ROOT}/lib/intel64)
 endif()
+
+# Include PM
+link_libraries(memkind)
 
 add_definitions(-DMKL_ILP64)
 include_directories(include ${INTEL_ROOT}/include ${MKL_ROOT}/include ${BOOST_ROOT})
 
 
-#Main compiler/linker settings 
+#Main compiler/linker settings
 if(MSVC)
 	#language options
-	add_compile_options(/permissive- /openmp:experimental /Zc:wchar_t /Zc:twoPhase- /Zc:forScope /Zc:inline /WX- /std:c++14 /Gd /W3 /MP /Zi /FC /nologo /diagnostics:classic) 
+	add_compile_options(/permissive- /openmp:experimental /Zc:wchar_t /Zc:twoPhase- /Zc:forScope /Zc:inline /WX- /std:c++14 /Gd /W3 /MP /Zi /FC /nologo /diagnostics:classic)
 	#code generation options
 	add_compile_options(/Qpar /fp:fast /Zp8 /fp:except- /EHsc /GS- /Gm- /Gy )
 	#optimization options
@@ -76,7 +79,7 @@ if(MSVC)
 	#path options
 	#add_compile_options(/Fdx64/Release/vc141.pdb /Fox64/Release/)
 	add_definitions(-DUSE_AVX2 -DUSE_ACCELERATED_PQ -D_WINDOWS -DNOMINMAX -DUNICODE)
-	
+
 	set(CMAKE_SHARED_LIBRARY_CXX_LINK_FLAGS "/MANIFEST /MACHINE:X64 /DEBUG:FULL /LTCG:incremental /NXCOMPAT /DYNAMICBASE /OPT:REF /SUBSYSTEM:CONSOLE /MANIFESTUAC:\"level='asInvoker' uiAccess='false'\"")
 	set(CMAKE_EXECUTABLE_CXX_LINK_FLAGS "/MANIFEST /MACHINE:X64 /DEBUG:FULL /LTCG:incremental /NXCOMPAT /DYNAMICBASE /OPT:REF /SUBSYSTEM:CONSOLE /MANIFESTUAC:\"level='asInvoker' uiAccess='false'\"")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(MSVC)
 	set(CMAKE_CXX_COMPILER $ENV{VCToolsInstallDir}/bin/Hostx64/x64/cl.exe)
 	set(CMAKE_CXX_LINK_EXECUTABLE $ENV{VCToolsInstallDir}/bin/Hostx64/x64/link.exe)
 else()
-	set(CMAKE_CXX_COMPILER clang++)
+	set(CMAKE_CXX_COMPILER g++)
 endif()
 
 project(diskann)

--- a/include/index.h
+++ b/include/index.h
@@ -5,6 +5,7 @@
 
 #include <cassert>
 #include <map>
+#include <memory>
 #include <sstream>
 #include <stack>
 #include <string>
@@ -24,10 +25,11 @@
            ((double) size * degree) * sizeof(unsigned) * SLACK_FACTOR))
 
 namespace diskann {
-  template<typename T, typename TagT = int>
+  template<typename T, typename TagT = int, typename Allocator = std::allocator<unsigned>>
   class Index {
    public:
-    DISKANN_DLLEXPORT Index(Metric m, const char *filename,
+    DISKANN_DLLEXPORT Index(Metric m, const char *filename, bool data_in_pm = false,
+                            const Allocator& allocator = std::allocator<unsigned>(),
                             const size_t max_points = 0, const size_t nd = 0,
                             const size_t num_frozen_pts = 0,
                             const bool   enable_tags = false,
@@ -98,15 +100,16 @@ namespace diskann {
     DISKANN_DLLEXPORT int eager_delete(const TagT        tag,
                                        const Parameters &parameters);
 
-    DISKANN_DLLEXPORT void optimize_graph();
+    DISKANN_DLLEXPORT void optimize_graph(bool use_pm = false);
 
     DISKANN_DLLEXPORT void search_with_opt_graph(const T *query, size_t K,
                                                  size_t L, unsigned *indices);
 
     /*  Internals of the library */
    protected:
+    const Allocator _allocator;
     typedef std::vector<SimpleNeighbor>        vecNgh;
-    typedef std::vector<std::vector<unsigned>> CompactGraph;
+    typedef std::vector<std::vector<unsigned, Allocator>> CompactGraph;
     CompactGraph                               _final_graph;
     CompactGraph                               _in_graph;
 

--- a/include/pm.h
+++ b/include/pm.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <stdexcept> // For some reason, "pmem_allocator.h" doesn't include this.
+#include <pmem_allocator.h>
+
+#include <cassert>
+#include <string>
+
+namespace diskann {
+  bool is_pm_init();
+  void init_pm(const std::string& dir);
+  void* __alloc(size_t size, size_t align, bool pm = false);
+  void __free(void* ptr);
+
+  template<typename T>
+  using pmem_allocator = libmemkind::pmem::allocator<T>;
+
+  // Bootstrap copying allocators with different type parameters.
+  const pmem_allocator<uint8_t>& _pm_allocator();
+
+  // Get a `pmem::allocator` for any type.
+  template<typename T>
+  pmem_allocator<T> pm_allocator()
+  {
+    return pmem_allocator<T>(_pm_allocator());
+  }
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -9,7 +9,7 @@ else()
 	#file(GLOB CPP_SOURCES *.cpp)
 	set(CPP_SOURCES ann_exception.cpp aux_utils.cpp index.cpp
         linux_aligned_file_reader.cpp math_utils.cpp memory_mapper.cpp
-        partition_and_pq.cpp  pq_flash_index.cpp logger.cpp utils.cpp)
+        partition_and_pq.cpp pm.cpp pq_flash_index.cpp logger.cpp utils.cpp)
 	add_library(${PROJECT_NAME} ${CPP_SOURCES})
 	add_library(${PROJECT_NAME}_s STATIC ${CPP_SOURCES})
 endif()

--- a/src/pm.cpp
+++ b/src/pm.cpp
@@ -1,0 +1,62 @@
+#include "pm.h"
+
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+#include <memkind.h>
+
+// Must be initialized before use.
+// Keep the allocation type of the base allocator to `uint8_t`.
+//
+// Templated function in the header file can copy-construct allocators with other
+// type parameters.
+static std::unique_ptr<libmemkind::pmem::allocator<uint8_t>> __allocator;
+static std::unordered_map<void*, size_t> __pm_pointers;
+
+const libmemkind::pmem::allocator<uint8_t>& diskann::_pm_allocator()
+{
+    assert(diskann::is_pm_init());
+    return *__allocator.get();
+}
+
+bool diskann::is_pm_init()
+{
+    return bool(__allocator);
+}
+
+void diskann::init_pm(const std::string& dir)
+{
+    if (!is_pm_init()) {
+        std::cout << "[PM} Initializing PM: " << dir << std::endl;
+        //auto policy = libmemkind::allocation_policy::CONSERVATIVE;
+        auto policy = libmemkind::allocation_policy::DEFAULT;
+        __allocator = std::make_unique<libmemkind::pmem::allocator<uint8_t>>(dir, 0, policy);
+    }
+}
+
+void* diskann::__alloc(size_t size, size_t align, bool pm)
+{
+    void* ptr;
+    if (pm) {
+        assert(is_pm_init());
+        ptr = (void*) __allocator->allocate(size);
+        __pm_pointers.insert({ptr, size});
+    } else {
+        ptr = ::aligned_alloc(align, size);
+    }
+    return ptr;
+}
+
+void diskann::__free(void* ptr)
+{
+    auto search = __pm_pointers.find(ptr);
+    if (search != __pm_pointers.end()) {
+        __allocator->deallocate((uint8_t*) ptr, search->second);
+        __pm_pointers.erase(search);
+    } else {
+        free(ptr);
+    }
+}
+

--- a/tests/build_memory_index.cpp
+++ b/tests/build_memory_index.cpp
@@ -5,6 +5,7 @@
 #include <omp.h>
 #include <string.h>
 #include "utils.h"
+#include "pm.h"
 
 #ifndef _WINDOWS
 #include <sys/mman.h>
@@ -15,11 +16,13 @@
 
 #include "memory_mapper.h"
 
-template<typename T>
+template<typename T, typename Allocator = std::allocator<unsigned>>
 int build_in_memory_index(const std::string& data_path, const unsigned R,
                           const unsigned L, const float alpha,
                           const std::string& save_path,
-                          const unsigned     num_threads) {
+                          const unsigned     num_threads,
+                          const bool         data_in_pm,
+                          const Allocator& allocator = std::allocator<unsigned>()) {
   diskann::Parameters paras;
   paras.Set<unsigned>("R", R);
   paras.Set<unsigned>("L", L);
@@ -29,7 +32,7 @@ int build_in_memory_index(const std::string& data_path, const unsigned R,
   paras.Set<bool>("saturate_graph", 0);
   paras.Set<unsigned>("num_threads", num_threads);
 
-  diskann::Index<T> index(diskann::L2, data_path.c_str());
+  diskann::Index<T,int,Allocator> index(diskann::L2, data_path.c_str(), data_in_pm, allocator);
   auto              s = std::chrono::high_resolution_clock::now();
   index.build(paras);
   std::chrono::duration<double> diff =
@@ -42,13 +45,13 @@ int build_in_memory_index(const std::string& data_path, const unsigned R,
 }
 
 int main(int argc, char** argv) {
-  if (argc != 8) {
+  if (argc != 11) {
     std::cout << "Usage: " << argv[0]
-              << "  [data_type<int8/uint8/float>]  [data_file.bin]  "
-                 "[output_index_file]  "
-              << "[R]  [L]  [alpha]"
-              << "  [num_threads_to_use]. See README for more information on "
-                 "parameters."
+              << " [data_type<int8/uint8/float>]  [data_file.bin] [output_index_file]"
+              << " [R]  [L]  [alpha]"
+              << " [num_threads_to_use]"
+              << " [PM directory (use \"null\" for none)] [Data in PM] [Graph in PM]."
+              << " See README for more information on parameters."
               << std::endl;
     exit(-1);
   }
@@ -59,16 +62,35 @@ int main(int argc, char** argv) {
   const unsigned    L = (unsigned) atoi(argv[5]);
   const float       alpha = (float) atof(argv[6]);
   const unsigned    num_threads = (unsigned) atoi(argv[7]);
+  const std::string pm_directory(argv[8]);
+  const bool data_in_pm = std::atoi(argv[9]);
+  const bool graph_in_pm = std::atoi(argv[10]);
 
-  if (std::string(argv[1]) == std::string("int8"))
-    build_in_memory_index<int8_t>(data_path, R, L, alpha, save_path,
-                                  num_threads);
-  else if (std::string(argv[1]) == std::string("uint8"))
-    build_in_memory_index<uint8_t>(data_path, R, L, alpha, save_path,
-                                   num_threads);
-  else if (std::string(argv[1]) == std::string("float"))
-    build_in_memory_index<float>(data_path, R, L, alpha, save_path,
-                                 num_threads);
-  else
-    std::cout << "Unsupported type. Use float/int8/uint8" << std::endl;
+  if (pm_directory != "null") {
+      diskann::init_pm(pm_directory);
+  } else if (graph_in_pm || data_in_pm) {
+      std::cout << "Please set the PM Directory in order to put the graph in PM" << std::endl;
+      exit(-1);
+  }
+
+  if (!graph_in_pm) {
+      if (std::string(argv[1]) == std::string("int8"))
+        build_in_memory_index<int8_t>(data_path, R, L, alpha, save_path, num_threads, data_in_pm);
+      else if (std::string(argv[1]) == std::string("uint8"))
+        build_in_memory_index<uint8_t>(data_path, R, L, alpha, save_path, num_threads, data_in_pm);
+      else if (std::string(argv[1]) == std::string("float"))
+        build_in_memory_index<float>(data_path, R, L, alpha, save_path, num_threads, data_in_pm);
+      else
+        std::cout << "Unsupported type. Use float/int8/uint8" << std::endl;
+  } else {
+      auto allocator = diskann::pm_allocator<unsigned>();
+      if (std::string(argv[1]) == std::string("int8"))
+        build_in_memory_index<int8_t>(data_path, R, L, alpha, save_path, num_threads, data_in_pm, allocator);
+      else if (std::string(argv[1]) == std::string("uint8"))
+        build_in_memory_index<uint8_t>(data_path, R, L, alpha, save_path, num_threads, data_in_pm, allocator);
+      else if (std::string(argv[1]) == std::string("float"))
+        build_in_memory_index<float>(data_path, R, L, alpha, save_path, num_threads, data_in_pm, allocator);
+      else
+        std::cout << "Unsupported type. Use float/int8/uint8" << std::endl;
+  }
 }


### PR DESCRIPTION
Hi there!

This proof of concept PR implements a small set of changes to explore using Optane PM to store the dataset and graph data structures for benchmarking purposes.

Additional arguments are added to the `build_memory_index` and `search_memory_index` binaries. These are:

- The directory to use for the PM mapping. The current PM programming model involves mounting the PM DIMMs as a DAX (Direct Access) filesystem. When files are memory mapped from this directory, no page cache is used and instead loads and stores to the mapped virtual memory addresses go straight to the underlying media. If you don't want to use PM, this argument can be left as "null"
- Boolean flag indicating whether the *dataset* should be placed in PM (true) or DRAM (false).
- Boolean flag indicating whether the *graph* should be placed in PM (true) or DRAM (false).

### Limitations
This PR is mainly meant for benchmarking purposes/start a discussion. As such, it only supports Linux based operating systems.

This change also adds an additional dependency of [`libmemkind`](https://github.com/memkind/memkind) to support heap allocations in either DRAM or PM. On Ubuntu systems, this library can be installed system wide with
```
apt install libmemkind-dev libmemkind0
```
Other distributions require building `libmemkind` from scratch (which fortunately is not too difficult).

Furthermore, though it uses persistent memory as if it were *volatile* memory. If robust persistence is required, a library like [PMDK](https://github.com/pmem/pmdk) would have to be used. The change set would be larger to support the transactional semantics of PMDK.

### Other Notes
The implementation of the `pmem_allocator` as a lazily initialized global is definitely a bit awkward (also definitely not particularly flexible). An alternative could be to replace the raw pointer for the dataset with something like a `unique_ptr` with the custom allocator - but this could lead to combinatorial expansion in Index template parameters to support the Cartesian product of datatypes/graph allocators/dataset allocators, which also seems less than ideal. Since allocations are not on the critical path, we could use something like `std::function` to wrap the allocation/free functions. I'm open to suggestions :smiley:

I'm more than happy to answer any questions, make changes to this PR, and provide any assistance in exploring this direction. Thanks!!