### PR TITLE
Ported pr #163 (Optimize neighbor insertion) into the latest version of the main branch

### DIFF
--- a/include/scratch.h
+++ b/include/scratch.h
@@ -44,7 +44,7 @@ namespace diskann {
     inline tsl::robin_set<unsigned> &visited() {
       return _visited;
     }
-    std::vector<Neighbor> &best_l_nodes() {
+    inline NeighborSet &best_l_nodes() {
       return _best_l_nodes;
     }
     inline tsl::robin_set<unsigned> &inserted_into_pool_rs() {
@@ -81,7 +81,7 @@ namespace diskann {
    private:
     std::vector<Neighbor>    _pool;
     tsl::robin_set<unsigned> _visited;
-    std::vector<Neighbor>    _best_l_nodes;
+    NeighborSet              _best_l_nodes;
     tsl::robin_set<unsigned> _inserted_into_pool_rs;
     boost::dynamic_bitset<> *_inserted_into_pool_bs;
     std::vector<unsigned>    _id_scratch;
@@ -115,7 +115,7 @@ namespace diskann {
     PQScratch<T> *_pq_scratch;
 
     tsl::robin_set<_u64>  visited;
-    std::vector<Neighbor> retset;
+    NeighborSet           retset;
     std::vector<Neighbor> full_retset;
 
     SSDQueryScratch(size_t aligned_dim, size_t visited_reserve);

--- a/include/scratch.h
+++ b/include/scratch.h
@@ -44,7 +44,7 @@ namespace diskann {
     inline tsl::robin_set<unsigned> &visited() {
       return _visited;
     }
-    inline NeighborSet &best_l_nodes() {
+    inline NeighborPriorityQueue &best_l_nodes() {
       return _best_l_nodes;
     }
     inline tsl::robin_set<unsigned> &inserted_into_pool_rs() {
@@ -81,7 +81,7 @@ namespace diskann {
    private:
     std::vector<Neighbor>    _pool;
     tsl::robin_set<unsigned> _visited;
-    NeighborSet              _best_l_nodes;
+    NeighborPriorityQueue    _best_l_nodes;
     tsl::robin_set<unsigned> _inserted_into_pool_rs;
     boost::dynamic_bitset<> *_inserted_into_pool_bs;
     std::vector<unsigned>    _id_scratch;
@@ -115,7 +115,7 @@ namespace diskann {
     PQScratch<T> *_pq_scratch;
 
     tsl::robin_set<_u64>  visited;
-    NeighborSet           retset;
+    NeighborPriorityQueue retset;
     std::vector<Neighbor> full_retset;
 
     SSDQueryScratch(size_t aligned_dim, size_t visited_reserve);

--- a/python/src/diskann_bindings.cpp
+++ b/python/src/diskann_bindings.cpp
@@ -287,7 +287,7 @@ PYBIND11_MODULE(diskannpy, m) {
 
   py::class_<Neighbor>(m, "Neighbor")
       .def(py::init<>())
-      .def(py::init<unsigned, float, bool>())
+      .def(py::init<unsigned, float>())
       .def(py::self < py::self)
       .def(py::self == py::self);
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -708,7 +708,8 @@ namespace diskann {
       const std::vector<unsigned> &init_ids, InMemQueryScratch<T> *scratch,
       bool ret_frozen, bool search_invocation) {
     std::vector<Neighbor>    &expanded_nodes = scratch->pool();
-    std::vector<Neighbor>    &best_L_nodes = scratch->best_l_nodes();
+    NeighborSet           &best_L_nodes = scratch->best_l_nodes();
+    best_L_nodes.reserve(Lsize);
     tsl::robin_set<unsigned> &inserted_into_pool_rs =
         scratch->inserted_into_pool_rs();
     boost::dynamic_bitset<> &inserted_into_pool_bs =
@@ -747,9 +748,6 @@ namespace diskann {
       pq_coord_scratch = pq_query_scratch->aligned_pq_coord_scratch;
     }
 
-    for (unsigned i = 0; i < Lsize + 1; i++) {
-      best_L_nodes[i].distance = std::numeric_limits<float>::max();
-    }
     if (expanded_nodes.size() > 0 || id_scratch.size() > 0) {
       throw ANNException("ERROR: Clear scratch space before passing.", -1,
                          __FUNCSIG__, __FILE__, __LINE__);
@@ -770,8 +768,8 @@ namespace diskann {
     }
 
     // Lambda to determine if a node has been visited
-    auto is_not_visited = [this, fast_iterate, inserted_into_pool_bs,
-                           inserted_into_pool_rs](const unsigned id) {
+    auto is_not_visited = [this, fast_iterate, &inserted_into_pool_bs,
+                           &inserted_into_pool_rs](const unsigned id) {
       return fast_iterate ? inserted_into_pool_bs[id] == 0
                           : inserted_into_pool_rs.find(id) ==
                                 inserted_into_pool_rs.end();
@@ -788,7 +786,6 @@ namespace diskann {
     };
 
     // Initialize the candidate pool with starting points
-    unsigned l = 0;
     for (auto id : init_ids) {
       if (id >= _max_points + _num_frozen_pts) {
         diskann::cerr << "Out of range loc found as an edge : " << id
@@ -812,100 +809,74 @@ namespace diskann {
         else
           distance = _distance->compare(_data + _aligned_dim * (size_t) id,
                                         aligned_query, (unsigned) _aligned_dim);
-        Neighbor nn = Neighbor(id, distance, true);
-        best_L_nodes[l++] = nn;
+        Neighbor nn = Neighbor(id, distance);
+        best_L_nodes.insert(nn);
       }
-      if (l == Lsize)
+      if (best_L_nodes.size() == Lsize)
         break;
     }
 
-    // sort best_L_nodes based on distance of each point to node_coords
-    std::sort(best_L_nodes.begin(), best_L_nodes.begin() + l);
-    unsigned best_unchanged = 0;
     uint32_t hops = 0;
     uint32_t cmps = 0;
 
-    while (best_unchanged < l) {
-      unsigned best_inserted_position = l;
-
-      if (best_L_nodes[best_unchanged].flag == false) {  // Expanded before
-        best_unchanged++;
-      } else {
-        best_L_nodes[best_unchanged].flag = false;  // Mark as expanded
-        auto n = best_L_nodes[best_unchanged].id;
-
-        // Add node to expanded nodes to create pool for prune later
-        if (!search_invocation && (best_L_nodes[best_unchanged].id != _start ||
-                                   _num_frozen_pts == 0 || ret_frozen)) {
-          expanded_nodes.emplace_back(best_L_nodes[best_unchanged]);
-        }
-
-        // Find which of the nodes in des have not been visited before
-        id_scratch.clear();
-        {
-          if (_dynamic_index)
-            _locks[n].lock();
-          for (auto id : _final_graph[n]) {
-            assert(id < _max_points + _num_frozen_pts);
-            if (is_not_visited(id)) {
-              id_scratch.push_back(id);
-            }
-          }
-
-          if (_dynamic_index)
-            _locks[n].unlock();
-        }
-
-        // Mark nodes visited
-        for (auto id : id_scratch) {
-          if (fast_iterate) {
-            inserted_into_pool_bs[id] = 1;
-          } else {
-            inserted_into_pool_rs.insert(id);
+    while (best_L_nodes.has_next()) {
+      auto nbr = best_L_nodes.pop();   
+      auto n = nbr.id;
+      // Add node to expanded nodes to create pool for prune later
+      if (!search_invocation &&
+          (n != _start || _num_frozen_pts == 0 || ret_frozen)) {
+        expanded_nodes.emplace_back(nbr);
+      }
+      // Find which of the nodes in des have not been visited before
+      id_scratch.clear();
+      {
+        if (_dynamic_index)
+          _locks[n].lock();
+        for (auto id : _final_graph[n]) {
+          assert(id < _max_points + _num_frozen_pts);
+          if (is_not_visited(id)) {
+            id_scratch.push_back(id);
           }
         }
 
-        // Compute to distances to the expanded, previously unvisted nodes
-        if (_pq_dist) {
-          compute_dists(id_scratch.data(), id_scratch.size(), dist_scratch);
+        if (_dynamic_index)
+          _locks[n].unlock();
+      }
 
+      // Mark nodes visited
+      for (auto id : id_scratch) {
+        if (fast_iterate) {
+          inserted_into_pool_bs[id] = 1;
         } else {
-          for (size_t m = 0; m < id_scratch.size(); ++m) {
-            unsigned id = id_scratch[m];
-
-            if (m + 1 < id_scratch.size()) {
-              auto nextn = id_scratch[m + 1];
-              diskann::prefetch_vector(
-                  (const char *) _data + _aligned_dim * (size_t) nextn,
-                  sizeof(T) * _aligned_dim);
-            }
-
-            dist_scratch[m] = _distance->compare(
-                aligned_query, _data + _aligned_dim * (size_t) id,
-                (unsigned) _aligned_dim);
-          }
+          inserted_into_pool_rs.insert(id);
         }
-        cmps += id_scratch.size();
+      }
 
-        // Insert <id, dist> pairs into the pool of candidates
+      // Compute to distances to the expanded, previously unvisted nodes
+      if (_pq_dist) {
+        compute_dists(id_scratch.data(), id_scratch.size(), dist_scratch);
+
+      } else {
         for (size_t m = 0; m < id_scratch.size(); ++m) {
-          if (dist_scratch[m] >= best_L_nodes[l - 1].distance && (l == Lsize))
-            continue;
+          unsigned id = id_scratch[m];
 
-          Neighbor nn(id_scratch[m], dist_scratch[m], true);
-          unsigned inserted_position =
-              InsertIntoPool(best_L_nodes.data(), l, nn);
-          if (l < Lsize)
-            ++l;
-          if (inserted_position < best_inserted_position)
-            best_inserted_position = inserted_position;
+          if (m + 1 < id_scratch.size()) {
+            auto nextn = id_scratch[m + 1];
+            diskann::prefetch_vector(
+                (const char *) _data + _aligned_dim * (size_t) nextn,
+                sizeof(T) * _aligned_dim);
+          }
+
+          dist_scratch[m] = _distance->compare(
+              aligned_query, _data + _aligned_dim * (size_t) id,
+              (unsigned) _aligned_dim);
         }
+      }
+      cmps += id_scratch.size();
 
-        // Find and update the best position perturbed in the pool
-        if (best_inserted_position <= best_unchanged)
-          best_unchanged = best_inserted_position;
-        else
-          ++best_unchanged;
+      // Insert <id, dist> pairs into the pool of candidates
+      for (size_t m = 0; m < id_scratch.size(); ++m) {
+        best_L_nodes.insert(Neighbor(id_scratch[m], dist_scratch[m]));
       }
     }
     return std::make_pair(hops, cmps);
@@ -1123,7 +1094,7 @@ namespace diskann {
                 _distance->compare(_data + _aligned_dim * (size_t) des,
                                    _data + _aligned_dim * (size_t) cur_nbr,
                                    (unsigned) _aligned_dim);
-            dummy_pool.emplace_back(Neighbor(cur_nbr, dist, true));
+            dummy_pool.emplace_back(Neighbor(cur_nbr, dist));
             dummy_visited.insert(cur_nbr);
           }
         }
@@ -1230,7 +1201,7 @@ namespace diskann {
                 _distance->compare(_data + _aligned_dim * (size_t) node,
                                    _data + _aligned_dim * (size_t) cur_nbr,
                                    (unsigned) _aligned_dim);
-            dummy_pool.emplace_back(Neighbor(cur_nbr, dist, true));
+            dummy_pool.emplace_back(Neighbor(cur_nbr, dist));
             dummy_visited.insert(cur_nbr);
           }
         }
@@ -1517,6 +1488,13 @@ namespace diskann {
     ScratchStoreManager<InMemQueryScratch<T>> manager(_query_scratch);
     auto                                      scratch = manager.scratch_space();
 
+    if (L > scratch->search_l) {
+      scratch->resize_for_query(L);
+      diskann::cout << "Expanding query scratch_space. Was created with Lsize: "
+                    << scratch->search_l << " but search L is: " << L
+                    << std::endl;
+    }
+
     return search_impl(query, K, L, indices, distances, scratch);
   }
 
@@ -1539,18 +1517,18 @@ namespace diskann {
     auto best_L_nodes = scratch->best_l_nodes();
 
     size_t pos = 0;
-    for (auto it : best_L_nodes) {
-      if (it.id < _max_points) {
-        indices[pos] =
-            (IdType) it.id;  // safe because our indices are always uint32_t and
-                             // IDType will be uint32_t or uint64_t
+    for (int i = 0; i < best_L_nodes.size(); ++i) {
+      if (best_L_nodes[i].id < _max_points) {
+        indices[pos] = (IdType) best_L_nodes[i]
+                           .id;  // safe because our indices are always uint32_t
+                                 // and IDType will be uint32_t or uint64_t
         if (distances != nullptr) {
 #ifdef EXEC_ENV_OLS
           distances[pos] = it.distance;  // DLVS expects negative distances
 #else
           distances[pos] = _dist_metric == diskann::Metric::INNER_PRODUCT
-                               ? -1 * it.distance
-                               : it.distance;
+                               ? -1 * best_L_nodes[i].distance
+                               : best_L_nodes[i].distance;
 #endif
         }
         pos++;
@@ -1700,8 +1678,7 @@ namespace diskann {
             Neighbor(j,
                      _distance->compare(_data + _aligned_dim * i,
                                         _data + _aligned_dim * (size_t) j,
-                                        (unsigned) _aligned_dim),
-                     true));
+                                        (unsigned) _aligned_dim)));
       }
 
       std::sort(expanded_nghrs.begin(), expanded_nghrs.end());
@@ -2335,7 +2312,7 @@ namespace diskann {
                                                     unsigned *indices) {
     DistanceFastL2<T> *dist_fast = (DistanceFastL2<T> *) _distance;
 
-    std::vector<Neighbor> retset(L + 1);
+    NeighborSet           retset(L);
     std::vector<unsigned> init_ids(L);
 
     boost::dynamic_bitset<> flags{_nd, 0};
@@ -2375,52 +2352,36 @@ namespace diskann {
       x++;
       float dist =
           dist_fast->compare(x, query, norm_x, (unsigned) _aligned_dim);
-      retset[i] = Neighbor(id, dist, true);
+      retset.insert(Neighbor(id, dist));
       flags[id] = true;
       L++;
     }
 
-    std::sort(retset.begin(), retset.begin() + L);
-    int k = 0;
-    while (k < (int) L) {
-      int nk = L;
-
-      if (retset[k].flag) {
-        retset[k].flag = false;
-        unsigned n = retset[k].id;
-
-        _mm_prefetch(_opt_graph + _node_size * n + _data_len, _MM_HINT_T0);
-        unsigned *neighbors =
-            (unsigned *) (_opt_graph + _node_size * n + _data_len);
-        unsigned MaxM = *neighbors;
-        neighbors++;
-        for (unsigned m = 0; m < MaxM; ++m)
-          _mm_prefetch(_opt_graph + _node_size * neighbors[m], _MM_HINT_T0);
-        for (unsigned m = 0; m < MaxM; ++m) {
-          unsigned id = neighbors[m];
-          if (flags[id])
-            continue;
-          flags[id] = 1;
-          T    *data = (T *) (_opt_graph + _node_size * id);
-          float norm = *data;
-          data++;
-          float dist =
-              dist_fast->compare(query, data, norm, (unsigned) _aligned_dim);
-          if (dist >= retset[L - 1].distance)
-            continue;
-          Neighbor nn(id, dist, true);
-          int      r = InsertIntoPool(retset.data(), L, nn);
-
-          // if(L+1 < retset.size()) ++L;
-          if (r < nk)
-            nk = r;
-        }
+    while (retset.has_next()) {
+      auto nbr = retset.pop();
+      auto n = nbr.id;
+      _mm_prefetch(_opt_graph + _node_size * n + _data_len, _MM_HINT_T0);
+      unsigned *neighbors =
+          (unsigned *) (_opt_graph + _node_size * n + _data_len);
+      unsigned MaxM = *neighbors;
+      neighbors++;
+      for (unsigned m = 0; m < MaxM; ++m)
+        _mm_prefetch(_opt_graph + _node_size * neighbors[m], _MM_HINT_T0);
+      for (unsigned m = 0; m < MaxM; ++m) {
+        unsigned id = neighbors[m];
+        if (flags[id])
+          continue;
+        flags[id] = 1;
+        T    *data = (T *) (_opt_graph + _node_size * id);
+        float norm = *data;
+        data++;
+        float dist =
+            dist_fast->compare(query, data, norm, (unsigned) _aligned_dim);
+        Neighbor nn(id, dist);
+        retset.insert(nn);
       }
-      if (nk <= k)
-        k = nk;
-      else
-        ++k;
     }
+
     for (size_t i = 0; i < K; i++) {
       indices[i] = retset[i].id;
     }

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -805,10 +805,10 @@ namespace diskann {
     };
     Timer query_timer, io_timer, cpu_timer;
 
-    tsl::robin_set<_u64>  &visited = query_scratch->visited;
-    std::vector<Neighbor> &retset = query_scratch->retset;
+    tsl::robin_set<_u64> &visited = query_scratch->visited;
+    NeighborSet          &retset = query_scratch->retset;
+    retset.reserve(l_search);
     std::vector<Neighbor> &full_retset = query_scratch->full_retset;
-    retset.reserve(l_search + 1);
 
     _u32  best_medoid = 0;
     float best_dist = (std::numeric_limits<float>::max)();
@@ -823,12 +823,8 @@ namespace diskann {
     }
 
     compute_dists(&best_medoid, 1, dist_scratch);
-    retset.push_back(Neighbor(best_medoid, dist_scratch[0], true));
+    retset.insert(Neighbor(best_medoid, dist_scratch[0]));
     visited.insert(best_medoid);
-
-    unsigned cur_list_size = 1;
-
-    std::sort(retset.begin(), retset.begin() + cur_list_size);
 
     unsigned cmps = 0;
     unsigned hops = 0;
@@ -846,8 +842,7 @@ namespace diskann {
         cached_nhoods;
     cached_nhoods.reserve(2 * beam_width);
 
-    while (k < cur_list_size && num_ios < io_limit) {
-      auto nk = cur_list_size;
+    while (retset.has_next() && num_ios < io_limit) {
       // clear iteration state
       frontier.clear();
       frontier_nhoods.clear();
@@ -855,30 +850,25 @@ namespace diskann {
       cached_nhoods.clear();
       sector_scratch_idx = 0;
       // find new beam
-      _u32 marker = k;
       _u32 num_seen = 0;
-      while (marker < cur_list_size && frontier.size() < beam_width &&
+      while (retset.has_next() && frontier.size() < beam_width &&
              num_seen < beam_width) {
-        if (retset[marker].flag) {
-          num_seen++;
-          auto iter = nhood_cache.find(retset[marker].id);
-          if (iter != nhood_cache.end()) {
-            cached_nhoods.push_back(
-                std::make_pair(retset[marker].id, iter->second));
-            if (stats != nullptr) {
-              stats->n_cache_hits++;
-            }
-          } else {
-            frontier.push_back(retset[marker].id);
+        auto nbr = retset.pop();
+        num_seen++;
+        auto iter = nhood_cache.find(nbr.id);
+        if (iter != nhood_cache.end()) {
+          cached_nhoods.push_back(std::make_pair(nbr.id, iter->second));
+          if (stats != nullptr) {
+            stats->n_cache_hits++;
           }
-          retset[marker].flag = false;
-          if (this->count_visited_nodes) {
-            reinterpret_cast<std::atomic<_u32> &>(
-                this->node_visit_counter[retset[marker].id].second)
-                .fetch_add(1);
-          }
+        } else {
+          frontier.push_back(nbr.id);
         }
-        marker++;
+        if (this->count_visited_nodes) {
+          reinterpret_cast<std::atomic<_u32> &>(
+              this->node_visit_counter[nbr.id].second)
+              .fetch_add(1);
+        }
       }
 
       // read nhoods of frontier ids
@@ -930,7 +920,7 @@ namespace diskann {
                     query_float, (_u8 *) node_fp_coords_copy);
         }
         full_retset.push_back(
-            Neighbor((unsigned) cached_nhood.first, cur_expanded_dist, true));
+            Neighbor((unsigned) cached_nhood.first, cur_expanded_dist));
 
         _u64      nnbrs = cached_nhood.second.first;
         unsigned *node_nbrs = cached_nhood.second.second;
@@ -948,20 +938,9 @@ namespace diskann {
           unsigned id = node_nbrs[m];
           if (visited.insert(id).second) {
             cmps++;
-            float dist = dist_scratch[m];
-            Neighbor nn(id, dist, true);
-            Neighbor &lastResult = retset[cur_list_size - 1];
-            if ((lastResult < nn || lastResult == nn) &&
-                (cur_list_size == l_search))
-              continue;
-            // Return position in sorted list where nn inserted.
-            auto r = InsertIntoPool(retset.data(), cur_list_size, nn);
-            if (cur_list_size < l_search)
-              ++cur_list_size;
-            if (r < nk)
-              // nk logs the best position in the retset that was
-              // updated due to neighbors of n.
-              nk = r;
+            float    dist = dist_scratch[m];
+            Neighbor nn(id, dist);
+            retset.insert(nn);
           }
         }
       }
@@ -1004,7 +983,7 @@ namespace diskann {
                 query_float, (_u8 *) node_fp_coords_copy);
         }
         full_retset.push_back(
-            Neighbor(frontier_nhood.first, cur_expanded_dist, true));
+            Neighbor(frontier_nhood.first, cur_expanded_dist));
         unsigned *node_nbrs = (node_buf + 1);
         // compute node_nbrs <-> query dist in PQ space
         cpu_timer.reset();
@@ -1024,19 +1003,9 @@ namespace diskann {
             if (stats != nullptr) {
               stats->n_cmps++;
             }
-            Neighbor nn(id, dist, true);
-            Neighbor &lastResult = retset[cur_list_size - 1];
-            if ((lastResult < nn || lastResult == nn) &&
-                (cur_list_size == l_search))
-              continue;
-            auto     r = InsertIntoPool(
-                    retset.data(), cur_list_size,
-                    nn);  // Return position in sorted list where nn inserted.
-            if (cur_list_size < l_search)
-              ++cur_list_size;
-            if (r < nk)
-              nk = r;  // nk logs the best position in the retset that was
-                       // updated due to neighbors of n.
+
+            Neighbor nn(id, dist);
+            retset.insert(nn);
           }
         }
 
@@ -1044,12 +1013,6 @@ namespace diskann {
           stats->cpu_us += (double) cpu_timer.elapsed();
         }
       }
-
-      // update best inserted position
-      if (nk <= k)
-        k = nk;  // k is the best position in retset updated in this round.
-      else
-        ++k;
 
       hops++;
     }

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -806,7 +806,7 @@ namespace diskann {
     Timer query_timer, io_timer, cpu_timer;
 
     tsl::robin_set<_u64> &visited = query_scratch->visited;
-    NeighborSet          &retset = query_scratch->retset;
+    NeighborPriorityQueue &retset = query_scratch->retset;
     retset.reserve(l_search);
     std::vector<Neighbor> &full_retset = query_scratch->full_retset;
 
@@ -842,7 +842,7 @@ namespace diskann {
         cached_nhoods;
     cached_nhoods.reserve(2 * beam_width);
 
-    while (retset.has_next() && num_ios < io_limit) {
+    while (retset.has_unexpanded_node() && num_ios < io_limit) {
       // clear iteration state
       frontier.clear();
       frontier_nhoods.clear();
@@ -851,9 +851,9 @@ namespace diskann {
       sector_scratch_idx = 0;
       // find new beam
       _u32 num_seen = 0;
-      while (retset.has_next() && frontier.size() < beam_width &&
+      while (retset.has_unexpanded_node() && frontier.size() < beam_width &&
              num_seen < beam_width) {
-        auto nbr = retset.pop();
+        auto nbr = retset.closest_unexpanded();
         num_seen++;
         auto iter = nhood_cache.find(nbr.id);
         if (iter != nhood_cache.end()) {

--- a/src/scratch.cpp
+++ b/src/scratch.cpp
@@ -38,7 +38,7 @@ namespace diskann {
 
     _pool.reserve(l_to_use * 10);
     _visited.reserve(l_to_use * 2);
-    _best_l_nodes.resize(l_to_use + 1);
+    _best_l_nodes.reserve(l_to_use);
     _inserted_into_pool_rs.reserve(l_to_use * 20);
     _inserted_into_pool_bs = new boost::dynamic_bitset<>();
     _id_scratch.reserve(2 * r);
@@ -59,6 +59,7 @@ namespace diskann {
     _visited.clear();
     _inserted_into_pool_rs.clear();
     _inserted_into_pool_bs->reset();
+    _best_l_nodes.clear();
     _id_scratch.clear();
     _occlude_factor.clear();
   }


### PR DESCRIPTION
Includes the fixes mentioned in the comments of pr #163. Contribution originally made by zh Wang https://github.com/hhy3 
Changes are primarily for code simplification and don't change api.

Additional changes:
NeighborSet uses the Neighbor::operator< for comparisons.
The NeighborSet::insert method excludes duplicate ids being inserted into the set.
Fixes the vector debug asserts that are raised in the windows environment. 