### PR TITLE
reverted to older insertintopool to handle slow builds

### DIFF
--- a/include/neighbor.h
+++ b/include/neighbor.h
@@ -48,21 +48,22 @@ namespace diskann {
     std::vector<SimpleNeighbor> pool;
   };
 
-  static inline unsigned InsertIntoPool(std::vector<Neighbor> &neighbors,
-                                        unsigned K, Neighbor nn) {
+static inline unsigned InsertIntoPool(Neighbor *addr, unsigned K,
+                                        Neighbor nn) {
     // find the location to insert
     unsigned left = 0, right = K - 1;
-    if (neighbors[left].distance > nn.distance) {
-      neighbors.insert(neighbors.begin() + left, nn);
+    if (addr[left].distance > nn.distance) {
+      memmove((char *) &addr[left + 1], &addr[left], K * sizeof(Neighbor));
+      addr[left] = nn;
       return left;
     }
-    if (neighbors[right].distance < nn.distance) {
-      neighbors.push_back(nn);
+    if (addr[right].distance < nn.distance) {
+      addr[K] = nn;
       return K;
     }
     while (right > 1 && left < right - 1) {
       unsigned mid = (left + right) / 2;
-      if (neighbors[mid].distance > nn.distance)
+      if (addr[mid].distance > nn.distance)
         right = mid;
       else
         left = mid;
@@ -70,16 +71,17 @@ namespace diskann {
     // check equal ID
 
     while (left > 0) {
-      if (neighbors[left].distance < nn.distance)
+      if (addr[left].distance < nn.distance)
         break;
-      if (neighbors[left].id == nn.id)
+      if (addr[left].id == nn.id)
         return K + 1;
       left--;
     }
-    if (neighbors[left].id == nn.id || neighbors[right].id == nn.id)
+    if (addr[left].id == nn.id || addr[right].id == nn.id)
       return K + 1;
-
-    neighbors.insert(neighbors.begin() + right, nn);
+    memmove((char *) &addr[right + 1], &addr[right],
+            (K - right) * sizeof(Neighbor));
+    addr[right] = nn;
     return right;
   }
 }  // namespace diskann

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -818,7 +818,7 @@ namespace diskann {
               continue;
 
             Neighbor nn(id, dist, true);
-            unsigned inserted_position = InsertIntoPool(best_L_nodes, l, nn);
+            unsigned inserted_position = InsertIntoPool(best_L_nodes.data(), l, nn);
             if (l < Lsize)
               ++l;
             if (inserted_position < best_inserted_position)
@@ -2277,7 +2277,7 @@ namespace diskann {
           if (dist >= retset[L - 1].distance)
             continue;
           Neighbor nn(id, dist, true);
-          int      r = InsertIntoPool(retset, L, nn);
+          int      r = InsertIntoPool(retset.data(), L, nn);
 
           // if(L+1 < retset.size()) ++L;
           if (r < nk)

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -971,7 +971,7 @@ namespace diskann {
               continue;
             Neighbor nn(id, dist, true);
             // Return position in sorted list where nn inserted.
-            auto r = InsertIntoPool(retset, cur_list_size, nn);
+            auto r = InsertIntoPool(retset.data(), cur_list_size, nn);
             if (cur_list_size < l_search)
               ++cur_list_size;
             if (r < nk)
@@ -1048,7 +1048,7 @@ namespace diskann {
               continue;
             Neighbor nn(id, dist, true);
             auto     r = InsertIntoPool(
-                    retset, cur_list_size,
+                    retset.data(), cur_list_size,
                     nn);  // Return position in sorted list where nn inserted.
             if (cur_list_size < l_search)
               ++cur_list_size;


### PR DESCRIPTION
Reverted to older InsertIntoPool in neighbor.h to fix some slow build latecy issue.
Will investigate more why the vector-based code is slow, meanwhile we can use the pointer method.