### PR TITLE
Added support for converting uint and int8 vectors to conversion tool fvec_to_bin

### DIFF
--- a/tests/utils/fvecs_to_bin.cpp
+++ b/tests/utils/fvecs_to_bin.cpp
@@ -4,7 +4,8 @@
 #include <iostream>
 #include "utils.h"
 
-void block_convert(std::ifstream& reader, std::ofstream& writer,
+// Convert float types
+void block_convert_float(std::ifstream& reader, std::ofstream& writer,
                    float* read_buf, float* write_buf, _u64 npts, _u64 ndims) {
   reader.read((char*) read_buf,
               npts * (ndims * sizeof(float) + sizeof(unsigned)));
@@ -15,11 +16,41 @@ void block_convert(std::ifstream& reader, std::ofstream& writer,
   writer.write((char*) write_buf, npts * ndims * sizeof(float));
 }
 
+// Convert byte types
+void block_convert_byte(std::ifstream& reader, std::ofstream& writer, _u8* read_buf,
+                   _u8* write_buf, _u64 npts, _u64 ndims) {
+  reader.read((char*) read_buf,
+              npts * (ndims * sizeof(_u8) + sizeof(unsigned)));
+  for (_u64 i = 0; i < npts; i++) {
+    memcpy(write_buf + i * ndims,
+           (read_buf + i * (ndims + sizeof(unsigned))) + sizeof(unsigned),
+           ndims * sizeof(_u8));
+  }
+  writer.write((char*) write_buf, npts * ndims * sizeof(_u8));
+}
+
 int main(int argc, char** argv) {
-  if (argc != 3) {
-    std::cout << argv[0] << " input_fvecs output_bin" << std::endl;
+  if (argc < 3 || argc > 4) {
+    std::cout << argv[0]
+              << " input_vecs output_bin (optional)datatype<int8/uint8/float>"
+              << std::endl;
     exit(-1);
   }
+
+  int datasize = sizeof(float);
+
+  if (argc == 4) {
+    if (strcmp(argv[3], "uint8") == 0 || strcmp(argv[3], "int8") == 0) {
+      datasize = sizeof(_u8);
+      std::cout << "Input/output datatype " << argv[3]
+                << std::endl;
+    } else if (strcmp(argv[3], "float") != 0) {
+      std::cout << "datatype arg invalid"
+                << std::endl;
+      exit(-1);
+    }
+  }
+
   std::ifstream reader(argv[1], std::ios::binary | std::ios::ate);
   _u64          fsize = reader.tellg();
   reader.seekg(0, std::ios::beg);
@@ -28,7 +59,7 @@ int main(int argc, char** argv) {
   reader.read((char*) &ndims_u32, sizeof(unsigned));
   reader.seekg(0, std::ios::beg);
   _u64 ndims = (_u64) ndims_u32;
-  _u64 npts = fsize / ((ndims + 1) * sizeof(float));
+  _u64 npts = fsize / ((ndims * datasize) + sizeof(unsigned));
   std::cout << "Dataset: #pts = " << npts << ", # dims = " << ndims
             << std::endl;
 
@@ -36,15 +67,23 @@ int main(int argc, char** argv) {
   _u64 nblks = ROUND_UP(npts, blk_size) / blk_size;
   std::cout << "# blks: " << nblks << std::endl;
   std::ofstream writer(argv[2], std::ios::binary);
-  int           npts_s32 = (_s32) npts;
-  int           ndims_s32 = (_s32) ndims;
+  _s32          npts_s32 = (_s32) npts;
+  _s32          ndims_s32 = (_s32) ndims;
   writer.write((char*) &npts_s32, sizeof(_s32));
   writer.write((char*) &ndims_s32, sizeof(_s32));
-  float* read_buf = new float[npts * (ndims + 1)];
-  float* write_buf = new float[npts * ndims];
+
+  _u64 chunknpts = std::min(npts, blk_size);
+  _u8* read_buf = new _u8[chunknpts * ((ndims * datasize) + sizeof(unsigned))];
+  _u8* write_buf = new _u8[chunknpts * ndims * datasize];
+
   for (_u64 i = 0; i < nblks; i++) {
     _u64 cblk_size = std::min(npts - i * blk_size, blk_size);
-    block_convert(reader, writer, read_buf, write_buf, cblk_size, ndims);
+    if (datasize == sizeof(float)) {
+      block_convert_float(reader, writer, (float*) read_buf, (float*) write_buf,
+                    cblk_size, ndims);
+    } else {
+      block_convert_byte(reader, writer, read_buf, write_buf, cblk_size, ndims);
+    }
     std::cout << "Block #" << i << " written" << std::endl;
   }
 

--- a/tests/utils/fvecs_to_bin.cpp
+++ b/tests/utils/fvecs_to_bin.cpp
@@ -30,28 +30,24 @@ void block_convert_byte(std::ifstream& reader, std::ofstream& writer, _u8* read_
 }
 
 int main(int argc, char** argv) {
-  if (argc < 3 || argc > 4) {
+  if (argc != 4) {
     std::cout << argv[0]
-              << " input_vecs output_bin (optional)datatype<int8/uint8/float>"
+              << " <float/int8/uint8> input_vecs output_bin"
               << std::endl;
     exit(-1);
   }
 
   int datasize = sizeof(float);
 
-  if (argc == 4) {
-    if (strcmp(argv[3], "uint8") == 0 || strcmp(argv[3], "int8") == 0) {
-      datasize = sizeof(_u8);
-      std::cout << "Input/output datatype " << argv[3]
-                << std::endl;
-    } else if (strcmp(argv[3], "float") != 0) {
-      std::cout << "datatype arg invalid"
-                << std::endl;
-      exit(-1);
-    }
+  if (strcmp(argv[1], "uint8") == 0 || strcmp(argv[1], "int8") == 0) {
+    datasize = sizeof(_u8);
+  } else if (strcmp(argv[1], "float") != 0) {
+    std::cout << "Error: type not supported. Use float/int8/uint8"
+              << std::endl;
+    exit(-1);
   }
 
-  std::ifstream reader(argv[1], std::ios::binary | std::ios::ate);
+  std::ifstream reader(argv[2], std::ios::binary | std::ios::ate);
   _u64          fsize = reader.tellg();
   reader.seekg(0, std::ios::beg);
 
@@ -66,7 +62,7 @@ int main(int argc, char** argv) {
   _u64 blk_size = 131072;
   _u64 nblks = ROUND_UP(npts, blk_size) / blk_size;
   std::cout << "# blks: " << nblks << std::endl;
-  std::ofstream writer(argv[2], std::ios::binary);
+  std::ofstream writer(argv[3], std::ios::binary);
   _s32          npts_s32 = (_s32) npts;
   _s32          ndims_s32 = (_s32) ndims;
   writer.write((char*) &npts_s32, sizeof(_s32));


### PR DESCRIPTION
Added uint8 and int8 conversion to the fvec_to_bin tool. Tool now takes an optional 3rd argument (uint8 or int8) to override the default float conversion.