### PR TITLE
A (GROSS!) first stab at executing Java code from within C++.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -357,3 +357,6 @@ MigrationBackup/
 cscope*
 
 build/
+.idea
+cmake-build-debug/
+*.class

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,15 @@ else()
 	add_compile_options(-march=native -Wall -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free -fopenmp -fopenmp-simd -funroll-loops -Wfatal-errors -DUSE_AVX2)
 endif()
 
+if (JNI)
+    if (MSVC)
+        message(FATAL_ERROR "This only works on Linux for now.")
+    endif()
+    message(STATUS "Setting up JNI stuff.")
+
+    include_directories(/usr/lib/jvm/java-18-openjdk-amd64/include /usr/lib/jvm/java-18-openjdk-amd64/include/linux)
+endif()
+
 add_subdirectory(src)
 add_subdirectory(tests)
 add_subdirectory(tests/utils)

--- a/include/jni/basic_file_reader.h
+++ b/include/jni/basic_file_reader.h
@@ -1,0 +1,21 @@
+#include <jni.h>
+#include "aligned_file_reader.h"
+
+class BasicFileReader { // should properly implement the AlignedFileReader, but I genuinely don't know what it's trying to achieve with all the threading in it
+ private:
+  JNIEnv &env;
+  jclass javaClass;
+  jmethodID javaConstructor;
+  jmethodID javaRead;
+  jmethodID javaClose;
+  jobject jniFileReader;
+ public:
+  BasicFileReader(JNIEnv &env);
+  ~BasicFileReader();
+
+  void open(const std::string &fname);
+  void close();
+
+  void read(std::vector<AlignedRead> &read_reqs);
+
+};

--- a/java/FileInputStreamMediator.java
+++ b/java/FileInputStreamMediator.java
@@ -1,0 +1,40 @@
+// package com.microsoft.diskann;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+public class FileInputStreamMediator implements Closeable {
+
+    private File file;
+    private FileInputStream stream;
+
+    public FileInputStreamMediator(final String canonicalPath) throws FileNotFoundException {
+        // TODO: add your preconditions here, make sure the file exists, is readable, etc
+        // we're not doing that because we're early days yet.
+        this.stream = new FileInputStream(new File(canonicalPath));
+    }
+
+    public boolean read(final int[] readFroms, final int[] readUntils, final long[] readIntos) throws Exception {
+        // these 3 arrays must be the same length
+        // the readIntos are currently just the memory we're supposed to read into, however one does that across JNI
+        // I'm going to punt on that and instead just print out all the readIntos and untils and we'll figure out
+        // how to actually read, using Java IO, <into> some pre-allocated C++ buffers
+        // in an absolute worst case scenario we can create our own return list of buffers and do a memcopy
+        // from one into another, but I'd prefer not to do that
+        if (readFroms.length != readUntils.length || readFroms.length != readIntos.length) {
+            throw new Exception("The 3 parallel arrays must be the same size"); // this is a terrible error messaging pattern, but I don't know what control I have over *exceptions*
+        }
+        for (int i = 0; i < readFroms.length; i++) {
+            System.out.println(String.format("I would have read from %d until %d and placed it into %d", readFroms[i], readUntils[i], readIntos[i]));
+        }
+        return true;
+    }
+
+    public void close() throws IOException {
+        this.stream.close();
+    }
+
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,9 @@ else()
         linux_aligned_file_reader.cpp math_utils.cpp natural_number_map.cpp
         natural_number_set.cpp memory_mapper.cpp partition.cpp pq.cpp
         pq_flash_index.cpp logger.cpp utils.cpp)
+    if (JNI)
+        list(APPEND CPP_SOURCES jni/basic_file_reader.cpp)
+    endif()
     add_library(${PROJECT_NAME} ${CPP_SOURCES})
     add_library(${PROJECT_NAME}_s STATIC ${CPP_SOURCES})
 endif()

