### PR TITLE
add_missing_sizeof_multiplier_in_SSD_scratch_init

### DIFF
--- a/src/scratch.cpp
+++ b/src/scratch.cpp
@@ -91,7 +91,7 @@ namespace diskann {
   template<typename T>
   SSDQueryScratch<T>::SSDQueryScratch(size_t aligned_dim,
                                       size_t visited_reserve) {
-    _u64 coord_alloc_size = ROUND_UP(MAX_N_CMPS * aligned_dim, 256);
+    _u64 coord_alloc_size = ROUND_UP(MAX_N_CMPS * aligned_dim * sizeof(T), 256);
 
     diskann::alloc_aligned((void **) &coord_scratch, coord_alloc_size, 256);
     diskann::alloc_aligned((void **) &sector_scratch,
@@ -102,7 +102,7 @@ namespace diskann {
 
     _pq_scratch = new PQScratch<T>(MAX_GRAPH_DEGREE, aligned_dim);
 
-    memset(coord_scratch, 0, MAX_N_CMPS * aligned_dim);
+    memset(coord_scratch, 0, MAX_N_CMPS * aligned_dim * sizeof(T));
     memset(aligned_query_T, 0, aligned_dim * sizeof(T));
 
     visited.reserve(visited_reserve);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
Add a sizeof(T) multiplier in malloc and memset in SSD scratch init. As @plutolove  says, this error can show up for float and int types at a #comparison threshold 4 times lower than MAX_N_CMP.

Defer the need to remove MAX_N_CMP multiplier to save space to a future PR.

#### Any other comments?

Replaces PR#143 raised by @plutolove since its difficult to rebase. This code moved to a different file.


