### PR TITLE
Added --qps_per_thread and --print_all_recalls switches

### DIFF
--- a/tests/search_memory_index.cpp
+++ b/tests/search_memory_index.cpp
@@ -28,10 +28,10 @@ template<typename T>
 int search_memory_index(diskann::Metric& metric, const std::string& index_path,
                         const std::string& result_path_prefix,
                         const std::string& query_file,
-                        std::string& truthset_file, const unsigned num_threads,
-                        const unsigned               recall_at,
+                        const std::string& truthset_file, const unsigned num_threads,
+                        const unsigned recall_at, const bool print_all_recalls,
                         const std::vector<unsigned>& Lvec, const bool dynamic,
-                        const bool tags) {
+                        const bool tags, const bool show_qps_per_thread) {
   // Load the query file
   T*        query = nullptr;
   unsigned* gt_ids = nullptr;
@@ -53,8 +53,8 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
     diskann::cout << " Truthset file " << truthset_file
                   << " not found. Not computing recall." << std::endl;
   }
-
-  diskann::Index<T, uint32_t> index(metric, query_dim, 0, dynamic, tags);
+  using TagT = uint32_t;
+  diskann::Index<T, TagT> index(metric, query_dim, 0, dynamic, tags);
   std::cout << "Index class instantiated" << std::endl;
   index.load(index_path.c_str(), num_threads,
              *(std::max_element(Lvec.begin(), Lvec.end())));
@@ -66,22 +66,30 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
   diskann::Parameters paras;
   std::cout.setf(std::ios_base::fixed, std::ios_base::floatfield);
   std::cout.precision(2);
-  std::string recall_string = "Recall@" + std::to_string(recall_at);
+  const std::string qps_title = show_qps_per_thread ? "QPS/thread" : "QPS";
+  unsigned table_width = 0;
   if (tags) {
-    std::cout << std::setw(4) << "Ls" << std::setw(12) << "QPS "
+    std::cout << std::setw(4) << "Ls" << std::setw(12) << qps_title
               << std::setw(20) << "Mean Latency (mus)" << std::setw(15)
               << "99.9 Latency";
+    table_width += 4 + 12 + 20 + 15;
   } else {
-    std::cout << std::setw(4) << "Ls" << std::setw(12) << "QPS "
+    std::cout << std::setw(4) << "Ls" << std::setw(12) << qps_title
               << std::setw(18) << "Avg dist cmps" << std::setw(20)
               << "Mean Latency (mus)" << std::setw(15) << "99.9 Latency";
+    table_width += 4 + 12 + 18 + 20 + 15;
   }
-  if (calc_recall_flag)
-    std::cout << std::setw(12) << recall_string;
+  unsigned recalls_to_print = 0;
+  const unsigned first_recall = print_all_recalls ? 1 : recall_at;
+  if (calc_recall_flag) {
+    for (unsigned curr_recall = first_recall; curr_recall <= recall_at; curr_recall++) {
+      std::cout << std::setw(12) << ("Recall@" + std::to_string(curr_recall));
+    }
+    recalls_to_print = recall_at + 1 - first_recall;
+    table_width += recalls_to_print * 12;
+  }
   std::cout << std::endl;
-  std::cout << "==============================================================="
-               "=================="
-            << std::endl;
+  std::cout << std::string(table_width, '=') << std::endl;
 
   std::vector<std::vector<uint32_t>> query_result_ids(Lvec.size());
   std::vector<std::vector<float>>    query_result_dists(Lvec.size());
@@ -91,9 +99,9 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
     cmp_stats = std::vector<unsigned>(query_num, 0);
   }
 
-  uint32_t* query_result_tags;
+  std::vector<TagT> query_result_tags;
   if (tags) {
-    query_result_tags = new uint32_t[recall_at * query_num];
+    query_result_tags.resize(recall_at * query_num);
   }
 
   for (uint32_t test_id = 0; test_id < Lvec.size(); test_id++) {
@@ -119,10 +127,10 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
             query_result_ids[test_id].data() + i * recall_at);
       } else if (tags) {
         index.search_with_tags(query + i * query_aligned_dim, recall_at, L,
-                               query_result_tags + i * recall_at, nullptr, res);
+                               query_result_tags.data() + i * recall_at, nullptr, res);
         for (int64_t r = 0; r < (int64_t) recall_at; r++) {
           query_result_ids[test_id][recall_at * i + r] =
-              *(query_result_tags + recall_at * i + r);
+              query_result_tags[recall_at * i + r];
         }
       } else {
         cmp_stats[i] =
@@ -137,35 +145,44 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
     }
     std::chrono::duration<double> diff =
         std::chrono::high_resolution_clock::now() - s;
-    float qps = (query_num / diff.count());
 
