### PR TITLE
Make PQFlashIndex data_dim readable by caller

### DIFF
--- a/include/pq_flash_index.h
+++ b/include/pq_flash_index.h
@@ -74,6 +74,8 @@ namespace diskann {
                                         const _u64          min_beam_width,
                                         QueryStats         *stats = nullptr);
 
+    DISKANN_DLLEXPORT _u64 get_data_dim();
+
     std::shared_ptr<AlignedFileReader> &reader;
 
    protected:

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -1196,6 +1196,11 @@ namespace diskann {
     return res_count;
   }
 
+  template<typename T>
+  _u64 PQFlashIndex<T>::get_data_dim() {
+    return data_dim;
+  }
+
 #ifdef EXEC_ENV_OLS
   template<typename T>
   char *PQFlashIndex<T>::getHeaderBytes() {

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -69,6 +69,6 @@ target_link_libraries(create_disk_layout ${PROJECT_NAME} ${DISKANN_ASYNC_LIB} ${
 
 # formatter
 if (LINUX)
-	add_custom_command(TARGET gen_random_slice PRE_BUILD COMMAND clang-format -i ../../../include/*.h ../../../include/dll/*.h ../../../src/*.cpp  ../../../tests/*.cpp ../../../src/dll/*.cpp ../../../tests/utils/*.cpp)
+	add_custom_command(TARGET gen_random_slice PRE_BUILD COMMAND clang-format -i ../../../include/*.h ../../../include/tsl/*.h ../../../src/*.cpp  ../../../tests/*.cpp ../../../src/dll/*.cpp ../../../tests/utils/*.cpp)
 endif()
 


### PR DESCRIPTION
PQ flash index now has multiple file layouts. Simplify support for getting index dimension by making a public getter