### PR TITLE
Readying publication of python releases to pypi

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -45,7 +45,7 @@ jobs:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          twine upload --repository testpypi wheelhouse/*.whl
+          twine upload wheelhouse/*.whl
       - name: Update release with SHA256 and Artifacts
         uses: softprops/action-gh-release@v1
         with:


### PR DESCRIPTION
This change will let us publish 0.4.0 to pypi.org.