-    float recall = 0;
-    if (calc_recall_flag)
-      recall = diskann::calculate_recall(query_num, gt_ids, gt_dists, gt_dim,
-                                         query_result_ids[test_id].data(),
-                                         recall_at, recall_at);
+    float displayed_qps = static_cast<float>(query_num) / diff.count();
+
+    if (show_qps_per_thread)
+        displayed_qps /= num_threads;
+
+    std::vector<float> recalls;
+    if (calc_recall_flag) {
+      recalls.reserve(recalls_to_print);
+      for (unsigned curr_recall = first_recall; curr_recall <= recall_at; curr_recall++) {
+          recalls.push_back(diskann::calculate_recall(query_num, gt_ids, gt_dists, gt_dim,
+                                                      query_result_ids[test_id].data(),
+                                                      recall_at, curr_recall));
+      }
+    }
 
     std::sort(latency_stats.begin(), latency_stats.end());
     float mean_latency =
         std::accumulate(latency_stats.begin(), latency_stats.end(), 0.0) /
-        query_num;
+        static_cast<float>(query_num);
 
     float avg_cmps =
         (float) std::accumulate(cmp_stats.begin(), cmp_stats.end(), 0) /
         (float) query_num;
 
     if (tags) {
-      std::cout << std::setw(4) << L << std::setw(12) << qps << std::setw(20)
+      std::cout << std::setw(4) << L << std::setw(12) << displayed_qps << std::setw(20)
                 << (float) mean_latency << std::setw(15)
                 << (float) latency_stats[(_u64)(0.999 * query_num)];
     } else {
-      std::cout << std::setw(4) << L << std::setw(12) << qps << std::setw(18)
+      std::cout << std::setw(4) << L << std::setw(12) << displayed_qps << std::setw(18)
                 << avg_cmps << std::setw(20) << (float) mean_latency
                 << std::setw(15)
                 << (float) latency_stats[(_u64)(0.999 * query_num)];
     }
-    if (calc_recall_flag)
+    for (float recall : recalls) {
       std::cout << std::setw(12) << recall;
+    }
     std::cout << std::endl;
   }
 
@@ -185,8 +202,6 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
   }
 
   diskann::aligned_free(query);
-  if (tags)
-    delete[] query_result_tags;
 
   return 0;
 }
@@ -196,7 +211,7 @@ int main(int argc, char** argv) {
       gt_file;
   unsigned              num_threads, K;
   std::vector<unsigned> Lvec;
-  bool                  dynamic, tags;
+  bool                  print_all_recalls, dynamic, tags, show_qps_per_thread;
 
   po::options_description desc{"Arguments"};
   try {
@@ -221,6 +236,9 @@ int main(int argc, char** argv) {
         "ground truth file for the queryset");
     desc.add_options()("recall_at,K", po::value<uint32_t>(&K)->required(),
                        "Number of neighbors to be returned");
+    desc.add_options()("print_all_recalls",
+        po::bool_switch(&print_all_recalls),
+        "Print recalls at all positions, from 1 up to specified recall_at value");
     desc.add_options()("search_list,L",
                        po::value<std::vector<unsigned>>(&Lvec)->multitoken(),
                        "List of L values of search");
@@ -234,6 +252,9 @@ int main(int argc, char** argv) {
                        "Whether the index is dynamic. Default false.");
     desc.add_options()("tags", po::value<bool>(&tags)->default_value(false),
                        "Whether to search with tags. Default false.");
+    desc.add_options()("qps_per_thread",
+                       po::bool_switch(&show_qps_per_thread),
+                       "Print overall QPS divided by the number of threads in the output table");
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -276,17 +297,21 @@ int main(int argc, char** argv) {
     if (data_type == std::string("int8")) {
       return search_memory_index<int8_t>(metric, index_path_prefix, result_path,
                                          query_file, gt_file, num_threads, K,
-                                         Lvec, dynamic, tags);
+                                         print_all_recalls, Lvec, dynamic, tags,
+                                         show_qps_per_thread);
     }
 
     else if (data_type == std::string("uint8")) {
       return search_memory_index<uint8_t>(metric, index_path_prefix,
                                           result_path, query_file, gt_file,
-                                          num_threads, K, Lvec, dynamic, tags);
+                                          num_threads, K, print_all_recalls,
+                                          Lvec, dynamic, tags,
+                                          show_qps_per_thread);
     } else if (data_type == std::string("float")) {
       return search_memory_index<float>(metric, index_path_prefix, result_path,
                                         query_file, gt_file, num_threads, K,
-                                        Lvec, dynamic, tags);
+                                        print_all_recalls, Lvec, dynamic, tags,
+                                        show_qps_per_thread);
     } else {
       std::cout << "Unsupported type. Use float/int8/uint8" << std::endl;
       return -1;


### PR DESCRIPTION
The --qps_per_thread switch prints the overall QPS divided by the number of
threads used to search in the output table (rather than the total QPS).

The --print_all_recalls switch prints recalls at all positions, from 1 up to
specified value (rathen than just the specified recall value). This is useful
with simulate_aggregate_recall tool to evaluate the overall system recall from
the recall of its partitions.