### PR TITLE
make neighbor compare stable

### DIFF
--- a/include/neighbor.h
+++ b/include/neighbor.h
@@ -21,8 +21,10 @@ namespace diskann {
     }
 
     inline bool operator<(const Neighbor &other) const {
-      return distance < other.distance;
+      return distance < other.distance ||
+          (distance == other.distance && id < other.id);
     }
+
     inline bool operator==(const Neighbor &other) const {
       return (id == other.id);
     }


### PR DESCRIPTION
## Motivation
Make neighbor compare stable.

We've observed that search results can have vectors with same distance value return in different order when search the same query vector multiple times, which makes the search results not deterministic in corner cases. This fixed that.