### PR TITLE
Use stable comparison through Neighbor class when inserting to result set

### DIFF
--- a/include/neighbor.h
+++ b/include/neighbor.h
@@ -34,18 +34,18 @@ namespace diskann {
                                         Neighbor nn) {
     // find the location to insert
     unsigned left = 0, right = K - 1;
-    if (addr[left].distance > nn.distance) {
+    if (nn < addr[left]) {
       memmove((char *) &addr[left + 1], &addr[left], K * sizeof(Neighbor));
       addr[left] = nn;
       return left;
     }
-    if (addr[right].distance < nn.distance) {
+    if (addr[right] < nn) {
       addr[K] = nn;
       return K;
     }
     while (right > 1 && left < right - 1) {
       unsigned mid = (left + right) / 2;
-      if (addr[mid].distance > nn.distance)
+      if (nn < addr[mid])
         right = mid;
       else
         left = mid;
@@ -53,7 +53,7 @@ namespace diskann {
     // check equal ID
 
     while (left > 0) {
-      if (addr[left].distance < nn.distance)
+      if (addr[left] < nn)
         break;
       if (addr[left].id == nn.id)
         return K + 1;

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -963,7 +963,8 @@ namespace diskann {
             cmps++;
             float dist = dist_scratch[m];
             Neighbor nn(id, dist, true);
-            if (retset[cur_list_size - 1] < nn &&
+            Neighbor &lastResult = retset[cur_list_size - 1];
+            if ((lastResult < nn || lastResult == nn) &&
                 (cur_list_size == l_search))
               continue;
             // Return position in sorted list where nn inserted.
@@ -1030,19 +1031,17 @@ namespace diskann {
         // process prefetch-ed nhood
         for (_u64 m = 0; m < nnbrs; ++m) {
           unsigned id = node_nbrs[m];
-          if (visited.find(id) != visited.end()) {
-            continue;
-          } else {
-            visited.insert(id);
+          if (visited.insert(id).second) {
             cmps++;
             float dist = dist_scratch[m];
             if (stats != nullptr) {
               stats->n_cmps++;
             }
-            if (dist >= retset[cur_list_size - 1].distance &&
+            Neighbor nn(id, dist, true);
+            Neighbor &lastResult = retset[cur_list_size - 1];
+            if ((lastResult < nn || lastResult == nn) &&
                 (cur_list_size == l_search))
               continue;
-            Neighbor nn(id, dist, true);
             auto     r = InsertIntoPool(
                     retset.data(), cur_list_size,
                     nn);  // Return position in sorted list where nn inserted.

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -959,16 +959,13 @@ namespace diskann {
         // process prefetched nhood
         for (_u64 m = 0; m < nnbrs; ++m) {
           unsigned id = node_nbrs[m];
-          if (visited.find(id) != visited.end()) {
-            continue;
-          } else {
-            visited.insert(id);
+          if (visited.insert(id).second) {
             cmps++;
             float dist = dist_scratch[m];
-            if (dist >= retset[cur_list_size - 1].distance &&
+            Neighbor nn(id, dist, true);
+            if (retset[cur_list_size - 1] < nn &&
                 (cur_list_size == l_search))
               continue;
-            Neighbor nn(id, dist, true);
             // Return position in sorted list where nn inserted.
             auto r = InsertIntoPool(retset.data(), cur_list_size, nn);
             if (cur_list_size < l_search)


### PR DESCRIPTION
# Motivation
Under `USE_BING_INFRA` complier flag, the code path is using async reads, so when BW > 1, the multiple IOs may return in arbitrary order, and because the insertion of the neighbors to the results set can be unstable as we didn't handle ties in distance, it can lead to final search results being unstable. So, instead, delegate the comparisons to Neighbor classes's `<` operator which handles that already by doing tie breaking based on node id.