### PR TITLE
Uncaught Exceptions

### DIFF
--- a/include/restapi/common.h
+++ b/include/restapi/common.h
@@ -13,5 +13,5 @@ namespace diskann {
                            TAGS_KEY = "tags", QUERY_ID_KEY = "query_id",
                            ERROR_MESSAGE_KEY = "error", L_KEY = "Ls",
                            TIME_TAKEN_KEY = "time_taken_in_us",
-                           PARTITION_KEY = "partition";
+                           PARTITION_KEY = "partition", UNKNOWN_ERROR = "unknown_error";
 }  // namespace diskann

--- a/src/restapi/server.cpp
+++ b/src/restapi/server.cpp
@@ -167,6 +167,11 @@ namespace diskann {
             response[ERROR_MESSAGE_KEY] = web::json::value::string(ex.what());
             return std::make_pair(web::http::status_codes::InternalError,
                                   response);
+          } catch (...) {
+            std:cerr << "Uncaught exception while processing query: " << queryId;
+            web::json::value response = prepareResponse(queryId, K);
+            response[ERROR_MESSAGE_KEY] = web::json::value::string(UNKNOWN_ERROR);
+            return std::make_pair(web::http::status_codes::InternalError, response);
           }
         })
         .then([=](std::pair<short unsigned int, web::json::value> response_status) {


### PR DESCRIPTION
# This isn't the actual fix for our uncaught exceptions

But I assert it's a reasonable fallback if something exceptional happens.

-----

For some reason the current catch block in our handle_post method isn't firing when parseJson throws an std::invalid_argument exception.

We _do_ still need to properly fix it so that that known case can be handled and we can give a better error message, but having a catch-all that doesn't instantly
terminate the process when an unexpected error happens in the handle_post seems reasonable too. It may mean that we don't have a good "die due to a critical,
unrecoverable error" mechanism, but it also means a posted request off the happy path doesn't terminate our server too.