### PR TITLE
Introduce a set tailored for storing available index locations

### DIFF
--- a/include/boost_dynamic_bitset_fwd.h
+++ b/include/boost_dynamic_bitset_fwd.h
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+#pragma once
+
+namespace boost {
+#ifndef BOOST_DYNAMIC_BITSET_FWD_HPP
+  template<typename Block = unsigned long,
+           typename Allocator = std::allocator<Block>>
+  class dynamic_bitset;
+#endif
+}  // namespace boost

--- a/include/index.h
+++ b/include/index.h
@@ -14,7 +14,9 @@
 #include "tsl/robin_set.h"
 #include "tsl/robin_map.h"
 
+#include "boost_dynamic_bitset_fwd.h"
 #include "distance.h"
+#include "natural_number_set.h"
 #include "neighbor.h"
 #include "parameters.h"
 #include "utils.h"
@@ -24,14 +26,6 @@
 #define GRAPH_SLACK_FACTOR 1.3
 #define OVERHEAD_FACTOR 1.1
 #define EXPAND_IF_FULL 0
-
-namespace boost {
-#ifndef BOOST_DYNAMIC_BITSET_FWD_HPP
-  template<typename Block = unsigned long,
-           typename Allocator = std::allocator<Block>>
-  class dynamic_bitset;
-#endif
-}  // namespace boost
 
 namespace diskann {
   inline double estimate_ram_usage(_u64 size, _u32 dim, _u32 datasize,
@@ -415,7 +409,7 @@ namespace diskann {
     std::unordered_map<unsigned, TagT> _location_to_tag;
 
     tsl::robin_set<unsigned> _delete_set;
-    tsl::robin_set<unsigned> _empty_slots;
+    natural_number_set<unsigned> _empty_slots;
 
     bool _support_eager_delete =
         false;  // Enables in-graph, requires more space

--- a/include/natural_number_set.h
+++ b/include/natural_number_set.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <memory>
+#include <type_traits>
 
 #include "boost_dynamic_bitset_fwd.h"
 
@@ -17,7 +18,7 @@ namespace diskann {
   template<typename T>
   class natural_number_set {
    public:
-    static_assert(std::is_trivial_v<T>, "Identifier must be a trivial type");
+    static_assert(std::is_trivial<T>::value, "Identifier must be a trivial type");
 
     natural_number_set();
 

--- a/include/natural_number_set.h
+++ b/include/natural_number_set.h
@@ -15,6 +15,10 @@ namespace diskann {
   // are needed. The memory usage of the set is determined by the largest
   // number of inserted entries (uses a vector as a backing store) as well as
   // the largest value to be placed in it (uses bitset as well).
+  //
+  // Thread-safety: this class is not thread-safe in general.
+  // Exception: multiple read-only operations (e.g. is_in_set, empty, size) are
+  // safe on the object only if there are no writers to it in parallel.
   template<typename T>
   class natural_number_set {
    public:

--- a/include/natural_number_set.h
+++ b/include/natural_number_set.h
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include <memory>
+
+#include "boost_dynamic_bitset_fwd.h"
+
+namespace diskann {
+  // A set of natural numbers (from 0 onwards). Made for scenario where the
+  // pool of numbers is consecutive from zero to some max value and very
+  // efficient methods for "add to set", "get any value from set", "is in set"
+  // are needed. The memory usage of the set is determined by the largest
+  // number of inserted entries (uses a vector as a backing store) as well as
+  // the largest value to be placed in it (uses bitset as well).
+  template<typename T>
+  class natural_number_set {
+   public:
+    static_assert(std::is_trivial_v<T>, "Identifier must be a trivial type");
+
+    natural_number_set();
+
+    bool   is_empty() const;
+    void   reserve(size_t count);
+    void   insert(T id);
+    T      pop_any();
+    void   clear();
+    size_t size() const;
+    bool   is_in_set(T id) const;
+
+   private:
+    // Values that are currently in set.
+    std::vector<T> _values_vector;
+
+    // Values that are currently in set where each bit being set to 1
+    // means that its index is in the set.
+    //
+    // Use a pointer here to allow for forward declaration of dynamic_bitset
+    // in public headers to avoid making boost a dependency for clients
+    // of DiskANN.
+    std::unique_ptr<boost::dynamic_bitset<>> _values_bitset;
+  };
+}  // namespace diskann

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,13 +4,14 @@
 set(CMAKE_CXX_STANDARD 14)
 
 if(MSVC)
-	add_subdirectory(dll)
+    add_subdirectory(dll)
 else()
-	#file(GLOB CPP_SOURCES *.cpp)
-	set(CPP_SOURCES ann_exception.cpp aux_utils.cpp distance.cpp index.cpp
-        linux_aligned_file_reader.cpp math_utils.cpp memory_mapper.cpp
-        partition_and_pq.cpp  pq_flash_index.cpp logger.cpp utils.cpp)
-	add_library(${PROJECT_NAME} ${CPP_SOURCES})
-	add_library(${PROJECT_NAME}_s STATIC ${CPP_SOURCES})
+    #file(GLOB CPP_SOURCES *.cpp)
+    set(CPP_SOURCES ann_exception.cpp aux_utils.cpp distance.cpp index.cpp
+        linux_aligned_file_reader.cpp math_utils.cpp natural_number_set.cpp
+        memory_mapper.cpp partition_and_pq.cpp pq_flash_index.cpp logger.cpp
+        utils.cpp)
+    add_library(${PROJECT_NAME} ${CPP_SOURCES})
+    add_library(${PROJECT_NAME}_s STATIC ${CPP_SOURCES})
 endif()
 install()

--- a/src/dll/CMakeLists.txt
+++ b/src/dll/CMakeLists.txt
@@ -2,7 +2,8 @@
 # Licensed under the MIT license.
 
 add_library(${PROJECT_NAME} SHARED dllmain.cpp ../partition_and_pq.cpp ../pq_flash_index.cpp ../logger.cpp ../utils.cpp 
-    ../windows_aligned_file_reader.cpp ../distance.cpp ../memory_mapper.cpp ../index.cpp ../math_utils.cpp ../aux_utils.cpp ../ann_exception.cpp)
+    ../windows_aligned_file_reader.cpp ../distance.cpp ../memory_mapper.cpp ../index.cpp ../math_utils.cpp ../aux_utils.cpp
+    ../ann_exception.cpp ../natural_number_set.cpp)
 
 set(TARGET_DIR "$<$<CONFIG:Debug>:${CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG}>$<$<CONFIG:Release>:${CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE}>")
 set(DISKANN_DLL_IMPLIB "${TARGET_DIR}/${PROJECT_NAME}.lib")

--- a/src/natural_number_set.cpp
+++ b/src/natural_number_set.cpp
@@ -1,0 +1,78 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+#include <boost/dynamic_bitset.hpp>
+
+#include "ann_exception.h"
+#include "natural_number_set.h"
+
+namespace diskann {
+  template<typename T>
+  natural_number_set<T>::natural_number_set()
+      : _values_bitset(std::make_unique<boost::dynamic_bitset<>>())
+  {
+  }
+
+  template<typename T>
+  bool natural_number_set<T>::is_empty() const
+  {
+      return _values_vector.empty();
+  }
+
+  template<typename T>
+  void natural_number_set<T>::reserve(size_t count)
+  {
+      _values_vector.reserve(count);
+      _values_bitset->reserve(count);
+  }
+
+  template<typename T>
+  void natural_number_set<T>::insert(T id)
+  {
+      _values_vector.emplace_back(id);
+
+      if (id >= _values_bitset->size())
+        _values_bitset->resize(static_cast<size_t>(id) + 1);
+
+      _values_bitset->set(id, true);
+  }
+
+  template<typename T>
+  T natural_number_set<T>::pop_any()
+  {
+      if (_values_vector.empty())
+      {
+          throw diskann::ANNException("No values available", -1, __FUNCSIG__, __FILE__, __LINE__);
+      }
+
+      const T id = _values_vector.back();
+      _values_vector.pop_back();
+
+      _values_bitset->set(id, false);
+
+      return id;
+  }
+
+  template<typename T>
+  void natural_number_set<T>::clear()
+  {
+      _values_vector.clear();
+      _values_bitset->clear();
+  }
+
+  template<typename T>
+  size_t natural_number_set<T>::size() const
+  {
+      return _values_vector.size();
+  }
+
+  template<typename T>
+  bool natural_number_set<T>::is_in_set(T id) const
+  {
+      return _values_bitset->test(id);
+  }
+
+
+  // Instantiate used templates.
+  template class natural_number_set<unsigned>;
+}  // namespace diskann


### PR DESCRIPTION
so that reserve_location (which runs under a lock) can be executed very quickly.

Before the change, calling enable_delete would populate the _empty_slots
robin_set with all available locations. This would cause insert_point
to slow to a crawl (nearly order of magnitude slower than expected) since
reserve_location would run relatively long to find an available slot
while holding a lock.

With the change, reserve_location gets the location almost immediately,
restoring the expected speed.