### PR TITLE
Origin/nmahapatro/sector ordering changes

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -450,7 +450,7 @@ namespace diskann {
         _tag_lock;  // RW lock for _tag_to_location and _location_to_tag
     std::shared_timed_mutex
         _delete_lock;  // RW Lock on _delete_set and _empty_slots
-
     static const float INDEX_GROWTH_FACTOR;
+    non_recursive_mutex _reorder_del_lock;
   };
 }  // namespace diskann

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1748,8 +1748,8 @@ void Index<T, TagT>::partition_packing(
       std::unordered_set<unsigned> &initial, boost::dynamic_bitset<> &deleted) {
     std::unordered_map<unsigned, unsigned> counts;
 
-    p_order[0] = seed_node;    
-    std::vector<non_recursive_mutex> porder_locks(omega);
+    p_order[0] = seed_node;
+    
     for (unsigned i = 1; i < omega; i++) {
       unsigned ve = p_order[i - 1];
       for (unsigned j = 0; j < _final_graph[ve].size(); j++) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1748,8 +1748,8 @@ void Index<T, TagT>::partition_packing(
       std::unordered_set<unsigned> &initial, boost::dynamic_bitset<> &deleted) {
     std::unordered_map<unsigned, unsigned> counts;
 
-    p_order[0] = seed_node;
-
+    p_order[0] = seed_node;    
+    std::vector<non_recursive_mutex> porder_locks(omega);
     for (unsigned i = 1; i < omega; i++) {
       unsigned ve = p_order[i - 1];
       for (unsigned j = 0; j < _final_graph[ve].size(); j++) {
@@ -1788,8 +1788,8 @@ void Index<T, TagT>::partition_packing(
             max_val = itr->second;
           }
         }
-#pragma omp critical
         {
+          LockGuard guard(_reorder_del_lock);
           if (deleted[max_it->first] == false) {
             deleted[max_it->first] = true;
             initial.erase(max_it->first);
@@ -1805,8 +1805,8 @@ void Index<T, TagT>::partition_packing(
         }
       }
       while (!found) {
-        #pragma omp critical
         {
+          LockGuard guard(_reorder_del_lock);
           for (auto itr = initial.begin(); itr != initial.end(); itr++) {
             if (deleted[*itr] == false) {
               p_order[i] = *(itr);
@@ -1842,8 +1842,8 @@ void Index<T, TagT>::partition_packing(
 
 
 
-    std::vector<std::mutex> in_locks (_nd);
-
+    std::vector<non_recursive_mutex> in_locks(_nd);
+    
 #pragma omp parallel for schedule(dynamic, 128)    
     for (_s64 i = 0; i < (_s64)(_final_graph.size()); i++) {
       for (unsigned j = 0; j < _final_graph[i].size(); j++) {
@@ -1862,8 +1862,8 @@ void Index<T, TagT>::partition_packing(
 #pragma omp parallel for schedule(dynamic, 1) num_threads(threads)
     for (_s64 i = 0; i < (_s64)(_nd / omega); i++) {
       unsigned seed_node;
-#pragma omp    critical
       {
+        LockGuard guard(_reorder_del_lock);
         seed_node = *(initial.begin());
         deleted[seed_node] = true;
         initial.erase(initial.begin());


### PR DESCRIPTION
* Replaced pragma critical with non_recursive_mutext (for both windows and linux compatibility)
* Removed reordering time from function argument