### PR TITLE
Fix compile issue in vc16

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1173,7 +1173,7 @@ namespace diskann {
 
       if (node_ctr % 100000 == 0) {
         diskann::cout << "\r" << (100.0 * node_ctr) / (visit_order.size())
-                      << "\% of index build completed." << std::flush;
+                      << "% of index build completed." << std::flush;
       }
     }
 

--- a/src/windows_aligned_file_reader.cpp
+++ b/src/windows_aligned_file_reader.cpp
@@ -35,7 +35,8 @@ void WindowsAlignedFileReader::register_thread() {
                                FILE_FLAG_OVERLAPPED | FILE_FLAG_RANDOM_ACCESS,
                            NULL);
   if (ctx.fhandle == INVALID_HANDLE_VALUE) {
-    diskann::cout << "Error opening " << m_filename.c_str()
+    diskann::cout << "Error opening "
+                  << std::string(m_filename.begin(), m_filename.end())
                   << " -- error=" << GetLastError() << std::endl;
   }
 


### PR DESCRIPTION
"%" isn't escape character.

std::basic_ostream char can't output wchar directly.