### PR TITLE
Fix locking errors in streaming code 

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -341,6 +341,9 @@ namespace diskann {
     ConcurrentQueue<InMemQueryScratch<T> *> _query_scratch;
 
     // data structures, flags and locks for dynamic indexing
+    // lazy_delete removes entry from _location_to_tag and _tag_to_location
+    // If _location_to_tag does not resolve a location, it was deleted.
+    // _empty_slots has unallocated slots and those freed by ::consolidate_delete
     tsl::sparse_map<TagT, unsigned>    _tag_to_location;
     natural_number_map<unsigned, TagT> _location_to_tag;
     natural_number_set<unsigned>       _empty_slots;

--- a/include/index.h
+++ b/include/index.h
@@ -267,10 +267,10 @@ namespace diskann {
     DISKANN_DLLEXPORT void compact_data();
     DISKANN_DLLEXPORT void compact_frozen_point();
 
-    // Remove deleted nodes from adj list of node i and absorb edges from
-    // deleted neighbors.
+    // Remove deleted nodes from adjacency list of node loc
+    // Replace removed neighbors with second order neighbors.
     // Acquires shared lock on _delete_lock
-    // Also acquires _locks[i] if lock_adj_list is set to true
+    // Also acquires _locks[i] for i = loc and out-neighbors of loc.
     void process_delete(const tsl::robin_set<unsigned> &old_delete_set,
                         size_t loc, const unsigned range, const unsigned maxc,
                         const float alpha, InMemQueryScratch<T> *scratch);

--- a/include/index.h
+++ b/include/index.h
@@ -184,7 +184,7 @@ namespace diskann {
     // memory should be allocated for vec before calling this function
     DISKANN_DLLEXPORT int get_vector_by_tag(TagT &tag, T *vec);
 
-    DISKANN_DLLEXPORT void print_status() const;
+    DISKANN_DLLEXPORT void print_status();
 
     DISKANN_DLLEXPORT void count_nodes_at_bfs_levels() const;
 

--- a/include/index.h
+++ b/include/index.h
@@ -355,7 +355,6 @@ namespace diskann {
     bool              _pq_generated = false;
     FixedChunkPQTable _pq_table;
 
-    bool _lazy_done = false;      // true if lazy deletions have been made
     bool _data_compacted = true;  // true if data has been compacted
     bool _is_saved = false;  // Gopal. Checking if the index is already saved.
     bool _conc_consolidate = false;  // use _lock while searching

--- a/include/index.h
+++ b/include/index.h
@@ -231,6 +231,8 @@ namespace diskann {
                          const float alpha, std::vector<unsigned> &pruned_list,
                          InMemQueryScratch<T> *scratch);
 
+    // Prunes candidates in @pool to a shorter list @result
+    // @pool must be sorted before calling
     void occlude_list(
         const unsigned location, std::vector<Neighbor> &pool, const float alpha,
         const unsigned degree, const unsigned maxc,

--- a/include/index.h
+++ b/include/index.h
@@ -228,8 +228,9 @@ namespace diskann {
         const std::vector<unsigned> &init_ids, InMemQueryScratch<T> *scratch,
         bool ret_frozen = true, bool search_invocation = false);
 
-    void search_for_point_and_add_links(int location, _u32 Lindex,
-                                        InMemQueryScratch<T> *scratch);
+    void search_for_point_and_prune(int location, _u32 Lindex,
+                                    std::vector<unsigned> &pruned_list,
+                                    InMemQueryScratch<T>  *scratch);
 
     void prune_neighbors(const unsigned location, std::vector<Neighbor> &pool,
                          std::vector<unsigned> &pruned_list,
@@ -315,7 +316,7 @@ namespace diskann {
 
     // Data
     T    *_data = nullptr;
-    char *_opt_graph;
+    char *_opt_graph = nullptr;
 
     // Graph related data structures
     std::vector<std::vector<unsigned>> _final_graph;

--- a/include/index.h
+++ b/include/index.h
@@ -272,8 +272,8 @@ namespace diskann {
     // Acquires shared lock on _delete_lock
     // Also acquires _locks[i] if lock_adj_list is set to true
     void process_delete(const tsl::robin_set<unsigned> &old_delete_set,
-                        size_t loc, const unsigned &range, const unsigned &maxc,
-                        const float &alpha, InMemQueryScratch<T> *scratch);
+                        size_t loc, const unsigned range, const unsigned maxc,
+                        const float alpha, InMemQueryScratch<T> *scratch);
 
     void initialize_query_scratch(uint32_t num_threads, uint32_t search_l,
                                   uint32_t indexing_l, uint32_t r,

--- a/include/scratch.h
+++ b/include/scratch.h
@@ -48,14 +48,12 @@ namespace diskann {
     inline uint32_t get_maxc() {
       return _maxc;
     }
-
     inline T *aligned_query() {
       return _aligned_query;
     }
     inline PQScratch<T> *pq_scratch() {
       return _pq_scratch;
     }
-
     inline std::vector<Neighbor> &pool() {
       return _pool;
     }
@@ -65,7 +63,6 @@ namespace diskann {
     inline std::vector<float> &occlude_factor() {
       return _occlude_factor;
     }
-
     inline tsl::robin_set<unsigned> &inserted_into_pool_rs() {
       return _inserted_into_pool_rs;
     }
@@ -77,6 +74,15 @@ namespace diskann {
     }
     inline std::vector<float> &dist_scratch() {
       return _dist_scratch;
+    }
+    inline tsl::robin_set<unsigned> &expanded_nodes_set() {
+      return _expanded_nodes_set;
+    }
+    inline std::vector<Neighbor> &expanded_nodes_vec() {
+      return _expanded_nghrs_vec;
+    }
+    inline std::vector<unsigned> &occlude_list_output() {
+      return _occlude_list_output;
     }
 
    private:
@@ -116,6 +122,11 @@ namespace diskann {
     // _dist_scratch must be > R*GRAPH_SLACK_FACTOR for iterate_to_fp
     // _dist_scratch should be at least the size of id_scratch
     std::vector<float> _dist_scratch;
+
+    //  Buffers used in process delete, capacity increases as needed
+    tsl::robin_set<unsigned> _expanded_nodes_set;
+    std::vector<Neighbor>    _expanded_nghrs_vec;
+    std::vector<unsigned>    _occlude_list_output;
   };
 
   //

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1693,9 +1693,9 @@ namespace diskann {
       }
     }
     if (modify) {
+      std::unique_lock<non_recursive_mutex> adj_list_lock(_locks[loc]);
       _final_graph[loc].clear();  // so we can pass it as the output buffer
                                   // for occlude_list
-      std::unique_lock<non_recursive_mutex> adj_list_lock(_locks[loc]);
       if (expanded_nodes_set.size() <= range) {
         for (auto &ngh : expanded_nodes_set)
           _final_graph[loc].push_back(ngh);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -943,6 +943,7 @@ namespace diskann {
 
     // Truncate pool at maxc and initialize scratch spaces
     assert(std::is_sorted(pool.begin(), pool.end()));
+    assert(result.size() == 0);
     if (pool.size() > maxc)
       pool.resize(maxc);
     std::vector<float> &occlude_factor = scratch->occlude_factor();
@@ -1695,6 +1696,7 @@ namespace diskann {
       }
       std::sort(expanded_nghrs.begin(), expanded_nghrs.end());
       std::unique_lock<non_recursive_mutex> adj_list_lock(_locks[loc]);
+      _final_graph[loc].clear(); // so we can pass it as the output buffer for occlude_list
       occlude_list(loc, expanded_nghrs, alpha, range, maxc, _final_graph[loc],
                    scratch, &old_delete_set);
     }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1644,7 +1644,10 @@ namespace diskann {
       return -2;
     }
 
-    std::unique_lock<std::shared_timed_mutex> update_lock(_update_lock);
+    std::unique_lock<std::shared_timed_mutex> ul(_update_lock);
+    std::unique_lock<std::shared_timed_mutex> tl(_tag_lock);
+    std::unique_lock<std::shared_timed_mutex> dl(_delete_lock);
+
     if (_data_compacted) {
       for (unsigned slot = (unsigned) _nd; slot < _max_points; ++slot) {
         _empty_slots.insert(slot);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1913,7 +1913,7 @@ namespace diskann {
 
       if ((new_location[old] < _max_points)  // If point continues to exist
           || (old >= _max_points && old < _max_points + _num_frozen_pts)) {
-        new_adj_list.clear();
+        new_adj_list.reserve(_final_graph[old].size());
         for (auto ngh_iter : _final_graph[old]) {
           if (empty_locations.find(ngh_iter) != empty_locations.end()) {
             ++num_dangling;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1700,10 +1700,9 @@ namespace diskann {
       }
     }
     if (modify) {
-      std::unique_lock<non_recursive_mutex> adj_list_lock(_locks[loc]);
-      _final_graph[loc].clear();  // so we can pass it as the output buffer
-                                  // for occlude_list
       if (expanded_nodes_set.size() <= range) {
+        std::unique_lock<non_recursive_mutex> adj_list_lock(_locks[loc]);
+        _final_graph[loc].clear();
         for (auto &ngh : expanded_nodes_set)
           _final_graph[loc].push_back(ngh);
       } else {
@@ -1716,6 +1715,8 @@ namespace diskann {
                                       (unsigned) _aligned_dim));
         }
         std::sort(expanded_nghrs_vec.begin(), expanded_nghrs_vec.end());
+        std::unique_lock<non_recursive_mutex> adj_list_lock(_locks[loc]);
+        _final_graph[loc].clear();  // To use as output buffer for occlude_list
         occlude_list(loc, expanded_nghrs_vec, alpha, range, maxc,
                      _final_graph[loc], scratch, &old_delete_set);
       }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1701,6 +1701,7 @@ namespace diskann {
           _final_graph[loc].push_back(ngh);
       } else {
         // Create a pool of Neighbor candidates from the expanded_nodes_set
+        expanded_nghrs_vec.reserve(expanded_nodes_set.size());
         for (auto &ngh : expanded_nodes_set) {
           expanded_nghrs_vec.emplace_back(
               ngh, _distance->compare(_data + _aligned_dim * loc,
@@ -1874,7 +1875,7 @@ namespace diskann {
 
     if (_delete_set->size() > 0) {
       throw ANNException(
-          "Can not compact data when index has non-trivial _delete_set of "
+          "Can not compact data when index has non-empty _delete_set of "
           "size: " +
               std::to_string(_delete_set->size()),
           -1, __FUNCSIG__, __FILE__, __LINE__);
@@ -2174,8 +2175,6 @@ namespace diskann {
     }
 
     // Find and add appropriate graph edges
-    std::vector<unsigned> pruned_list;
-
     ScratchStoreManager<InMemQueryScratch<T>> manager(_query_scratch);
     auto                                      scratch = manager.scratch_space();
     search_for_point_and_add_links(location, _indexingQueueSize, scratch);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2233,7 +2233,12 @@ namespace diskann {
   }
 
   template<typename T, typename TagT>
-  void Index<T, TagT>::print_status() const {
+  void Index<T, TagT>::print_status() {
+    std::shared_lock<std::shared_timed_mutex> ul(_update_lock);
+    std::shared_lock<std::shared_timed_mutex> cl(_consolidate_lock);
+    std::shared_lock<std::shared_timed_mutex> tl(_tag_lock);
+    std::shared_lock<std::shared_timed_mutex> dl(_delete_lock);
+
     diskann::cout << "------------------- Index object: " << (uint64_t) this
                   << " -------------------" << std::endl;
     diskann::cout << "Number of points: " << _nd << std::endl;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -486,8 +486,6 @@ namespace diskann {
       _empty_slots.insert((uint32_t) i);
     }
 
-    _lazy_done = _delete_set->size() != 0;
-
     reposition_frozen_point_to_end();
     diskann::cout << "Num frozen points:" << _num_frozen_pts << " _nd: " << _nd
                   << " _start: " << _start
@@ -1652,7 +1650,6 @@ namespace diskann {
       }
     }
 
-    _lazy_done = false;
     return 0;
   }
 
@@ -1802,9 +1799,6 @@ namespace diskann {
     if (!_conc_consolidate) {
       update_lock.unlock();
     }
-
-    if (_delete_set->size() == 0)
-      _lazy_done = false;
 
     double duration = timer.elapsed() / 1000000.0;
     diskann::cout << " done in " << duration << " seconds." << std::endl;
@@ -2185,7 +2179,6 @@ namespace diskann {
     std::shared_lock<std::shared_timed_mutex> ul(_update_lock);
     std::unique_lock<std::shared_timed_mutex> tl(_tag_lock);
     std::unique_lock<std::shared_timed_mutex> dl(_delete_lock);
-    _lazy_done = true;
     _data_compacted = false;
 
     if (_tag_to_location.find(tag) == _tag_to_location.end()) {
@@ -2212,7 +2205,6 @@ namespace diskann {
     std::shared_lock<std::shared_timed_mutex> ul(_update_lock);
     std::unique_lock<std::shared_timed_mutex> tl(_tag_lock);
     std::unique_lock<std::shared_timed_mutex> dl(_delete_lock);
-    _lazy_done = true;
     _data_compacted = false;
 
     for (auto tag : tags) {
@@ -2254,8 +2246,7 @@ namespace diskann {
     diskann::cout << "Number of empty slots: " << _empty_slots.size()
                   << std::endl;
     diskann::cout << std::boolalpha
-                  << "Data compacted: " << this->_data_compacted
-                  << " Lazy done: " << this->_lazy_done << std::endl;
+                  << "Data compacted: " << this->_data_compacted << std::endl;
     diskann::cout << "---------------------------------------------------------"
                      "------------"
                   << std::endl;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1892,7 +1892,7 @@ namespace diskann {
     }
 
     // If start node is removed, throw an exception
-    if (!_location_to_tag.contains(_start)) {
+    if (_start < _max_points && !_location_to_tag.contains(_start)) {
       throw diskann::ANNException("ERROR: Start node deleted.", -1, __FUNCSIG__,
                                   __FILE__, __LINE__);
     }

--- a/src/scratch.cpp
+++ b/src/scratch.cpp
@@ -53,6 +53,10 @@ namespace diskann {
 
     _id_scratch.clear();
     _dist_scratch.clear();
+
+    _expanded_nodes_set.clear();
+    _expanded_nghrs_vec.clear();
+    _occlude_list_output.clear();
   }
 
   template<typename T>


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
Fixes #198 
Replaces https://github.com/microsoft/DiskANN/pull/203; this PR is rebased with latest commit on main
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
Fixes errors in locking around deletes and consolidation. Details:

convert _delete_set member in index class to an unique_ptr

Add shared_lock over delete_lock to process_delete; move adj list lock inside process_delete

insert acqires exclusive delete_lock before calling reserve_location(); change comments on locking requirements for calling reserve_location()

In search_for_points_and_add_links(), remove unnecessary checks of pool against delete_set. The function already checks the final results against _location_to_tag

Copy by reference when scratch spaces are returned

use reference to iterate over vector when modifying it's contents

minor changes to help compiler optimize better

acquire shared delete lock to check delete set size

change locking in process_delete to avoid deadlock

#### Any other comments?

