### PR TITLE
make CI tests for SSD based search faster.

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -66,127 +66,130 @@ jobs:
         echo "diskann_built_tests=./x64/Release" >> $GITHUB_ENV
         echo "diskann_built_utils=./x64/Release" >> $GITHUB_ENV
 
-    - name: Generate 10K random floating points in 10 dims and compute GT
+    - name: Generate 10K random float32 index vectors, 1K query vectors, in 10 dims and compute GT
       run: |
         ${{ env.diskann_built_utils }}/rand_data_gen --data_type float --output_file ./rand_float_10D_10K_norm1.0.bin -D 10 -N 10000 --norm 1.0
-        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type float --dist_fn l2 --base_file ./rand_float_10D_10K_norm1.0.bin --query_file ./rand_float_10D_10K_norm1.0.bin --gt_file ./l2_rand_float_10D_10K_norm1.0_self_gt100 --K 100
-        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type float --dist_fn mips --base_file ./rand_float_10D_10K_norm1.0.bin --query_file ./rand_float_10D_10K_norm1.0.bin --gt_file ./mips_rand_float_10D_10K_norm1.0_self_gt100 --K 100
-        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type float --dist_fn cosine --base_file ./rand_float_10D_10K_norm1.0.bin --query_file ./rand_float_10D_10K_norm1.0.bin --gt_file ./cosine_rand_float_10D_10K_norm1.0_self_gt100 --K 100
+        ${{ env.diskann_built_utils }}/rand_data_gen --data_type float --output_file ./rand_float_10D_1K_norm1.0.bin -D 10 -N 1000 --norm 1.0
+        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type float --dist_fn l2 --base_file ./rand_float_10D_10K_norm1.0.bin --query_file ./rand_float_10D_1K_norm1.0.bin --gt_file ./l2_rand_float_10D_10K_norm1.0_10D_1K_norm1.0_gt100 --K 100
+        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type float --dist_fn mips --base_file ./rand_float_10D_10K_norm1.0.bin --query_file ./rand_float_10D_1K_norm1.0.bin --gt_file ./mips_rand_float_10D_10K_norm1.0_10D_1K_norm1.0_gt100 --K 100
+        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type float --dist_fn cosine --base_file ./rand_float_10D_10K_norm1.0.bin --query_file ./rand_float_10D_1K_norm1.0.bin --gt_file ./cosine_rand_float_10D_10K_norm1.0_10D_1K_norm1.0_gt100 --K 100
     - name: build and search in-memory index with L2 metrics
       run: |   
         ${{ env.diskann_built_tests }}/build_memory_index --data_type float --dist_fn l2 --data_path ./rand_float_10D_10K_norm1.0.bin --index_path_prefix ./index_l2_rand_float_10D_10K_norm1.0
-        ${{ env.diskann_built_tests }}/search_memory_index --data_type float --dist_fn l2 --index_path_prefix ./index_l2_rand_float_10D_10K_norm1.0 --query_file ./rand_float_10D_10K_norm1.0.bin --recall_at 10 --result_path temp --gt_file ./l2_rand_float_10D_10K_norm1.0_self_gt100 -L  16 32
-        ${{ env.diskann_built_tests }}/search_memory_index --data_type float --dist_fn fast_l2 --index_path_prefix ./index_l2_rand_float_10D_10K_norm1.0 --query_file ./rand_float_10D_10K_norm1.0.bin --recall_at 10 --result_path temp --gt_file ./l2_rand_float_10D_10K_norm1.0_self_gt100 -L  16 32
+        ${{ env.diskann_built_tests }}/search_memory_index --data_type float --dist_fn l2 --index_path_prefix ./index_l2_rand_float_10D_10K_norm1.0 --query_file ./rand_float_10D_1K_norm1.0.bin --recall_at 10 --result_path temp --gt_file ./l2_rand_float_10D_10K_norm1.0_10D_1K_norm1.0_gt100 -L  16 32
+        ${{ env.diskann_built_tests }}/search_memory_index --data_type float --dist_fn fast_l2 --index_path_prefix ./index_l2_rand_float_10D_10K_norm1.0 --query_file ./rand_float_10D_1K_norm1.0.bin --recall_at 10 --result_path temp --gt_file ./l2_rand_float_10D_10K_norm1.0_10D_1K_norm1.0_gt100 -L  16 32
     - name: build and search in-memory index with MIPS metric
       run: |   
         ${{ env.diskann_built_tests }}/build_memory_index --data_type float --dist_fn mips --data_path ./rand_float_10D_10K_norm1.0.bin --index_path_prefix ./index_mips_rand_float_10D_10K_norm1.0
-        ${{ env.diskann_built_tests }}/search_memory_index --data_type float --dist_fn mips --index_path_prefix ./index_l2_rand_float_10D_10K_norm1.0 --query_file ./rand_float_10D_10K_norm1.0.bin --recall_at 10 --result_path temp --gt_file ./mips_rand_float_10D_10K_norm1.0_self_gt100 -L  16 32
+        ${{ env.diskann_built_tests }}/search_memory_index --data_type float --dist_fn mips --index_path_prefix ./index_l2_rand_float_10D_10K_norm1.0 --query_file ./rand_float_10D_1K_norm1.0.bin --recall_at 10 --result_path temp --gt_file ./mips_rand_float_10D_10K_norm1.0_10D_1K_norm1.0_gt100 -L  16 32
     - name: build and search in-memory index with cosine metric
       run: |   
         ${{ env.diskann_built_tests }}/build_memory_index --data_type float --dist_fn cosine --data_path ./rand_float_10D_10K_norm1.0.bin --index_path_prefix ./index_cosine_rand_float_10D_10K_norm1.0
