### PR TITLE
fix filter disk Index Search (filter threshold build unverified)

### DIFF
--- a/src/disk_utils.cpp
+++ b/src/disk_utils.cpp
@@ -1196,19 +1196,19 @@ namespace diskann {
     // into replica dummy points which evenly distribute the filters. The rest
     // of index build happens on the augmented base and labels
     std::string augmented_data_file, augmented_labels_file;
-    if (use_filters) {
-      augmented_data_file = index_prefix_path + "_augmented_data.bin";
-      augmented_labels_file = index_prefix_path + "_augmented_labels.txt";
-      dummy_remap_file = index_prefix_path + "_dummy_remap.txt";
+    if (use_filters) {      
       if (filter_threshold != 0) {
+        augmented_data_file = index_prefix_path + "_augmented_data.bin";
+        augmented_labels_file = index_prefix_path + "_augmented_labels.txt";
+        dummy_remap_file = index_prefix_path + "_dummy_remap.txt";
         breakup_dense_points<T>(
             data_file_to_use, label_file, filter_threshold, augmented_data_file,
             augmented_labels_file,
             dummy_remap_file);  // RKNOTE: This has large memory footprint, need
                                 // to make this streaming
+        data_file_to_use = augmented_data_file;
+        labels_file_to_use = augmented_labels_file;
       }
-      data_file_to_use = augmented_data_file;
-      labels_file_to_use = augmented_labels_file;
     }
 
 

--- a/src/disk_utils.cpp
+++ b/src/disk_utils.cpp
@@ -1197,9 +1197,9 @@ namespace diskann {
     // of index build happens on the augmented base and labels
     std::string augmented_data_file, augmented_labels_file;
     if (use_filters) {      
+      augmented_data_file = index_prefix_path + "_augmented_data.bin";
+      augmented_labels_file = index_prefix_path + "_augmented_labels.txt"; 
       if (filter_threshold != 0) {
-        augmented_data_file = index_prefix_path + "_augmented_data.bin";
-        augmented_labels_file = index_prefix_path + "_augmented_labels.txt";
         dummy_remap_file = index_prefix_path + "_dummy_remap.txt";
         breakup_dense_points<T>(
             data_file_to_use, label_file, filter_threshold, augmented_data_file,
@@ -1274,6 +1274,13 @@ namespace diskann {
     diskann::cout << timer.elapsed_seconds_for_step("generating disk layout")
                   << std::endl;
 
+    double ten_percent_points = std::ceil(points_num * 0.1);
+    double num_sample_points = ten_percent_points > MAX_SAMPLE_POINTS_FOR_WARMUP
+                                   ? MAX_SAMPLE_POINTS_FOR_WARMUP
+                                   : ten_percent_points;
+    double sample_sampling_rate = num_sample_points / points_num;
+    gen_random_slice<T>(data_file_to_use.c_str(), sample_base_prefix,
+                        sample_sampling_rate);
     if (use_filters) {
       copy_file(mem_labels_file, disk_labels_file);
       std::remove(mem_labels_file.c_str());
@@ -1284,14 +1291,6 @@ namespace diskann {
       std::remove(augmented_data_file.c_str());
       std::remove(augmented_labels_file.c_str());
     }
-
-    double ten_percent_points = std::ceil(points_num * 0.1);
-    double num_sample_points = ten_percent_points > MAX_SAMPLE_POINTS_FOR_WARMUP
-                                   ? MAX_SAMPLE_POINTS_FOR_WARMUP
-                                   : ten_percent_points;
-    double sample_sampling_rate = num_sample_points / points_num;
-    gen_random_slice<T>(data_file_to_use.c_str(), sample_base_prefix,
-                        sample_sampling_rate);
 
     std::remove(mem_index_path.c_str());
     if (use_disk_pq)

--- a/src/disk_utils.cpp
+++ b/src/disk_utils.cpp
@@ -55,7 +55,7 @@ namespace diskann {
     }
 
     size_t num_blocks = DIV_ROUND_UP(fsize, read_blk_size);
-    char  *dump = new char[read_blk_size];
+    char * dump = new char[read_blk_size];
     for (_u64 i = 0; i < num_blocks; i++) {
       size_t cur_block_size = read_blk_size > fsize - (i * read_blk_size)
                                   ? fsize - (i * read_blk_size)
@@ -93,13 +93,13 @@ namespace diskann {
   size_t calculate_num_pq_chunks(double final_index_ram_limit,
                                  size_t points_num, uint32_t dim,
                                  const std::vector<std::string> &param_list) {
-    size_t num_pq_chunks = (size_t) (std::floor)(
-        _u64(final_index_ram_limit / (double) points_num));
+    size_t num_pq_chunks =
+        (size_t)(std::floor)(_u64(final_index_ram_limit / (double) points_num));
     diskann::cout << "Calculated num_pq_chunks :" << num_pq_chunks << std::endl;
     if (param_list.size() >= 6) {
       float compress_ratio = (float) atof(param_list[5].c_str());
       if (compress_ratio > 0 && compress_ratio <= 1) {
-        size_t chunks_by_cr = (size_t) (std::floor)(compress_ratio * dim);
+        size_t chunks_by_cr = (size_t)(std::floor)(compress_ratio * dim);
 
         if (chunks_by_cr > 0 && chunks_by_cr < num_pq_chunks) {
           diskann::cout << "Compress ratio:" << compress_ratio
@@ -156,7 +156,7 @@ namespace diskann {
   T *load_warmup(MemoryMappedFiles &files, const std::string &cache_warmup_file,
                  uint64_t &warmup_num, uint64_t warmup_dim,
                  uint64_t warmup_aligned_dim) {
-    T       *warmup = nullptr;
+    T *      warmup = nullptr;
     uint64_t file_dim, file_aligned_dim;
 
     if (files.fileExists(cache_warmup_file)) {
@@ -189,7 +189,7 @@ namespace diskann {
   template<typename T>
   T *load_warmup(const std::string &cache_warmup_file, uint64_t &warmup_num,
                  uint64_t warmup_dim, uint64_t warmup_aligned_dim) {
-    T       *warmup = nullptr;
+    T *      warmup = nullptr;
     uint64_t file_dim, file_aligned_dim;
 
     if (file_exists(cache_warmup_file)) {
@@ -284,8 +284,7 @@ namespace diskann {
               });
     diskann::cout << "Finished computing node -> shards map" << std::endl;
 
-
-// will merge all the labels to medoids files of each shard into one
+    // will merge all the labels to medoids files of each shard into one
     // combined file
     if (use_filters) {
       std::unordered_map<std::string, std::vector<_u32>>
@@ -332,7 +331,6 @@ namespace diskann {
       }
       mapping_writer.close();
     }
-
 
     // create cached vamana readers
     std::vector<cached_ifstream> vamana_readers(nshards);
@@ -436,7 +434,7 @@ namespace diskann {
       // read from shard_id ifstream
       vamana_readers[shard_id].read((char *) &shard_nnbrs, sizeof(unsigned));
 
-     if (shard_nnbrs == 0) {
+      if (shard_nnbrs == 0) {
         std::cout << "WARNING: shard #" << shard_id << ", node_id " << node_id
                   << " has 0 nbrs" << std::endl;
       }
@@ -477,8 +475,7 @@ namespace diskann {
     return 0;
   }
 
-
-// TODO: Make this a streaming implementation to avoid exceeding the memory
+  // TODO: Make this a streaming implementation to avoid exceeding the memory
   // budget
   template<typename T>
   void breakup_dense_points(const std::string data_file,
@@ -594,24 +591,23 @@ namespace diskann {
       delete[] ids;
   }
 
-
-
   template<typename T>
-  int build_merged_vamana_index(std::string     base_file,
-                                diskann::Metric compareMetric, unsigned L,
-                                unsigned R, double sampling_rate,
-                                double ram_budget, std::string mem_index_path,
-                                std::string medoids_file,
-                                std::string centroids_file,
-                                size_t build_pq_bytes, bool use_opq, bool use_filters,
-      const std::string &label_file, const std::string &labels_to_medoids_file,
+  int build_merged_vamana_index(
+      std::string base_file, diskann::Metric compareMetric, unsigned L,
+      unsigned R, double sampling_rate, double ram_budget,
+      std::string mem_index_path, std::string medoids_file,
+      std::string centroids_file, size_t build_pq_bytes, bool use_opq,
+      bool use_filters, const std::string &label_file,
+      const std::string &labels_to_medoids_file,
       const std::string &universal_label, const _u32 Lf) {
     size_t base_num, base_dim;
     diskann::get_bin_metadata(base_file, base_num, base_dim);
 
     double full_index_ram =
         estimate_ram_usage(base_num, base_dim, sizeof(T), R);
-    if (full_index_ram < ram_budget * 1024 * 1024 * 1024) { // TODO: Make this honest when there is filter support
+    if (full_index_ram <
+        ram_budget * 1024 * 1024 *
+            1024) {  // TODO: Make this honest when there is filter support
       diskann::cout << "Full index fits in RAM budget, should consume at most "
                     << full_index_ram / (1024 * 1024 * 1024)
                     << "GiBs, so building in one shot" << std::endl;
@@ -657,7 +653,6 @@ namespace diskann {
       return 0;
     }
 
-
     // where the universal label is to be saved in the final graph
     std::string final_index_universal_label_file =
         mem_index_path + "_universal_label.txt";
@@ -665,7 +660,7 @@ namespace diskann {
     std::string merged_index_prefix = mem_index_path + "_tempFiles";
 
     Timer timer;
-    int         num_parts =
+    int   num_parts =
         partition_with_ram_budget<T>(base_file, sampling_rate, ram_budget,
                                      2 * R / 3, merged_index_prefix, 2);
     diskann::cout << timer.elapsed_seconds_for_step("partitioning data")
@@ -717,9 +712,9 @@ namespace diskann {
         }
         _pvamanaIndex->build_filtered_index(
             shard_base_file.c_str(), shard_labels_file, shard_base_pts, paras);
-      }      
+      }
       _pvamanaIndex->save(shard_index_file.c_str());
-     // copy universal label file from first shard to the final destination
+      // copy universal label file from first shard to the final destination
       // index, since all shards anyway share the universal label
       if (p == 0) {
         std::string shard_universal_label_file =
@@ -732,14 +727,17 @@ namespace diskann {
 
       std::remove(shard_base_file.c_str());
     }
-    diskann::cout << timer.elapsed_seconds_for_step("building indices on shards") << std::endl;
+    diskann::cout << timer.elapsed_seconds_for_step(
+                         "building indices on shards")
+                  << std::endl;
 
     timer.reset();
     diskann::merge_shards(merged_index_prefix + "_subshard-", "_mem.index",
                           merged_index_prefix + "_subshard-", "_ids_uint32.bin",
                           num_parts, R, mem_index_path, medoids_file,
                           use_filters, labels_to_medoids_file);
-   diskann::cout << timer.elapsed_seconds_for_step("merging indices") << std::endl;
+    diskann::cout << timer.elapsed_seconds_for_step("merging indices")
+                  << std::endl;
 
     // delete tempFiles
     for (int p = 0; p < num_parts; p++) {
@@ -748,7 +746,7 @@ namespace diskann {
       std::string shard_id_file = merged_index_prefix + "_subshard-" +
                                   std::to_string(p) + "_ids_uint32.bin";
       std::string shard_labels_file = merged_index_prefix + "_subshard-" +
-                                      std::to_string(p) + "_labels.txt";                                  
+                                      std::to_string(p) + "_labels.txt";
       std::string shard_index_file =
           merged_index_prefix + "_subshard-" + std::to_string(p) + "_mem.index";
       std::string shard_index_file_data = shard_index_file + ".data";
@@ -767,7 +765,7 @@ namespace diskann {
         std::remove(shard_index_label_file.c_str());
         std::remove(shard_index_label_map_file.c_str());
         std::remove(shard_index_univ_label_file.c_str());
-      }      
+      }
     }
     return 0;
   }
@@ -789,7 +787,7 @@ namespace diskann {
     while (!stop_flag) {
       std::vector<uint64_t> tuning_sample_result_ids_64(tuning_sample_num, 0);
       std::vector<float>    tuning_sample_result_dists(tuning_sample_num, 0);
-      diskann::QueryStats  *stats = new diskann::QueryStats[tuning_sample_num];
+      diskann::QueryStats * stats = new diskann::QueryStats[tuning_sample_num];
 
       auto s = std::chrono::high_resolution_clock::now();
 #pragma omp parallel for schedule(dynamic, 1) num_threads(nthreads)
@@ -816,7 +814,7 @@ namespace diskann {
       if (qps > max_qps && lat_999 < (15000) + mean_latency * 2) {
         max_qps = qps;
         best_bw = cur_bw;
-        cur_bw = (uint32_t) (std::ceil)((float) cur_bw * 1.1f);
+        cur_bw = (uint32_t)(std::ceil)((float) cur_bw * 1.1f);
       } else {
         stop_flag = true;
       }
@@ -1047,9 +1045,9 @@ namespace diskann {
 
   template<typename T>
   int build_disk_index(const char *dataFilePath, const char *indexFilePath,
-                       const char     *indexBuildParameters,
-                       diskann::Metric compareMetric, bool use_opq, bool use_filters,
-                       const std::string &label_file,
+                       const char *    indexBuildParameters,
+                       diskann::Metric compareMetric, bool use_opq,
+                       bool use_filters, const std::string &label_file,
                        const std::string &universal_label,
                        const _u32 filter_threshold, const _u32 Lf) {
     std::stringstream parser;
@@ -1211,7 +1209,6 @@ namespace diskann {
       }
     }
 
-
     size_t points_num, dim;
 
     Timer timer;
@@ -1225,7 +1222,7 @@ namespace diskann {
                                       compareMetric, p_val, disk_pq_dims);
     }
     size_t num_pq_chunks =
-        (size_t) (std::floor)(_u64(final_index_ram_limit / points_num));
+        (size_t)(std::floor)(_u64(final_index_ram_limit / points_num));
 
     num_pq_chunks = num_pq_chunks <= 0 ? 1 : num_pq_chunks;
     num_pq_chunks = num_pq_chunks > dim ? dim : num_pq_chunks;
@@ -1238,7 +1235,8 @@ namespace diskann {
     generate_quantized_data<T>(data_file_to_use, pq_pivots_path,
                                pq_compressed_vectors_path, compareMetric, p_val,
                                num_pq_chunks, use_opq);
-    diskann::cout << timer.elapsed_seconds_for_step("generating quantized data") << std::endl;
+    diskann::cout << timer.elapsed_seconds_for_step("generating quantized data")
+                  << std::endl;
 
 // Gopal. Splitting diskann_dll into separate DLLs for search and build.
 // This code should only be available in the "build" DLL.
@@ -1251,9 +1249,8 @@ namespace diskann {
     diskann::build_merged_vamana_index<T>(
         data_file_to_use.c_str(), diskann::Metric::L2, L, R, p_val,
         indexing_ram_budget, mem_index_path, medoids_path, centroids_path,
-        build_pq_bytes, use_opq,
-        use_filters, labels_file_to_use, labels_to_medoids_path,
-        universal_label, Lf);
+        build_pq_bytes, use_opq, use_filters, labels_file_to_use,
+        labels_to_medoids_path, universal_label, Lf);
     diskann::cout << timer.elapsed_seconds_for_step(
                          "building merged vamana index")
                   << std::endl;
@@ -1354,22 +1351,19 @@ namespace diskann {
   template DISKANN_DLLEXPORT int build_disk_index<int8_t>(
       const char *dataFilePath, const char *indexFilePath,
       const char *indexBuildParameters, diskann::Metric compareMetric,
-      bool use_opq,
-      bool use_filters, const std::string &label_file,
+      bool use_opq, bool use_filters, const std::string &label_file,
       const std::string &universal_label, const _u32 filter_threshold,
       const _u32 Lf);
   template DISKANN_DLLEXPORT int build_disk_index<uint8_t>(
       const char *dataFilePath, const char *indexFilePath,
       const char *indexBuildParameters, diskann::Metric compareMetric,
-      bool use_opq,
-      bool use_filters, const std::string &label_file,
+      bool use_opq, bool use_filters, const std::string &label_file,
       const std::string &universal_label, const _u32 filter_threshold,
       const _u32 Lf);
   template DISKANN_DLLEXPORT int build_disk_index<float>(
       const char *dataFilePath, const char *indexFilePath,
       const char *indexBuildParameters, diskann::Metric compareMetric,
-      bool use_opq,
-      bool use_filters, const std::string &label_file,
+      bool use_opq, bool use_filters, const std::string &label_file,
       const std::string &universal_label, const _u32 filter_threshold,
       const _u32 Lf);
 
@@ -1377,21 +1371,24 @@ namespace diskann {
       std::string base_file, diskann::Metric compareMetric, unsigned L,
       unsigned R, double sampling_rate, double ram_budget,
       std::string mem_index_path, std::string medoids_path,
-      std::string centroids_file, size_t build_pq_bytes, bool use_opq, bool use_filters,
-      const std::string &label_file, const std::string &labels_to_medoids_file,
+      std::string centroids_file, size_t build_pq_bytes, bool use_opq,
+      bool use_filters, const std::string &label_file,
+      const std::string &labels_to_medoids_file,
       const std::string &universal_label, const _u32 Lf);
   template DISKANN_DLLEXPORT int build_merged_vamana_index<float>(
       std::string base_file, diskann::Metric compareMetric, unsigned L,
       unsigned R, double sampling_rate, double ram_budget,
       std::string mem_index_path, std::string medoids_path,
-      std::string centroids_file, size_t build_pq_bytes, bool use_opq, bool use_filters,
-      const std::string &label_file, const std::string &labels_to_medoids_file,
+      std::string centroids_file, size_t build_pq_bytes, bool use_opq,
+      bool use_filters, const std::string &label_file,
+      const std::string &labels_to_medoids_file,
       const std::string &universal_label, const _u32 Lf);
   template DISKANN_DLLEXPORT int build_merged_vamana_index<uint8_t>(
       std::string base_file, diskann::Metric compareMetric, unsigned L,
       unsigned R, double sampling_rate, double ram_budget,
       std::string mem_index_path, std::string medoids_path,
-      std::string centroids_file, size_t build_pq_bytes, bool use_opq, bool use_filters,
-      const std::string &label_file, const std::string &labels_to_medoids_file,
+      std::string centroids_file, size_t build_pq_bytes, bool use_opq,
+      bool use_filters, const std::string &label_file,
+      const std::string &labels_to_medoids_file,
       const std::string &universal_label, const _u32 Lf);
 };  // namespace diskann

--- a/src/disk_utils.cpp
+++ b/src/disk_utils.cpp
@@ -605,9 +605,9 @@ namespace diskann {
 
     double full_index_ram =
         estimate_ram_usage(base_num, base_dim, sizeof(T), R);
-    if (full_index_ram <
-        ram_budget * 1024 * 1024 *
-            1024) {  // TODO: Make this honest when there is filter support
+
+    // TODO: Make this honest when there is filter support
+    if (full_index_ram < ram_budget * 1024 * 1024 * 1024) {  
       diskann::cout << "Full index fits in RAM budget, should consume at most "
                     << full_index_ram / (1024 * 1024 * 1024)
                     << "GiBs, so building in one shot" << std::endl;

--- a/src/disk_utils.cpp
+++ b/src/disk_utils.cpp
@@ -1196,9 +1196,9 @@ namespace diskann {
     // into replica dummy points which evenly distribute the filters. The rest
     // of index build happens on the augmented base and labels
     std::string augmented_data_file, augmented_labels_file;
-    if (use_filters) {      
+    if (use_filters) {
       augmented_data_file = index_prefix_path + "_augmented_data.bin";
-      augmented_labels_file = index_prefix_path + "_augmented_labels.txt"; 
+      augmented_labels_file = index_prefix_path + "_augmented_labels.txt";
       if (filter_threshold != 0) {
         dummy_remap_file = index_prefix_path + "_dummy_remap.txt";
         breakup_dense_points<T>(

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -173,7 +173,7 @@ namespace diskann {
       return 0;
     }
     size_t tag_bytes_written;
-    TagT  *tag_data = new TagT[_nd + _num_frozen_pts];
+    TagT * tag_data = new TagT[_nd + _num_frozen_pts];
     for (_u32 i = 0; i < _nd; i++) {
       TagT tag;
       if (_location_to_tag.try_get(i, tag)) {
@@ -226,7 +226,7 @@ namespace diskann {
       max_degree = _final_graph[i].size() > max_degree
                        ? (_u32) _final_graph[i].size()
                        : max_degree;
-      index_size += (_u64) (sizeof(unsigned) * (GK + 1));
+      index_size += (_u64)(sizeof(unsigned) * (GK + 1));
     }
     out.seekp(file_offset, out.beg);
     out.write((char *) &index_size, sizeof(uint64_t));
@@ -270,8 +270,7 @@ namespace diskann {
     std::unique_lock<std::shared_timed_mutex> dl(_delete_lock);
 
     if (!_save_as_one_file) {
-
-    if (_filtered_index) {
+      if (_filtered_index) {
         if (_filter_to_medoid_id.size() > 0) {
           std::ofstream medoid_writer(std::string(filename) +
                                       "_labels_to_medoids.txt");
@@ -350,7 +349,7 @@ namespace diskann {
     }
 
     size_t file_dim, file_num_points;
-    TagT  *tag_data;
+    TagT * tag_data;
 #ifdef EXEC_ENV_OLS
     load_bin<TagT>(reader, tag_data, file_num_points, file_dim);
 #else
@@ -473,7 +472,7 @@ namespace diskann {
 
     size_t tags_file_num_pts = 0, graph_num_pts = 0, data_file_num_pts = 0;
 
-  std::string mem_index_file(filename);
+    std::string mem_index_file(filename);
     std::string labels_file = mem_index_file + "_labels.txt";
     std::string labels_to_medoids = mem_index_file + "_labels_to_medoids.txt";
     if (file_exists(labels_file)) {
@@ -754,7 +753,7 @@ namespace diskann {
 #pragma omp parallel for schedule(static, 65536)
     for (_s64 i = 0; i < (_s64) _nd; i++) {
       // extract point and distance reference
-      float   &dist = distances[i];
+      float &  dist = distances[i];
       const T *cur_vec = _data + (i * (size_t) _aligned_dim);
       dist = 0;
       float diff = 0;
@@ -782,11 +781,11 @@ namespace diskann {
   template<typename T, typename TagT>
   std::pair<uint32_t, uint32_t> Index<T, TagT>::iterate_to_fixed_point(
       const T *query, const unsigned Lsize,
-      const std::vector<unsigned> &init_ids, InMemQueryScratch<T> *scratch, bool use_filter,
-      const std::vector<std::string> &filter_label, 
+      const std::vector<unsigned> &init_ids, InMemQueryScratch<T> *scratch,
+      bool use_filter, const std::vector<std::string> &filter_label,
       bool ret_frozen, bool search_invocation) {
-    std::vector<Neighbor>    &expanded_nodes = scratch->pool();
-    std::vector<Neighbor>    &best_L_nodes = scratch->best_l_nodes();
+    std::vector<Neighbor> &   expanded_nodes = scratch->pool();
+    std::vector<Neighbor> &   best_L_nodes = scratch->best_l_nodes();
     tsl::robin_set<unsigned> &inserted_into_pool_rs =
         scratch->inserted_into_pool_rs();
     boost::dynamic_bitset<> &inserted_into_pool_bs =
@@ -803,7 +802,7 @@ namespace diskann {
     float *query_float;
     float *query_rotated;
     float *pq_dists;
-    _u8   *pq_coord_scratch;
+    _u8 *  pq_coord_scratch;
     // Intialize PQ related scratch to use PQ based distances
     if (_pq_dist) {
       // Get scratch spaces
@@ -876,7 +875,7 @@ namespace diskann {
             __FILE__, __LINE__);
       }
 
-     if (use_filter) {
+      if (use_filter) {
         std::vector<std::string> common_filters;
         auto &                   x = _pts_to_labels[id];
         std::set_intersection(filter_label.begin(), filter_label.end(),
@@ -933,9 +932,13 @@ namespace diskann {
         if (!search_invocation && (best_L_nodes[best_unchanged].id != _start ||
                                    _num_frozen_pts == 0 || ret_frozen)) {
           if (!use_filter) {
-          expanded_nodes.emplace_back(best_L_nodes[best_unchanged]); 
-          } else { // in filter based indexing, the same point might invoke multiple iterate_to_fixed_points, so need to be careful not to add the same item to pool multiple times. 
-           if (std::find(expanded_nodes.begin(), expanded_nodes.end(), best_L_nodes[best_unchanged]) == expanded_nodes.end()) {
+            expanded_nodes.emplace_back(best_L_nodes[best_unchanged]);
+          } else {  // in filter based indexing, the same point might invoke
+                    // multiple iterate_to_fixed_points, so need to be careful
+                    // not to add the same item to pool multiple times.
+            if (std::find(expanded_nodes.begin(), expanded_nodes.end(),
+                          best_L_nodes[best_unchanged]) ==
+                expanded_nodes.end()) {
               expanded_nodes.emplace_back(best_L_nodes[best_unchanged]);
             }
           }
@@ -951,7 +954,7 @@ namespace diskann {
 
             if (use_filter) {  // NOTE: NEED TO CHECK IF THIS CORRECT WITH
                                // NEW LOCKS.
-//              _u32                     id = _final_graph[n][m];
+              //              _u32                     id = _final_graph[n][m];
               std::vector<std::string> common_filters;
               auto &                   x = _pts_to_labels[id];
               std::set_intersection(filter_label.begin(), filter_label.end(),
@@ -967,7 +970,6 @@ namespace diskann {
               if (common_filters.size() == 0)
                 continue;
             }
-
 
             if (is_not_visited(id)) {
               id_scratch.push_back(id);
@@ -1036,21 +1038,22 @@ namespace diskann {
   template<typename T, typename TagT>
   void Index<T, TagT>::search_for_point_and_add_links(
       int location, _u32 Lindex, InMemQueryScratch<T> *scratch, bool use_filter,
-                            const std::vector<std::string> &filters, _u32 filteredLindex) {
+      const std::vector<std::string> &filters, _u32 filteredLindex) {
     std::vector<unsigned> init_ids;
     init_ids.emplace_back(_start);
 
     std::vector<std::string> dummy;
 
     if (!use_filter) {
-    iterate_to_fixed_point(_data + _aligned_dim * location, Lindex, init_ids,
-                           scratch, false, dummy, true, false);
+      iterate_to_fixed_point(_data + _aligned_dim * location, Lindex, init_ids,
+                             scratch, false, dummy, true, false);
     } else {
-           std::vector<_u32> filter_specific_start_nodes;
-            for (auto &x : _pts_to_labels[location])
-              filter_specific_start_nodes.emplace_back(_filter_to_medoid_id[x]);
-            iterate_to_fixed_point(_data + _aligned_dim * location, filteredLindex, filter_specific_start_nodes,
-                           scratch, true, _pts_to_labels[location], true, false);
+      std::vector<_u32> filter_specific_start_nodes;
+      for (auto &x : _pts_to_labels[location])
+        filter_specific_start_nodes.emplace_back(_filter_to_medoid_id[x]);
+      iterate_to_fixed_point(_data + _aligned_dim * location, filteredLindex,
+                             filter_specific_start_nodes, scratch, true,
+                             _pts_to_labels[location], true, false);
     }
 
     auto &pool = scratch->pool();
@@ -1081,7 +1084,7 @@ namespace diskann {
       _final_graph[location].clear();
       _final_graph[location].shrink_to_fit();
       _final_graph[location].reserve(
-          (_u64) (_indexingRange * GRAPH_SLACK_FACTOR * 1.05));
+          (_u64)(_indexingRange * GRAPH_SLACK_FACTOR * 1.05));
 
       for (auto link : pruned_list) {
         if (_conc_consolidate)
@@ -1103,7 +1106,7 @@ namespace diskann {
                                     const float alpha, const unsigned degree,
                                     const unsigned         maxc,
                                     std::vector<Neighbor> &result,
-                                    InMemQueryScratch<T>  *scratch) {
+                                    InMemQueryScratch<T> * scratch) {
     if (pool.size() == 0)
       return;
 
@@ -1134,7 +1137,7 @@ namespace diskann {
           if (occlude_factor[t] > alpha)
             continue;
 
-         bool prune_allowed = true;
+          bool prune_allowed = true;
           if (_filtered_index) {
             _u32 a = iter->id;
             _u32 b = iter2->id;
@@ -1149,7 +1152,6 @@ namespace diskann {
           }
           if (!prune_allowed)
             continue;
-
 
           float djk =
               _distance->compare(_data + _aligned_dim * (size_t) iter2->id,
@@ -1178,7 +1180,7 @@ namespace diskann {
   void Index<T, TagT>::prune_neighbors(const unsigned         location,
                                        std::vector<Neighbor> &pool,
                                        std::vector<unsigned> &pruned_list,
-                                       InMemQueryScratch<T>  *scratch) {
+                                       InMemQueryScratch<T> * scratch) {
     prune_neighbors(location, pool, _indexingRange, _indexingMaxC,
                     _indexingAlpha, pruned_list, scratch);
   }
@@ -1232,7 +1234,7 @@ namespace diskann {
   void Index<T, TagT>::inter_insert(unsigned               n,
                                     std::vector<unsigned> &pruned_list,
                                     const _u32             range,
-                                    InMemQueryScratch<T>  *scratch) {
+                                    InMemQueryScratch<T> * scratch) {
     const auto &src_pool = pruned_list;
 
     assert(!src_pool.empty());
@@ -1245,9 +1247,9 @@ namespace diskann {
       bool                  prune_needed = false;
       {
         LockGuard guard(_locks[des]);
-        auto     &des_pool = _final_graph[des];
+        auto &    des_pool = _final_graph[des];
         if (std::find(des_pool.begin(), des_pool.end(), n) == des_pool.end()) {
-          if (des_pool.size() < (_u64) (GRAPH_SLACK_FACTOR * range)) {
+          if (des_pool.size() < (_u64)(GRAPH_SLACK_FACTOR * range)) {
             des_pool.emplace_back(n);
             prune_needed = false;
           } else {
@@ -1263,7 +1265,7 @@ namespace diskann {
         std::vector<Neighbor>    dummy_pool(0);
 
         size_t reserveSize =
-            (size_t) (std::ceil(1.05 * GRAPH_SLACK_FACTOR * range));
+            (size_t)(std::ceil(1.05 * GRAPH_SLACK_FACTOR * range));
         dummy_visited.reserve(reserveSize);
         dummy_pool.reserve(reserveSize);
 
@@ -1295,7 +1297,7 @@ namespace diskann {
   template<typename T, typename TagT>
   void Index<T, TagT>::inter_insert(unsigned               n,
                                     std::vector<unsigned> &pruned_list,
-                                    InMemQueryScratch<T>  *scratch) {
+                                    InMemQueryScratch<T> * scratch) {
     inter_insert(n, pruned_list, _indexingRange, scratch);
   }
 
@@ -1311,11 +1313,11 @@ namespace diskann {
       omp_set_num_threads(num_threads);
 
     _indexingQueueSize = parameters.Get<unsigned>("L");  // Search list size
-   _u32        Lf = 0;
+    _u32 Lf = 0;
     if (_filtered_index) {
       Lf = parameters.Get<unsigned>(
           "Lf");  // candidate list size for filtered build
-    }    
+    }
     _indexingRange = parameters.Get<unsigned>("R");
     _indexingMaxC = parameters.Get<unsigned>("C");
     _indexingAlpha = parameters.Get<float>("alpha");
@@ -1340,7 +1342,7 @@ namespace diskann {
 
     for (uint64_t p = 0; p < _nd; p++) {
       _final_graph[p].reserve(
-          (size_t) (std::ceil(_indexingRange * GRAPH_SLACK_FACTOR * 1.05)));
+          (size_t)(std::ceil(_indexingRange * GRAPH_SLACK_FACTOR * 1.05)));
     }
 
     std::vector<unsigned> init_ids;
@@ -1349,8 +1351,7 @@ namespace diskann {
     diskann::Timer link_timer;
 
 #pragma omp parallel for schedule(dynamic, 2048)
-    for (_s64 node_ctr = 0; node_ctr < (_s64) (visit_order.size());
-         node_ctr++) {
+    for (_s64 node_ctr = 0; node_ctr < (_s64)(visit_order.size()); node_ctr++) {
       auto node = visit_order[node_ctr];
 
       ScratchStoreManager<InMemQueryScratch<T>> manager(_query_scratch);
@@ -1368,8 +1369,7 @@ namespace diskann {
       diskann::cout << "Starting final cleanup.." << std::flush;
     }
 #pragma omp parallel for schedule(dynamic, 2048)
-    for (_s64 node_ctr = 0; node_ctr < (_s64) (visit_order.size());
-         node_ctr++) {
+    for (_s64 node_ctr = 0; node_ctr < (_s64)(visit_order.size()); node_ctr++) {
       auto node = visit_order[node_ctr];
       if (_final_graph[node].size() > _indexingRange) {
         ScratchStoreManager<InMemQueryScratch<T>> manager(_query_scratch);
@@ -1497,7 +1497,7 @@ namespace diskann {
 
   template<typename T, typename TagT>
   void Index<T, TagT>::build(const T *data, const size_t num_points_to_load,
-                             Parameters              &parameters,
+                             Parameters &             parameters,
                              const std::vector<TagT> &tags) {
     if (num_points_to_load == 0) {
       throw ANNException("Do not call build with 0 points", -1, __FUNCSIG__,
@@ -1523,9 +1523,9 @@ namespace diskann {
   }
 
   template<typename T, typename TagT>
-  void Index<T, TagT>::build(const char              *filename,
+  void Index<T, TagT>::build(const char *             filename,
                              const size_t             num_points_to_load,
-                             Parameters              &parameters,
+                             Parameters &             parameters,
                              const std::vector<TagT> &tags) {
     if (num_points_to_load == 0)
       throw ANNException("Do not call build with 0 points", -1, __FUNCSIG__,
@@ -1625,7 +1625,7 @@ namespace diskann {
   }
 
   template<typename T, typename TagT>
-  void Index<T, TagT>::build(const char  *filename,
+  void Index<T, TagT>::build(const char * filename,
                              const size_t num_points_to_load,
                              Parameters &parameters, const char *tag_filename) {
     std::vector<TagT> tags;
@@ -1638,7 +1638,7 @@ namespace diskann {
         if (file_exists(tag_filename)) {
           diskann::cout << "Loading tags from " << tag_filename
                         << " for vamana index build" << std::endl;
-          TagT  *tag_data = nullptr;
+          TagT * tag_data = nullptr;
           size_t npts, ndim;
           diskann::load_bin(tag_filename, tag_data, npts, ndim);
           if (npts < num_points_to_load) {
@@ -1663,8 +1663,7 @@ namespace diskann {
     build(filename, num_points_to_load, parameters, tags);
   }
 
-
-template<typename T, typename TagT>
+  template<typename T, typename TagT>
   void Index<T, TagT>::parse_label_file(const std::string &map_file) {
     // old Format of Label txt file: id \t filters with comma separators
     // new Format of Label txt file: filters with comma separators
@@ -1764,8 +1763,8 @@ template<typename T, typename TagT>
           _filter_to_medoid_id[x] = best_medoid;
           _medoid_counts[best_medoid]++;
           std::stringstream a;
-                    //a << "Medoid of " << x << " is " << best_medoid <<
-                    //std::endl; std::cout << a.str();
+          // a << "Medoid of " << x << " is " << best_medoid <<
+          // std::endl; std::cout << a.str();
         }
       }
 #pragma omp critical
@@ -1778,13 +1777,12 @@ template<typename T, typename TagT>
     this->build(filename, num_points_to_load, parameters, tags);
   }
 
-
   template<typename T, typename TagT>
   template<typename IdType>
-  std::pair<uint32_t, uint32_t> Index<T, TagT>::search(const T       *query,
+  std::pair<uint32_t, uint32_t> Index<T, TagT>::search(const T *      query,
                                                        const size_t   K,
                                                        const unsigned L,
-                                                       IdType        *indices,
+                                                       IdType *       indices,
                                                        float *distances) {
     ScratchStoreManager<InMemQueryScratch<T>> manager(_query_scratch);
     auto                                      scratch = manager.scratch_space();
@@ -1798,13 +1796,12 @@ template<typename T, typename TagT>
       const T *query, const size_t K, const unsigned L, IdType *indices,
       float *distances, InMemQueryScratch<T> *scratch, bool use_filters,
       const std::string &filter_label) {
-    std::vector<unsigned> init_ids;
+    std::vector<unsigned>    init_ids;
     std::vector<std::string> filter_vec;
-
 
     std::shared_lock<std::shared_timed_mutex> lock(_update_lock);
 
-  if (use_filters) {
+    if (use_filters) {
       if (_filter_to_medoid_id.find(filter_label) != _filter_to_medoid_id.end())
         init_ids.emplace_back(_filter_to_medoid_id[filter_label]);
       else {
@@ -1821,8 +1818,8 @@ template<typename T, typename TagT>
     T *aligned_query = scratch->aligned_query();
     memcpy(aligned_query, query, _dim * sizeof(T));
 
-    auto retval =
-        iterate_to_fixed_point(aligned_query, L, init_ids, scratch, use_filters, filter_vec, true, true);
+    auto retval = iterate_to_fixed_point(aligned_query, L, init_ids, scratch,
+                                         use_filters, filter_vec, true, true);
 
     auto best_L_nodes = scratch->best_l_nodes();
 
@@ -1861,11 +1858,10 @@ template<typename T, typename TagT>
                        filter_label);
   }
 
-
   template<typename T, typename TagT>
   size_t Index<T, TagT>::search_with_tags(const T *query, const uint64_t K,
                                           const unsigned L, TagT *tags,
-                                          float            *distances,
+                                          float *           distances,
                                           std::vector<T *> &res_vectors) {
     ScratchStoreManager<InMemQueryScratch<T>> manager(_query_scratch);
     auto                                      scratch = manager.scratch_space();
@@ -1876,7 +1872,7 @@ template<typename T, typename TagT>
                     << scratch->search_l << " but search L is: " << L
                     << std::endl;
     }
-    _u32  *indices = scratch->indices();
+    _u32 * indices = scratch->indices();
     float *dist_interim = scratch->interim_dists();
     search_impl(query, L, L, indices, dist_interim, scratch);
 
@@ -2100,7 +2096,7 @@ template<typename T, typename TagT>
         }
       }
     }
-    for (_s64 loc = _max_points; loc < (_s64) (_max_points + _num_frozen_pts);
+    for (_s64 loc = _max_points; loc < (_s64)(_max_points + _num_frozen_pts);
          loc++) {
       LockGuard                                 adj_list_lock(_locks[loc]);
       ScratchStoreManager<InMemQueryScratch<T>> manager(_query_scratch);
@@ -2432,7 +2428,7 @@ template<typename T, typename TagT>
         tl.lock();
 
         if (_nd >= _max_points) {
-          auto new_max_points = (size_t) (_max_points * INDEX_GROWTH_FACTOR);
+          auto new_max_points = (size_t)(_max_points * INDEX_GROWTH_FACTOR);
           resize(new_max_points);
         }
 
@@ -2508,7 +2504,7 @@ template<typename T, typename TagT>
 
   template<typename T, typename TagT>
   void Index<T, TagT>::lazy_delete(const std::vector<TagT> &tags,
-                                   std::vector<TagT>       &failed_tags) {
+                                   std::vector<TagT> &      failed_tags) {
     if (failed_tags.size() > 0) {
       throw ANNException("failed_tags should be passed as an empty list", -1,
                          __FUNCSIG__, __FILE__, __LINE__);
@@ -2641,7 +2637,7 @@ template<typename T, typename TagT>
 
     boost::dynamic_bitset<> flags{_nd, 0};
     unsigned                tmp_l = 0;
-    unsigned               *neighbors =
+    unsigned *              neighbors =
         (unsigned *) (_opt_graph + _node_size * _start + _data_len);
     unsigned MaxM_ep = *neighbors;
     neighbors++;
@@ -2671,7 +2667,7 @@ template<typename T, typename TagT>
       unsigned id = init_ids[i];
       if (id >= _nd)
         continue;
-      T    *x = (T *) (_opt_graph + _node_size * id);
+      T *   x = (T *) (_opt_graph + _node_size * id);
       float norm_x = *x;
       x++;
       float dist =
@@ -2702,7 +2698,7 @@ template<typename T, typename TagT>
           if (flags[id])
             continue;
           flags[id] = 1;
-          T    *data = (T *) (_opt_graph + _node_size * id);
+          T *   data = (T *) (_opt_graph + _node_size * id);
           float norm = *data;
           data++;
           float dist =
@@ -2746,60 +2742,60 @@ template<typename T, typename TagT>
   template DISKANN_DLLEXPORT class Index<uint8_t, uint64_t>;
 
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<float, uint64_t>::search<uint64_t>(const float *query, const size_t K,
+                             Index<float, uint64_t>::search<uint64_t>(const float *query, const size_t K,
                                            const unsigned L, uint64_t *indices,
                                            float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<float, uint64_t>::search<uint32_t>(const float *query, const size_t K,
+                             Index<float, uint64_t>::search<uint32_t>(const float *query, const size_t K,
                                            const unsigned L, uint32_t *indices,
                                            float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<uint8_t, uint64_t>::search<uint64_t>(const uint8_t *query,
+                             Index<uint8_t, uint64_t>::search<uint64_t>(const uint8_t *query,
                                              const size_t K, const unsigned L,
                                              uint64_t *indices,
-                                             float    *distances);
+                                             float *   distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<uint8_t, uint64_t>::search<uint32_t>(const uint8_t *query,
+                             Index<uint8_t, uint64_t>::search<uint32_t>(const uint8_t *query,
                                              const size_t K, const unsigned L,
                                              uint32_t *indices,
-                                             float    *distances);
+                                             float *   distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<int8_t, uint64_t>::search<uint64_t>(const int8_t *query, const size_t K,
+                             Index<int8_t, uint64_t>::search<uint64_t>(const int8_t *query, const size_t K,
                                             const unsigned L, uint64_t *indices,
                                             float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<int8_t, uint64_t>::search<uint32_t>(const int8_t *query, const size_t K,
+                             Index<int8_t, uint64_t>::search<uint32_t>(const int8_t *query, const size_t K,
                                             const unsigned L, uint32_t *indices,
                                             float *distances);
   // TagT==uint32_t
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<float, uint32_t>::search<uint64_t>(const float *query, const size_t K,
+                             Index<float, uint32_t>::search<uint64_t>(const float *query, const size_t K,
                                            const unsigned L, uint64_t *indices,
                                            float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<float, uint32_t>::search<uint32_t>(const float *query, const size_t K,
+                             Index<float, uint32_t>::search<uint32_t>(const float *query, const size_t K,
                                            const unsigned L, uint32_t *indices,
                                            float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<uint8_t, uint32_t>::search<uint64_t>(const uint8_t *query,
+                             Index<uint8_t, uint32_t>::search<uint64_t>(const uint8_t *query,
                                              const size_t K, const unsigned L,
                                              uint64_t *indices,
-                                             float    *distances);
+                                             float *   distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<uint8_t, uint32_t>::search<uint32_t>(const uint8_t *query,
+                             Index<uint8_t, uint32_t>::search<uint32_t>(const uint8_t *query,
                                              const size_t K, const unsigned L,
                                              uint32_t *indices,
-                                             float    *distances);
+                                             float *   distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<int8_t, uint32_t>::search<uint64_t>(const int8_t *query, const size_t K,
+                             Index<int8_t, uint32_t>::search<uint64_t>(const int8_t *query, const size_t K,
                                             const unsigned L, uint64_t *indices,
                                             float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<int8_t, uint32_t>::search<uint32_t>(const int8_t *query, const size_t K,
+                             Index<int8_t, uint32_t>::search<uint32_t>(const int8_t *query, const size_t K,
                                             const unsigned L, uint32_t *indices,
                                             float *distances);
 
- template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
+  template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
                              Index<float, uint64_t>::search_with_filters<uint64_t>(
       const float *query, const std::string &filter_label, const size_t K,
       const unsigned L, uint64_t *indices, float *distances);

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1665,8 +1665,7 @@ namespace diskann {
 
   template<typename T, typename TagT>
   void Index<T, TagT>::parse_label_file(const std::string &map_file) {
-    // old Format of Label txt file: id \t filters with comma separators
-    // new Format of Label txt file: filters with comma separators
+    // Format of Label txt file: filters with comma separators
 
     std::ifstream infile(map_file);
     std::string   line, token;
@@ -1683,9 +1682,6 @@ namespace diskann {
     while (std::getline(infile, line)) {
       std::istringstream       iss(line);
       std::vector<std::string> lbls(0);
-      // long int              val;
-      // getline(iss, token, '\t');
-      // _u32 i = (_u32) std::stoul(token);
       getline(iss, token, '\t');
       std::istringstream new_iss(token);
       while (getline(new_iss, token, ',')) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1666,6 +1666,9 @@ namespace diskann {
 
 template<typename T, typename TagT>
   void Index<T, TagT>::parse_label_file(const std::string &map_file) {
+    // old Format of Label txt file: id \t filters with comma separators
+    // new Format of Label txt file: filters with comma separators
+
     std::ifstream infile(map_file);
     std::string   line, token;
     unsigned      line_cnt = 0;
@@ -1682,8 +1685,8 @@ template<typename T, typename TagT>
       std::istringstream       iss(line);
       std::vector<std::string> lbls(0);
       // long int              val;
-//      getline(iss, token, '\t');
-//      _u32 i = (_u32) std::stoul(token);
+      // getline(iss, token, '\t');
+      // _u32 i = (_u32) std::stoul(token);
       getline(iss, token, '\t');
       std::istringstream new_iss(token);
       while (getline(new_iss, token, ',')) {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -292,7 +292,6 @@ namespace diskann {
         if (_pts_to_labels.size() > 0) {
           std::ofstream label_writer(std::string(filename) + "_labels.txt");
           for (_u32 i = 0; i < _pts_to_labels.size(); i++) {
-            label_writer << i << '\t';
             for (_u32 j = 0; j < (_pts_to_labels[i].size() - 1); j++) {
               label_writer << _pts_to_labels[i][j] << ",";
             }

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -559,9 +559,15 @@ namespace diskann {
   template<typename T>
   int PQFlashIndex<T>::load(uint32_t num_threads, const char *index_prefix) {
 #endif
+    std::string pq_table_bin = std::string(index_prefix) + "_pq_pivots.bin";
+    std::string pq_compressed_vectors =
+        std::string(index_prefix) + "_pq_compressed.bin";
+    std::string disk_index_file = std::string(index_prefix) + "_disk.index";
+    std::string medoids_file = std::string(disk_index_file) + "_medoids.bin";
+    std::string centroids_file =
+        std::string(disk_index_file) + "_centroids.bin";
 
-
-  std::string labels_file = std ::string(disk_index_file) + "_labels.txt";
+    std::string labels_file = std ::string(disk_index_file) + "_labels.txt";
     std::string labels_to_medoids =
         std ::string(disk_index_file) + "_labels_to_medoids.txt";
    std::string dummy_map_file =
@@ -632,14 +638,7 @@ namespace diskann {
       }      
     }
 
-    std::string pq_table_bin = std::string(index_prefix) + "_pq_pivots.bin";
-    std::string pq_compressed_vectors =
-        std::string(index_prefix) + "_pq_compressed.bin";
-    std::string disk_index_file = std::string(index_prefix) + "_disk.index";
-    std::string medoids_file = std::string(disk_index_file) + "_medoids.bin";
-    std::string centroids_file =
-        std::string(disk_index_file) + "_centroids.bin";
-
+    
     size_t pq_file_dim, pq_file_num_centroids;
 #ifdef EXEC_ENV_OLS
     get_bin_metadata(files, pq_table_bin, pq_file_num_centroids, pq_file_dim,

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-
 #include "common_includes.h"
 
 #include "timer.h"
@@ -19,7 +18,7 @@
 #define READ_UNSIGNED(stream, val) stream.read((char *) &val, sizeof(unsigned))
 
 // sector # on disk where node_id is present with in the graph part
-#define NODE_SECTOR_NO(node_id) (((_u64) (node_id)) / nnodes_per_sector + 1)
+#define NODE_SECTOR_NO(node_id) (((_u64)(node_id)) / nnodes_per_sector + 1)
 
 // obtains region of sector containing node
 #define OFFSET_TO_NODE(sector_buf, node_id) \
@@ -34,17 +33,17 @@
 
 // sector # beyond the end of graph where data for id is present for reordering
 #define VECTOR_SECTOR_NO(id) \
-  (((_u64) (id)) / nvecs_per_sector + reorder_data_start_sector)
+  (((_u64)(id)) / nvecs_per_sector + reorder_data_start_sector)
 
 // sector # beyond the end of graph where data for id is present for reordering
 #define VECTOR_SECTOR_OFFSET(id) \
-  ((((_u64) (id)) % nvecs_per_sector) * data_dim * sizeof(float))
+  ((((_u64)(id)) % nvecs_per_sector) * data_dim * sizeof(float))
 
 namespace diskann {
 
   template<typename T>
   PQFlashIndex<T>::PQFlashIndex(std::shared_ptr<AlignedFileReader> &fileReader,
-                                diskann::Metric m)
+                                diskann::Metric                     m)
       : reader(fileReader), metric(m) {
     if (m == diskann::Metric::COSINE || m == diskann::Metric::INNER_PRODUCT) {
       if (std::is_floating_point<T>::value) {
@@ -93,7 +92,7 @@ namespace diskann {
 
     if (_pts_to_labels != nullptr) {
       delete[] _pts_to_labels;
-    }    
+    }
   }
 
   template<typename T>
@@ -143,7 +142,7 @@ namespace diskann {
       std::vector<std::pair<_u32, char *>> nhoods;
       for (_u64 node_idx = start_idx; node_idx < end_idx; node_idx++) {
         AlignedRead read;
-        char       *buf = nullptr;
+        char *      buf = nullptr;
         alloc_aligned((void **) &buf, SECTOR_LEN, SECTOR_LEN);
         nhoods.push_back(std::make_pair(node_list[node_idx], buf));
         read.len = SECTOR_LEN;
@@ -165,8 +164,8 @@ namespace diskann {
 #endif
         auto &nhood = nhoods[i];
         char *node_buf = OFFSET_TO_NODE(nhood.second, nhood.first);
-        T    *node_coords = OFFSET_TO_NODE_COORDS(node_buf);
-        T    *cached_coords = coord_cache_buf + node_idx * aligned_dim;
+        T *   node_coords = OFFSET_TO_NODE_COORDS(node_buf);
+        T *   cached_coords = coord_cache_buf + node_idx * aligned_dim;
         memcpy(cached_coords, node_coords, disk_bytes_per_point);
         coord_cache.insert(std::make_pair(nhood.first, cached_coords));
 
@@ -174,7 +173,7 @@ namespace diskann {
         unsigned *node_nhood = OFFSET_TO_NODE_NHOOD(node_buf);
 
         auto                        nnbrs = *node_nhood;
-        unsigned                   *nbrs = node_nhood + 1;
+        unsigned *                  nbrs = node_nhood + 1;
         std::pair<_u32, unsigned *> cnhood;
         cnhood.first = nnbrs;
         cnhood.second = nhood_cache_buf + node_idx * (max_degree + 1);
@@ -209,7 +208,7 @@ namespace diskann {
     }
 
     _u64 sample_num, sample_dim, sample_aligned_dim;
-    T   *samples;
+    T *  samples;
 
 #ifdef EXEC_ENV_OLS
     if (files.fileExists(sample_bin)) {
@@ -262,7 +261,7 @@ namespace diskann {
     node_list.clear();
 
     // Do not cache more than 10% of the nodes in the index
-    _u64 tenp_nodes = (_u64) (std::round(this->num_points * 0.1));
+    _u64 tenp_nodes = (_u64)(std::round(this->num_points * 0.1));
     if (num_nodes_to_cache > tenp_nodes) {
       diskann::cout << "Reducing nodes to cache from: " << num_nodes_to_cache
                     << " to: " << tenp_nodes
@@ -345,7 +344,7 @@ namespace diskann {
           auto &nhood = nhoods[i];
 
           // insert node coord into coord_cache
-          char     *node_buf = OFFSET_TO_NODE(nhood.second, nhood.first);
+          char *    node_buf = OFFSET_TO_NODE(nhood.second, nhood.first);
           unsigned *node_nhood = OFFSET_TO_NODE_NHOOD(node_buf);
           _u64      nnbrs = (_u64) *node_nhood;
           unsigned *nbrs = node_nhood + 1;
@@ -397,7 +396,7 @@ namespace diskann {
     // borrow ctx
     ScratchStoreManager<SSDThreadData<T>> manager(this->thread_data);
     auto                                  data = manager.scratch_space();
-    IOContext                            &ctx = data->ctx;
+    IOContext &                           ctx = data->ctx;
     diskann::cout << "Loading centroid data from medoids vector data of "
                   << num_medoids << " medoid(s)" << std::endl;
     for (uint64_t cur_m = 0; cur_m < num_medoids; cur_m++) {
@@ -432,8 +431,7 @@ namespace diskann {
     }
   }
 
-
- template<typename T>
+  template<typename T>
   inline int32_t PQFlashIndex<T>::get_filter_number(
       const std::string &filter_label) {
     int idx = -1;
@@ -550,7 +548,6 @@ namespace diskann {
     }
   }
 
-
 #ifdef EXEC_ENV_OLS
   template<typename T>
   int PQFlashIndex<T>::load(MemoryMappedFiles &files, uint32_t num_threads,
@@ -570,8 +567,8 @@ namespace diskann {
     std::string labels_file = std ::string(disk_index_file) + "_labels.txt";
     std::string labels_to_medoids =
         std ::string(disk_index_file) + "_labels_to_medoids.txt";
-   std::string dummy_map_file =
-        std ::string(disk_index_file) + "_dummy_map.txt";        
+    std::string dummy_map_file =
+        std ::string(disk_index_file) + "_dummy_map.txt";
     if (file_exists(labels_file)) {
       parse_label_file(labels_file);
       if (file_exists(labels_to_medoids)) {
@@ -606,7 +603,7 @@ namespace diskann {
         universal_label_reader.close();
         set_universal_label(univ_label);
       }
-     if (file_exists(dummy_map_file)) {
+      if (file_exists(dummy_map_file)) {
         std::ifstream dummy_map_stream(dummy_map_file);
 
         std::string line, token;
@@ -635,10 +632,9 @@ namespace diskann {
         }
         dummy_map_stream.close();
         std::cout << "Loaded dummy map" << std::endl;
-      }      
+      }
     }
 
-    
     size_t pq_file_dim, pq_file_num_centroids;
 #ifdef EXEC_ENV_OLS
     get_bin_metadata(files, pq_table_bin, pq_file_num_centroids, pq_file_dim,
@@ -728,7 +724,7 @@ namespace diskann {
     this->setup_thread_data(num_threads);
     this->max_nthreads = num_threads;
 
-    char                    *bytes = getHeaderBytes();
+    char *                   bytes = getHeaderBytes();
     ContentBuf               buf(bytes, HEADER_SIZE);
     std::basic_istream<char> index_metadata(&buf);
 #else
@@ -865,7 +861,7 @@ namespace diskann {
     } else {
       num_medoids = 1;
       medoids = new uint32_t[1];
-      medoids[0] = (_u32) (medoid_id_on_file);
+      medoids[0] = (_u32)(medoid_id_on_file);
       use_medoids_data_as_centroids();
     }
 
@@ -917,7 +913,7 @@ namespace diskann {
   template<typename T>
   void PQFlashIndex<T>::cached_beam_search(const T *query1, const _u64 k_search,
                                            const _u64 l_search, _u64 *indices,
-                                           float      *distances,
+                                           float *     distances,
                                            const _u64  beam_width,
                                            const bool  use_reorder_data,
                                            QueryStats *stats) {
@@ -927,36 +923,35 @@ namespace diskann {
   }
 
   template<typename T>
-  void PQFlashIndex<T>::cached_beam_search(const T *query1, const _u64 k_search,
-                                           const _u64 l_search, _u64 *indices,
-                                           float      *distances,
-                                           const _u64  beam_width, const bool use_filter,
-        const std::string &filter_label,
-                                           const bool  use_reorder_data,
-                                           QueryStats *stats) {
-    cached_beam_search(query1, k_search, l_search, indices, distances,
-                       beam_width, use_filter, filter_label, std::numeric_limits<_u32>::max(),
-                       use_reorder_data, stats);
-  }
-
-template<typename T>
   void PQFlashIndex<T>::cached_beam_search(
       const T *query1, const _u64 k_search, const _u64 l_search, _u64 *indices,
-      float *distances, const _u64 beam_width, const _u32 io_limit,
-      const bool use_reorder_data, QueryStats *stats) {
-        std::string dummy_filter_string;
+      float *distances, const _u64 beam_width, const bool use_filter,
+      const std::string &filter_label, const bool use_reorder_data,
+      QueryStats *stats) {
     cached_beam_search(query1, k_search, l_search, indices, distances,
-                       beam_width, false, dummy_filter_string, std::numeric_limits<_u32>::max(),
-                       use_reorder_data, stats);
-      }
+                       beam_width, use_filter, filter_label,
+                       std::numeric_limits<_u32>::max(), use_reorder_data,
+                       stats);
+  }
 
   template<typename T>
   void PQFlashIndex<T>::cached_beam_search(
       const T *query1, const _u64 k_search, const _u64 l_search, _u64 *indices,
-      float *distances, const _u64 beam_width,  const bool use_filter,
-        const std::string &filter_label, const _u32 io_limit,
+      float *distances, const _u64 beam_width, const _u32 io_limit,
       const bool use_reorder_data, QueryStats *stats) {
+    std::string dummy_filter_string;
+    cached_beam_search(query1, k_search, l_search, indices, distances,
+                       beam_width, false, dummy_filter_string,
+                       std::numeric_limits<_u32>::max(), use_reorder_data,
+                       stats);
+  }
 
+  template<typename T>
+  void PQFlashIndex<T>::cached_beam_search(
+      const T *query1, const _u64 k_search, const _u64 l_search, _u64 *indices,
+      float *distances, const _u64 beam_width, const bool use_filter,
+      const std::string &filter_label, const _u32 io_limit,
+      const bool use_reorder_data, QueryStats *stats) {
     int32_t filter_num = 0;
     if (use_filter) {
       filter_num = get_filter_number(filter_label);
@@ -969,14 +964,13 @@ template<typename T>
       }
     }
 
-
     if (beam_width > MAX_N_SECTOR_READS)
       throw ANNException("Beamwidth can not be higher than MAX_N_SECTOR_READS",
                          -1, __FUNCSIG__, __FILE__, __LINE__);
 
     ScratchStoreManager<SSDThreadData<T>> manager(this->thread_data);
     auto                                  data = manager.scratch_space();
-    IOContext                            &ctx = data->ctx;
+    IOContext &                           ctx = data->ctx;
     auto                                  query_scratch = &(data->scratch);
     auto pq_query_scratch = query_scratch->_pq_scratch;
 
@@ -986,7 +980,7 @@ template<typename T>
     // copy query to thread specific aligned and allocated memory (for distance
     // calculations we need aligned data)
     float  query_norm = 0;
-    T     *aligned_query_T = query_scratch->aligned_query_T;
+    T *    aligned_query_T = query_scratch->aligned_query_T;
     float *query_float = pq_query_scratch->aligned_query_float;
     float *query_rotated = pq_query_scratch->rotated_query;
 
@@ -1013,7 +1007,7 @@ template<typename T>
     }
 
     // pointers to buffers for data
-    T    *data_buf = query_scratch->coord_scratch;
+    T *   data_buf = query_scratch->coord_scratch;
     _u64 &data_buf_idx = query_scratch->coord_idx;
     _mm_prefetch((char *) data_buf, _MM_HINT_T1);
 
@@ -1029,7 +1023,7 @@ template<typename T>
 
     // query <-> neighbor list
     float *dist_scratch = pq_query_scratch->aligned_dist_scratch;
-    _u8   *pq_coord_scratch = pq_query_scratch->aligned_pq_coord_scratch;
+    _u8 *  pq_coord_scratch = pq_query_scratch->aligned_pq_coord_scratch;
 
     // lambda to batch compute query<-> node distances in PQ space
     auto compute_dists = [this, pq_coord_scratch, pq_dists](const unsigned *ids,
@@ -1042,7 +1036,7 @@ template<typename T>
     };
     Timer query_timer, io_timer, cpu_timer;
 
-    tsl::robin_set<_u64>  &visited = query_scratch->visited;
+    tsl::robin_set<_u64> & visited = query_scratch->visited;
     std::vector<Neighbor> &retset = query_scratch->retset;
     std::vector<Neighbor> &full_retset = query_scratch->full_retset;
     retset.reserve(l_search + 1);
@@ -1050,15 +1044,15 @@ template<typename T>
     _u32  best_medoid = 0;
     float best_dist = (std::numeric_limits<float>::max)();
     if (!use_filter) {
-    for (_u64 cur_m = 0; cur_m < num_medoids; cur_m++) {
-      float cur_expanded_dist = dist_cmp_float->compare(
-          query_float, centroid_data + aligned_dim * cur_m,
-          (unsigned) aligned_dim);
-      if (cur_expanded_dist < best_dist) {
-        best_medoid = medoids[cur_m];
-        best_dist = cur_expanded_dist;
+      for (_u64 cur_m = 0; cur_m < num_medoids; cur_m++) {
+        float cur_expanded_dist = dist_cmp_float->compare(
+            query_float, centroid_data + aligned_dim * cur_m,
+            (unsigned) aligned_dim);
+        if (cur_expanded_dist < best_dist) {
+          best_medoid = medoids[cur_m];
+          best_dist = cur_expanded_dist;
+        }
       }
-    }
     } else if (_filter_to_medoid_id.find(filter_label) !=
                _filter_to_medoid_id.end()) {
       best_medoid = _filter_to_medoid_id[filter_label];
@@ -1160,7 +1154,7 @@ template<typename T>
       // process cached nhoods
       for (auto &cached_nhood : cached_nhoods) {
         auto  global_cache_iter = coord_cache.find(cached_nhood.first);
-        T    *node_fp_coords_copy = global_cache_iter->second;
+        T *   node_fp_coords_copy = global_cache_iter->second;
         float cur_expanded_dist;
         if (!use_disk_index_pq) {
           cur_expanded_dist = dist_cmp->compare(
@@ -1174,14 +1168,15 @@ template<typename T>
                 disk_pq_table.l2_distance(  // disk_pq does not support OPQ yet
                     query_float, (_u8 *) node_fp_coords_copy);
         }
-          _u32  real_id = cached_nhood.first;
-          if (_dummy_pts.find(real_id) != _dummy_pts.end()) {
-            real_id = _dummy_to_real_map[real_id];
-            }
-          Neighbor real_nbr(real_id, cur_expanded_dist, true); 
-          if (std::find(full_retset.begin(), full_retset.end(), real_nbr) == full_retset.end()) {
-            full_retset.emplace_back(real_nbr);
-          }
+        _u32 real_id = cached_nhood.first;
+        if (_dummy_pts.find(real_id) != _dummy_pts.end()) {
+          real_id = _dummy_to_real_map[real_id];
+        }
+        Neighbor real_nbr(real_id, cur_expanded_dist, true);
+        if (std::find(full_retset.begin(), full_retset.end(), real_nbr) ==
+            full_retset.end()) {
+          full_retset.emplace_back(real_nbr);
+        }
 
         _u64      nnbrs = cached_nhood.second.first;
         unsigned *node_nbrs = cached_nhood.second.second;
@@ -1198,16 +1193,15 @@ template<typename T>
         for (_u64 m = 0; m < nnbrs; ++m) {
           unsigned id = node_nbrs[m];
           if (visited.insert(id).second) {
-
             if (!use_filter && _dummy_pts.find(id) != _dummy_pts.end())
               continue;
 
             if (use_filter && !find_label_in_point(id, filter_num) &&
                 !find_label_in_point(id, _universal_filter_num))
-              continue;            
+              continue;
             cmps++;
-            float dist = dist_scratch[m];
-            Neighbor nn(id, dist, true);
+            float     dist = dist_scratch[m];
+            Neighbor  nn(id, dist, true);
             Neighbor &lastResult = retset[cur_list_size - 1];
             if ((lastResult < nn || lastResult == nn) &&
                 (cur_list_size == l_search))
@@ -1240,8 +1234,8 @@ template<typename T>
         char *node_disk_buf =
             OFFSET_TO_NODE(frontier_nhood.second, frontier_nhood.first);
         unsigned *node_buf = OFFSET_TO_NODE_NHOOD(node_disk_buf);
-        _u64      nnbrs = (_u64) (*node_buf);
-        T        *node_fp_coords = OFFSET_TO_NODE_COORDS(node_disk_buf);
+        _u64      nnbrs = (_u64)(*node_buf);
+        T *       node_fp_coords = OFFSET_TO_NODE_COORDS(node_disk_buf);
         //        assert(data_buf_idx < MAX_N_CMPS);
         if (data_buf_idx == MAX_N_CMPS)
           data_buf_idx = 0;
@@ -1262,15 +1256,15 @@ template<typename T>
                 query_float, (_u8 *) node_fp_coords_copy);
         }
 
-          _u32  real_id = frontier_nhood.first;
-          if (_dummy_pts.find(real_id) != _dummy_pts.end()) {
-            real_id = _dummy_to_real_map[real_id];
-            }
-          Neighbor real_nbr(real_id, cur_expanded_dist, true); 
-          if (std::find(full_retset.begin(), full_retset.end(), real_nbr) == full_retset.end()) {
-            full_retset.emplace_back(real_nbr);
-          }
-
+        _u32 real_id = frontier_nhood.first;
+        if (_dummy_pts.find(real_id) != _dummy_pts.end()) {
+          real_id = _dummy_to_real_map[real_id];
+        }
+        Neighbor real_nbr(real_id, cur_expanded_dist, true);
+        if (std::find(full_retset.begin(), full_retset.end(), real_nbr) ==
+            full_retset.end()) {
+          full_retset.emplace_back(real_nbr);
+        }
 
         full_retset.push_back(
             Neighbor(frontier_nhood.first, cur_expanded_dist, true));
@@ -1288,27 +1282,25 @@ template<typename T>
         for (_u64 m = 0; m < nnbrs; ++m) {
           unsigned id = node_nbrs[m];
           if (visited.insert(id).second) {
-
             if (!use_filter && _dummy_pts.find(id) != _dummy_pts.end())
               continue;
 
-
             if (use_filter && !find_label_in_point(id, filter_num) &&
                 !find_label_in_point(id, _universal_filter_num))
-              continue;            
+              continue;
             cmps++;
             float dist = dist_scratch[m];
             if (stats != nullptr) {
               stats->n_cmps++;
             }
-            Neighbor nn(id, dist, true);
+            Neighbor  nn(id, dist, true);
             Neighbor &lastResult = retset[cur_list_size - 1];
             if ((lastResult < nn || lastResult == nn) &&
                 (cur_list_size == l_search))
               continue;
-            auto     r = InsertIntoPool(
-                    retset.data(), cur_list_size,
-                    nn);  // Return position in sorted list where nn inserted.
+            auto r = InsertIntoPool(
+                retset.data(), cur_list_size,
+                nn);  // Return position in sorted list where nn inserted.
             if (cur_list_size < l_search)
               ++cur_list_size;
             if (r < nk)
@@ -1418,10 +1410,10 @@ template<typename T>
   _u32 PQFlashIndex<T>::range_search(const T *query1, const double range,
                                      const _u64          min_l_search,
                                      const _u64          max_l_search,
-                                     std::vector<_u64>  &indices,
+                                     std::vector<_u64> & indices,
                                      std::vector<float> &distances,
                                      const _u64          min_beam_width,
-                                     QueryStats         *stats) {
+                                     QueryStats *        stats) {
     _u32 res_count = 0;
 
     bool stop_flag = false;
@@ -1444,7 +1436,7 @@ template<typename T>
         } else if (i == l_search - 1)
           res_count = l_search;
       }
-      if (res_count < (_u32) (l_search / 2.0))
+      if (res_count < (_u32)(l_search / 2.0))
         stop_flag = true;
       l_search = l_search * 2;
       if (l_search > max_l_search)
@@ -1462,13 +1454,13 @@ template<typename T>
 
   template<typename T>
   diskann::Metric PQFlashIndex<T>::get_metric() {
-        return this->metric;
+    return this->metric;
   }
 
 #ifdef EXEC_ENV_OLS
   template<typename T>
   char *PQFlashIndex<T>::getHeaderBytes() {
-    IOContext  &ctx = reader->get_ctx();
+    IOContext & ctx = reader->get_ctx();
     AlignedRead readReq;
     readReq.buf = new char[PQFlashIndex<T>::HEADER_SIZE];
     readReq.len = PQFlashIndex<T>::HEADER_SIZE;

--- a/tests/search_memory_index.cpp
+++ b/tests/search_memory_index.cpp
@@ -120,6 +120,7 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
     }
 
     query_result_ids[test_id].resize(recall_at * query_num);
+    query_result_dists[test_id].resize(recall_at * query_num);  // Added this
     std::vector<T*> res = std::vector<T*>();
 
     auto s = std::chrono::high_resolution_clock::now();

--- a/tests/search_memory_index.cpp
+++ b/tests/search_memory_index.cpp
@@ -31,7 +31,8 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
                         const unsigned num_threads, const unsigned recall_at,
                         const bool                   print_all_recalls,
                         const std::vector<unsigned>& Lvec, const bool dynamic,
-                        const bool tags, const bool show_qps_per_thread, const std::string& filter_label) {
+                        const bool tags, const bool show_qps_per_thread,
+                        const std::string& filter_label) {
   // Load the query file
   T*        query = nullptr;
   unsigned* gt_ids = nullptr;
@@ -52,10 +53,9 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
   } else {
     diskann::cout << " Truthset file " << truthset_file
                   << " not found. Not computing recall." << std::endl;
-
   }
 
- bool filtered_search = false;
+  bool filtered_search = false;
   if (filter_label != "")
     filtered_search = true;
 
@@ -128,13 +128,13 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
 #pragma omp parallel for schedule(dynamic, 1)
     for (int64_t i = 0; i < (int64_t) query_num; i++) {
       auto qs = std::chrono::high_resolution_clock::now();
-     if (filtered_search) {
+      if (filtered_search) {
         auto retval = index.search_with_filters(
             query + i * query_aligned_dim, filter_label, recall_at, L,
             query_result_ids[test_id].data() + i * recall_at,
             query_result_dists[test_id].data() + i * recall_at);
         cmp_stats[i] = retval.second;
-      } else if (metric == diskann::FAST_L2) {        
+      } else if (metric == diskann::FAST_L2) {
         index.search_with_optimized_layout(
             query + i * query_aligned_dim, recall_at, L,
             query_result_ids[test_id].data() + i * recall_at);
@@ -188,12 +188,12 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
     if (tags) {
       std::cout << std::setw(4) << L << std::setw(12) << displayed_qps
                 << std::setw(20) << (float) mean_latency << std::setw(15)
-                << (float) latency_stats[(_u64) (0.999 * query_num)];
+                << (float) latency_stats[(_u64)(0.999 * query_num)];
     } else {
       std::cout << std::setw(4) << L << std::setw(12) << displayed_qps
                 << std::setw(18) << avg_cmps << std::setw(20)
                 << (float) mean_latency << std::setw(15)
-                << (float) latency_stats[(_u64) (0.999 * query_num)];
+                << (float) latency_stats[(_u64)(0.999 * query_num)];
     }
     for (float recall : recalls) {
       std::cout << std::setw(12) << recall;

--- a/tests/search_memory_index.cpp
+++ b/tests/search_memory_index.cpp
@@ -120,7 +120,7 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
     }
 
     query_result_ids[test_id].resize(recall_at * query_num);
-    query_result_dists[test_id].resize(recall_at * query_num);  // Added this
+    query_result_dists[test_id].resize(recall_at * query_num);
     std::vector<T*> res = std::vector<T*>();
 
     auto s = std::chrono::high_resolution_clock::now();

--- a/tests/utils/compute_groundtruth.cpp
+++ b/tests/utils/compute_groundtruth.cpp
@@ -409,7 +409,7 @@ inline void parse_label_file_into_vec(
     std::istringstream       iss(line);
     std::vector<std::string> lbls(0);
 
-    getline(iss, token, '\t');
+    //getline(iss, token, '\t');
     getline(iss, token, '\t');
     std::istringstream new_iss(token);
     while (getline(new_iss, token, ',')) {

--- a/tests/utils/compute_groundtruth.cpp
+++ b/tests/utils/compute_groundtruth.cpp
@@ -75,7 +75,7 @@ void compute_l2sq(float *const points_l2sq, const float *const matrix,
 
 void distsq_to_points(
     const size_t dim,
-    float       *dist_matrix,  // Col Major, cols are queries, rows are points
+    float *      dist_matrix,  // Col Major, cols are queries, rows are points
     size_t npoints, const float *const points,
     const float *const points_l2sq,  // points in Col major
     size_t nqueries, const float *const queries,
@@ -103,7 +103,7 @@ void distsq_to_points(
 
 void inner_prod_to_points(
     const size_t dim,
-    float       *dist_matrix,  // Col Major, cols are queries, rows are points
+    float *      dist_matrix,  // Col Major, cols are queries, rows are points
     size_t npoints, const float *const points, size_t nqueries,
     const float *const queries,
     float *ones_vec = NULL)  // Scratchspace of num_data size and init to 1.0
@@ -208,28 +208,28 @@ void exact_knn(
       for (_u64 p = 0; p < k; p++)
         point_dist.emplace(
             p, dist_matrix[(ptrdiff_t) p +
-                           (ptrdiff_t) (q - q_b) * (ptrdiff_t) npoints]);
+                           (ptrdiff_t)(q - q_b) * (ptrdiff_t) npoints]);
       for (_u64 p = k; p < npoints; p++) {
         if (point_dist.top().second >
             dist_matrix[(ptrdiff_t) p +
-                        (ptrdiff_t) (q - q_b) * (ptrdiff_t) npoints])
+                        (ptrdiff_t)(q - q_b) * (ptrdiff_t) npoints])
           point_dist.emplace(
               p, dist_matrix[(ptrdiff_t) p +
-                             (ptrdiff_t) (q - q_b) * (ptrdiff_t) npoints]);
+                             (ptrdiff_t)(q - q_b) * (ptrdiff_t) npoints]);
         if (point_dist.size() > k)
           point_dist.pop();
       }
       for (ptrdiff_t l = 0; l < (ptrdiff_t) k; ++l) {
-        closest_points[(ptrdiff_t) (k - 1 - l) +
-                       (ptrdiff_t) q * (ptrdiff_t) k] = point_dist.top().first;
-        dist_closest_points[(ptrdiff_t) (k - 1 - l) +
+        closest_points[(ptrdiff_t)(k - 1 - l) + (ptrdiff_t) q * (ptrdiff_t) k] =
+            point_dist.top().first;
+        dist_closest_points[(ptrdiff_t)(k - 1 - l) +
                             (ptrdiff_t) q * (ptrdiff_t) k] =
             point_dist.top().second;
         point_dist.pop();
       }
       assert(std::is_sorted(
           dist_closest_points + (ptrdiff_t) q * (ptrdiff_t) k,
-          dist_closest_points + (ptrdiff_t) (q + 1) * (ptrdiff_t) k));
+          dist_closest_points + (ptrdiff_t)(q + 1) * (ptrdiff_t) k));
     }
     std::cout << "Computed exact k-NN for queries: [" << q_b << "," << q_e
               << ")" << std::endl;
@@ -396,7 +396,6 @@ inline void save_groundtruth_as_one_file(const std::string filename,
   std::cout << "Finished writing truthset" << std::endl;
 }
 
-
 inline void parse_label_file_into_vec(
     size_t &line_cnt, const std::string &map_file,
     std::vector<std::vector<std::string>> &pts_to_labels) {
@@ -409,7 +408,7 @@ inline void parse_label_file_into_vec(
     std::istringstream       iss(line);
     std::vector<std::string> lbls(0);
 
-    //getline(iss, token, '\t');
+    // getline(iss, token, '\t');
     getline(iss, token, '\t');
     std::istringstream new_iss(token);
     while (getline(new_iss, token, ',')) {
@@ -479,7 +478,7 @@ int aux_main(const std::string &base_file, const std::string &label_file,
 
   std::vector<std::vector<std::pair<uint32_t, float>>> results(nqueries);
 
-  int   *closest_points = new int[nqueries * k];
+  int *  closest_points = new int[nqueries * k];
   float *dist_closest_points = new float[nqueries * k];
 
   std::vector<std::vector<std::string>> pts_to_labels;
@@ -489,7 +488,7 @@ int aux_main(const std::string &base_file, const std::string &label_file,
 
   for (int p = 0; p < num_parts; p++) {
     size_t start_id = p * PARTSIZE;
-   if (filter_label == "") {
+    if (filter_label == "") {
       load_bin_as_float<T>(base_file.c_str(), base_data, npoints, dim, p);
     } else {
       rev_map = load_filtered_bin_as_float<T>(
@@ -499,7 +498,7 @@ int aux_main(const std::string &base_file, const std::string &label_file,
     int *  closest_points_part = new int[nqueries * k];
     float *dist_closest_points_part = new float[nqueries * k];
 
-   _u32 part_k;
+    _u32 part_k;
     if (filter_label == "") {
       part_k = k < npoints ? k : npoints;
       exact_knn(dim, part_k, closest_points_part, dist_closest_points_part,
@@ -525,7 +524,7 @@ int aux_main(const std::string &base_file, const std::string &label_file,
           results[i].push_back(std::make_pair(
               (uint32_t)(rev_map[closest_points_part[i * part_k + j]]),
               dist_closest_points_part[i * part_k + j]));
-        }      
+        }
       }
     }
 
@@ -572,7 +571,7 @@ int aux_main(const std::string &base_file, const std::string &label_file,
 int main(int argc, char **argv) {
   std::string data_type, dist_fn, base_file, query_file, gt_file, tags_file,
       label_file, filter_label, universal_label;
-  uint64_t    K;
+  uint64_t K;
 
   try {
     po::options_description desc{"Arguments"};
@@ -645,11 +644,14 @@ int main(int argc, char **argv) {
 
   try {
     if (data_type == std::string("float"))
-      aux_main<float>(base_file, label_file, query_file, gt_file, K,  filter_label, universal_label, metric, tags_file);
+      aux_main<float>(base_file, label_file, query_file, gt_file, K,
+                      filter_label, universal_label, metric, tags_file);
     if (data_type == std::string("int8"))
-      aux_main<int8_t>(base_file, label_file,  query_file, gt_file, K,  filter_label, universal_label,  metric, tags_file);
+      aux_main<int8_t>(base_file, label_file, query_file, gt_file, K,
+                       filter_label, universal_label, metric, tags_file);
     if (data_type == std::string("uint8"))
-      aux_main<uint8_t>(base_file, label_file,  query_file, gt_file, K,  filter_label, universal_label,  metric, tags_file);
+      aux_main<uint8_t>(base_file, label_file, query_file, gt_file, K,
+                        filter_label, universal_label, metric, tags_file);
   } catch (const std::exception &e) {
     std::cout << std::string(e.what()) << std::endl;
     diskann::cerr << "Compute GT failed." << std::endl;

--- a/tests/utils/compute_groundtruth.cpp
+++ b/tests/utils/compute_groundtruth.cpp
@@ -408,7 +408,6 @@ inline void parse_label_file_into_vec(
     std::istringstream       iss(line);
     std::vector<std::string> lbls(0);
 
-    // getline(iss, token, '\t');
     getline(iss, token, '\t');
     std::istringstream new_iss(token);
     while (getline(new_iss, token, ',')) {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.

Fix filter search for memory and disk Index

- fixed label file format to be in sync (while reading the format was [ filters ] however during writing format was [ id \t filters ]). hence Invalid labels were getting used during search
- During Disk Index load, the argument for parse_label_file was incorrect (undeclared variable disk_index_file). hence, label file was not getting loaded.
- Resized query_result_dist vector for memory index
- gen_random_slice uses augmented data in case of filter threshold > 0. But the augmented file was deleted before generating the slices. Hence, shifted the remove file part after random gen_random_slice function.

filtered build and search disk and memory index verified with filter threshold 0.


#### Any other comments?

