### PR TITLE
Clang-Format Enhancements

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -30,10 +30,14 @@ jobs:
             wget https://registrationcenter-download.intel.com/akdlm/irc_nas/18487/l_BaseKit_p_2022.1.2.146.sh
             sudo sh l_BaseKit_p_2022.1.2.146.sh -a --components intel.oneapi.lin.mkl.devel --action install --eula accept -s
         fi
-    - name: Clang Format Check
+    - name: Ubuntu CMake Configure
       if: runner.os != 'Windows'
       run: |
         mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
+
+    - name: Clang Format Check
+      if: ${{ matrix.os == 'ubuntu-latest' }}
+      run: |
         make checkformat
 
     - name: build

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -26,7 +26,7 @@ jobs:
         if [ "${{ matrix.os }}" != "ubuntu-18.04" ]; then
             sudo apt install cmake g++ libaio-dev libgoogle-perftools-dev clang-format libboost-dev libboost-program-options-dev libmkl-full-dev libunwind-dev-
         else
-            sudo apt install cmake g++ libaio-dev libgoogle-perftools-dev clang-format libboost-dev libboost-program-options-dev libunwind-dev-
+            sudo apt install cmake g++ libaio-dev libgoogle-perftools-dev clang-format libboost-dev libboost-program-options-dev
             wget https://registrationcenter-download.intel.com/akdlm/irc_nas/18487/l_BaseKit_p_2022.1.2.146.sh
             sudo sh l_BaseKit_p_2022.1.2.146.sh -a --components intel.oneapi.lin.mkl.devel --action install --eula accept -s
         fi

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -34,7 +34,7 @@ jobs:
       if: runner.os != 'Windows'
       run: |
         mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
-        # make checkformat - this will be turned on after all files are clang-formatted
+        make checkformat
 
     - name: build
       if: runner.os != 'Windows'

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Clang Format Check
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
-        make checkformat
+        cd build && make checkformat
 
     - name: build
       if: runner.os != 'Windows'

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -30,11 +30,16 @@ jobs:
             wget https://registrationcenter-download.intel.com/akdlm/irc_nas/18487/l_BaseKit_p_2022.1.2.146.sh
             sudo sh l_BaseKit_p_2022.1.2.146.sh -a --components intel.oneapi.lin.mkl.devel --action install --eula accept -s
         fi
+    - name: Clang Format Check
+      if: runner.os != 'Windows'
+      run: |
+        mkdir build && cd build && cmake ..
+        # make checkformat - this will be turned on after all files are clang-formatted
 
     - name: build
       if: runner.os != 'Windows'
       run: |
-        mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release .. && make -j
+        make -j
 
     - name: Add VisualStudio command line tools into path
       if: runner.os == 'Windows'

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -39,7 +39,7 @@ jobs:
     - name: build
       if: runner.os != 'Windows'
       run: |
-        make -j
+        cd build && make -j
 
     - name: Add VisualStudio command line tools into path
       if: runner.os == 'Windows'

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -24,7 +24,7 @@ jobs:
       if: runner.os != 'Windows'
       run: |
         if [ "${{ matrix.os }}" != "ubuntu-18.04" ]; then
-            sudo apt install cmake g++ libaio-dev libgoogle-perftools-dev clang-format libboost-dev libboost-program-options-dev libmkl-full-dev libunwind-dev-
+            sudo apt install cmake g++ libaio-dev libgoogle-perftools-dev libunwind-dev clang-format libboost-dev libboost-program-options-dev libmkl-full-dev
         else
             sudo apt install cmake g++ libaio-dev libgoogle-perftools-dev clang-format libboost-dev libboost-program-options-dev
             wget https://registrationcenter-download.intel.com/akdlm/irc_nas/18487/l_BaseKit_p_2022.1.2.146.sh

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -24,9 +24,9 @@ jobs:
       if: runner.os != 'Windows'
       run: |
         if [ "${{ matrix.os }}" != "ubuntu-18.04" ]; then
-            sudo apt install cmake g++ libaio-dev libgoogle-perftools-dev clang-format libboost-dev libboost-program-options-dev libmkl-full-dev
+            sudo apt install cmake g++ libaio-dev libgoogle-perftools-dev clang-format libboost-dev libboost-program-options-dev libmkl-full-dev libunwind-dev-
         else
-            sudo apt install cmake g++ libaio-dev libgoogle-perftools-dev clang-format libboost-dev libboost-program-options-dev
+            sudo apt install cmake g++ libaio-dev libgoogle-perftools-dev clang-format libboost-dev libboost-program-options-dev libunwind-dev-
             wget https://registrationcenter-download.intel.com/akdlm/irc_nas/18487/l_BaseKit_p_2022.1.2.146.sh
             sudo sh l_BaseKit_p_2022.1.2.146.sh -a --components intel.oneapi.lin.mkl.devel --action install --eula accept -s
         fi

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Clang Format Check
       if: runner.os != 'Windows'
       run: |
