### PR TITLE
Harshasi/remove alloc in cached beam search

### DIFF
--- a/include/pq_flash_index.h
+++ b/include/pq_flash_index.h
@@ -48,6 +48,8 @@ namespace diskann {
 
     tsl::robin_set<_u64> *visited = nullptr;
 
+    std::vector<Neighbor> full_retset;
+
     void reset() {
       coord_idx = 0;
       sector_idx = 0;

--- a/include/pq_flash_index.h
+++ b/include/pq_flash_index.h
@@ -118,7 +118,8 @@ namespace diskann {
 
    protected:
     DISKANN_DLLEXPORT void use_medoids_data_as_centroids();
-    DISKANN_DLLEXPORT void setup_thread_data(_u64 nthreads);
+    DISKANN_DLLEXPORT void setup_thread_data(_u64 nthreads,
+                                             _u64 visited_reserve = 4096);
     DISKANN_DLLEXPORT void destroy_thread_data();
 
    private:

--- a/include/pq_flash_index.h
+++ b/include/pq_flash_index.h
@@ -29,7 +29,7 @@
 namespace diskann {
   template<typename T>
   struct QueryScratch {
-    T *  coord_scratch = nullptr;  // MUST BE AT LEAST [MAX_N_CMPS * data_dim]
+    T   *coord_scratch = nullptr;  // MUST BE AT LEAST [MAX_N_CMPS * data_dim]
     _u64 coord_idx = 0;            // index of next [data_dim] scratch to use
 
     char *sector_scratch =
@@ -42,18 +42,21 @@ namespace diskann {
         nullptr;  // MUST BE AT LEAST diskann MAX_DEGREE
     _u8 *aligned_pq_coord_scratch =
         nullptr;  // MUST BE AT LEAST  [N_CHUNKS * MAX_DEGREE]
-    T *    aligned_query_T = nullptr;
+    T     *aligned_query_T = nullptr;
     float *aligned_query_float = nullptr;
     float *rotated_query = nullptr;
 
     tsl::robin_set<_u64> *visited = nullptr;
-
+    std::vector<Neighbor> retset;
     std::vector<Neighbor> full_retset;
+    
 
     void reset() {
       coord_idx = 0;
       sector_idx = 0;
       visited->clear();  // does not deallocate memory.
+      retset.clear();
+      full_retset.clear();
     }
   };
 
@@ -109,10 +112,10 @@ namespace diskann {
     DISKANN_DLLEXPORT _u32 range_search(const T *query1, const double range,
                                         const _u64          min_l_search,
                                         const _u64          max_l_search,
-                                        std::vector<_u64> & indices,
+                                        std::vector<_u64>  &indices,
                                         std::vector<float> &distances,
                                         const _u64          min_beam_width,
-                                        QueryStats *        stats = nullptr);
+                                        QueryStats         *stats = nullptr);
 
     std::shared_ptr<AlignedFileReader> &reader;
 
@@ -158,7 +161,7 @@ namespace diskann {
     // data: _u8 * n_chunks
     // chunk_size = chunk size of each dimension chunk
     // pq_tables = float* [[2^8 * [chunk_size]] * n_chunks]
-    _u8 *             data = nullptr;
+    _u8              *data = nullptr;
     _u64              n_chunks;
     FixedChunkPQTable pq_table;
 
@@ -184,27 +187,27 @@ namespace diskann {
     float *centroid_data = nullptr;
 
     // nhood_cache
-    unsigned *                                    nhood_cache_buf = nullptr;
+    unsigned                                     *nhood_cache_buf = nullptr;
     tsl::robin_map<_u32, std::pair<_u32, _u32 *>> nhood_cache;
 
     // coord_cache
-    T *                       coord_cache_buf = nullptr;
+    T                        *coord_cache_buf = nullptr;
     tsl::robin_map<_u32, T *> coord_cache;
 
     // thread-specific scratch
-    ConcurrentQueue<ThreadData<T>> thread_data;
-    _u64                           max_nthreads;
-    bool                           load_flag = false;
-    bool                           count_visited_nodes = false;
-    bool                           reorder_data_exists = false;
-    _u64                           reoreder_data_offset = 0;
+    ConcurrentQueue<ThreadData<T> *> thread_data;
+    _u64                             max_nthreads;
+    bool                             load_flag = false;
+    bool                             count_visited_nodes = false;
+    bool                             reorder_data_exists = false;
+    _u64                             reoreder_data_offset = 0;
 
 #ifdef EXEC_ENV_OLS
     // Set to a larger value than the actual header to accommodate
     // any additions we make to the header. This is an outer limit
     // on how big the header can be.
     static const int HEADER_SIZE = SECTOR_LEN;
-    char *           getHeaderBytes();
+    char            *getHeaderBytes();
 #endif
   };
 }  // namespace diskann

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -139,6 +139,8 @@ namespace diskann {
         memset(scratch.aligned_query_float, 0,
                this->aligned_dim * sizeof(float));
         memset(scratch.rotated_query, 0, this->aligned_dim * sizeof(float));
+        
+        scratch.full_retset.reserve(4096);
 
         ThreadData<T> data;
         data.ctx = ctx;
@@ -901,8 +903,8 @@ namespace diskann {
     std::vector<Neighbor> retset(l_search + 1);
     tsl::robin_set<_u64> &visited = *(query_scratch->visited);
 
-    std::vector<Neighbor> full_retset;
-    full_retset.reserve(4096);
+    std::vector<Neighbor>& full_retset = query_scratch->full_retset;
+    full_retset.clear();
     _u32                        best_medoid = 0;
     float                       best_dist = (std::numeric_limits<float>::max)();
     std::vector<SimpleNeighbor> medoid_dists;

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -108,9 +108,11 @@ namespace diskann {
     for (_s64 thread = 0; thread < (_s64) nthreads; thread++) {
 #pragma omp critical
       {
+        ThreadData<T> *data = new ThreadData<T>;
         this->reader->register_thread();
-        IOContext &     ctx = this->reader->get_ctx();
-        QueryScratch<T> scratch;
+        data->ctx = this->reader->get_ctx();
+        QueryScratch<T> &scratch = data->scratch;
+
         _u64 coord_alloc_size = ROUND_UP(MAX_N_CMPS * this->aligned_dim, 256);
         diskann::alloc_aligned((void **) &scratch.coord_scratch,
                                coord_alloc_size, 256);
@@ -142,9 +144,6 @@ namespace diskann {
         
         scratch.full_retset.reserve(visited_reserve);
 
-        ThreadData<T> data;
-        data.ctx = ctx;
-        data.scratch = scratch;
         this->thread_data.push(data);
       }
     }
@@ -156,12 +155,12 @@ namespace diskann {
     diskann::cout << "Clearing scratch" << std::endl;
     assert(this->thread_data.size() == this->max_nthreads);
     while (this->thread_data.size() > 0) {
-      ThreadData<T> data = this->thread_data.pop();
-      while (data.scratch.sector_scratch == nullptr) {
+      auto data = this->thread_data.pop();
+      while (data->scratch.sector_scratch == nullptr) {
         this->thread_data.wait_for_push_notify();
         data = this->thread_data.pop();
       }
-      auto &scratch = data.scratch;
+      auto &scratch = data->scratch;
       diskann::aligned_free((void *) scratch.coord_scratch);
       diskann::aligned_free((void *) scratch.sector_scratch);
       diskann::aligned_free((void *) scratch.aligned_pq_coord_scratch);
@@ -172,6 +171,7 @@ namespace diskann {
       diskann::aligned_free((void *) scratch.aligned_query_T);
 
       delete scratch.visited;
+      delete data;
     }
     this->reader->deregister_all_threads();
   }
@@ -182,13 +182,13 @@ namespace diskann {
     _u64 num_cached_nodes = node_list.size();
 
     // borrow thread data
-    ThreadData<T> this_thread_data = this->thread_data.pop();
-    while (this_thread_data.scratch.sector_scratch == nullptr) {
+    auto this_thread_data = this->thread_data.pop();
+    while (this_thread_data->scratch.sector_scratch == nullptr) {
       this->thread_data.wait_for_push_notify();
       this_thread_data = this->thread_data.pop();
     }
 
-    IOContext &ctx = this_thread_data.ctx;
+    IOContext &ctx = this_thread_data->ctx;
 
     nhood_cache_buf = new unsigned[num_cached_nodes * (max_degree + 1)];
     memset(nhood_cache_buf, 0, num_cached_nodes * (max_degree + 1));
@@ -341,13 +341,13 @@ namespace diskann {
     diskann::cout << "Caching " << num_nodes_to_cache << "..." << std::endl;
 
     // borrow thread data
-    ThreadData<T> this_thread_data = this->thread_data.pop();
-    while (this_thread_data.scratch.sector_scratch == nullptr) {
+    auto this_thread_data = this->thread_data.pop();
+    while (this_thread_data->scratch.sector_scratch == nullptr) {
       this->thread_data.wait_for_push_notify();
       this_thread_data = this->thread_data.pop();
     }
 
-    IOContext &ctx = this_thread_data.ctx;
+    IOContext &ctx = this_thread_data->ctx;
 
     std::unique_ptr<tsl::robin_set<unsigned>> cur_level, prev_level;
     cur_level = std::make_unique<tsl::robin_set<unsigned>>();
@@ -472,12 +472,12 @@ namespace diskann {
     std::memset(centroid_data, 0, num_medoids * aligned_dim * sizeof(float));
 
     // borrow ctx
-    ThreadData<T> data = this->thread_data.pop();
-    while (data.scratch.sector_scratch == nullptr) {
+    auto data = this->thread_data.pop();
+    while (data->scratch.sector_scratch == nullptr) {
       this->thread_data.wait_for_push_notify();
       data = this->thread_data.pop();
     }
-    IOContext &ctx = data.ctx;
+    IOContext &ctx = data->ctx;
     diskann::cout << "Loading centroid data from medoids vector data of "
                   << num_medoids << " medoid(s)" << std::endl;
     for (uint64_t cur_m = 0; cur_m < num_medoids; cur_m++) {
@@ -824,30 +824,36 @@ namespace diskann {
       const T *query1, const _u64 k_search, const _u64 l_search, _u64 *indices,
       float *distances, const _u64 beam_width, const _u32 io_limit,
       const bool use_reorder_data, QueryStats *stats) {
-    ThreadData<T> data = this->thread_data.pop();
-    while (data.scratch.sector_scratch == nullptr) {
-      this->thread_data.wait_for_push_notify();
-      data = this->thread_data.pop();
-    }
-
     if (beam_width > MAX_N_SECTOR_READS)
       throw ANNException("Beamwidth can not be higher than MAX_N_SECTOR_READS",
                          -1, __FUNCSIG__, __FILE__, __LINE__);
 
+    auto data = this->thread_data.pop();
+    while (data->scratch.sector_scratch == nullptr) {
+      this->thread_data.wait_for_push_notify();
+      data = this->thread_data.pop();
+    }
+    IOContext &ctx = data->ctx;
+    auto       query_scratch = &(data->scratch);
+
+    // reset query scratch
+    query_scratch->reset();
+
+
     // copy query to thread specific aligned and allocated memory (for distance
     // calculations we need aligned data)
     float        query_norm = 0;
-    const T *    query = data.scratch.aligned_query_T;
-    const float *query_float = data.scratch.aligned_query_float;
-    float *      query_rotated = data.scratch.rotated_query;
+    const T     *query = query_scratch->aligned_query_T;
+    const float *query_float = query_scratch->aligned_query_float;
+    float       *query_rotated = query_scratch->rotated_query;
 
     for (uint32_t i = 0; i < this->data_dim;
          i++) {  // need to check if this is correct for MIPS search
       if ((i == (this->data_dim - 1)) &&
           (metric == diskann::Metric::INNER_PRODUCT))
         break;
-      data.scratch.aligned_query_float[i] = query1[i];
-      data.scratch.aligned_query_T[i] = query1[i];
+      query_scratch->aligned_query_float[i] = query1[i];
+      query_scratch->aligned_query_T[i] = query1[i];
       query_rotated[i] = query1[i];
       query_norm += query1[i] * query1[i];
     }
@@ -856,20 +862,15 @@ namespace diskann {
     // to 0 (this is the extra coordindate used to convert MIPS to L2 search)
     if (metric == diskann::Metric::INNER_PRODUCT) {
       query_norm = std::sqrt(query_norm);
-      data.scratch.aligned_query_T[this->data_dim - 1] = 0;
-      data.scratch.aligned_query_float[this->data_dim - 1] = 0;
+      query_scratch->aligned_query_T[this->data_dim - 1] = 0;
+      query_scratch->aligned_query_float[this->data_dim - 1] = 0;
       query_rotated[this->data_dim - 1] = 0;
       for (uint32_t i = 0; i < this->data_dim - 1; i++) {
-        data.scratch.aligned_query_T[i] /= query_norm;
-        data.scratch.aligned_query_float[i] /= query_norm;
+        query_scratch->aligned_query_T[i] /= query_norm;
+        query_scratch->aligned_query_float[i] /= query_norm;
       }
     }
 
-    IOContext &ctx = data.ctx;
-    auto       query_scratch = &(data.scratch);
-
-    // reset query
-    query_scratch->reset();
 
     // pointers to buffers for data
     T *   data_buf = query_scratch->coord_scratch;
@@ -900,11 +901,13 @@ namespace diskann {
                        dists_out);
     };
     Timer                 query_timer, io_timer, cpu_timer;
-    std::vector<Neighbor> retset(l_search + 1);
-    tsl::robin_set<_u64> &visited = *(query_scratch->visited);
 
+    tsl::robin_set<_u64> &visited = *(query_scratch->visited);
+    std::vector<Neighbor> &retset = query_scratch->retset;
     std::vector<Neighbor>& full_retset = query_scratch->full_retset;
-    full_retset.clear();
+    retset.reserve(l_search + 1);
+
+
     _u32                        best_medoid = 0;
     float                       best_dist = (std::numeric_limits<float>::max)();
     std::vector<SimpleNeighbor> medoid_dists;
@@ -919,9 +922,10 @@ namespace diskann {
     }
 
     compute_dists(&best_medoid, 1, dist_scratch);
-    retset[0].id = best_medoid;
+    /*retset[0].id = best_medoid;
     retset[0].distance = dist_scratch[0];
-    retset[0].flag = true;
+    retset[0].flag = true;*/
+    retset.push_back(Neighbor(best_medoid, dist_scratch[0], true));
     visited.insert(best_medoid);
 
     unsigned cur_list_size = 1;

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -100,7 +100,7 @@ namespace diskann {
   }
 
   template<typename T>
-  void PQFlashIndex<T>::setup_thread_data(_u64 nthreads) {
+  void PQFlashIndex<T>::setup_thread_data(_u64 nthreads, _u64 visited_reserve) {
     diskann::cout << "Setting up thread-specific contexts for nthreads: "
                   << nthreads << std::endl;
 // omp parallel for to generate unique thread IDs
@@ -129,7 +129,7 @@ namespace diskann {
         diskann::alloc_aligned((void **) &scratch.aligned_query_float,
                                this->aligned_dim * sizeof(float),
                                8 * sizeof(float));
-        scratch.visited = new tsl::robin_set<_u64>(4096);
+        scratch.visited = new tsl::robin_set<_u64>(visited_reserve);
         diskann::alloc_aligned((void **) &scratch.rotated_query,
                                this->aligned_dim * sizeof(float),
                                8 * sizeof(float));
@@ -140,7 +140,7 @@ namespace diskann {
                this->aligned_dim * sizeof(float));
         memset(scratch.rotated_query, 0, this->aligned_dim * sizeof(float));
         
-        scratch.full_retset.reserve(4096);
+        scratch.full_retset.reserve(visited_reserve);
 
         ThreadData<T> data;
         data.ctx = ctx;


### PR DESCRIPTION
concurrent queue handles a pointer to ThreadData rather than cloning