### PR TITLE
logger abstraction and few code fixes for making diskann.dll buildable with EXEC_ENV_OLS turned on

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -14,6 +14,10 @@
 #include "tsl/robin_map.h"
 #include "tsl/sparse_map.h"
 
+#ifdef EXEC_ENV_OLS
+#include "aligned_file_reader.h"
+#endif
+
 #include "boost_dynamic_bitset_fwd.h"
 #include "distance.h"
 #include "locking.h"
@@ -138,6 +142,13 @@ namespace diskann {
     // Load functions
     DISKANN_DLLEXPORT void load(const char *index_file, uint32_t num_threads,
                                 uint32_t search_l);
+#ifdef EXEC_ENV_OLS
+    DISKANN_DLLEXPORT void load(AlignedFileReader &reader,
+                                uint32_t num_threads, uint32_t search_l);
+#else
+    DISKANN_DLLEXPORT void  load(const char *index_file, uint32_t num_threads,
+                                uint32_t search_l);
+#endif        
 
     // get some private variables
     DISKANN_DLLEXPORT size_t get_num_points();
@@ -365,11 +376,19 @@ namespace diskann {
     DISKANN_DLLEXPORT _u64   save_data(std::string filename);
     DISKANN_DLLEXPORT _u64   save_tags(std::string filename);
     DISKANN_DLLEXPORT _u64   save_delete_list(const std::string &filename);
+#ifdef EXEC_ENV_OLS
+    DISKANN_DLLEXPORT size_t load_graph(AlignedFileReader &reade,
+                                        size_t            expected_num_points);
+    DISKANN_DLLEXPORT size_t load_data(AlignedFileReader &reader);
+    DISKANN_DLLEXPORT size_t load_tags(AlignedFileReader &reader);
+    DISKANN_DLLEXPORT size_t load_delete_set(AlignedFileReader &reader);
+#else
     DISKANN_DLLEXPORT size_t load_graph(const std::string filename,
                                         size_t            expected_num_points);
     DISKANN_DLLEXPORT size_t load_data(std::string filename0);
     DISKANN_DLLEXPORT size_t load_tags(const std::string tag_file_name);
     DISKANN_DLLEXPORT size_t load_delete_set(const std::string &filename);
+#endif
 
    private:
     // Distance functions

--- a/include/index.h
+++ b/include/index.h
@@ -140,8 +140,6 @@ namespace diskann {
                                 bool        compact_before_save = false);
 
     // Load functions
-    DISKANN_DLLEXPORT void load(const char *index_file, uint32_t num_threads,
-                                uint32_t search_l);
 #ifdef EXEC_ENV_OLS
     DISKANN_DLLEXPORT void load(AlignedFileReader &reader,
                                 uint32_t num_threads, uint32_t search_l);

--- a/include/logger.h
+++ b/include/logger.h
@@ -1,10 +1,24 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
+#pragma once
 
+#include <functional>
 #include <iostream>
 #include "windows_customizations.h"
 
 namespace diskann {
   DISKANN_DLLEXPORT extern std::basic_ostream<char> cout;
   DISKANN_DLLEXPORT extern std::basic_ostream<char> cerr;
+
+  enum class DISKANN_DLLEXPORT LogLevel {
+      LL_Info = 0,
+      LL_Error,
+      LL_Count
+  };
+
+#ifdef EXEC_ENV_OLS
+   DISKANN_DLLEXPORT void SetCustomLogger(
+       std::function<void(LogLevel, const char*)> logger);
+#endif
+
 }  // namespace diskann

--- a/include/logger_impl.h
+++ b/include/logger_impl.h
@@ -6,26 +6,8 @@
 #include <sstream>
 #include <mutex>
 
-#ifdef EXEC_ENV_OLS
-#include "IANNIndex.h"
-#include "ANNLogging.h"
-#endif
-
 #include "ann_exception.h"
-
-#ifndef EXEC_ENV_OLS
-namespace ANNIndex {
-  enum LogLevel {
-    LL_Debug = 0,
-    LL_Info,
-    LL_Status,
-    LL_Warning,
-    LL_Error,
-    LL_Assert,
-    LL_Count
-  };
-};
-#endif
+#include "logger.h"
 
 namespace diskann {
   class ANNStreamBuf : public std::basic_streambuf<char> {
@@ -46,7 +28,7 @@ namespace diskann {
     char*              _buf;
     int                _bufIndex;
     std::mutex         _mutex;
-    ANNIndex::LogLevel _logLevel;
+    LogLevel _logLevel;
 
     int  flush();
     void logImpl(char* str, int numchars);

--- a/include/utils.h
+++ b/include/utils.h
@@ -158,6 +158,9 @@ inline int delete_file(const std::string& fileName) {
   }
 }
 
+#ifdef EXEC_ENV_OLS
+class AlignedFileReader;
+#endif
 namespace diskann {
   static const size_t MAX_SIZE_OF_STREAMBUF = 2LL * 1024 * 1024 * 1024;
 
@@ -312,7 +315,6 @@ namespace diskann {
                  2 * sizeof(uint32_t));  // No need to copy!
   }
 
-  class AlignedFileReader;
   DISKANN_DLLEXPORT void get_bin_metadata(AlignedFileReader& reader,
                                           size_t& npts, size_t& ndim,
                                           size_t offset = 0);

--- a/src/dll/CMakeLists.txt
+++ b/src/dll/CMakeLists.txt
@@ -6,13 +6,12 @@ add_library(${PROJECT_NAME} SHARED dllmain.cpp ../partition_and_pq.cpp ../pq_fla
     ../ann_exception.cpp ../natural_number_set.cpp ../natural_number_map.cpp)
 
 set(TARGET_DIR "$<$<CONFIG:Debug>:${CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG}>$<$<CONFIG:Release>:${CMAKE_LIBRARY_OUTPUT_DIRECTORY_RELEASE}>")
-set(DISKANN_DLL_IMPLIB "${TARGET_DIR}/${PROJECT_NAME}.lib")
 
 target_compile_definitions(${PROJECT_NAME} PRIVATE _USRDLL _WINDLL)
 target_compile_options(${PROJECT_NAME} PRIVATE /MD /GL)
 target_include_directories(${PROJECT_NAME} PRIVATE ${DISKANN_MKL_INCLUDE_DIRECTORIES})
 
-target_link_options(${PROJECT_NAME} PRIVATE /DLL /IMPLIB:${DISKANN_DLL_IMPLIB} /LTCG)
+target_link_options(${PROJECT_NAME} PRIVATE /DLL /LTCG)
 target_link_libraries(${PROJECT_NAME} PRIVATE ${DISKANN_MKL_LINK_LIBRARIES})
 
 if (DISKANN_DLL_TCMALLOC_LINK_OPTIONS)

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -746,7 +746,7 @@ namespace diskann {
 #ifdef EXEC_ENV_OLS
     _u32 nodes_read = 0;
     _u64 cc = 0;
-    _u64 graph_offset = file_offset + header_size;
+    _u64 graph_offset = header_size;
     while (nodes_read < expected_num_points) {
       _u32 k;
       read_value(reader, k, graph_offset);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -418,7 +418,7 @@ namespace diskann {
       compact_data();
       compact_frozen_point();
     } else {
-      if (not _data_compacted) {
+      if (!_data_compacted) {
         throw ANNException(
             "Index save for non-compacted index is not yet implemented", -1,
             __FUNCSIG__, __FILE__, __LINE__);
@@ -2204,7 +2204,7 @@ namespace diskann {
 
     std::unique_lock<std::shared_timed_mutex> cl(_consolidate_lock,
                                                  std::defer_lock);
-    if (not cl.try_lock()) {
+    if (!cl.try_lock()) {
       diskann::cerr
           << "Consildate delete function failed to acquire consolidate lock"
           << std::endl;
@@ -2232,7 +2232,7 @@ namespace diskann {
 #pragma omp parallel for num_threads(num_threads) schedule(dynamic, 8192)
     for (_s64 loc = 0; loc < (_s64) _max_points; loc++) {
       if (old_delete_set.find((_u32) loc) == old_delete_set.end() &&
-          not _empty_slots.is_in_set((_u32) loc)) {
+          !_empty_slots.is_in_set((_u32) loc)) {
         if (_conc_consolidate) {
           LockGuard adj_list_lock(_locks[loc]);
           process_delete(old_delete_set, loc, range, maxc, alpha);

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -4,10 +4,6 @@
 #include <cstring>
 #include <iostream>
 
-#ifdef EXEC_ENV_OLS
-#include "ANNLoggingImpl.hpp"
-#endif
-
 #include "logger_impl.h"
 #include "windows_customizations.h"
 
@@ -19,6 +15,14 @@ namespace diskann {
   DISKANN_DLLEXPORT std::basic_ostream<char> cout(&coutBuff);
   DISKANN_DLLEXPORT std::basic_ostream<char> cerr(&cerrBuff);
 
+#ifdef EXEC_ENV_OLS
+  std::function<void(LogLevel, const char*)> g_logger;
+
+  void SetCustomLogger(std::function<void(LogLevel, const char*)> logger) {
+    g_logger = logger;
+  }
+#endif
+
   ANNStreamBuf::ANNStreamBuf(FILE* fp) {
     if (fp == nullptr) {
       throw diskann::ANNException(
@@ -29,8 +33,8 @@ namespace diskann {
           "The custom logger only supports stdout and stderr.", -1);
     }
     _fp = fp;
-    _logLevel = (_fp == stdout) ? ANNIndex::LogLevel::LL_Info
-                                : ANNIndex::LogLevel::LL_Error;
+    _logLevel = (_fp == stdout) ? LogLevel::LL_Info
+                                : LogLevel::LL_Error;
 #ifdef EXEC_ENV_OLS
     _buf = new char[BUFFER_SIZE + 1];  // See comment in the header
 #else
@@ -77,7 +81,8 @@ namespace diskann {
   void ANNStreamBuf::logImpl(char* str, int num) {
 #ifdef EXEC_ENV_OLS
     str[num] = '\0';  // Safe. See the c'tor.
-    DiskANNLogging(_logLevel, str);
+    // Invoke the OLS custom logging function.
+    g_logger(_logLevel, str);
 #else
     fwrite(str, sizeof(char), num, _fp);
     fflush(_fp);

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -82,7 +82,9 @@ namespace diskann {
 #ifdef EXEC_ENV_OLS
     str[num] = '\0';  // Safe. See the c'tor.
     // Invoke the OLS custom logging function.
-    g_logger(_logLevel, str);
+    if (g_logger) {
+      g_logger(_logLevel, str);
+    }
 #else
     fwrite(str, sizeof(char), num, _fp);
     fflush(_fp);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -5,6 +5,10 @@
 
 #include <stdio.h>
 
+#ifdef EXEC_ENV_OLS
+#include "aligned_file_reader.h"
+#endif
+
 const uint32_t MAX_REQUEST_SIZE = 1024 * 1024 * 1024;  // 64MB
 const uint32_t MAX_SIMULTANEOUS_READ_REQUESTS = 128;
 
@@ -226,4 +230,259 @@ namespace diskann {
                   << std::endl;
   }
 
+ #ifdef EXEC_ENV_OLS
+  void get_bin_metadata(AlignedFileReader& reader,
+                        size_t& npts, size_t& ndim, size_t offset) {
+    std::vector<AlignedRead> readReqs;
+    AlignedRead              readReq;
+    uint32_t                 buf[2];  // npts/ndim are uint32_ts.
+
+    readReq.buf = buf;
+    readReq.offset = offset;
+    readReq.len = 2 * sizeof(uint32_t);
+    readReqs.push_back(readReq);
+
+    IOContext& ctx = reader.get_ctx();
+    reader.read(readReqs, ctx);  // synchronous
+    if ((*(ctx.m_pRequestsStatus))[0] == IOContext::READ_SUCCESS) {
+      npts = buf[0];
+      ndim = buf[1];
+      diskann::cout << "File has: " << npts << " points, " << ndim
+                    << " dimensions at offset: " << offset << std::endl;
+    } else {
+      std::stringstream str;
+      str << "Could not read binary metadata from index file at offset: "
+          << offset << std::endl;
+      throw diskann::ANNException(str.str(), -1, __FUNCSIG__, __FILE__,
+                                  __LINE__);
+    }
+  }
+
+  template<typename T>
+  void load_bin(AlignedFileReader& reader, T*& data,
+                                  size_t& npts, size_t& ndim, size_t offset) {
+    // Code assumes that the reader is already setup correctly.
+    get_bin_metadata(reader, npts, ndim, offset);
+    data = new T[npts * ndim];
+
+    size_t data_size = npts * ndim * sizeof(T);
+    size_t write_offset = 0;
+    size_t read_start = offset + 2 * sizeof(uint32_t);
+
+    // BingAlignedFileReader can only read uint32_t bytes of data. So,
+    // we limit ourselves even more to reading 1GB at a time.
+    std::vector<AlignedRead> readReqs;
+    while (data_size > 0) {
+      AlignedRead readReq;
+      readReq.buf = data + write_offset;
+      readReq.offset = read_start + write_offset;
+      readReq.len = data_size > MAX_REQUEST_SIZE ? MAX_REQUEST_SIZE : data_size;
+      readReqs.push_back(readReq);
+      // in the corner case, the loop will not execute
+      data_size -= readReq.len;
+      write_offset += readReq.len;
+    }
+    IOContext& ctx = reader.get_ctx();
+    reader.read(readReqs, ctx);
+    for (int i = 0; i < readReqs.size(); i++) {
+      // Since we are making sync calls, no request will be in the
+      // READ_WAIT state.
+      if ((*(ctx.m_pRequestsStatus))[i] != IOContext::READ_SUCCESS) {
+        std::stringstream str;
+        str << "Could not read binary data from index file at offset: "
+            << readReqs[i].offset << std::endl;
+        throw diskann::ANNException(str.str(), -1, __FUNCSIG__, __FILE__,
+                                    __LINE__);
+      }
+    }
+  }
+  template<typename T>
+  void load_bin(AlignedFileReader& reader,
+                std::unique_ptr<T[]>& data, size_t& npts, size_t& ndim, size_t offset) {
+    T* ptr = nullptr;
+    load_bin(reader, ptr, npts, ndim, offset);
+    data.reset(ptr);
+  }
+
+  template<typename T>
+  void copy_aligned_data_from_file(AlignedFileReader& reader,
+                                                     T*& data, size_t& npts,
+                                                     size_t&       ndim,
+                                                     const size_t& rounded_dim,
+                                   size_t        offset) {
+    if (data == nullptr) {
+      diskann::cerr << "Memory was not allocated for " << data
+                    << " before calling the load function. Exiting..."
+                    << std::endl;
+      throw diskann::ANNException(
+          "Null pointer passed to copy_aligned_data_from_file()", -1,
+          __FUNCSIG__, __FILE__, __LINE__);
+    }
+
+    size_t pts, dim;
+    get_bin_metadata(reader, pts, dim, offset);
+
+    if (ndim != dim || npts != pts) {
+      std::stringstream ss;
+      ss << "Either file dimension: " << dim
+         << " is != passed dimension: " << ndim << " or file #pts: " << pts
+         << " is != passed #pts: " << npts << std::endl;
+      throw diskann::ANNException(ss.str(), -1, __FUNCSIG__, __FILE__,
+                                  __LINE__);
+    }
+
+    // Instead of reading one point of ndim size and setting (rounded_dim - dim)
+    // values to zero We'll set everything to zero and read in chunks of data at
+    // the appropriate locations.
+    size_t read_offset = offset + 2 * sizeof(uint32_t);
+    memset(data, 0, npts * rounded_dim * sizeof(T));
+    int                      i = 0;
+    std::vector<AlignedRead> read_requests;
+
+    while (i < npts) {
+      int j = 0;
+      read_requests.clear();
+      while (j < MAX_SIMULTANEOUS_READ_REQUESTS && i < npts) {
+        AlignedRead read_req;
+        read_req.buf = data + i * rounded_dim;
+        read_req.len = dim * sizeof(T);
+        read_req.offset = read_offset + i * dim * sizeof(T);
+        read_requests.push_back(read_req);
+        i++;
+        j++;
+      }
+      IOContext& ctx = reader.get_ctx();
+      reader.read(read_requests, ctx);
+      for (int k = 0; k < read_requests.size(); k++) {
+        if ((*ctx.m_pRequestsStatus)[k] != IOContext::READ_SUCCESS) {
+          throw diskann::ANNException(
+              "Load data from file using AlignedReader failed.", -1,
+              __FUNCSIG__, __FILE__, __LINE__);
+        }
+      }
+    }
+  }
+
+  // Unlike load_bin, assumes that data is already allocated 'size' entries
+  template<typename T>
+  void read_array(AlignedFileReader& reader, T* data, size_t size,
+                  size_t offset) {
+    if (data == nullptr) {
+      throw diskann::ANNException("read_array requires an allocated buffer.",
+                                  -1);
+      if (size * sizeof(T) > MAX_REQUEST_SIZE) {
+        std::stringstream ss;
+        ss << "Cannot read more than " << MAX_REQUEST_SIZE
+           << " bytes. Current request size: " << std::to_string(size)
+           << " sizeof(T): " << sizeof(T) << std::endl;
+        throw diskann::ANNException(ss.str(), -1, __FUNCSIG__, __FILE__,
+                                    __LINE__);
+      }
+      std::vector<AlignedRead> read_requests;
+      AlignedRead              read_req;
+      read_req.buf = data;
+      read_req.len = size * sizeof(T);
+      read_req.offset = offset;
+      read_requests.push_back(read_req);
+      IOContext& ctx = reader.get_ctx();
+      reader.read(read_requests, ctx);
+
+      if ((*(ctx.m_pRequestsStatus))[0] != IOContext::READ_SUCCESS) {
+        std::stringstream ss;
+        ss << "Failed to read_array() of size: " << size * sizeof(T)
+           << " at offset: " << offset << " from reader. " << std::endl;
+        throw diskann::ANNException(ss.str(), -1, __FUNCSIG__, __FILE__,
+                                    __LINE__);
+      }
+    }
+  }
+
+  template<typename T>
+  void read_value(AlignedFileReader& reader, T& value, size_t offset) {
+    read_array(reader, &value, 1, offset);
+  }
+
+  template DISKANN_DLLEXPORT void load_bin<uint8_t>(
+      AlignedFileReader& reader, std::unique_ptr<uint8_t[]>& data, size_t& npts,
+      size_t& ndim, size_t offset);
+  template DISKANN_DLLEXPORT void load_bin<int8_t>(
+      AlignedFileReader& reader, std::unique_ptr<int8_t[]>& data, size_t& npts,
+      size_t& ndim, size_t offset);
+  template DISKANN_DLLEXPORT void load_bin<uint32_t>(
+      AlignedFileReader& reader, std::unique_ptr<uint32_t[]>& data,
+      size_t& npts, size_t& ndim, size_t offset);
+  template DISKANN_DLLEXPORT void load_bin<uint64_t>(
+      AlignedFileReader& reader, std::unique_ptr<uint64_t[]>& data,
+      size_t& npts, size_t& ndim, size_t offset);
+  template DISKANN_DLLEXPORT void load_bin<int64_t>(
+      AlignedFileReader& reader, std::unique_ptr<int64_t[]>& data, size_t& npts,
+      size_t& ndim, size_t offset);
+  template DISKANN_DLLEXPORT void load_bin<float>(
+      AlignedFileReader& reader, std::unique_ptr<float[]>& data, size_t& npts,
+      size_t& ndim, size_t offset);
+
+  template DISKANN_DLLEXPORT void load_bin<uint8_t>(AlignedFileReader& reader,
+                                                    uint8_t*&          data,
+                                                    size_t& npts, size_t& ndim,
+                                                    size_t  offset);
+  template DISKANN_DLLEXPORT void load_bin<int64_t>(AlignedFileReader& reader,
+                                                    int64_t*&          data,
+                                                    size_t& npts, size_t& ndim,
+                                                    size_t offset);
+  template DISKANN_DLLEXPORT void load_bin<uint64_t>(AlignedFileReader& reader,
+                                                     uint64_t*&         data,
+                                                     size_t& npts, size_t& ndim,
+                                                     size_t offset);
+  template DISKANN_DLLEXPORT void load_bin<uint32_t>(AlignedFileReader& reader,
+                                                     uint32_t*&         data,
+                                                     size_t& npts, size_t& ndim,
+                                                     size_t offset);
+  template DISKANN_DLLEXPORT void load_bin<int32_t>(AlignedFileReader& reader,
+                                                     int32_t*&         data,
+                                                     size_t& npts, size_t& ndim,
+                                                     size_t offset);
+
+  template DISKANN_DLLEXPORT void copy_aligned_data_from_file<uint8_t>(
+      AlignedFileReader& reader, uint8_t*& data, size_t& npts, size_t& dim,
+      const size_t& rounded_dim, size_t offset);
+  template DISKANN_DLLEXPORT void copy_aligned_data_from_file<int8_t>(
+      AlignedFileReader& reader, int8_t*& data, size_t& npts, size_t& dim,
+      const size_t& rounded_dim, size_t offset);
+  template DISKANN_DLLEXPORT void copy_aligned_data_from_file<float>(
+      AlignedFileReader& reader, float*& data, size_t& npts, size_t& dim,
+      const size_t& rounded_dim, size_t offset);
+
+  template DISKANN_DLLEXPORT void read_array<char>(AlignedFileReader& reader,
+                                                   char* data, size_t size,
+                                                   size_t offset);
+
+  template DISKANN_DLLEXPORT void read_array<uint8_t>(AlignedFileReader& reader,
+                                                      uint8_t*           data,
+                                                      size_t             size,
+                                                      size_t offset);
+  template DISKANN_DLLEXPORT void read_array<int8_t>(AlignedFileReader& reader,
+                                                     int8_t* data, size_t size,
+                                                     size_t offset);
+  template DISKANN_DLLEXPORT void read_array<uint32_t>(AlignedFileReader& reader,
+                                                     uint32_t* data, size_t size,
+                                                     size_t offset);
+  template DISKANN_DLLEXPORT void read_array<float>(AlignedFileReader& reader,
+                                                    float* data, size_t size,
+                                                    size_t offset);
+
+  template DISKANN_DLLEXPORT void read_value<uint8_t>(AlignedFileReader& reader,
+                                                      uint8_t&           value,
+                                                      size_t offset);
+  template DISKANN_DLLEXPORT void read_value<int8_t>(AlignedFileReader& reader,
+                                                     int8_t&            value,
+                                                     size_t             offset);
+  template DISKANN_DLLEXPORT void read_value<float>(AlignedFileReader& reader,
+                                                    float&             value,
+                                                    size_t             offset);
+  template DISKANN_DLLEXPORT void read_value<uint32_t>(
+      AlignedFileReader& reader, uint32_t& value, size_t offset);
+  template DISKANN_DLLEXPORT void read_value<uint64_t>(
+      AlignedFileReader& reader, uint64_t& value, size_t offset);
+
+#endif
 }  // namespace diskann


### PR DESCRIPTION
# Changes
All changes only effects when "EXEC_ENV_OLS" is defined:
- Expose a `SetCustomLogger `function to pass in custom logging function so we can invoke it, this replaced the old undefined `DISKANNLOGGING `micro and removed dependency on some unnecessary headers, like `IANNIndex.h, ANNLogging.h` etc.
- Start with supporting log level `Info` and `Error `only as that's what `diskann::cout `or `diskan::cerr` supports.
- Added missing declarations for overloads that takes `AlighedFileReader` in `index.h`
- Added missing implementations for following function overloads that takes `AlighedFileReader` in `utils.cpp `(copied from DLSV repo): `get_bin_metadata, load_bin, copy_aligned_data_from_file, read_array, read_value`