### PR TITLE
`make` is not installed by default on Ubuntu 22.04.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See [guidelines](CONTRIBUTING.md) for contributing to this project.
 Install the following packages through apt-get
 
 ```bash
-sudo apt install cmake g++ libaio-dev libgoogle-perftools-dev clang-format libboost-all-dev
+sudo apt install make cmake g++ libaio-dev libgoogle-perftools-dev clang-format libboost-all-dev
 ```
 
 ### Install Intel MKL


### PR DESCRIPTION
Putting it in our install command should not result in any troubles.