-        ${{ env.diskann_built_tests }}/search_memory_index --data_type float --dist_fn cosine --index_path_prefix ./index_l2_rand_float_10D_10K_norm1.0 --query_file ./rand_float_10D_10K_norm1.0.bin --recall_at 10 --result_path temp --gt_file ./cosine_rand_float_10D_10K_norm1.0_self_gt100 -L  16 32
+        ${{ env.diskann_built_tests }}/search_memory_index --data_type float --dist_fn cosine --index_path_prefix ./index_l2_rand_float_10D_10K_norm1.0 --query_file ./rand_float_10D_1K_norm1.0.bin --recall_at 10 --result_path temp --gt_file ./cosine_rand_float_10D_10K_norm1.0_10D_1K_norm1.0_gt100 -L  16 32
     - name: build and search disk index (one shot graph build, L2, no diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type float --dist_fn l2 --data_path ./rand_float_10D_10K_norm1.0.bin --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskfull_oneshot -R 16 -L 32 -B 0.00003 -M 1 
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type float --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskfull_oneshot --result_path /tmp/res --query_file ./rand_float_10D_10K_norm1.0.bin --gt_file ./l2_rand_float_10D_10K_norm1.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type float --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskfull_oneshot --result_path /tmp/res --query_file ./rand_float_10D_1K_norm1.0.bin --gt_file ./l2_rand_float_10D_10K_norm1.0_10D_1K_norm1.0_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name: build and search disk index (sharded graph build, L2, no diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type float --dist_fn l2 --data_path ./rand_float_10D_10K_norm1.0.bin --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskfull_sharded -R 16 -L 32 -B 0.00003 -M 0.00006
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type float --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskfull_sharded --result_path /tmp/res --query_file ./rand_float_10D_10K_norm1.0.bin --gt_file ./l2_rand_float_10D_10K_norm1.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type float --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskfull_sharded --result_path /tmp/res --query_file ./rand_float_10D_1K_norm1.0.bin --gt_file ./l2_rand_float_10D_10K_norm1.0_10D_1K_norm1.0_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name: build and search disk index (one shot graph build, L2, diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type float --dist_fn l2 --data_path ./rand_float_10D_10K_norm1.0.bin --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskpq_oneshot -R 16 -L 32 -B 0.00003 -M 1 --PQ_disk_bytes 5
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type float --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskpq_oneshot --result_path /tmp/res --query_file ./rand_float_10D_10K_norm1.0.bin --gt_file ./l2_rand_float_10D_10K_norm1.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type float --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskpq_oneshot --result_path /tmp/res --query_file ./rand_float_10D_1K_norm1.0.bin --gt_file ./l2_rand_float_10D_10K_norm1.0_10D_1K_norm1.0_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name: build and search disk index (sharded graph build, MIPS, diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type float --dist_fn mips --data_path ./rand_float_10D_10K_norm1.0.bin --index_path_prefix ./disk_index_mips_rand_float_10D_10K_norm1.0_diskpq_sharded -R 16 -L 32 -B 0.00003 -M 0.00006 --PQ_disk_bytes 5
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type float --dist_fn l2 --index_path_prefix ./disk_index_mips_rand_float_10D_10K_norm1.0_diskpq_sharded --result_path /tmp/res --query_file ./rand_float_10D_10K_norm1.0.bin --gt_file ./mips_rand_float_10D_10K_norm1.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type float --dist_fn l2 --index_path_prefix ./disk_index_mips_rand_float_10D_10K_norm1.0_diskpq_sharded --result_path /tmp/res --query_file ./rand_float_10D_1K_norm1.0.bin --gt_file ./mips_rand_float_10D_10K_norm1.0_10D_1K_norm1.0_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name:  build and search an incremental index
       run: |
         ${{ env.diskann_built_tests }}/test_insert_deletes_consolidate --data_type float --dist_fn l2 --data_path rand_float_10D_10K_norm1.0.bin --index_path_prefix index_ins_del -R 64 -L 300 --alpha 1.2 -T 8 --points_to_skip 0 --max_points_to_insert 7500 --beginning_index_size 0 --points_per_checkpoint 1000 --checkpoints_per_snapshot 0 --points_to_delete_from_beginning 2500 --start_deletes_after 5000 --do_concurrent true --start_point_norm 3.2;
-        ${{ env.diskann_built_utils }}/compute_groundtruth --data_type float --dist_fn l2 --base_file index_ins_del.after-concurrent-delete-del2500-7500.data --query_file rand_float_10D_10K_norm1.0.bin --K 100 --gt_file gt100_random10D_10K-conc-2500-7500 --tags_file index_ins_del.after-concurrent-delete-del2500-7500.tags
-        ${{ env.diskann_built_tests }}/search_memory_index --data_type float --dist_fn l2 --index_path_prefix index_ins_del.after-concurrent-delete-del2500-7500 --result_path res_ins_del --query_file rand_float_10D_10K_norm1.0.bin --gt_file gt100_random10D_10K-conc-2500-7500 -K 10 -L 20 40 60 80 100 -T 8 --dynamic true --tags 1
+        ${{ env.diskann_built_utils }}/compute_groundtruth --data_type float --dist_fn l2 --base_file index_ins_del.after-concurrent-delete-del2500-7500.data --query_file rand_float_10D_1K_norm1.0.bin --K 100 --gt_file gt100_random10D_1K-conc-2500-7500 --tags_file index_ins_del.after-concurrent-delete-del2500-7500.tags
+        ${{ env.diskann_built_tests }}/search_memory_index --data_type float --dist_fn l2 --index_path_prefix index_ins_del.after-concurrent-delete-del2500-7500 --result_path res_ins_del --query_file ./rand_float_10D_1K_norm1.0.bin --gt_file gt100_random10D_1K-conc-2500-7500 -K 10 -L 20 40 60 80 100 -T 8 --dynamic true --tags 1
     - name:  test a streaming index
       run: |
         ${{ env.diskann_built_tests }}/test_streaming_scenario --data_type float --dist_fn l2 --data_path rand_float_10D_10K_norm1.0.bin --index_path_prefix index_stream -R 64 -L 600 --alpha 1.2 --insert_threads 4 --consolidate_threads 4 --max_points_to_insert 10000 --active_window 4000 --consolidate_interval 2000 --start_point_norm 3.2
-        ${{ env.diskann_built_utils }}/compute_groundtruth --data_type float --dist_fn l2 --base_file index_stream.after-streaming-act4000-cons2000-max10000.data --query_file rand_float_10D_10K_norm1.0.bin --K 100 --gt_file gt100_base-act4000-cons2000-max10000 --tags_file index_stream.after-streaming-act4000-cons2000-max10000.tags
-        ${{ env.diskann_built_tests }}/search_memory_index --data_type float --dist_fn l2 --index_path_prefix index_stream.after-streaming-act4000-cons2000-max10000 --result_path res_stream --query_file rand_float_10D_10K_norm1.0.bin --gt_file gt100_base-act4000-cons2000-max10000 -K 10 -L 20 40 60 80 100 -T 64 --dynamic true --tags 1
+        ${{ env.diskann_built_utils }}/compute_groundtruth --data_type float --dist_fn l2 --base_file index_stream.after-streaming-act4000-cons2000-max10000.data --query_file rand_float_10D_1K_norm1.0.bin --K 100 --gt_file gt100_base-act4000-cons2000-max10000 --tags_file index_stream.after-streaming-act4000-cons2000-max10000.tags
+        ${{ env.diskann_built_tests }}/search_memory_index --data_type float --dist_fn l2 --index_path_prefix index_stream.after-streaming-act4000-cons2000-max10000 --result_path res_stream --query_file ./rand_float_10D_1K_norm1.0.bin --gt_file gt100_base-act4000-cons2000-max10000 -K 10 -L 20 40 60 80 100 -T 64 --dynamic true --tags 1
 
 
-    - name: Generate 10K random int8 points in 10 dims and compute GT
+    - name: Generate 10K random int8 index vectors, 1K query vectors, in 10 dims and compute GT
       run: |
         ${{ env.diskann_built_utils }}/rand_data_gen --data_type int8 --output_file ./rand_int8_10D_10K_norm50.0.bin -D 10 -N 10000 --norm 50.0
-        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type int8 --dist_fn l2 --base_file ./rand_int8_10D_10K_norm50.0.bin --query_file ./rand_int8_10D_10K_norm50.0.bin --gt_file ./l2_rand_int8_10D_10K_norm50.0_self_gt100 --K 100
-        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type int8 --dist_fn mips --base_file ./rand_int8_10D_10K_norm50.0.bin --query_file ./rand_int8_10D_10K_norm50.0.bin --gt_file ./mips_rand_int8_10D_10K_norm50.0_self_gt100 --K 100
-        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type int8 --dist_fn cosine --base_file ./rand_int8_10D_10K_norm50.0.bin --query_file ./rand_int8_10D_10K_norm50.0.bin --gt_file ./cosine_rand_int8_10D_10K_norm50.0_self_gt100 --K 100
+        ${{ env.diskann_built_utils }}/rand_data_gen --data_type int8 --output_file ./rand_int8_10D_1K_norm50.0.bin -D 10 -N 1000 --norm 50.0
+        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type int8 --dist_fn l2 --base_file ./rand_int8_10D_10K_norm50.0.bin --query_file ./rand_int8_10D_1K_norm50.0.bin --gt_file ./l2_rand_int8_10D_10K_norm50.0_10D_1K_norm50.0_gt100 --K 100
+        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type int8 --dist_fn mips --base_file ./rand_int8_10D_10K_norm50.0.bin --query_file ./rand_int8_10D_1K_norm50.0.bin --gt_file ./mips_rand_int8_10D_10K_norm50.0_10D_1K_norm50.0_gt100 --K 100
+        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type int8 --dist_fn cosine --base_file ./rand_int8_10D_10K_norm50.0.bin --query_file ./rand_int8_10D_1K_norm50.0.bin --gt_file ./cosine_rand_int8_10D_10K_norm50.0_10D_1K_norm50.0_gt100 --K 100
     - name: build and search in-memory index with L2 metrics
       run: |   
         ${{ env.diskann_built_tests }}/build_memory_index --data_type int8 --dist_fn l2 --data_path ./rand_int8_10D_10K_norm50.0.bin --index_path_prefix ./index_l2_rand_int8_10D_10K_norm50.0
-        ${{ env.diskann_built_tests }}/search_memory_index --data_type int8 --dist_fn l2 --index_path_prefix ./index_l2_rand_int8_10D_10K_norm50.0 --query_file ./rand_int8_10D_10K_norm50.0.bin --recall_at 10 --result_path temp --gt_file ./l2_rand_int8_10D_10K_norm50.0_self_gt100 -L  16 32
+        ${{ env.diskann_built_tests }}/search_memory_index --data_type int8 --dist_fn l2 --index_path_prefix ./index_l2_rand_int8_10D_10K_norm50.0 --query_file ./rand_int8_10D_1K_norm50.0.bin --recall_at 10 --result_path temp --gt_file ./l2_rand_int8_10D_10K_norm50.0_10D_1K_norm50.0_gt100 -L  16 32
     - name: build and search in-memory index with cosine metric
       run: |   
         ${{ env.diskann_built_tests }}/build_memory_index --data_type int8 --dist_fn cosine --data_path ./rand_int8_10D_10K_norm50.0.bin --index_path_prefix ./index_cosine_rand_int8_10D_10K_norm50.0
-        ${{ env.diskann_built_tests }}/search_memory_index --data_type int8 --dist_fn cosine --index_path_prefix ./index_l2_rand_int8_10D_10K_norm50.0 --query_file ./rand_int8_10D_10K_norm50.0.bin --recall_at 10 --result_path temp --gt_file ./cosine_rand_int8_10D_10K_norm50.0_self_gt100 -L  16 32
+        ${{ env.diskann_built_tests }}/search_memory_index --data_type int8 --dist_fn cosine --index_path_prefix ./index_l2_rand_int8_10D_10K_norm50.0 --query_file ./rand_int8_10D_1K_norm50.0.bin --recall_at 10 --result_path temp --gt_file ./cosine_rand_int8_10D_10K_norm50.0_10D_1K_norm50.0_gt100 -L  16 32
     - name: build and search disk index (one shot graph build, L2, no diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type int8 --dist_fn l2 --data_path ./rand_int8_10D_10K_norm50.0.bin --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskfull_oneshot -R 16 -L 32 -B 0.00003 -M 1 
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type int8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskfull_oneshot --result_path /tmp/res --query_file ./rand_int8_10D_10K_norm50.0.bin --gt_file ./l2_rand_int8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type int8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskfull_oneshot --result_path /tmp/res --query_file ./rand_int8_10D_1K_norm50.0.bin --gt_file ./l2_rand_int8_10D_10K_norm50.0_10D_1K_norm50.0_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name: build and search disk index (sharded graph build, L2, no diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type int8 --dist_fn l2 --data_path ./rand_int8_10D_10K_norm50.0.bin --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskfull_sharded -R 16 -L 32 -B 0.00003 -M 0.00006
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type int8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskfull_sharded --result_path /tmp/res --query_file ./rand_int8_10D_10K_norm50.0.bin --gt_file ./l2_rand_int8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type int8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskfull_sharded --result_path /tmp/res --query_file ./rand_int8_10D_1K_norm50.0.bin --gt_file ./l2_rand_int8_10D_10K_norm50.0_10D_1K_norm50.0_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name: build and search disk index (one shot graph build, L2, diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type int8 --dist_fn l2 --data_path ./rand_int8_10D_10K_norm50.0.bin --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskpq_oneshot -R 16 -L 32 -B 0.00003 -M 1 --PQ_disk_bytes 5
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type int8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskpq_oneshot --result_path /tmp/res --query_file ./rand_int8_10D_10K_norm50.0.bin --gt_file ./l2_rand_int8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type int8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskpq_oneshot --result_path /tmp/res --query_file ./rand_int8_10D_1K_norm50.0.bin --gt_file ./l2_rand_int8_10D_10K_norm50.0_10D_1K_norm50.0_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name:  build and search an incremental index
       run: |
         ${{ env.diskann_built_tests }}/test_insert_deletes_consolidate --data_type int8 --dist_fn l2 --data_path rand_int8_10D_10K_norm50.0.bin --index_path_prefix index_ins_del -R 64 -L 300 --alpha 1.2 -T 8 --points_to_skip 0 --max_points_to_insert 7500 --beginning_index_size 0 --points_per_checkpoint 1000 --checkpoints_per_snapshot 0 --points_to_delete_from_beginning 2500 --start_deletes_after 5000 --do_concurrent true --start_point_norm 200;
-        ${{ env.diskann_built_utils }}/compute_groundtruth --data_type int8 --dist_fn l2 --base_file index_ins_del.after-concurrent-delete-del2500-7500.data --query_file rand_int8_10D_10K_norm50.0.bin --K 100 --gt_file gt100_random10D_10K-conc-2500-7500 --tags_file index_ins_del.after-concurrent-delete-del2500-7500.tags
-        ${{ env.diskann_built_tests }}/search_memory_index --data_type int8 --dist_fn l2 --index_path_prefix index_ins_del.after-concurrent-delete-del2500-7500 --result_path res_ins_del --query_file rand_int8_10D_10K_norm50.0.bin --gt_file gt100_random10D_10K-conc-2500-7500 -K 10 -L 20 40 60 80 100 -T 8 --dynamic true --tags 1
+        ${{ env.diskann_built_utils }}/compute_groundtruth --data_type int8 --dist_fn l2 --base_file index_ins_del.after-concurrent-delete-del2500-7500.data --query_file rand_int8_10D_1K_norm50.0.bin --K 100 --gt_file gt100_random10D_1K-conc-2500-7500 --tags_file index_ins_del.after-concurrent-delete-del2500-7500.tags
+        ${{ env.diskann_built_tests }}/search_memory_index --data_type int8 --dist_fn l2 --index_path_prefix index_ins_del.after-concurrent-delete-del2500-7500 --result_path res_ins_del --query_file ./rand_int8_10D_1K_norm50.0.bin --gt_file gt100_random10D_1K-conc-2500-7500 -K 10 -L 20 40 60 80 100 -T 8 --dynamic true --tags 1
     - name:  test a streaming index
       run: |
         ${{ env.diskann_built_tests }}/test_streaming_scenario --data_type int8 --dist_fn l2 --data_path rand_int8_10D_10K_norm50.0.bin --index_path_prefix index_stream -R 64 -L 600 --alpha 1.2 --insert_threads 4 --consolidate_threads 4 --max_points_to_insert 10000 --active_window 4000 --consolidate_interval 2000 --start_point_norm 200
-        ${{ env.diskann_built_utils }}/compute_groundtruth --data_type int8 --dist_fn l2 --base_file index_stream.after-streaming-act4000-cons2000-max10000.data --query_file rand_int8_10D_10K_norm50.0.bin --K 100 --gt_file gt100_base-act4000-cons2000-max10000 --tags_file index_stream.after-streaming-act4000-cons2000-max10000.tags
-        ${{ env.diskann_built_tests }}/search_memory_index --data_type int8 --dist_fn l2 --index_path_prefix index_stream.after-streaming-act4000-cons2000-max10000 --result_path res_stream --query_file rand_int8_10D_10K_norm50.0.bin --gt_file gt100_base-act4000-cons2000-max10000 -K 10 -L 20 40 60 80 100 -T 64 --dynamic true --tags 1
+        ${{ env.diskann_built_utils }}/compute_groundtruth --data_type int8 --dist_fn l2 --base_file index_stream.after-streaming-act4000-cons2000-max10000.data --query_file rand_int8_10D_1K_norm50.0.bin --K 100 --gt_file gt100_base-act4000-cons2000-max10000 --tags_file index_stream.after-streaming-act4000-cons2000-max10000.tags
+        ${{ env.diskann_built_tests }}/search_memory_index --data_type int8 --dist_fn l2 --index_path_prefix index_stream.after-streaming-act4000-cons2000-max10000 --result_path res_stream --query_file ./rand_int8_10D_1K_norm50.0.bin --gt_file gt100_base-act4000-cons2000-max10000 -K 10 -L 20 40 60 80 100 -T 64 --dynamic true --tags 1
 
 
-    - name: Generate 10K random uint8 points in 10 dims and compute GT
+    - name: Generate 10K random uint8 index vectors, 1K query vectors, in 10 dims and compute GT
       run: |
         ${{ env.diskann_built_utils }}/rand_data_gen --data_type uint8 --output_file ./rand_uint8_10D_10K_norm50.0.bin -D 10 -N 10000 --norm 50.0
-        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type uint8 --dist_fn l2 --base_file ./rand_uint8_10D_10K_norm50.0.bin --query_file ./rand_uint8_10D_10K_norm50.0.bin --gt_file ./l2_rand_uint8_10D_10K_norm50.0_self_gt100 --K 100
-        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type uint8 --dist_fn mips --base_file ./rand_uint8_10D_10K_norm50.0.bin --query_file ./rand_uint8_10D_10K_norm50.0.bin --gt_file ./mips_rand_uint8_10D_10K_norm50.0_self_gt100 --K 100
-        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type uint8 --dist_fn cosine --base_file ./rand_uint8_10D_10K_norm50.0.bin --query_file ./rand_uint8_10D_10K_norm50.0.bin --gt_file ./cosine_rand_uint8_10D_10K_norm50.0_self_gt100 --K 100
+        ${{ env.diskann_built_utils }}/rand_data_gen --data_type uint8 --output_file ./rand_uint8_10D_1K_norm50.0.bin -D 10 -N 1000 --norm 50.0
+        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type uint8 --dist_fn l2 --base_file ./rand_uint8_10D_10K_norm50.0.bin --query_file ./rand_uint8_10D_1K_norm50.0.bin --gt_file ./l2_rand_uint8_10D_10K_norm50.0_10D_1K_norm50.0_gt100 --K 100
+        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type uint8 --dist_fn mips --base_file ./rand_uint8_10D_10K_norm50.0.bin --query_file ./rand_uint8_10D_1K_norm50.0.bin --gt_file ./mips_rand_uint8_10D_10K_norm50.0_10D_1K_norm50.0_gt100 --K 100
+        ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type uint8 --dist_fn cosine --base_file ./rand_uint8_10D_10K_norm50.0.bin --query_file ./rand_uint8_10D_1K_norm50.0.bin --gt_file ./cosine_rand_uint8_10D_10K_norm50.0_10D_1K_norm50.0_gt100 --K 100
     - name: build and search in-memory index with L2 metrics
       run: |   
         ${{ env.diskann_built_tests }}/build_memory_index --data_type uint8 --dist_fn l2 --data_path ./rand_uint8_10D_10K_norm50.0.bin --index_path_prefix ./index_l2_rand_uint8_10D_10K_norm50.0
-        ${{ env.diskann_built_tests }}/search_memory_index --data_type uint8 --dist_fn l2 --index_path_prefix ./index_l2_rand_uint8_10D_10K_norm50.0 --query_file ./rand_uint8_10D_10K_norm50.0.bin --recall_at 10 --result_path temp --gt_file ./l2_rand_uint8_10D_10K_norm50.0_self_gt100 -L  16 32
+        ${{ env.diskann_built_tests }}/search_memory_index --data_type uint8 --dist_fn l2 --index_path_prefix ./index_l2_rand_uint8_10D_10K_norm50.0 --query_file ./rand_uint8_10D_1K_norm50.0.bin --recall_at 10 --result_path temp --gt_file ./l2_rand_uint8_10D_10K_norm50.0_10D_1K_norm50.0_gt100 -L  16 32
     - name: build and search in-memory index with cosine metric
       run: |   
         ${{ env.diskann_built_tests }}/build_memory_index --data_type uint8 --dist_fn cosine --data_path ./rand_uint8_10D_10K_norm50.0.bin --index_path_prefix ./index_cosine_rand_uint8_10D_10K_norm50.0
-        ${{ env.diskann_built_tests }}/search_memory_index --data_type uint8 --dist_fn cosine --index_path_prefix ./index_l2_rand_uint8_10D_10K_norm50.0 --query_file ./rand_uint8_10D_10K_norm50.0.bin --recall_at 10 --result_path temp --gt_file ./cosine_rand_uint8_10D_10K_norm50.0_self_gt100 -L  16 32
+        ${{ env.diskann_built_tests }}/search_memory_index --data_type uint8 --dist_fn cosine --index_path_prefix ./index_l2_rand_uint8_10D_10K_norm50.0 --query_file ./rand_uint8_10D_1K_norm50.0.bin --recall_at 10 --result_path temp --gt_file ./cosine_rand_uint8_10D_10K_norm50.0_10D_1K_norm50.0_gt100 -L  16 32
     - name: build and search disk index (one shot graph build, L2, no diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type uint8 --dist_fn l2 --data_path ./rand_uint8_10D_10K_norm50.0.bin --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskfull_oneshot -R 16 -L 32 -B 0.00003 -M 1 
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type uint8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskfull_oneshot --result_path /tmp/res --query_file ./rand_uint8_10D_10K_norm50.0.bin --gt_file ./l2_rand_uint8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type uint8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskfull_oneshot --result_path /tmp/res --query_file ./rand_uint8_10D_1K_norm50.0.bin --gt_file ./l2_rand_uint8_10D_10K_norm50.0_10D_1K_norm50.0_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name: build and search disk index (sharded graph build, L2, no diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type uint8 --dist_fn l2 --data_path ./rand_uint8_10D_10K_norm50.0.bin --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskfull_sharded -R 16 -L 32 -B 0.00003 -M 0.00006
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type uint8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskfull_sharded --result_path /tmp/res --query_file ./rand_uint8_10D_10K_norm50.0.bin --gt_file ./l2_rand_uint8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type uint8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskfull_sharded --result_path /tmp/res --query_file ./rand_uint8_10D_1K_norm50.0.bin --gt_file ./l2_rand_uint8_10D_10K_norm50.0_10D_1K_norm50.0_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name: build and search disk index (one shot graph build, L2, diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type uint8 --dist_fn l2 --data_path ./rand_uint8_10D_10K_norm50.0.bin --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskpq_oneshot -R 16 -L 32 -B 0.00003 -M 1 --PQ_disk_bytes 5
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type uint8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskpq_oneshot --result_path /tmp/res --query_file ./rand_uint8_10D_10K_norm50.0.bin --gt_file ./l2_rand_uint8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type uint8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskpq_oneshot --result_path /tmp/res --query_file ./rand_uint8_10D_1K_norm50.0.bin --gt_file ./l2_rand_uint8_10D_10K_norm50.0_10D_1K_norm50.0_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name:  build and search an incremental index
       run: |
         ${{ env.diskann_built_tests }}/test_insert_deletes_consolidate --data_type uint8 --dist_fn l2 --data_path rand_uint8_10D_10K_norm50.0.bin --index_path_prefix index_ins_del -R 64 -L 300 --alpha 1.2 -T 8 --points_to_skip 0 --max_points_to_insert 7500 --beginning_index_size 0 --points_per_checkpoint 1000 --checkpoints_per_snapshot 0 --points_to_delete_from_beginning 2500 --start_deletes_after 5000 --do_concurrent true --start_point_norm 200;
-        ${{ env.diskann_built_utils }}/compute_groundtruth --data_type uint8 --dist_fn l2 --base_file index_ins_del.after-concurrent-delete-del2500-7500.data --query_file rand_uint8_10D_10K_norm50.0.bin --K 100 --gt_file gt100_random10D_10K-conc-2500-7500 --tags_file index_ins_del.after-concurrent-delete-del2500-7500.tags
-        ${{ env.diskann_built_tests }}/search_memory_index --data_type uint8 --dist_fn l2 --index_path_prefix index_ins_del.after-concurrent-delete-del2500-7500 --result_path res_ins_del --query_file rand_uint8_10D_10K_norm50.0.bin --gt_file gt100_random10D_10K-conc-2500-7500 -K 10 -L 20 40 60 80 100 -T 8 --dynamic true --tags 1
+        ${{ env.diskann_built_utils }}/compute_groundtruth --data_type uint8 --dist_fn l2 --base_file index_ins_del.after-concurrent-delete-del2500-7500.data --query_file rand_uint8_10D_1K_norm50.0.bin --K 100 --gt_file gt100_random10D_10K-conc-2500-7500 --tags_file index_ins_del.after-concurrent-delete-del2500-7500.tags
+        ${{ env.diskann_built_tests }}/search_memory_index --data_type uint8 --dist_fn l2 --index_path_prefix index_ins_del.after-concurrent-delete-del2500-7500 --result_path res_ins_del --query_file ./rand_uint8_10D_1K_norm50.0.bin --gt_file gt100_random10D_10K-conc-2500-7500 -K 10 -L 20 40 60 80 100 -T 8 --dynamic true --tags 1
     - name:  test a streaming index
       run: |
         ${{ env.diskann_built_tests }}/test_streaming_scenario --data_type uint8 --dist_fn l2 --data_path rand_uint8_10D_10K_norm50.0.bin --index_path_prefix index_stream -R 64 -L 600 --alpha 1.2 --insert_threads 4 --consolidate_threads 4 --max_points_to_insert 10000 --active_window 4000 --consolidate_interval 2000 --start_point_norm 200
-        ${{ env.diskann_built_utils }}/compute_groundtruth --data_type uint8 --dist_fn l2 --base_file index_stream.after-streaming-act4000-cons2000-max10000.data --query_file rand_uint8_10D_10K_norm50.0.bin --K 100 --gt_file gt100_base-act4000-cons2000-max10000 --tags_file index_stream.after-streaming-act4000-cons2000-max10000.tags
-        ${{ env.diskann_built_tests }}/search_memory_index --data_type uint8 --dist_fn l2 --index_path_prefix index_stream.after-streaming-act4000-cons2000-max10000 --result_path res_stream --query_file rand_uint8_10D_10K_norm50.0.bin --gt_file gt100_base-act4000-cons2000-max10000 -K 10 -L 20 40 60 80 100 -T 64 --dynamic true --tags 1
+        ${{ env.diskann_built_utils }}/compute_groundtruth --data_type uint8 --dist_fn l2 --base_file index_stream.after-streaming-act4000-cons2000-max10000.data --query_file rand_uint8_10D_1K_norm50.0.bin --K 100 --gt_file gt100_base-act4000-cons2000-max10000 --tags_file index_stream.after-streaming-act4000-cons2000-max10000.tags
+        ${{ env.diskann_built_tests }}/search_memory_index --data_type uint8 --dist_fn l2 --index_path_prefix index_stream.after-streaming-act4000-cons2000-max10000 --result_path res_stream --query_file ./rand_uint8_10D_1K_norm50.0.bin --gt_file gt100_base-act4000-cons2000-max10000 -K 10 -L 20 40 60 80 100 -T 64 --dynamic true --tags 1
 
     - uses: actions/setup-python@v3
     - name: Install cibuildwheel

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -88,19 +88,19 @@ jobs:
     - name: build and search disk index (one shot graph build, L2, no diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type float --dist_fn l2 --data_path ./rand_float_10D_10K_norm1.0.bin --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskfull_oneshot -R 16 -L 32 -B 0.00003 -M 1 
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type float --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskfull_oneshot --result_path /tmp/res --query_file ./rand_float_10D_10K_norm1.0.bin --gt_file ./l2_rand_float_10D_10K_norm1.0_self_gt100 --recall_at 5 -L 10 12 14 16 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type float --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskfull_oneshot --result_path /tmp/res --query_file ./rand_float_10D_10K_norm1.0.bin --gt_file ./l2_rand_float_10D_10K_norm1.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name: build and search disk index (sharded graph build, L2, no diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type float --dist_fn l2 --data_path ./rand_float_10D_10K_norm1.0.bin --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskfull_sharded -R 16 -L 32 -B 0.00003 -M 0.00006
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type float --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskfull_sharded --result_path /tmp/res --query_file ./rand_float_10D_10K_norm1.0.bin --gt_file ./l2_rand_float_10D_10K_norm1.0_self_gt100 --recall_at 5 -L 10 12 14 16 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type float --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskfull_sharded --result_path /tmp/res --query_file ./rand_float_10D_10K_norm1.0.bin --gt_file ./l2_rand_float_10D_10K_norm1.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name: build and search disk index (one shot graph build, L2, diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type float --dist_fn l2 --data_path ./rand_float_10D_10K_norm1.0.bin --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskpq_oneshot -R 16 -L 32 -B 0.00003 -M 1 --PQ_disk_bytes 5
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type float --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskpq_oneshot --result_path /tmp/res --query_file ./rand_float_10D_10K_norm1.0.bin --gt_file ./l2_rand_float_10D_10K_norm1.0_self_gt100 --recall_at 5 -L 10 12 14 16 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type float --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_float_10D_10K_norm1.0_diskpq_oneshot --result_path /tmp/res --query_file ./rand_float_10D_10K_norm1.0.bin --gt_file ./l2_rand_float_10D_10K_norm1.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name: build and search disk index (sharded graph build, MIPS, diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type float --dist_fn mips --data_path ./rand_float_10D_10K_norm1.0.bin --index_path_prefix ./disk_index_mips_rand_float_10D_10K_norm1.0_diskpq_sharded -R 16 -L 32 -B 0.00003 -M 0.00006 --PQ_disk_bytes 5
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type float --dist_fn l2 --index_path_prefix ./disk_index_mips_rand_float_10D_10K_norm1.0_diskpq_sharded --result_path /tmp/res --query_file ./rand_float_10D_10K_norm1.0.bin --gt_file ./mips_rand_float_10D_10K_norm1.0_self_gt100 --recall_at 5 -L 10 12 14 16 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type float --dist_fn l2 --index_path_prefix ./disk_index_mips_rand_float_10D_10K_norm1.0_diskpq_sharded --result_path /tmp/res --query_file ./rand_float_10D_10K_norm1.0.bin --gt_file ./mips_rand_float_10D_10K_norm1.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name:  build and search an incremental index
       run: |
         ${{ env.diskann_built_tests }}/test_insert_deletes_consolidate --data_type float --dist_fn l2 --data_path rand_float_10D_10K_norm1.0.bin --index_path_prefix index_ins_del -R 64 -L 300 --alpha 1.2 -T 8 --points_to_skip 0 --max_points_to_insert 7500 --beginning_index_size 0 --points_per_checkpoint 1000 --checkpoints_per_snapshot 0 --points_to_delete_from_beginning 2500 --start_deletes_after 5000 --do_concurrent true --start_point_norm 3.2;
@@ -130,15 +130,15 @@ jobs:
     - name: build and search disk index (one shot graph build, L2, no diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type int8 --dist_fn l2 --data_path ./rand_int8_10D_10K_norm50.0.bin --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskfull_oneshot -R 16 -L 32 -B 0.00003 -M 1 
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type int8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskfull_oneshot --result_path /tmp/res --query_file ./rand_int8_10D_10K_norm50.0.bin --gt_file ./l2_rand_int8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 10 12 14 16 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type int8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskfull_oneshot --result_path /tmp/res --query_file ./rand_int8_10D_10K_norm50.0.bin --gt_file ./l2_rand_int8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name: build and search disk index (sharded graph build, L2, no diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type int8 --dist_fn l2 --data_path ./rand_int8_10D_10K_norm50.0.bin --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskfull_sharded -R 16 -L 32 -B 0.00003 -M 0.00006
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type int8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskfull_sharded --result_path /tmp/res --query_file ./rand_int8_10D_10K_norm50.0.bin --gt_file ./l2_rand_int8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 10 12 14 16 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type int8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskfull_sharded --result_path /tmp/res --query_file ./rand_int8_10D_10K_norm50.0.bin --gt_file ./l2_rand_int8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name: build and search disk index (one shot graph build, L2, diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type int8 --dist_fn l2 --data_path ./rand_int8_10D_10K_norm50.0.bin --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskpq_oneshot -R 16 -L 32 -B 0.00003 -M 1 --PQ_disk_bytes 5
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type int8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskpq_oneshot --result_path /tmp/res --query_file ./rand_int8_10D_10K_norm50.0.bin --gt_file ./l2_rand_int8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 10 12 14 16 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type int8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_int8_10D_10K_norm50.0_diskpq_oneshot --result_path /tmp/res --query_file ./rand_int8_10D_10K_norm50.0.bin --gt_file ./l2_rand_int8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name:  build and search an incremental index
       run: |
         ${{ env.diskann_built_tests }}/test_insert_deletes_consolidate --data_type int8 --dist_fn l2 --data_path rand_int8_10D_10K_norm50.0.bin --index_path_prefix index_ins_del -R 64 -L 300 --alpha 1.2 -T 8 --points_to_skip 0 --max_points_to_insert 7500 --beginning_index_size 0 --points_per_checkpoint 1000 --checkpoints_per_snapshot 0 --points_to_delete_from_beginning 2500 --start_deletes_after 5000 --do_concurrent true --start_point_norm 200;
@@ -168,15 +168,15 @@ jobs:
     - name: build and search disk index (one shot graph build, L2, no diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type uint8 --dist_fn l2 --data_path ./rand_uint8_10D_10K_norm50.0.bin --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskfull_oneshot -R 16 -L 32 -B 0.00003 -M 1 
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type uint8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskfull_oneshot --result_path /tmp/res --query_file ./rand_uint8_10D_10K_norm50.0.bin --gt_file ./l2_rand_uint8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 10 12 14 16 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type uint8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskfull_oneshot --result_path /tmp/res --query_file ./rand_uint8_10D_10K_norm50.0.bin --gt_file ./l2_rand_uint8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name: build and search disk index (sharded graph build, L2, no diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type uint8 --dist_fn l2 --data_path ./rand_uint8_10D_10K_norm50.0.bin --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskfull_sharded -R 16 -L 32 -B 0.00003 -M 0.00006
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type uint8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskfull_sharded --result_path /tmp/res --query_file ./rand_uint8_10D_10K_norm50.0.bin --gt_file ./l2_rand_uint8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 10 12 14 16 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type uint8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskfull_sharded --result_path /tmp/res --query_file ./rand_uint8_10D_10K_norm50.0.bin --gt_file ./l2_rand_uint8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name: build and search disk index (one shot graph build, L2, diskPQ) 
       run: |   
         ${{ env.diskann_built_tests }}/build_disk_index --data_type uint8 --dist_fn l2 --data_path ./rand_uint8_10D_10K_norm50.0.bin --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskpq_oneshot -R 16 -L 32 -B 0.00003 -M 1 --PQ_disk_bytes 5
-        ${{ env.diskann_built_tests }}/search_disk_index --data_type uint8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskpq_oneshot --result_path /tmp/res --query_file ./rand_uint8_10D_10K_norm50.0.bin --gt_file ./l2_rand_uint8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 10 12 14 16 -W 2 --num_nodes_to_cache 10 -T 16
+        ${{ env.diskann_built_tests }}/search_disk_index --data_type uint8 --dist_fn l2 --index_path_prefix ./disk_index_l2_rand_uint8_10D_10K_norm50.0_diskpq_oneshot --result_path /tmp/res --query_file ./rand_uint8_10D_10K_norm50.0.bin --gt_file ./l2_rand_uint8_10D_10K_norm50.0_self_gt100 --recall_at 5 -L 5 10 -W 2 --num_nodes_to_cache 10 -T 16
     - name:  build and search an incremental index
       run: |
         ${{ env.diskann_built_tests }}/test_insert_deletes_consolidate --data_type uint8 --dist_fn l2 --data_path rand_uint8_10D_10K_norm50.0.bin --index_path_prefix index_ins_del -R 64 -L 300 --alpha 1.2 -T 8 --points_to_skip 0 --max_points_to_insert 7500 --beginning_index_size 0 --points_per_checkpoint 1000 --checkpoints_per_snapshot 0 --points_to_delete_from_beginning 2500 --start_deletes_after 5000 --do_concurrent true --start_point_norm 200;


### PR DESCRIPTION
Disk based search takes a lot of time on CI tests. Two changes to make to reduce each test from ~100seconds to about 10 seconds:
* Reducing the number and size of search parameter to to {5, 10}.
* Reducing the number of queries to 1K from 10K.