### PR TITLE
Added a memory and space efficient map for location to tag mapping to replace std::unordered_map

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -10,7 +10,6 @@
 #include <sstream>
 #include <stack>
 #include <string>
-#include <unordered_map>
 #include "tsl/robin_set.h"
 #include "tsl/robin_map.h"
 #include "tsl/sparse_map.h"
@@ -18,6 +17,7 @@
 #include "boost_dynamic_bitset_fwd.h"
 #include "distance.h"
 #include "locking.h"
+#include "natural_number_map.h"
 #include "natural_number_set.h"
 #include "neighbor.h"
 #include "parameters.h"
@@ -409,7 +409,7 @@ namespace diskann {
 
     // data structures, flags and locks for dynamic indexing
     tsl::sparse_map<TagT, unsigned> _tag_to_location;
-    std::unordered_map<unsigned, TagT> _location_to_tag;
+    natural_number_map<unsigned, TagT> _location_to_tag;
 
     tsl::robin_set<unsigned>     _delete_set;
     natural_number_set<unsigned> _empty_slots;

--- a/include/natural_number_map.h
+++ b/include/natural_number_map.h
@@ -1,0 +1,87 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+#pragma once
+
+#include <memory>
+#include <type_traits>
+
+#include "boost_dynamic_bitset_fwd.h"
+
+namespace diskann {
+  // A map whose key is a natural number (from 0 onwards) and maps to a value.
+  // Made as both memory and performance efficient map for scenario such as
+  // DiskANN location-to-tag map. There, the pool of numbers is consecutive from
+  // zero to some max value, and it's expected that most if not all keys from 0
+  // up to some current maximum will be present in the map. The memory usage of
+  // the map is determined by the largest inserted key since it uses vector as a
+  // backing store and bitset for presence indication.
+  //
+  // Thread-safety: this class is not thread-safe in general.
+  // Exception: multiple read-only operations are safe on the object only if
+  // there are no writers to it in parallel.
+  template<typename Key, typename Value>
+  class natural_number_map {
+   public:
+    static_assert(std::is_trivial<Key>::value, "Key must be a trivial type");
+    // Some of the class member prototypes are done with this assumption to
+    // minimize verbosity since it's the only use case.
+    static_assert(std::is_trivial<Value>::value,
+                  "Value must be a trivial type");
+
+    // Represents a reference to a element in the map. Used while iterating
+    // over map entries.
+    struct position {
+      size_t _key;
+      // The number of keys that were enumerated when iterating through the map
+      // so far. Used to early-terminate enumeration when ithere
+      // are no more entries in the map.
+      size_t _keys_already_enumerated;
+
+      // Returns whether it's valid to access the element at this position in
+      // the map.
+      bool is_valid() const;
+    };
+
+    natural_number_map();
+
+    void   reserve(size_t count);
+    size_t size() const;
+
+    void set(Key key, Value value);
+    void erase(Key key);
+
+    bool contains(Key key) const;
+    bool try_get(Key key, Value& value) const;
+
+    // Returns the value at the specified position. Prerequisite: position is
+    // valid.
+    Value get(const position& pos) const;
+
+    // Finds the first element in the map, if any. Invalidated by changes in the
+    // map.
+    position find_first() const;
+
+    // Finds the next element in the map after the specified position.
+    // Invalidated by changes in the map.
+    position find_next(const position& after_position) const;
+
+    void clear();
+
+   private:
+    // Number of entries in the map. Not the same as size() of the
+    // _values_vector below.
+    size_t _size;
+
+    // Array of values. The key is the index of the value.
+    std::vector<Value> _values_vector;
+
+    // Values that are in the set have the corresponding bit index set
+    // to 1.
+    //
+    // Use a pointer here to allow for forward declaration of dynamic_bitset
+    // in public headers to avoid making boost a dependency for clients
+    // of DiskANN.
+    std::unique_ptr<boost::dynamic_bitset<>> _values_bitset;
+  };
+}  // namespace diskann

--- a/include/natural_number_set.h
+++ b/include/natural_number_set.h
@@ -38,8 +38,8 @@ namespace diskann {
     // Values that are currently in set.
     std::vector<T> _values_vector;
 
-    // Values that are currently in set where each bit being set to 1
-    // means that its index is in the set.
+    // Values that are in the set have the corresponding bit index set
+    // to 1.
     //
     // Use a pointer here to allow for forward declaration of dynamic_bitset
     // in public headers to avoid making boost a dependency for clients

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,9 +8,9 @@ if(MSVC)
 else()
     #file(GLOB CPP_SOURCES *.cpp)
     set(CPP_SOURCES ann_exception.cpp aux_utils.cpp distance.cpp index.cpp
-        linux_aligned_file_reader.cpp math_utils.cpp natural_number_set.cpp
-        memory_mapper.cpp partition_and_pq.cpp pq_flash_index.cpp logger.cpp
-        utils.cpp)
+        linux_aligned_file_reader.cpp math_utils.cpp natural_number_map.cpp
+        natural_number_set.cpp memory_mapper.cpp partition_and_pq.cpp
+        pq_flash_index.cpp logger.cpp utils.cpp)
     add_library(${PROJECT_NAME} ${CPP_SOURCES})
     add_library(${PROJECT_NAME}_s STATIC ${CPP_SOURCES})
 endif()

--- a/src/dll/CMakeLists.txt
+++ b/src/dll/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 add_library(${PROJECT_NAME} SHARED dllmain.cpp ../partition_and_pq.cpp ../pq_flash_index.cpp ../logger.cpp ../utils.cpp 
     ../windows_aligned_file_reader.cpp ../distance.cpp ../memory_mapper.cpp ../index.cpp ../math_utils.cpp ../aux_utils.cpp
-    ../ann_exception.cpp ../natural_number_set.cpp)
+    ../ann_exception.cpp ../natural_number_set.cpp ../natural_number_map.cpp)
 
 set(TARGET_DIR "$<$<CONFIG:Debug>:${CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG}>$<$<CONFIG:Release>:${CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE}>")
 set(DISKANN_DLL_IMPLIB "${TARGET_DIR}/${PROJECT_NAME}.lib")

