### PR TITLE
Switch to integer filter comparisons for in-memory membrANNe indices

### DIFF
--- a/include/disk_utils.h
+++ b/include/disk_utils.h
@@ -94,7 +94,7 @@ DISKANN_DLLEXPORT void extract_shard_labels(
       std::string centroids_file, size_t build_pq_bytes, bool use_opq, bool use_filters = false,
       const std::string &label_file = std::string(""),
       const std::string &labels_to_medoids_file = std::string(""),
-      const std::string &universal_label = "", const _u32 Lf = 0);
+      const label &universal_label = UINT_MAX, const _u32 Lf = 0);
 
   template<typename T>
   DISKANN_DLLEXPORT uint32_t optimize_beamwidth(
@@ -111,7 +111,7 @@ DISKANN_DLLEXPORT void extract_shard_labels(
       bool               use_filters = false,
       const std::string &label_file =
           std::string(""),  // default is empty string for no label_file
-      const std::string &universal_label = "", const _u32 filter_threshold = 0,
+      const label &universal_label = UINT_MAX, const _u32 filter_threshold = 0,
       const _u32 Lf = 0);  // default is empty string for no universal label););
 
 

--- a/include/index.h
+++ b/include/index.h
@@ -128,7 +128,7 @@ namespace diskann {
         const size_t num_points_to_load, Parameters &parameters,
         const std::vector<TagT> &tags = std::vector<TagT>());
 
-    DISKANN_DLLEXPORT void set_universal_label(const std::string &label);
+    DISKANN_DLLEXPORT void set_universal_label(const label &label);
 
 
     // Set starting point of an index before inserting any points incrementally
@@ -160,7 +160,7 @@ namespace diskann {
 // Filter support search
     template<typename IndexType>
     DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t> search_with_filters(
-        const T *query, const std::string &filter_label, const size_t K,
+        const T *query, const label &filter_label, const size_t K,
         const unsigned L, IndexType *indices, float *distances);
 
 
@@ -239,17 +239,17 @@ namespace diskann {
                                               float                *distances,
                                               InMemQueryScratch<T> *scratch,
         bool               use_filters = false,
-        const std::string &filter_label = std::string());
+        const label &filter_label = -1);
 
     std::pair<uint32_t, uint32_t> iterate_to_fixed_point(
         const T *node_coords, const unsigned Lindex,
         const std::vector<unsigned> &init_ids, InMemQueryScratch<T> *scratch,  bool use_filter,
-        const std::vector<std::string> &filters, 
+        const std::vector<label> &filters, 
         bool ret_frozen = true, bool search_invocation = false);
 
     void search_for_point_and_add_links(int location, _u32 Lindex,
                                         InMemQueryScratch<T> *scratch, bool use_filter = false,
-                            const std::vector<std::string> &filters  = std::vector<std::string>(), _u32 filteredLindex = 0);
+                            const std::vector<label> &filters  = std::vector<label>(), _u32 filteredLindex = 0);
 
     void prune_neighbors(const unsigned location, std::vector<Neighbor> &pool,
                          std::vector<unsigned> &pruned_list,
@@ -358,13 +358,13 @@ namespace diskann {
    // Filter Support
 
     bool                                  _filtered_index = false;
-    std::vector<std::vector<std::string>> _pts_to_labels;
-    tsl::robin_set<std::string>           _labels;
+    std::vector<std::vector<label>> _pts_to_labels;
+    tsl::robin_set<label>           _labels;
     std::string                           _labels_file;
-    std::unordered_map<std::string, _u32> _filter_to_medoid_id;
+    std::unordered_map<label, _u32> _filter_to_medoid_id;
     std::unordered_map<_u32, _u32>        _medoid_counts;
     bool                                  _use_universal_label = false;
-    std::string                           _universal_label = "";
+    label                           _universal_label = UINT_MAX;
 
 
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -151,6 +151,7 @@ class AlignedFileReader;
 
 namespace diskann {
   static const size_t MAX_SIZE_OF_STREAMBUF = 2LL * 1024 * 1024 * 1024;
+	typedef unsigned label;
 
   inline void alloc_aligned(void** ptr, size_t size, size_t align) {
     *ptr = nullptr;

--- a/src/disk_utils.cpp
+++ b/src/disk_utils.cpp
@@ -599,7 +599,7 @@ namespace diskann {
       std::string centroids_file, size_t build_pq_bytes, bool use_opq,
       bool use_filters, const std::string &label_file,
       const std::string &labels_to_medoids_file,
-      const std::string &universal_label, const _u32 Lf) {
+      const label &universal_label, const _u32 Lf) {
     size_t base_num, base_dim;
     diskann::get_bin_metadata(base_file, base_num, base_dim);
 
@@ -631,7 +631,7 @@ namespace diskann {
       if (!use_filters)
         _pvamanaIndex->build(base_file.c_str(), base_num, paras);
       else {
-        if (universal_label != "") {  //  indicates no universal label
+        if (universal_label != UINT_MAX) {  //  indicates no universal label
           _pvamanaIndex->set_universal_label(universal_label);
         }
         _pvamanaIndex->build_filtered_index(base_file.c_str(), label_file,
@@ -707,7 +707,7 @@ namespace diskann {
       } else {
         diskann::extract_shard_labels(label_file, shard_ids_file,
                                       shard_labels_file);
-        if (universal_label != "") {  //  indicates no universal label
+        if (universal_label != UINT_MAX) {  //  indicates no universal label
           _pvamanaIndex->set_universal_label(universal_label);
         }
         _pvamanaIndex->build_filtered_index(
@@ -719,7 +719,7 @@ namespace diskann {
       if (p == 0) {
         std::string shard_universal_label_file =
             shard_index_file + "_universal_label.txt";
-        if (universal_label != "") {
+        if (universal_label != UINT_MAX) {
           copy_file(shard_universal_label_file,
                     final_index_universal_label_file);
         }
@@ -1048,7 +1048,7 @@ namespace diskann {
                        const char *    indexBuildParameters,
                        diskann::Metric compareMetric, bool use_opq,
                        bool use_filters, const std::string &label_file,
-                       const std::string &universal_label,
+                       const label &universal_label,
                        const _u32 filter_threshold, const _u32 Lf) {
     std::stringstream parser;
     parser << std::string(indexBuildParameters);
@@ -1281,7 +1281,7 @@ namespace diskann {
     if (use_filters) {
       copy_file(mem_labels_file, disk_labels_file);
       std::remove(mem_labels_file.c_str());
-      if (universal_label != "") {
+      if (universal_label != UINT_MAX) {
         copy_file(mem_univ_label_file, disk_univ_label_file);
         std::remove(mem_univ_label_file.c_str());
       }
@@ -1352,19 +1352,19 @@ namespace diskann {
       const char *dataFilePath, const char *indexFilePath,
       const char *indexBuildParameters, diskann::Metric compareMetric,
       bool use_opq, bool use_filters, const std::string &label_file,
-      const std::string &universal_label, const _u32 filter_threshold,
+      const label &universal_label, const _u32 filter_threshold,
       const _u32 Lf);
   template DISKANN_DLLEXPORT int build_disk_index<uint8_t>(
       const char *dataFilePath, const char *indexFilePath,
       const char *indexBuildParameters, diskann::Metric compareMetric,
       bool use_opq, bool use_filters, const std::string &label_file,
-      const std::string &universal_label, const _u32 filter_threshold,
+      const label &universal_label, const _u32 filter_threshold,
       const _u32 Lf);
   template DISKANN_DLLEXPORT int build_disk_index<float>(
       const char *dataFilePath, const char *indexFilePath,
       const char *indexBuildParameters, diskann::Metric compareMetric,
       bool use_opq, bool use_filters, const std::string &label_file,
-      const std::string &universal_label, const _u32 filter_threshold,
+      const label &universal_label, const _u32 filter_threshold,
       const _u32 Lf);
 
   template DISKANN_DLLEXPORT int build_merged_vamana_index<int8_t>(
@@ -1374,7 +1374,7 @@ namespace diskann {
       std::string centroids_file, size_t build_pq_bytes, bool use_opq,
       bool use_filters, const std::string &label_file,
       const std::string &labels_to_medoids_file,
-      const std::string &universal_label, const _u32 Lf);
+      const label &universal_label, const _u32 Lf);
   template DISKANN_DLLEXPORT int build_merged_vamana_index<float>(
       std::string base_file, diskann::Metric compareMetric, unsigned L,
       unsigned R, double sampling_rate, double ram_budget,
@@ -1382,7 +1382,7 @@ namespace diskann {
       std::string centroids_file, size_t build_pq_bytes, bool use_opq,
       bool use_filters, const std::string &label_file,
       const std::string &labels_to_medoids_file,
-      const std::string &universal_label, const _u32 Lf);
+      const label &universal_label, const _u32 Lf);
   template DISKANN_DLLEXPORT int build_merged_vamana_index<uint8_t>(
       std::string base_file, diskann::Metric compareMetric, unsigned L,
       unsigned R, double sampling_rate, double ram_budget,
@@ -1390,5 +1390,5 @@ namespace diskann {
       std::string centroids_file, size_t build_pq_bytes, bool use_opq,
       bool use_filters, const std::string &label_file,
       const std::string &labels_to_medoids_file,
-      const std::string &universal_label, const _u32 Lf);
+      const label &universal_label, const _u32 Lf);
 };  // namespace diskann

--- a/tests/build_disk_index.cpp
+++ b/tests/build_disk_index.cpp
@@ -97,8 +97,10 @@ int main(int argc, char** argv) {
   }
 
   bool use_filters = false;
+	diskann::label int_universal_label = UINT_MAX;
   if (label_file != "") {
     use_filters = true;
+		int_universal_label = (diskann::label) std::stoul(universal_label);
   }
 
   diskann::Metric metric;
@@ -138,20 +140,20 @@ int main(int argc, char** argv) {
 
   try {
     if (data_type == std::string("int8"))
-      return diskann::build_disk_index<int8_t>(
-          data_path.c_str(), index_path_prefix.c_str(), params.c_str(), metric,
-          use_opq, use_filters, label_file, universal_label, filter_threshold,
-          Lf);
+      return diskann::build_disk_index<int8_t>(data_path.c_str(),
+                                               index_path_prefix.c_str(),
+                                               params.c_str(), metric, use_opq,
+          use_filters, label_file, int_universal_label, filter_threshold, Lf);
     else if (data_type == std::string("uint8"))
       return diskann::build_disk_index<uint8_t>(
           data_path.c_str(), index_path_prefix.c_str(), params.c_str(), metric,
-          use_opq, use_filters, label_file, universal_label, filter_threshold,
-          Lf);
+          use_opq,
+          use_filters, label_file, int_universal_label, filter_threshold, Lf);
     else if (data_type == std::string("float"))
-      return diskann::build_disk_index<float>(
-          data_path.c_str(), index_path_prefix.c_str(), params.c_str(), metric,
-          use_opq, use_filters, label_file, universal_label, filter_threshold,
-          Lf);
+      return diskann::build_disk_index<float>(data_path.c_str(),
+                                              index_path_prefix.c_str(),
+                                              params.c_str(), metric, use_opq,
+          use_filters, label_file, int_universal_label, filter_threshold, Lf);
     else {
       diskann::cerr << "Error. Unsupported data type" << std::endl;
       return -1;

--- a/tests/build_memory_index.cpp
+++ b/tests/build_memory_index.cpp
@@ -49,7 +49,8 @@ int build_in_memory_index(const diskann::Metric& metric,
     index.build(data_path.c_str(), data_num, paras);
   } else {
     if (universal_label != "") {
-      index.set_universal_label(universal_label);
+			diskann::label int_universal_label = (diskann::label) std::stoul(universal_label);
+      index.set_universal_label(int_universal_label);
     }
     index.build_filtered_index(data_path.c_str(), label_file, data_num, paras);
   }

--- a/tests/search_memory_index.cpp
+++ b/tests/search_memory_index.cpp
@@ -58,6 +58,7 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
   bool filtered_search = false;
   if (filter_label != "")
     filtered_search = true;
+	diskann::label int_filter_label = (diskann::label) std::stoul(filter_label);
 
   using TagT = uint32_t;
   diskann::Index<T, TagT> index(metric, query_dim, 0, dynamic, tags);
@@ -130,7 +131,7 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
       auto qs = std::chrono::high_resolution_clock::now();
       if (filtered_search) {
         auto retval = index.search_with_filters(
-            query + i * query_aligned_dim, filter_label, recall_at, L,
+            query + i * query_aligned_dim, int_filter_label, recall_at, L,
             query_result_ids[test_id].data() + i * recall_at,
             query_result_dists[test_id].data() + i * recall_at);
         cmp_stats[i] = retval.second;


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
Current `std::set_intersection` calls for comparing the filters of two nodes rely on vectors of `std::string` based labels. Due to the overhead of comparing `std::strings`, we introduce a change requiring the labels to be integers. This change is required to reach the performance advertised in the WWW paper.

#### Any other comments?
In a future PR, we will introduce functionality to convert `std::string` labels into integers within the API, removing the requirement for the labels to be integers.