-        mkdir build && cd build && cmake ..
+        mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release ..
         # make checkformat - this will be turned on after all files are clang-formatted
 
     - name: build

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Clang Format Check
       run: |
         mkdir build && cd build && cmake ..
-        # make checkformat -- eventually I'll turn this on, but not until all our files are clang-formatted
+        make checkformat
     - name: build
       run: |
         cd build && make -j

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -15,7 +15,7 @@ jobs:
         # make checkformat -- eventually I'll turn this on, but not until all our files are clang-formatted
     - name: build
       run: |
-        make -j
+        cd build && make -j
 
   windows-build:
     name: Build for ${{ matrix.os }}

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -8,7 +8,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Install deps
       run: |
-        sudo apt install cmake g++ libaio-dev libgoogle-perftools-dev clang-format libboost-dev libboost-program-options-dev libmkl-full-dev
+        sudo apt install cmake g++ libaio-dev libgoogle-perftools-dev clang-format libboost-dev libboost-program-options-dev libmkl-full-dev libunwind-dev-
     - name: Clang Format Check
       run: |
         mkdir build && cd build && cmake ..

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -9,9 +9,13 @@ jobs:
     - name: Install deps
       run: |
         sudo apt install cmake g++ libaio-dev libgoogle-perftools-dev clang-format libboost-dev libboost-program-options-dev libmkl-full-dev
+    - name: Clang Format Check
+      run: |
+        mkdir build && cd build && cmake ..
+        # make checkformat -- eventually I'll turn this on, but not until all our files are clang-formatted
     - name: build
       run: |
-        mkdir build && cd build && cmake .. && make -j
+        make -j
 
   windows-build:
     name: Build for ${{ matrix.os }}

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -8,7 +8,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Install deps
       run: |
-        sudo apt install cmake g++ libaio-dev libgoogle-perftools-dev clang-format libboost-dev libboost-program-options-dev libmkl-full-dev libunwind-dev-
+        sudo apt install cmake g++ libaio-dev libgoogle-perftools-dev libunwind-dev clang-format libboost-dev libboost-program-options-dev libmkl-full-dev
     - name: Clang Format Check
       run: |
         mkdir build && cd build && cmake ..

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,3 +242,6 @@ if (MSVC)
                    "Alternatively, use MSBuild to build:\n\n"
                    "msbuild.exe ${PROJECT_NAME}.sln /m /nologo /t:Build /p:Configuration=\"Release\" /property:Platform=\"x64\"\n")
 endif()
+
+include(clang-format.cmake)
+

--- a/clang-format.cmake
+++ b/clang-format.cmake
@@ -14,7 +14,6 @@ if (NOT MSVC)
 		checkformat
 		COMMAND /usr/bin/clang-format
 		--dry-run
-		-Werror
 		${ALL_SOURCE_FILES}
 	)
 endif()

--- a/clang-format.cmake
+++ b/clang-format.cmake
@@ -1,0 +1,20 @@
+if (NOT MSVC)
+	message(STATUS "Setting up `make format` and `make checkformat`")
+	# additional target to perform clang-format run, requires clang-format
+	# get all project files
+	file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.h)
+
+	add_custom_target(
+		format
+	        COMMAND /usr/bin/clang-format
+        	-i
+        	${ALL_SOURCE_FILES}
+	)
+	add_custom_target(
+		checkformat
+		COMMAND /usr/bin/clang-format
+		--dry-run
+		-Werror
+		${ALL_SOURCE_FILES}
+	)
+endif()

