### PR TITLE
fixing a signed vs unsigned comparison

### DIFF
--- a/include/restapi/server.h
+++ b/include/restapi/server.h
@@ -28,7 +28,7 @@ namespace diskann {
     web::json::value prepareResponse(const int64_t& queryId, const int k);
 
     template<class T>
-    void parseJson(const utility::string_t& body, int& k, int64_t& queryId,
+    void parseJson(const utility::string_t& body, unsigned int& k, int64_t& queryId,
                    T*& queryVector, unsigned int& dimensions, unsigned& Ls);
 
     web::json::value idsToJsonArray(const diskann::SearchResult& result);

--- a/src/restapi/server.cpp
+++ b/src/restapi/server.cpp
@@ -102,7 +102,7 @@ namespace diskann {
     message.extract_string(true)
         .then([=](utility::string_t body) {
           int64_t queryId = -1;
-          int     K = 0;
+          unsigned int     K = 0;
           try {
             T*           queryVector = nullptr;
             unsigned int dimensions = 0;
@@ -165,7 +165,7 @@ namespace diskann {
   }
 
   template<class T>
-  void Server::parseJson(const utility::string_t& body, int& k,
+  void Server::parseJson(const utility::string_t& body, unsigned int& k,
                          int64_t& queryId, T*& queryVector,
                          unsigned int& dimensions, unsigned& Ls) {
     std::cout << body << std::endl;


### PR DESCRIPTION
This is a small change of a protected method in the Server class to remove a couple of warnings on comparisons between signed int and unsigned int.


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.

#### Any other comments?