--- a/src/jni/basic_file_reader.cpp
+++ b/src/jni/basic_file_reader.cpp
@@ -1,0 +1,68 @@
+#include <jni.h>
+#include "jni/basic_file_reader.h"
+
+#include <iostream>
+
+BasicFileReader::BasicFileReader(JNIEnv& env) : env(env) {
+  this->javaClass = env.FindClass("FileInputStreamMediator");
+  if (this->javaClass == nullptr) {
+    std::cerr << "ERROR: Java class FileInputStreamMediator not found" << std::endl;
+  }
+  this->javaConstructor = this->env.GetMethodID(this->javaClass, "<init>", "(Ljava/lang/String;)V");
+  // this would be a great place to verify the methods and arguments we expect to pass in are meeting our criteria
+  if (this->javaConstructor == nullptr) {
+    std::cerr << "ERROR: Java class FileInputStreamMediator does not comply with expected interface (ctor)" << std::endl;
+  }
+  this->javaClose = this->env.GetMethodID(this->javaClass, "close", "()V");
+  if (this->javaClose == nullptr) {
+    std::cerr << "ERROR: Java class FileInputStreamMediator does not comply with expected interface (close)" << std::endl;
+  }
+  // https://docs.oracle.com/javase/1.5.0/docs/guide/jni/spec/types.html#wp276 you'll need this. trust me.
+  this->javaRead = this->env.GetMethodID(this->javaClass, "read", "([I[I[J)Z");
+  if (this->javaRead == nullptr) {
+    std::cerr << "ERROR: Java class FileInputStreamMediator does not comply with expected interface (read)" << std::endl;
+  }
+}
+
+BasicFileReader::~BasicFileReader() {
+  // I do nothing
+}
+
+void BasicFileReader::open(const std::string &fname) {
+  jobject fileName = this->env.NewStringUTF(fname.c_str());
+  this->jniFileReader = this->env.NewObject(this->javaClass, this->javaConstructor, fileName);
+}
+
+void BasicFileReader::close() {
+  jboolean foo = this->env.CallBooleanMethod(this->jniFileReader, this->javaClose);
+  if (this->env.ExceptionOccurred()) {
+    std::cerr << "Things went wrong when we closed our JNI File Reader: " << std::endl;
+    this->env.ExceptionDescribe();
+    this->env.ExceptionClear();
+    exit(-1);
+  }
+}
+
+void BasicFileReader::read(std::vector<AlignedRead> &read_reqs) {
+  jsize size = (jsize)read_reqs.size();
+  jintArray readFroms = this->env.NewIntArray(size);
+  jint readFromValues[size];
+
+  jintArray readUntils = this->env.NewIntArray(size);
+  jint readUntilValues[size];
+
+  jlongArray readIntos = this->env.NewLongArray(size);
+  jlong readIntoValues[size];
+  for (size_t i = 0; i < read_reqs.size(); i++) {
+    readFromValues[i] = (jint)read_reqs[i].offset;
+    readUntilValues[i] = (jint)read_reqs[i].len; // readUntil could be named better
+    readIntoValues[i] = (jlong)read_reqs[i].buf;
+  }
+
+  this->env.SetIntArrayRegion(readFroms, 0, size, readFromValues);
+  this->env.SetIntArrayRegion(readUntils, 0, size, readUntilValues);
+  this->env.SetLongArrayRegion(readIntos, 0, size, readIntoValues);
+
+  // so now we can finally call the dang method
+  this->env.CallVoidMethod(this->jniFileReader, this->javaRead, readFroms, readUntils, readIntos);
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,3 +29,12 @@ target_link_libraries(test_insert_deletes_consolidate ${PROJECT_NAME} ${DISKANN_
 
 add_executable(search_memory_index_dynamic search_memory_index_dynamic.cpp)
 target_link_libraries(search_memory_index_dynamic ${PROJECT_NAME} ${DISKANN_TOOLS_TCMALLOC_LINK_OPTIONS} Boost::program_options)
+
+if (JNI)
+    add_executable(diskann_with_java_io diskann_with_java_io.cpp)
+    target_link_libraries(diskann_with_java_io ${PROJECT_NAME}
+            ${DISKANN_TOOLS_TCMALLOC_LINK_OPTIONS}
+            Boost::program_options
+            /usr/lib/jvm/java-18-openjdk-amd64/lib/server/libjvm.so
+    )
+endif()

--- a/tests/diskann_with_java_io.cpp
+++ b/tests/diskann_with_java_io.cpp
@@ -1,0 +1,41 @@
+//
+// Created by dax on 11/7/22.
+//
+
+#include <jni.h>
+#include <iostream>
+#include "jni/basic_file_reader.h"
+#include "aligned_file_reader.h"
+
+int main()
+{
+  JavaVM *jvm;
+  JNIEnv *env;
+  JavaVMInitArgs vm_args;
+  JavaVMOption* options = new JavaVMOption[1];
+  options[0].optionString = "-Djava.class.path=/home/dax/dev/DiskANN/java/";
+  vm_args.version = JNI_VERSION_10; // we probably need a much newer version than this
+  vm_args.nOptions = 1;
+  vm_args.options = options;
+  vm_args.ignoreUnrecognized = false;
+  jint rc = JNI_CreateJavaVM(&jvm, (void**)&env, &vm_args);
+  delete options;
+  if (rc != JNI_OK) {
+    std::cout << "Something went wrong creating the JavaVM for DiskANN: " << rc << std::endl;
+  }
+  // here's where the work goes
+
+  std::vector<AlignedRead> reads;
+  AlignedRead aligned;
+  aligned.offset = 2*512;
+  aligned.len = 10*512;
+  aligned.buf = (void *) (10000*512); // a fake buffer that we never allocated and I'm really glad our java reader
+                                      // doesn't actually try to write here yet
+  reads.push_back(aligned);
+  BasicFileReader reader(*env);
+  reader.open("/home/dax/dev/DiskANN/CMakeLists.txt");
+  reader.read(reads);
+
+  // and here's where we clean up
+  jvm->DestroyJavaVM();
+}


### PR DESCRIPTION
Next steps would be to actually implement the AlignedFileReader interface for the jni spec, of which the direct byte buffer access from https://docs.oracle.com/en/java/javase/16/docs/specs/jni/functions.html#newdirectbytebuffer might be useful.

This is not actually intended for merge, but it is a way of showing the differing files and steps necessary to get the barest bones implementation into the mix.