--- a/include/distance.h
+++ b/include/distance.h
@@ -2,7 +2,7 @@
 #include "windows_customizations.h"
 
 namespace diskann {
-  enum Metric { L2 = 0, INNER_PRODUCT = 1, COSINE = 2, FAST_L2 = 3};
+  enum Metric { L2 = 0, INNER_PRODUCT = 1, COSINE = 2, FAST_L2 = 3 };
 
   template<typename T>
   class Distance {

--- a/include/logger_impl.h
+++ b/include/logger_impl.h
@@ -50,9 +50,9 @@ namespace diskann {
 #ifdef EXEC_ENV_OLS
     static const int BUFFER_SIZE = 1024;
 #else
-    //Allocating an arbitrarily small buffer here because the overflow() and
-    //other function implementations push the BUFFER_SIZE chars into the 
-    //buffer before flushing to fwrite.  
+    // Allocating an arbitrarily small buffer here because the overflow() and
+    // other function implementations push the BUFFER_SIZE chars into the
+    // buffer before flushing to fwrite.
     static const int BUFFER_SIZE = 4;
 #endif
 

--- a/include/neighbor.h
+++ b/include/neighbor.h
@@ -22,7 +22,7 @@ namespace diskann {
 
     inline bool operator<(const Neighbor &other) const {
       return distance < other.distance ||
-          (distance == other.distance && id < other.id);
+             (distance == other.distance && id < other.id);
     }
 
     inline bool operator==(const Neighbor &other) const {

--- a/include/parameters.h
+++ b/include/parameters.h
@@ -45,7 +45,7 @@ namespace diskann {
 
     template<typename ParamType>
     inline ParamType Get(const std::string &name,
-                         const ParamType &  default_value) {
+                         const ParamType   &default_value) {
       try {
         return Get<ParamType>(name);
       } catch (std::invalid_argument e) {

--- a/include/percentile_stats.h
+++ b/include/percentile_stats.h
@@ -45,7 +45,7 @@ namespace diskann {
     std::sort(vals.begin(), vals.end(),
               [](const T &left, const T &right) { return left < right; });
 
-    auto retval = vals[(uint64_t)(percentile * len)];
+    auto retval = vals[(uint64_t) (percentile * len)];
     vals.clear();
     return retval;
   }

--- a/include/tsl/_clang-format
+++ b/include/tsl/_clang-format
@@ -1,0 +1,3 @@
+DisableFormat: true
+SortIncludes: Never
+

--- a/include/utils.h
+++ b/include/utils.h
@@ -109,14 +109,14 @@ typedef uint8_t  _u8;
 typedef int8_t   _s8;
 inline void      open_file_to_write(std::ofstream&     writer,
                                     const std::string& filename) {
-  writer.exceptions(std::ofstream::failbit | std::ofstream::badbit);
-  if (!file_exists(filename))
+       writer.exceptions(std::ofstream::failbit | std::ofstream::badbit);
+       if (!file_exists(filename))
     writer.open(filename, std::ios::binary | std::ios::out);
   else
     writer.open(filename, std::ios::binary | std::ios::in | std::ios::out);
 
   if (writer.fail()) {
-    char buff[1024];
+         char buff[1024];
 #ifdef _WINDOWS
     strerror_s(buff, 1024, errno);
 #else

--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -72,7 +72,7 @@ namespace diskann {
   //
   // L2 distance functions.
   //
-  
+
   float DistanceL2Int8::compare(const int8_t *a, const int8_t *b,
                                 uint32_t size) const {
     int32_t result = 0;
@@ -80,7 +80,7 @@ namespace diskann {
 #ifdef _WINDOWS
 #ifdef USE_AVX2
     __m256 r = _mm256_setzero_ps();
-    char * pX = (char *) a, *pY = (char *) b;
+    char  *pX = (char *) a, *pY = (char *) b;
     while (size >= 32) {
       __m256i r1 = _mm256_subs_epi8(_mm256_loadu_si256((__m256i *) pX),
                                     _mm256_loadu_si256((__m256i *) pY));
@@ -102,16 +102,16 @@ namespace diskann {
 #else
 #pragma omp simd reduction(+ : result) aligned(a, b : 8)
     for (_s32 i = 0; i < (_s32) size; i++) {
-      result += ((int32_t)((int16_t) a[i] - (int16_t) b[i])) *
-                ((int32_t)((int16_t) a[i] - (int16_t) b[i]));
+      result += ((int32_t) ((int16_t) a[i] - (int16_t) b[i])) *
+                ((int32_t) ((int16_t) a[i] - (int16_t) b[i]));
     }
     return (float) result;
 #endif
 #else
 #pragma omp simd reduction(+ : result) aligned(a, b : 8)
     for (int32_t i = 0; i < (int32_t) size; i++) {
-      result += ((int32_t)((int16_t) a[i] - (int16_t) b[i])) *
-                ((int32_t)((int16_t) a[i] - (int16_t) b[i]));
+      result += ((int32_t) ((int16_t) a[i] - (int16_t) b[i])) *
+                ((int32_t) ((int16_t) a[i] - (int16_t) b[i]));
     }
     return (float) result;
 #endif
@@ -124,8 +124,8 @@ namespace diskann {
 #pragma omp simd reduction(+ : result) aligned(a, b : 8)
 #endif
     for (int32_t i = 0; i < (int32_t) size; i++) {
-      result += ((int32_t)((int16_t) a[i] - (int16_t) b[i])) *
-                ((int32_t)((int16_t) a[i] - (int16_t) b[i]));
+      result += ((int32_t) ((int16_t) a[i] - (int16_t) b[i])) *
+                ((int32_t) ((int16_t) a[i] - (int16_t) b[i]));
     }
     return (float) result;
   }
@@ -143,7 +143,7 @@ namespace diskann {
     float result = 0;
 #ifdef USE_AVX2
     // assume size is divisible by 8
-    uint16_t niters = (uint16_t)(size / 8);
+    uint16_t niters = (uint16_t) (size / 8);
     __m256   sum = _mm256_setzero_ps();
     for (uint16_t j = 0; j < niters; j++) {
       // scope is a[8j:8j+7], b[8j:8j+7]

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -783,7 +783,8 @@ namespace diskann {
               std::stringstream msg;
               msg << "Out of range edge " << _final_graph[n][m]
                   << " found at vertex " << n << std::endl;
-              msg <<" max pts, num_frozen = " << _max_points <<", " << _num_frozen_pts << std::endl;
+              msg << " max pts, num_frozen = " << _max_points << ", "
+                  << _num_frozen_pts << std::endl;
               throw diskann::ANNException(msg.str(), -1, __FUNCSIG__, __FILE__,
                                           __LINE__);
             }
@@ -818,7 +819,8 @@ namespace diskann {
               continue;
 
             Neighbor nn(id, dist, true);
-            unsigned inserted_position = InsertIntoPool(best_L_nodes.data(), l, nn);
+            unsigned inserted_position =
+                InsertIntoPool(best_L_nodes.data(), l, nn);
             if (l < Lsize)
               ++l;
             if (inserted_position < best_inserted_position)

--- a/src/math_utils.cpp
+++ b/src/math_utils.cpp
@@ -179,7 +179,7 @@ namespace math_utils {
 #pragma omp parallel for schedule(static, 1)
       for (int64_t j = cur_blk * PAR_BLOCK_SIZE;
            j <
-           std::min((_s64) num_points, (_s64)((cur_blk + 1) * PAR_BLOCK_SIZE));
+           std::min((_s64) num_points, (_s64) ((cur_blk + 1) * PAR_BLOCK_SIZE));
            j++) {
         for (size_t l = 0; l < k; l++) {
           size_t this_center_id =

--- a/src/partition.cpp
+++ b/src/partition.cpp
@@ -42,8 +42,8 @@ void gen_random_slice(const std::string base_file,
       std::string(output_prefix + "_ids.bin").c_str(), std::ios::binary);
 
   std::random_device
-               rd;  // Will be used to obtain a seed for the random number engine
-  auto         x = rd();
+       rd;  // Will be used to obtain a seed for the random number engine
+  auto x = rd();
   std::mt19937 generator(
       x);  // Standard mersenne_twister_engine seeded with rd()
   std::uniform_real_distribution<float> distribution(0, 1);
@@ -146,13 +146,13 @@ template<typename T>
 void gen_random_slice(const T *inputdata, size_t npts, size_t ndims,
                       double p_val, float *&sampled_data, size_t &slice_size) {
   std::vector<std::vector<float>> sampled_vectors;
-  const T *                       cur_vector_T;
+  const T                        *cur_vector_T;
 
   p_val = p_val < 1 ? p_val : 1;
 
   std::random_device
-               rd;  // Will be used to obtain a seed for the random number engine
-  size_t       x = rd();
+         rd;  // Will be used to obtain a seed for the random number engine
+  size_t x = rd();
   std::mt19937 generator(
       (unsigned) x);  // Standard mersenne_twister_engine seeded with rd()
   std::uniform_real_distribution<float> distribution(0, 1);
@@ -176,7 +176,6 @@ void gen_random_slice(const T *inputdata, size_t npts, size_t ndims,
   }
 }
 
-
 int estimate_cluster_sizes(float *test_data_float, size_t num_test,
                            float *pivots, const size_t num_centers,
                            const size_t test_dim, const size_t k_base,
@@ -190,7 +189,7 @@ int estimate_cluster_sizes(float *test_data_float, size_t num_test,
   }
 
   size_t block_size = num_test <= BLOCK_SIZE ? num_test : BLOCK_SIZE;
-  _u32 * block_closest_centers = new _u32[block_size * k_base];
+  _u32  *block_closest_centers = new _u32[block_size * k_base];
   float *block_data_float;
 
   size_t num_blocks = DIV_ROUND_UP(num_test, block_size);
@@ -294,7 +293,7 @@ int shard_data_into_clusters(const std::string data_file, float *pivots,
     for (size_t p = 0; p < cur_blk_size; p++) {
       for (size_t p1 = 0; p1 < k_base; p1++) {
         size_t   shard_id = block_closest_centers[p * k_base + p1];
-        uint32_t original_point_map_id = (uint32_t)(start_id + p);
+        uint32_t original_point_map_id = (uint32_t) (start_id + p);
         shard_data_writer[shard_id].write(
             (char *) (block_data_T.get() + p * dim), sizeof(T) * dim);
         shard_idmap_writer[shard_id].write((char *) &original_point_map_id,
@@ -390,7 +389,7 @@ int shard_data_into_clusters_only_ids(const std::string data_file,
     for (size_t p = 0; p < cur_blk_size; p++) {
       for (size_t p1 = 0; p1 < k_base; p1++) {
         size_t   shard_id = block_closest_centers[p * k_base + p1];
-        uint32_t original_point_map_id = (uint32_t)(start_id + p);
+        uint32_t original_point_map_id = (uint32_t) (start_id + p);
         shard_idmap_writer[shard_id].write((char *) &original_point_map_id,
                                            sizeof(uint32_t));
         shard_counts[shard_id]++;
@@ -459,7 +458,7 @@ int retrieve_shard_data_from_ids(const std::string data_file,
                      sizeof(T) * (cur_blk_size * dim));
 
     for (size_t p = 0; p < cur_blk_size; p++) {
-      uint32_t original_point_map_id = (uint32_t)(start_id + p);
+      uint32_t original_point_map_id = (uint32_t) (start_id + p);
       if (cur_pos == shard_size)
         break;
       if (original_point_map_id == shard_ids[cur_pos]) {
@@ -592,9 +591,9 @@ int partition_with_ram_budget(const std::string data_file,
                            train_dim, k_base, cluster_sizes);
 
     for (auto &p : cluster_sizes) {
-      p = (_u64)(p /
-                 sampling_rate);  // to account for the fact that p is the size
-                                  // of the shard over the testing sample.
+      p = (_u64) (p /
+                  sampling_rate);  // to account for the fact that p is the size
+                                   // of the shard over the testing sample.
       double cur_shard_ram_estimate =
           diskann::estimate_ram_usage(p, train_dim, sizeof(T), graph_degree);
 
@@ -625,7 +624,7 @@ int partition_with_ram_budget(const std::string data_file,
 // Instantations of supported templates
 
 template void DISKANN_DLLEXPORT
-                                gen_random_slice<int8_t>(const std::string base_file,
+gen_random_slice<int8_t>(const std::string base_file,
                          const std::string output_prefix, double sampling_rate);
 template void DISKANN_DLLEXPORT gen_random_slice<uint8_t>(
     const std::string base_file, const std::string output_prefix,
@@ -635,7 +634,7 @@ gen_random_slice<float>(const std::string base_file,
                         const std::string output_prefix, double sampling_rate);
 
 template void DISKANN_DLLEXPORT
-                                gen_random_slice<float>(const float *inputdata, size_t npts, size_t ndims,
+gen_random_slice<float>(const float *inputdata, size_t npts, size_t ndims,
                         double p_val, float *&sampled_data, size_t &slice_size);
 template void DISKANN_DLLEXPORT gen_random_slice<uint8_t>(
     const uint8_t *inputdata, size_t npts, size_t ndims, double p_val,

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -823,8 +823,8 @@ namespace diskann {
     std::vector<Neighbor> &full_retset = query_scratch->full_retset;
     retset.reserve(l_search + 1);
 
-    _u32                        best_medoid = 0;
-    float                       best_dist = (std::numeric_limits<float>::max)();
+    _u32  best_medoid = 0;
+    float best_dist = (std::numeric_limits<float>::max)();
     for (_u64 cur_m = 0; cur_m < num_medoids; cur_m++) {
       float cur_expanded_dist = dist_cmp_float->compare(
           query_float, centroid_data + aligned_dim * cur_m,

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -67,7 +67,7 @@ bool AvxSupportedCPU = false;
 #endif
 
 namespace diskann {
-  
+
   void block_convert(std::ofstream& writr, std::ifstream& readr,
                      float* read_buf, _u64 npts, _u64 ndims) {
     readr.read((char*) read_buf, npts * ndims * sizeof(float));
@@ -120,7 +120,7 @@ namespace diskann {
                   << std::endl;
   }
 
-    double calculate_recall(unsigned num_queries, unsigned* gold_std,
+  double calculate_recall(unsigned num_queries, unsigned* gold_std,
                           float* gs_dist, unsigned dim_gs,
                           unsigned* our_results, unsigned dim_or,
                           unsigned recall_at) {
@@ -238,7 +238,6 @@ namespace diskann {
     }
     return total_recall / (num_queries);
   }
-
 
 #ifdef EXEC_ENV_OLS
   void get_bin_metadata(AlignedFileReader& reader, size_t& npts, size_t& ndim,

--- a/src/windows_aligned_file_reader.cpp
+++ b/src/windows_aligned_file_reader.cpp
@@ -90,7 +90,7 @@ void WindowsAlignedFileReader::read(std::vector<AlignedRead>& read_reqs,
     // batch start/end
     _u64 batch_start = MAX_IO_DEPTH * i;
     _u64 batch_size =
-        std::min((_u64)(n_reqs - batch_start), (_u64) MAX_IO_DEPTH);
+        std::min((_u64) (n_reqs - batch_start), (_u64) MAX_IO_DEPTH);
 
     // fill OVERLAPPED and issue them
     for (_u64 j = 0; j < batch_size; j++) {

--- a/tests/range_search_disk_index.cpp
+++ b/tests/range_search_disk_index.cpp
@@ -202,8 +202,8 @@ int search_disk_index(diskann::Metric&   metric,
       std::vector<_u64>  indices;
       std::vector<float> distances;
       _u32               res_count = _pFlashIndex->range_search(
-          query + (i * query_aligned_dim), search_range, L, max_list_size,
-          indices, distances, optimized_beamwidth, stats + i);
+                        query + (i * query_aligned_dim), search_range, L, max_list_size,
+                        indices, distances, optimized_beamwidth, stats + i);
       query_result_ids[test_id][i].reserve(res_count);
       query_result_ids[test_id][i].resize(res_count);
       for (_u32 idx = 0; idx < res_count; idx++)

--- a/tests/search_memory_index_dynamic.cpp
+++ b/tests/search_memory_index_dynamic.cpp
@@ -136,7 +136,7 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
     std::cout << std::setw(4) << L << std::setw(12) << qps << std::setw(18)
               << avg_cmps << std::setw(20) << (float) mean_latency
               << std::setw(15)
-              << (float) latency_stats[(_u64)(0.999 * query_num)];
+              << (float) latency_stats[(_u64) (0.999 * query_num)];
     if (calc_recall_flag)
       std::cout << std::setw(12) << recall;
     std::cout << std::endl;

--- a/tests/utils/CMakeLists.txt
+++ b/tests/utils/CMakeLists.txt
@@ -66,9 +66,3 @@ target_link_libraries(merge_shards ${PROJECT_NAME} ${DISKANN_TOOLS_TCMALLOC_LINK
 add_executable(create_disk_layout create_disk_layout.cpp)
 target_link_libraries(create_disk_layout ${PROJECT_NAME} ${DISKANN_ASYNC_LIB} ${DISKANN_TOOLS_TCMALLOC_LINK_OPTIONS})
 
-
-# formatter
-if (LINUX)
-	add_custom_command(TARGET gen_random_slice PRE_BUILD COMMAND clang-format -i ../../../include/*.h ../../../include/dll/*.h ../../../src/*.cpp  ../../../tests/*.cpp ../../../src/dll/*.cpp ../../../tests/utils/*.cpp)
-endif()
-

--- a/tests/utils/compute_groundtruth.cpp
+++ b/tests/utils/compute_groundtruth.cpp
@@ -75,7 +75,7 @@ void compute_l2sq(float *const points_l2sq, const float *const matrix,
 
 void distsq_to_points(
     const size_t dim,
-    float *      dist_matrix,  // Col Major, cols are queries, rows are points
+    float       *dist_matrix,  // Col Major, cols are queries, rows are points
     size_t npoints, const float *const points,
     const float *const points_l2sq,  // points in Col major
     size_t nqueries, const float *const queries,
@@ -103,7 +103,7 @@ void distsq_to_points(
 
 void inner_prod_to_points(
     const size_t dim,
-    float *      dist_matrix,  // Col Major, cols are queries, rows are points
+    float       *dist_matrix,  // Col Major, cols are queries, rows are points
     size_t npoints, const float *const points, size_t nqueries,
     const float *const queries,
     float *ones_vec = NULL)  // Scratchspace of num_data size and init to 1.0
@@ -208,28 +208,28 @@ void exact_knn(
       for (_u64 p = 0; p < k; p++)
         point_dist.emplace(
             p, dist_matrix[(ptrdiff_t) p +
-                           (ptrdiff_t)(q - q_b) * (ptrdiff_t) npoints]);
+                           (ptrdiff_t) (q - q_b) * (ptrdiff_t) npoints]);
       for (_u64 p = k; p < npoints; p++) {
         if (point_dist.top().second >
             dist_matrix[(ptrdiff_t) p +
-                        (ptrdiff_t)(q - q_b) * (ptrdiff_t) npoints])
+                        (ptrdiff_t) (q - q_b) * (ptrdiff_t) npoints])
           point_dist.emplace(
               p, dist_matrix[(ptrdiff_t) p +
-                             (ptrdiff_t)(q - q_b) * (ptrdiff_t) npoints]);
+                             (ptrdiff_t) (q - q_b) * (ptrdiff_t) npoints]);
         if (point_dist.size() > k)
           point_dist.pop();
       }
       for (ptrdiff_t l = 0; l < (ptrdiff_t) k; ++l) {
-        closest_points[(ptrdiff_t)(k - 1 - l) + (ptrdiff_t) q * (ptrdiff_t) k] =
-            point_dist.top().first;
-        dist_closest_points[(ptrdiff_t)(k - 1 - l) +
+        closest_points[(ptrdiff_t) (k - 1 - l) +
+                       (ptrdiff_t) q * (ptrdiff_t) k] = point_dist.top().first;
+        dist_closest_points[(ptrdiff_t) (k - 1 - l) +
                             (ptrdiff_t) q * (ptrdiff_t) k] =
             point_dist.top().second;
         point_dist.pop();
       }
       assert(std::is_sorted(
           dist_closest_points + (ptrdiff_t) q * (ptrdiff_t) k,
-          dist_closest_points + (ptrdiff_t)(q + 1) * (ptrdiff_t) k));
+          dist_closest_points + (ptrdiff_t) (q + 1) * (ptrdiff_t) k));
     }
     std::cout << "Computed exact k-NN for queries: [" << q_b << "," << q_e
               << ")" << std::endl;
@@ -345,7 +345,7 @@ template<typename T>
 int aux_main(const std::string &base_file, const std::string &query_file,
              const std::string &gt_file, size_t k,
              const diskann::Metric &metric,
-             const std::string &    tags_file = std::string("")) {
+             const std::string     &tags_file = std::string("")) {
   size_t npoints, nqueries, dim;
 
   float *base_data;
@@ -389,13 +389,13 @@ int aux_main(const std::string &base_file, const std::string &query_file,
 
   std::vector<std::vector<std::pair<uint32_t, float>>> results(nqueries);
 
-  int *  closest_points = new int[nqueries * k];
+  int   *closest_points = new int[nqueries * k];
   float *dist_closest_points = new float[nqueries * k];
 
   for (int p = 0; p < num_parts; p++) {
     size_t start_id = p * PARTSIZE;
     load_bin_as_float<T>(base_file.c_str(), base_data, npoints, dim, p);
-    int *  closest_points_part = new int[nqueries * k];
+    int   *closest_points_part = new int[nqueries * k];
     float *dist_closest_points_part = new float[nqueries * k];
 
     auto nr = std::min(npoints, k);
@@ -409,7 +409,7 @@ int aux_main(const std::string &base_file, const std::string &query_file,
           if (location_to_tag[closest_points_part[i * k + j] + start_id] == 0)
             continue;
         results[i].push_back(std::make_pair(
-            (uint32_t)(closest_points_part[i * nr + j] + start_id),
+            (uint32_t) (closest_points_part[i * nr + j] + start_id),
             dist_closest_points_part[i * nr + j]));
       }
     }

--- a/tests/utils/count_bfs_levels.cpp
+++ b/tests/utils/count_bfs_levels.cpp
@@ -26,7 +26,8 @@ namespace po = boost::program_options;
 template<typename T>
 void bfs_count(const std::string& index_path, unsigned data_dims) {
   using TagT = uint32_t;
-  diskann::Index<T, TagT> index(diskann::Metric::L2, data_dims, 0, false, false);
+  diskann::Index<T, TagT> index(diskann::Metric::L2, data_dims, 0, false,
+                                false);
   std::cout << "Index class instantiated" << std::endl;
   index.load(index_path.c_str(), 1, 100);
   std::cout << "Index loaded" << std::endl;
@@ -46,8 +47,7 @@ int main(int argc, char** argv) {
     desc.add_options()("index_path_prefix",
                        po::value<std::string>(&index_path_prefix)->required(),
                        "Path prefix to the index");
-    desc.add_options()("data_dims",
-                       po::value<unsigned>(&data_dims)->required(),
+    desc.add_options()("data_dims", po::value<unsigned>(&data_dims)->required(),
                        "Dimensionality of the data");
 
     po::variables_map vm;

--- a/tests/utils/float_bin_to_int8.cpp
+++ b/tests/utils/float_bin_to_int8.cpp
@@ -12,7 +12,7 @@ void block_convert(std::ofstream& writer, int8_t* write_buf,
   for (_u64 i = 0; i < npts; i++) {
     for (_u64 d = 0; d < ndims; d++) {
       write_buf[d + i * ndims] =
-          (int8_t)((read_buf[d + i * ndims] - bias) * (254.0 / scale));
+          (int8_t) ((read_buf[d + i * ndims] - bias) * (254.0 / scale));
     }
   }
   writer.write((char*) write_buf, npts * ndims);

--- a/tests/utils/fvecs_to_bin.cpp
+++ b/tests/utils/fvecs_to_bin.cpp
@@ -6,7 +6,8 @@
 
 // Convert float types
 void block_convert_float(std::ifstream& reader, std::ofstream& writer,
-                   float* read_buf, float* write_buf, _u64 npts, _u64 ndims) {
+                         float* read_buf, float* write_buf, _u64 npts,
+                         _u64 ndims) {
   reader.read((char*) read_buf,
               npts * (ndims * sizeof(float) + sizeof(unsigned)));
   for (_u64 i = 0; i < npts; i++) {
@@ -17,8 +18,8 @@ void block_convert_float(std::ifstream& reader, std::ofstream& writer,
 }
 
 // Convert byte types
-void block_convert_byte(std::ifstream& reader, std::ofstream& writer, _u8* read_buf,
-                   _u8* write_buf, _u64 npts, _u64 ndims) {
+void block_convert_byte(std::ifstream& reader, std::ofstream& writer,
+                        _u8* read_buf, _u8* write_buf, _u64 npts, _u64 ndims) {
   reader.read((char*) read_buf,
               npts * (ndims * sizeof(_u8) + sizeof(unsigned)));
   for (_u64 i = 0; i < npts; i++) {
@@ -31,8 +32,7 @@ void block_convert_byte(std::ifstream& reader, std::ofstream& writer, _u8* read_
 
 int main(int argc, char** argv) {
   if (argc != 4) {
-    std::cout << argv[0]
-              << " <float/int8/uint8> input_vecs output_bin"
+    std::cout << argv[0] << " <float/int8/uint8> input_vecs output_bin"
               << std::endl;
     exit(-1);
   }
@@ -42,8 +42,7 @@ int main(int argc, char** argv) {
   if (strcmp(argv[1], "uint8") == 0 || strcmp(argv[1], "int8") == 0) {
     datasize = sizeof(_u8);
   } else if (strcmp(argv[1], "float") != 0) {
-    std::cout << "Error: type not supported. Use float/int8/uint8"
-              << std::endl;
+    std::cout << "Error: type not supported. Use float/int8/uint8" << std::endl;
     exit(-1);
   }
 
@@ -76,7 +75,7 @@ int main(int argc, char** argv) {
     _u64 cblk_size = std::min(npts - i * blk_size, blk_size);
     if (datasize == sizeof(float)) {
       block_convert_float(reader, writer, (float*) read_buf, (float*) write_buf,
-                    cblk_size, ndims);
+                          cblk_size, ndims);
     } else {
       block_convert_byte(reader, writer, read_buf, write_buf, cblk_size, ndims);
     }

--- a/tests/utils/generate_pq.cpp
+++ b/tests/utils/generate_pq.cpp
@@ -5,7 +5,6 @@
 #include "pq.h"
 #include "partition.h"
 
-
 #define KMEANS_ITERS_FOR_PQ 15
 
 template<typename T>
@@ -46,19 +45,19 @@ bool generate_pq(const std::string& data_path,
 
 int main(int argc, char** argv) {
   if (argc != 7) {
-    std::cout
-        << "Usage: \n"
-        << argv[0]
-        << "  <data_type[float/uint8/int8]>   <data_file[.bin]>"
-           "  <PQ_prefix_path>  <target-bytes/data-point>  <sampling_rate> <PQ(0)/OPQ(1)>"
-        << std::endl;
+    std::cout << "Usage: \n"
+              << argv[0]
+              << "  <data_type[float/uint8/int8]>   <data_file[.bin]>"
+                 "  <PQ_prefix_path>  <target-bytes/data-point>  "
+                 "<sampling_rate> <PQ(0)/OPQ(1)>"
+              << std::endl;
   } else {
     const std::string data_path(argv[2]);
     const std::string index_prefix_path(argv[3]);
     const size_t      num_pq_centers = 256;
     const size_t      num_pq_chunks = (size_t) atoi(argv[4]);
     const float       sampling_rate = atof(argv[5]);
-    const bool        opq = atoi(argv[6]) == 0 ? false : true; 
+    const bool        opq = atoi(argv[6]) == 0 ? false : true;
 
     if (std::string(argv[1]) == std::string("float"))
       generate_pq<float>(data_path, index_prefix_path, num_pq_centers,


### PR DESCRIPTION
This commit uses CMake to set up a pair of custom targets: `format` and `checkformat`, invoked via `make format` or `make checkformat`.

`make format` will format all .cpp or .h files in source as per our _clang-format specifications. Linux developers should be sure to use this prior to pushing. Windows developers will need to execute clang-format through Visual Studio (see: https://learn.microsoft.com/en-us/visualstudio/ide/reference/options-text-editor-c-cpp-formatting?view=vs-2022 ).

Any code that is not formatted will be called out as part of our CICD process when `make checkformat` is run. Any detected incompabitibilities with our `_clang-format` rules will cause `make checkformat` - a custom target wrapping `clang-format --dry-run -Werror <filelist>` - to fail, and thus fail the build.

This first commit adds the custom targets, removes the old clang-format rules predicated on building `test/utils/gen_random_slice`, and stubs out new steps in our github workflows.

`make checkformat` is left commented out, because a dozen or more files have not been clang-formatted in quite some time. I want to review these changes prior to muddying up the PR with dozens of formatting changes left as a result of us following these defined rules.