### PR TITLE
Revert "move vector space reservation from cached_beam_search to thread-speci…"

### DIFF
--- a/include/pq_flash_index.h
+++ b/include/pq_flash_index.h
@@ -48,8 +48,6 @@ namespace diskann {
 
     tsl::robin_set<_u64> *visited = nullptr;
 
-    std::vector<Neighbor> full_retset;
-
     void reset() {
       coord_idx = 0;
       sector_idx = 0;
@@ -118,8 +116,7 @@ namespace diskann {
 
    protected:
     DISKANN_DLLEXPORT void use_medoids_data_as_centroids();
-    DISKANN_DLLEXPORT void setup_thread_data(_u64 nthreads,
-                                             _u64 visited_reserve = 4096);
+    DISKANN_DLLEXPORT void setup_thread_data(_u64 nthreads);
     DISKANN_DLLEXPORT void destroy_thread_data();
 
    private:

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -100,7 +100,7 @@ namespace diskann {
   }
 
   template<typename T>
-  void PQFlashIndex<T>::setup_thread_data(_u64 nthreads, _u64 visited_reserve) {
+  void PQFlashIndex<T>::setup_thread_data(_u64 nthreads) {
     diskann::cout << "Setting up thread-specific contexts for nthreads: "
                   << nthreads << std::endl;
 // omp parallel for to generate unique thread IDs
@@ -129,7 +129,7 @@ namespace diskann {
         diskann::alloc_aligned((void **) &scratch.aligned_query_float,
                                this->aligned_dim * sizeof(float),
                                8 * sizeof(float));
-        scratch.visited = new tsl::robin_set<_u64>(visited_reserve);
+        scratch.visited = new tsl::robin_set<_u64>(4096);
         diskann::alloc_aligned((void **) &scratch.rotated_query,
                                this->aligned_dim * sizeof(float),
                                8 * sizeof(float));
@@ -139,8 +139,6 @@ namespace diskann {
         memset(scratch.aligned_query_float, 0,
                this->aligned_dim * sizeof(float));
         memset(scratch.rotated_query, 0, this->aligned_dim * sizeof(float));
-        
-        scratch.full_retset.reserve(visited_reserve);
 
         ThreadData<T> data;
         data.ctx = ctx;
@@ -903,8 +901,8 @@ namespace diskann {
     std::vector<Neighbor> retset(l_search + 1);
     tsl::robin_set<_u64> &visited = *(query_scratch->visited);
 
-    std::vector<Neighbor>& full_retset = query_scratch->full_retset;
-    full_retset.clear();
+    std::vector<Neighbor> full_retset;
+    full_retset.reserve(4096);
     _u32                        best_medoid = 0;
     float                       best_dist = (std::numeric_limits<float>::max)();
     std::vector<SimpleNeighbor> medoid_dists;


### PR DESCRIPTION
Reverts microsoft/DiskANN#131
Need to make the conc queue for scratch space work with pointers.