### PR TITLE
Fix undefined symbol errors during python setup.py install by renaming variables

### DIFF
--- a/python/src/diskann_bindings.cpp
+++ b/python/src/diskann_bindings.cpp
@@ -100,14 +100,6 @@ struct DiskANNIndex {
     return 0;
   }
 
-  int _build_disk_index_float(const char     *dataFilePath,
-                              const char     *indexFilePath,
-                              const char     *indexBuildParameters,
-                              diskann::Metric compareMetric) {
-    return diskann::build_disk_index<float>(dataFilePath, indexFilePath,
-                                            indexBuildParameters, compareMetric);
-  }
-
   void search(std::vector<T> &query, const _u64 query_idx, const _u64 dim,
               const _u64 num_queries, const _u64 knn, const _u64 l_search,
               const _u64 beam_width, std::vector<unsigned> &ids,

--- a/python/src/diskann_bindings.cpp
+++ b/python/src/diskann_bindings.cpp
@@ -104,8 +104,8 @@ struct DiskANNIndex {
                               const char     *indexFilePath,
                               const char     *indexBuildParameters,
                               diskann::Metric compareMetric) {
-    return diskann::build_disk_index<float>(data_file_path, index_prefix_path,
-                                            params.c_str(), self.get_metric());
+    return diskann::build_disk_index<float>(dataFilePath, indexFilePath,
+                                            indexBuildParameters, compareMetric);
   }
 
   void search(std::vector<T> &query, const _u64 query_idx, const _u64 dim,

--- a/python/tests/test_build_disk_index.py
+++ b/python/tests/test_build_disk_index.py
@@ -3,6 +3,7 @@
 
 import time
 import argparse
+import diskannpy
 from diskannpy import Metric, Parameters, DiskANNFloatIndex
 
 


### PR DESCRIPTION
Observed the following errors on running
```
python3 setup.py install
```
```
python/src/diskann_bindings.cpp: In member function ‘int DiskANNIndex<T>::_build_disk_index_float(const char*, const char*, const char*, diskann::Metric)’:
python/src/diskann_bindings.cpp:107:45: error: ‘data_file_path’ was not declared in this scope;
```

Further, ```diskannpy``` was referenced in python/tests/test_build_disk_index.py but not imported. Kindly let me know if it needs to go as a separate PR