--- a/src/natural_number_map.cpp
+++ b/src/natural_number_map.cpp
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+#include <assert.h>
+#include <boost/dynamic_bitset.hpp>
+
+#include "natural_number_map.h"
+
+namespace diskann {
+  static constexpr auto invalid_position = boost::dynamic_bitset<>::npos;
+
+  template<typename Key, typename Value>
+  natural_number_map<Key, Value>::natural_number_map()
+      : _size(0), _values_bitset(std::make_unique<boost::dynamic_bitset<>>()) {
+  }
+
+  template<typename Key, typename Value>
+  void natural_number_map<Key, Value>::reserve(size_t count) {
+    _values_vector.reserve(count);
+    _values_bitset->reserve(count);
+  }
+
+  template<typename Key, typename Value>
+  size_t natural_number_map<Key, Value>::size() const {
+    return _size;
+  }
+
+  template<typename Key, typename Value>
+  void natural_number_map<Key, Value>::set(Key key, Value value) {
+    if (key >= _values_bitset->size()) {
+      _values_bitset->resize(static_cast<size_t>(key) + 1);
+      _values_vector.resize(_values_bitset->size());
+    }
+
+    _values_vector[key] = value;
+    const bool was_present = _values_bitset->test_set(key, true);
+
+    if (!was_present) {
+      ++_size;
+    }
+  }
+
+  template<typename Key, typename Value>
+  void natural_number_map<Key, Value>::erase(Key key) {
+    if (key < _values_bitset->size()) {
+      const bool was_present = _values_bitset->test_set(key, false);
+
+      if (was_present) {
+        --_size;
+      }
+    }
+  }
+
+  template<typename Key, typename Value>
+  bool natural_number_map<Key, Value>::contains(Key key) const {
+    return key < _values_bitset->size() && _values_bitset->test(key);
+  }
+
+  template<typename Key, typename Value>
+  bool natural_number_map<Key, Value>::try_get(Key key, Value& value) const {
+    if (!contains(key)) {
+      return false;
+    }
+
+    value = _values_vector[key];
+    return true;
+  }
+
+  template<typename Key, typename Value>
+  typename natural_number_map<Key, Value>::position
+  natural_number_map<Key, Value>::find_first() const {
+    return position{_size > 0 ? _values_bitset->find_first() : invalid_position,
+                    0};
+  }
+
+  template<typename Key, typename Value>
+  typename natural_number_map<Key, Value>::position
+  natural_number_map<Key, Value>::find_next(
+      const position& after_position) const {
+    return position{after_position._keys_already_enumerated < _size
+                        ? _values_bitset->find_next(after_position._key)
+                        : invalid_position,
+                    after_position._keys_already_enumerated + 1};
+  }
+
+  template<typename Key, typename Value>
+  bool natural_number_map<Key, Value>::position::is_valid() const {
+    return _key != invalid_position;
+  }
+
+  template<typename Key, typename Value>
+  Value natural_number_map<Key, Value>::get(const position& pos) const {
+    assert(pos.is_valid());
+    return _values_vector[pos._key];
+  }
+
+  template<typename Key, typename Value>
+  void natural_number_map<Key, Value>::clear() {
+    _size = 0;
+    _values_vector.clear();
+    _values_bitset->clear();
+  }
+
+  // Instantiate used templates.
+  template class natural_number_map<unsigned, int32_t>;
+  template class natural_number_map<unsigned, uint32_t>;
+  template class natural_number_map<unsigned, int64_t>;
+  template class natural_number_map<unsigned, uint64_t>;
+}  // namespace diskann


### PR DESCRIPTION
For example, in a test with 40M vectors, the new map saves close to 90 bytes
per element when used with <unsigned, uint64_t> types.