### PR TITLE
Origin/add sector reordering

### DIFF
--- a/src/aux_utils.cpp
+++ b/src/aux_utils.cpp
@@ -844,7 +844,7 @@ namespace diskann {
     *(_u64 *) (sector_buf.get() + 0 * sizeof(_u64)) = disk_index_file_size;
     *(_u64 *) (sector_buf.get() + 1 * sizeof(_u64)) = npts_64;
     if(reorder_data){
-      *(_u64 *) (sector_buf.get() + 2 * sizeof(_u64)) = lorder_data[medoid];
+      *(_u64 *) (sector_buf.get() + 2 * sizeof(_u64)) = porder_data[medoid];
     }else{
       *(_u64 *) (sector_buf.get() + 2 * sizeof(_u64)) = medoid;
     }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2023,8 +2023,8 @@ void Index<T, TagT>::partition_packing(
     std::vector<std::mutex> in_locks (_nd);
 
 #pragma omp parallel for schedule(dynamic, 128)    
-    for (_s64 i = 0; i < _final_graph.size(); i++) {
-      for (_s64 j = 0; j < _final_graph[i].size(); j++) {
+    for (_s64 i = 0; i < (_s64)(_final_graph.size()); i++) {
+      for (_s64 j = 0; j < (_s64)(_final_graph[i].size()); j++) {
         {
           LockGuard lock(in_locks[_final_graph[i][j]]);
         _in_graph[_final_graph[i][j]].emplace_back(i);
@@ -2038,7 +2038,7 @@ void Index<T, TagT>::partition_packing(
     }
 
 #pragma omp parallel for schedule(dynamic, 1) num_threads(threads)
-    for (_s64 i = 0; i < _nd / omega; i++) {
+    for (_s64 i = 0; i < (_s64)(_nd / omega); i++) {
       unsigned seed_node;
 #pragma omp    critical
       {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2023,8 +2023,8 @@ void Index<T, TagT>::partition_packing(
     std::vector<std::mutex> in_locks (_nd);
 
 #pragma omp parallel for schedule(dynamic, 128)    
-    for (unsigned i = 0; i < _final_graph.size(); i++) {
-      for (unsigned j = 0; j < _final_graph[i].size(); j++) {
+    for (_s64 i = 0; i < _final_graph.size(); i++) {
+      for (_s64 j = 0; j < _final_graph[i].size(); j++) {
         {
           LockGuard lock(in_locks[_final_graph[i][j]]);
         _in_graph[_final_graph[i][j]].emplace_back(i);
@@ -2038,7 +2038,7 @@ void Index<T, TagT>::partition_packing(
     }
 
 #pragma omp parallel for schedule(dynamic, 1) num_threads(threads)
-    for (unsigned i = 0; i < _nd / omega; i++) {
+    for (_s64 i = 0; i < _nd / omega; i++) {
       unsigned seed_node;
 #pragma omp    critical
       {


### PR DESCRIPTION
modified disk layout for sector reordering.

1. The lorder and porder files are loaded into memory using load_bin function.
2. reordered the sector based on the new ordering.
3. New neighbors are modified based on the reordering.
4. Does medoid need to be changed in the metadata? **[Please check]** - 848 to 852 lines