### PR TITLE
labels from strings to ints for in-memory build

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -25,7 +25,6 @@
 #define DEFAULT_MAXC 750
 
 namespace diskann {
-    typedef unsigned label;
 
   inline double estimate_ram_usage(_u64 size, _u32 dim, _u32 datasize,
                                    _u32 degree) {
@@ -123,15 +122,13 @@ namespace diskann {
                                  Parameters              &parameters,
                                  const std::vector<TagT> &tags);
 
-
-// Filtered Support
+    // Filtered Support
     DISKANN_DLLEXPORT void build_filtered_index(
         const char *filename, const std::string &label_file,
         const size_t num_points_to_load, Parameters &parameters,
         const std::vector<TagT> &tags = std::vector<TagT>());
 
     DISKANN_DLLEXPORT void set_universal_label(const label &label);
-
 
     // Set starting point of an index before inserting any points incrementally
     DISKANN_DLLEXPORT void set_start_point(T *data);
@@ -159,12 +156,11 @@ namespace diskann {
                                               float            *distances,
                                               std::vector<T *> &res_vectors);
 
-// Filter support search
+    // Filter support search
     template<typename IndexType>
     DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t> search_with_filters(
         const T *query, const label &filter_label, const size_t K,
         const unsigned L, IndexType *indices, float *distances);
-
 
     // Will fail if tag already in the index or if tag=0.
     DISKANN_DLLEXPORT int insert_point(const T *point, const TagT tag);
@@ -236,22 +232,22 @@ namespace diskann {
     void parse_label_file(const std::string &map_file);
 
     template<typename IDType>
-    std::pair<uint32_t, uint32_t> search_impl(const T *query, const size_t K,
-                                              const unsigned L, IDType *indices,
-                                              float                *distances,
-                                              InMemQueryScratch<T> *scratch,
-        bool               use_filters = false,
-        const label &filter_label = -1);
+    std::pair<uint32_t, uint32_t> search_impl(
+        const T *query, const size_t K, const unsigned L, IDType *indices,
+        float *distances, InMemQueryScratch<T> *scratch,
+        bool use_filters = false, const label &filter_label = UINT_MAX);
 
     std::pair<uint32_t, uint32_t> iterate_to_fixed_point(
         const T *node_coords, const unsigned Lindex,
-        const std::vector<unsigned> &init_ids, InMemQueryScratch<T> *scratch,  bool use_filter,
-        const std::vector<label> &filters, 
+        const std::vector<unsigned> &init_ids, InMemQueryScratch<T> *scratch,
+        bool use_filter, const std::vector<label> &filters,
         bool ret_frozen = true, bool search_invocation = false);
 
-    void search_for_point_and_add_links(int location, _u32 Lindex,
-                                        InMemQueryScratch<T> *scratch, bool use_filter = false,
-                            const std::vector<label> &filters  = std::vector<label>(), _u32 filteredLindex = 0);
+    void search_for_point_and_add_links(
+        int location, _u32 Lindex, InMemQueryScratch<T> *scratch,
+        bool                      use_filter = false,
+        const std::vector<label> &filters = std::vector<label>(),
+        _u32                      filteredLindex = 0);
 
     void prune_neighbors(const unsigned location, std::vector<Neighbor> &pool,
                          std::vector<unsigned> &pruned_list,
@@ -356,19 +352,16 @@ namespace diskann {
     bool _enable_tags = false;
     bool _normalize_vecs = false;  // Using normalied L2 for cosine.
 
+    // Filter Support
 
-   // Filter Support
-
-    bool                                  _filtered_index = false;
+    bool                            _filtered_index = false;
     std::vector<std::vector<label>> _pts_to_labels;
     tsl::robin_set<label>           _labels;
-    std::string                           _labels_file;
+    std::string                     _labels_file;
     std::unordered_map<label, _u32> _filter_to_medoid_id;
-    std::unordered_map<_u32, _u32>        _medoid_counts;
-    bool                                  _use_universal_label = false;
+    std::unordered_map<_u32, _u32>  _medoid_counts;
+    bool                            _use_universal_label = false;
     label                           _universal_label = 0;
-
-
 
     // Indexing parameters
     uint32_t _indexingQueueSize;

--- a/include/index.h
+++ b/include/index.h
@@ -25,6 +25,8 @@
 #define DEFAULT_MAXC 750
 
 namespace diskann {
+    typedef unsigned label;
+
   inline double estimate_ram_usage(_u64 size, _u32 dim, _u32 datasize,
                                    _u32 degree) {
     double size_of_data = ((double) size) * ROUND_UP(dim, 8) * datasize;
@@ -128,7 +130,7 @@ namespace diskann {
         const size_t num_points_to_load, Parameters &parameters,
         const std::vector<TagT> &tags = std::vector<TagT>());
 
-    DISKANN_DLLEXPORT void set_universal_label(const std::string &label);
+    DISKANN_DLLEXPORT void set_universal_label(const label &label);
 
 
     // Set starting point of an index before inserting any points incrementally
@@ -160,7 +162,7 @@ namespace diskann {
 // Filter support search
     template<typename IndexType>
     DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t> search_with_filters(
-        const T *query, const std::string &filter_label, const size_t K,
+        const T *query, const label &filter_label, const size_t K,
         const unsigned L, IndexType *indices, float *distances);
 
 
@@ -239,17 +241,17 @@ namespace diskann {
                                               float                *distances,
                                               InMemQueryScratch<T> *scratch,
         bool               use_filters = false,
-        const std::string &filter_label = std::string());
+        const label &filter_label = -1);
 
     std::pair<uint32_t, uint32_t> iterate_to_fixed_point(
         const T *node_coords, const unsigned Lindex,
         const std::vector<unsigned> &init_ids, InMemQueryScratch<T> *scratch,  bool use_filter,
-        const std::vector<std::string> &filters, 
+        const std::vector<label> &filters, 
         bool ret_frozen = true, bool search_invocation = false);
 
     void search_for_point_and_add_links(int location, _u32 Lindex,
                                         InMemQueryScratch<T> *scratch, bool use_filter = false,
-                            const std::vector<std::string> &filters  = std::vector<std::string>(), _u32 filteredLindex = 0);
+                            const std::vector<label> &filters  = std::vector<label>(), _u32 filteredLindex = 0);
 
     void prune_neighbors(const unsigned location, std::vector<Neighbor> &pool,
                          std::vector<unsigned> &pruned_list,
@@ -358,13 +360,13 @@ namespace diskann {
    // Filter Support
 
     bool                                  _filtered_index = false;
-    std::vector<std::vector<std::string>> _pts_to_labels;
-    tsl::robin_set<std::string>           _labels;
+    std::vector<std::vector<label>> _pts_to_labels;
+    tsl::robin_set<label>           _labels;
     std::string                           _labels_file;
-    std::unordered_map<std::string, _u32> _filter_to_medoid_id;
+    std::unordered_map<label, _u32> _filter_to_medoid_id;
     std::unordered_map<_u32, _u32>        _medoid_counts;
     bool                                  _use_universal_label = false;
-    std::string                           _universal_label = "";
+    label                           _universal_label = 0;
 
 
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -93,6 +93,7 @@ typedef uint16_t _u16;
 typedef int16_t  _s16;
 typedef uint8_t  _u8;
 typedef int8_t   _s8;
+typedef unsigned label;
 inline void      open_file_to_write(std::ofstream&     writer,
                                     const std::string& filename) {
        writer.exceptions(std::ofstream::failbit | std::ofstream::badbit);
@@ -546,7 +547,6 @@ namespace diskann {
   }
 #endif
 
-
   inline void copy_file(std::string in_file, std::string out_file) {
     std::ifstream source(in_file, std::ios::binary);
     std::ofstream dest(out_file, std::ios::binary);
@@ -559,7 +559,6 @@ namespace diskann {
     source.close();
     dest.close();
   }
-
 
   DISKANN_DLLEXPORT double calculate_recall(
       unsigned num_queries, unsigned* gold_std, float* gs_dist, unsigned dim_gs,
@@ -597,8 +596,8 @@ namespace diskann {
 #else
       strerror_r(errno, buff, 1024);
 #endif
-      std::string error_message = std::string("Failed to open file") + filename +
-          " for write because " + buff;
+      std::string error_message = std::string("Failed to open file") +
+                                  filename + " for write because " + buff;
       diskann::cerr << error_message << std::endl;
       throw diskann::ANNException(error_message, -1);
     }

--- a/src/disk_utils.cpp
+++ b/src/disk_utils.cpp
@@ -287,7 +287,7 @@ namespace diskann {
     // will merge all the labels to medoids files of each shard into one
     // combined file
     if (use_filters) {
-      std::unordered_map<std::string, std::vector<_u32>>
+      std::unordered_map<unsigned, std::vector<_u32>>
           global_label_to_medoids;
 
       for (_u64 i = 0; i < nshards; i++) {
@@ -302,16 +302,19 @@ namespace diskann {
           std::istringstream iss(line);
           _u32               cnt = 0;
           _u32               medoid;
-          std::string        label;
+          label        label;
           while (std::getline(iss, token, ',')) {
             token.erase(std::remove(token.begin(), token.end(), '\n'),
                         token.end());
             token.erase(std::remove(token.begin(), token.end(), '\r'),
                         token.end());
+            
+            unsigned token_as_num = std::stoul(token);
+
             if (cnt == 0)
-              label = token;
+              label = token_as_num;
             else
-              medoid = (_u32) stoul(token);
+              medoid = token_as_num;
             cnt++;
           }
           global_label_to_medoids[label].push_back(idmaps[i][medoid]);
@@ -494,7 +497,7 @@ namespace diskann {
 
     _u32 point_cnt = 0;
 
-    std::vector<std::vector<std::string>> labels_per_point;
+    std::vector<std::vector<label>> labels_per_point;
     labels_per_point.resize(npts);
 
     _u32 dense_pts = 0;
@@ -517,7 +520,8 @@ namespace diskann {
                       token.end());
           token.erase(std::remove(token.begin(), token.end(), '\r'),
                       token.end());
-          labels_per_point[label_host].push_back(token);
+          unsigned token_as_num = std::stoul(token);
+          labels_per_point[label_host].push_back(token_as_num);
           lbl_cnt++;
         }
         point_cnt++;
@@ -632,7 +636,7 @@ namespace diskann {
         _pvamanaIndex->build(base_file.c_str(), base_num, paras);
       else {
         if (universal_label != "") {  //  indicates no universal label
-          _pvamanaIndex->set_universal_label(universal_label);
+          _pvamanaIndex->set_universal_label(std::stoul(universal_label));
         }
         _pvamanaIndex->build_filtered_index(base_file.c_str(), label_file,
                                             base_num, paras);
@@ -708,7 +712,7 @@ namespace diskann {
         diskann::extract_shard_labels(label_file, shard_ids_file,
                                       shard_labels_file);
         if (universal_label != "") {  //  indicates no universal label
-          _pvamanaIndex->set_universal_label(universal_label);
+          _pvamanaIndex->set_universal_label(std::stoul(universal_label));
         }
         _pvamanaIndex->build_filtered_index(
             shard_base_file.c_str(), shard_labels_file, shard_base_pts, paras);

--- a/src/disk_utils.cpp
+++ b/src/disk_utils.cpp
@@ -55,7 +55,7 @@ namespace diskann {
     }
 
     size_t num_blocks = DIV_ROUND_UP(fsize, read_blk_size);
-    char * dump = new char[read_blk_size];
+    char  *dump = new char[read_blk_size];
     for (_u64 i = 0; i < num_blocks; i++) {
       size_t cur_block_size = read_blk_size > fsize - (i * read_blk_size)
                                   ? fsize - (i * read_blk_size)
@@ -93,13 +93,13 @@ namespace diskann {
   size_t calculate_num_pq_chunks(double final_index_ram_limit,
                                  size_t points_num, uint32_t dim,
                                  const std::vector<std::string> &param_list) {
-    size_t num_pq_chunks =
-        (size_t)(std::floor)(_u64(final_index_ram_limit / (double) points_num));
+    size_t num_pq_chunks = (size_t) (std::floor)(
+        _u64(final_index_ram_limit / (double) points_num));
     diskann::cout << "Calculated num_pq_chunks :" << num_pq_chunks << std::endl;
     if (param_list.size() >= 6) {
       float compress_ratio = (float) atof(param_list[5].c_str());
       if (compress_ratio > 0 && compress_ratio <= 1) {
-        size_t chunks_by_cr = (size_t)(std::floor)(compress_ratio * dim);
+        size_t chunks_by_cr = (size_t) (std::floor)(compress_ratio * dim);
 
         if (chunks_by_cr > 0 && chunks_by_cr < num_pq_chunks) {
           diskann::cout << "Compress ratio:" << compress_ratio
@@ -156,7 +156,7 @@ namespace diskann {
   T *load_warmup(MemoryMappedFiles &files, const std::string &cache_warmup_file,
                  uint64_t &warmup_num, uint64_t warmup_dim,
                  uint64_t warmup_aligned_dim) {
-    T *      warmup = nullptr;
+    T       *warmup = nullptr;
     uint64_t file_dim, file_aligned_dim;
 
     if (files.fileExists(cache_warmup_file)) {
@@ -189,7 +189,7 @@ namespace diskann {
   template<typename T>
   T *load_warmup(const std::string &cache_warmup_file, uint64_t &warmup_num,
                  uint64_t warmup_dim, uint64_t warmup_aligned_dim) {
-    T *      warmup = nullptr;
+    T       *warmup = nullptr;
     uint64_t file_dim, file_aligned_dim;
 
     if (file_exists(cache_warmup_file)) {
@@ -287,8 +287,7 @@ namespace diskann {
     // will merge all the labels to medoids files of each shard into one
     // combined file
     if (use_filters) {
-      std::unordered_map<unsigned, std::vector<_u32>>
-          global_label_to_medoids;
+      std::unordered_map<unsigned, std::vector<_u32>> global_label_to_medoids;
 
       for (_u64 i = 0; i < nshards; i++) {
         std::ifstream mapping_reader;
@@ -302,13 +301,13 @@ namespace diskann {
           std::istringstream iss(line);
           _u32               cnt = 0;
           _u32               medoid;
-          label        label;
+          label              label;
           while (std::getline(iss, token, ',')) {
             token.erase(std::remove(token.begin(), token.end(), '\n'),
                         token.end());
             token.erase(std::remove(token.begin(), token.end(), '\r'),
                         token.end());
-            
+
             unsigned token_as_num = std::stoul(token);
 
             if (cnt == 0)
@@ -488,7 +487,7 @@ namespace diskann {
                             const std::string out_metadata_file) {
     std::string   token, line;
     std::ifstream labels_stream(labels_file);
-    T *           data;
+    T            *data;
     _u64          npts, ndims;
     diskann::load_bin<T>(data_file, data, npts, ndims);
 
@@ -611,7 +610,7 @@ namespace diskann {
         estimate_ram_usage(base_num, base_dim, sizeof(T), R);
 
     // TODO: Make this honest when there is filter support
-    if (full_index_ram < ram_budget * 1024 * 1024 * 1024) {  
+    if (full_index_ram < ram_budget * 1024 * 1024 * 1024) {
       diskann::cout << "Full index fits in RAM budget, should consume at most "
                     << full_index_ram / (1024 * 1024 * 1024)
                     << "GiBs, so building in one shot" << std::endl;
@@ -791,7 +790,7 @@ namespace diskann {
     while (!stop_flag) {
       std::vector<uint64_t> tuning_sample_result_ids_64(tuning_sample_num, 0);
       std::vector<float>    tuning_sample_result_dists(tuning_sample_num, 0);
-      diskann::QueryStats * stats = new diskann::QueryStats[tuning_sample_num];
+      diskann::QueryStats  *stats = new diskann::QueryStats[tuning_sample_num];
 
       auto s = std::chrono::high_resolution_clock::now();
 #pragma omp parallel for schedule(dynamic, 1) num_threads(nthreads)
@@ -818,7 +817,7 @@ namespace diskann {
       if (qps > max_qps && lat_999 < (15000) + mean_latency * 2) {
         max_qps = qps;
         best_bw = cur_bw;
-        cur_bw = (uint32_t)(std::ceil)((float) cur_bw * 1.1f);
+        cur_bw = (uint32_t) (std::ceil)((float) cur_bw * 1.1f);
       } else {
         stop_flag = true;
       }
@@ -1049,7 +1048,7 @@ namespace diskann {
 
   template<typename T>
   int build_disk_index(const char *dataFilePath, const char *indexFilePath,
-                       const char *    indexBuildParameters,
+                       const char     *indexBuildParameters,
                        diskann::Metric compareMetric, bool use_opq,
                        bool use_filters, const std::string &label_file,
                        const std::string &universal_label,
@@ -1226,7 +1225,7 @@ namespace diskann {
                                       compareMetric, p_val, disk_pq_dims);
     }
     size_t num_pq_chunks =
-        (size_t)(std::floor)(_u64(final_index_ram_limit / points_num));
+        (size_t) (std::floor)(_u64(final_index_ram_limit / points_num));
 
     num_pq_chunks = num_pq_chunks <= 0 ? 1 : num_pq_chunks;
     num_pq_chunks = num_pq_chunks > dim ? dim : num_pq_chunks;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -512,7 +512,7 @@ namespace diskann {
       if (file_exists(universal_label_file)) {
         std::ifstream universal_label_reader(universal_label_file);
         universal_label_reader >> _universal_label;
-        _use_universal_label = true;  // to check
+        _use_universal_label = true;
         universal_label_reader.close();
       }
     }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -489,16 +489,17 @@ namespace diskann {
           std::istringstream iss(line);
           _u32               cnt = 0;
           _u32               medoid = 0;
-          std::string        label;
+          label        label;
           while (std::getline(iss, token, ',')) {
             token.erase(std::remove(token.begin(), token.end(), '\n'),
                         token.end());
             token.erase(std::remove(token.begin(), token.end(), '\r'),
                         token.end());
+            unsigned token_as_num = std::stoul(token);
             if (cnt == 0)
-              label = token;
+              label = token_as_num;
             else
-              medoid = (_u32) stoul(token);
+              medoid = token_as_num;
             cnt++;
           }
           _filter_to_medoid_id[label] = medoid;
@@ -511,7 +512,7 @@ namespace diskann {
       if (file_exists(universal_label_file)) {
         std::ifstream universal_label_reader(universal_label_file);
         universal_label_reader >> _universal_label;
-        _use_universal_label = true;
+        _use_universal_label = true; // to check
         universal_label_reader.close();
       }
     }
@@ -782,7 +783,7 @@ namespace diskann {
   std::pair<uint32_t, uint32_t> Index<T, TagT>::iterate_to_fixed_point(
       const T *query, const unsigned Lsize,
       const std::vector<unsigned> &init_ids, InMemQueryScratch<T> *scratch,
-      bool use_filter, const std::vector<std::string> &filter_label,
+      bool use_filter, const std::vector<label> &filter_label,
       bool ret_frozen, bool search_invocation) {
     std::vector<Neighbor> &   expanded_nodes = scratch->pool();
     std::vector<Neighbor> &   best_L_nodes = scratch->best_l_nodes();
@@ -876,7 +877,7 @@ namespace diskann {
       }
 
       if (use_filter) {
-        std::vector<std::string> common_filters;
+        std::vector<label> common_filters;
         auto &                   x = _pts_to_labels[id];
         std::set_intersection(filter_label.begin(), filter_label.end(),
                               x.begin(), x.end(),
@@ -955,7 +956,7 @@ namespace diskann {
             if (use_filter) {  // NOTE: NEED TO CHECK IF THIS CORRECT WITH
                                // NEW LOCKS.
               //              _u32                     id = _final_graph[n][m];
-              std::vector<std::string> common_filters;
+              std::vector<label> common_filters;
               auto &                   x = _pts_to_labels[id];
               std::set_intersection(filter_label.begin(), filter_label.end(),
                                     x.begin(), x.end(),
@@ -1038,11 +1039,11 @@ namespace diskann {
   template<typename T, typename TagT>
   void Index<T, TagT>::search_for_point_and_add_links(
       int location, _u32 Lindex, InMemQueryScratch<T> *scratch, bool use_filter,
-      const std::vector<std::string> &filters, _u32 filteredLindex) {
+      const std::vector<label> &filters, _u32 filteredLindex) {
     std::vector<unsigned> init_ids;
     init_ids.emplace_back(_start);
 
-    std::vector<std::string> dummy;
+    std::vector<label> dummy;
 
     if (!use_filter) {
       iterate_to_fixed_point(_data + _aligned_dim * location, Lindex, init_ids,
@@ -1674,21 +1675,22 @@ namespace diskann {
     while (std::getline(infile, line)) {
       line_cnt++;
     }
-    _pts_to_labels.resize(line_cnt, std::vector<std::string>());
+    _pts_to_labels.resize(line_cnt, std::vector<label>());
 
     infile.clear();
     infile.seekg(0, std::ios::beg);
     line_cnt = 0;
     while (std::getline(infile, line)) {
       std::istringstream       iss(line);
-      std::vector<std::string> lbls(0);
+      std::vector<label> lbls(0);
       getline(iss, token, '\t');
       std::istringstream new_iss(token);
       while (getline(new_iss, token, ',')) {
         token.erase(std::remove(token.begin(), token.end(), '\n'), token.end());
         token.erase(std::remove(token.begin(), token.end(), '\r'), token.end());
-        lbls.push_back(token);
-        _labels.insert(token);
+        unsigned token_as_num = std::stoul(token);
+        lbls.push_back(token_as_num);
+        _labels.insert(token_as_num);
       }
       if (lbls.size() <= 0) {
         std::cout << "No label found";
@@ -1703,7 +1705,7 @@ namespace diskann {
   }
 
   template<typename T, typename TagT>
-  void Index<T, TagT>::set_universal_label(const std::string &label) {
+  void Index<T, TagT>::set_universal_label(const label &label) {
     _use_universal_label = true;
     _universal_label = label;
   }
@@ -1791,9 +1793,9 @@ namespace diskann {
   std::pair<uint32_t, uint32_t> Index<T, TagT>::search_impl(
       const T *query, const size_t K, const unsigned L, IdType *indices,
       float *distances, InMemQueryScratch<T> *scratch, bool use_filters,
-      const std::string &filter_label) {
+      const label &filter_label) {
     std::vector<unsigned>    init_ids;
-    std::vector<std::string> filter_vec;
+    std::vector<label> filter_vec;
 
     std::shared_lock<std::shared_timed_mutex> lock(_update_lock);
 
@@ -1845,7 +1847,7 @@ namespace diskann {
   template<typename T, typename TagT>
   template<typename IndexType>
   std::pair<uint32_t, uint32_t> Index<T, TagT>::search_with_filters(
-      const T *query, const std::string &filter_label, const size_t K,
+      const T *query, const label &filter_label, const size_t K,
       const unsigned L, IndexType *indices, float *distance) {
     ScratchStoreManager<InMemQueryScratch<T>> manager(_query_scratch);
     auto                                      scratch = manager.scratch_space();
@@ -2793,52 +2795,52 @@ namespace diskann {
 
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
                              Index<float, uint64_t>::search_with_filters<uint64_t>(
-      const float *query, const std::string &filter_label, const size_t K,
+      const float *query, const label &filter_label, const size_t K,
       const unsigned L, uint64_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
                              Index<float, uint64_t>::search_with_filters<uint32_t>(
-      const float *query, const std::string &filter_label, const size_t K,
+      const float *query, const label &filter_label, const size_t K,
       const unsigned L, uint32_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
                              Index<uint8_t, uint64_t>::search_with_filters<uint64_t>(
-      const uint8_t *query, const std::string &filter_label, const size_t K,
+      const uint8_t *query, const label &filter_label, const size_t K,
       const unsigned L, uint64_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
                              Index<uint8_t, uint64_t>::search_with_filters<uint32_t>(
-      const uint8_t *query, const std::string &filter_label, const size_t K,
+      const uint8_t *query, const label &filter_label, const size_t K,
       const unsigned L, uint32_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
                              Index<int8_t, uint64_t>::search_with_filters<uint64_t>(
-      const int8_t *query, const std::string &filter_label, const size_t K,
+      const int8_t *query, const label &filter_label, const size_t K,
       const unsigned L, uint64_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
                              Index<int8_t, uint64_t>::search_with_filters<uint32_t>(
-      const int8_t *query, const std::string &filter_label, const size_t K,
+      const int8_t *query, const label &filter_label, const size_t K,
       const unsigned L, uint32_t *indices, float *distances);
   // TagT==uint32_t
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
                              Index<float, uint32_t>::search_with_filters<uint64_t>(
-      const float *query, const std::string &filter_label, const size_t K,
+      const float *query, const label &filter_label, const size_t K,
       const unsigned L, uint64_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
                              Index<float, uint32_t>::search_with_filters<uint32_t>(
-      const float *query, const std::string &filter_label, const size_t K,
+      const float *query, const label &filter_label, const size_t K,
       const unsigned L, uint32_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
                              Index<uint8_t, uint32_t>::search_with_filters<uint64_t>(
-      const uint8_t *query, const std::string &filter_label, const size_t K,
+      const uint8_t *query, const label &filter_label, const size_t K,
       const unsigned L, uint64_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
                              Index<uint8_t, uint32_t>::search_with_filters<uint32_t>(
-      const uint8_t *query, const std::string &filter_label, const size_t K,
+      const uint8_t *query, const label &filter_label, const size_t K,
       const unsigned L, uint32_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
                              Index<int8_t, uint32_t>::search_with_filters<uint64_t>(
-      const int8_t *query, const std::string &filter_label, const size_t K,
+      const int8_t *query, const label &filter_label, const size_t K,
       const unsigned L, uint64_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
                              Index<int8_t, uint32_t>::search_with_filters<uint32_t>(
-      const int8_t *query, const std::string &filter_label, const size_t K,
+      const int8_t *query, const label &filter_label, const size_t K,
       const unsigned L, uint32_t *indices, float *distances);
 
 }  // namespace diskann

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -173,7 +173,7 @@ namespace diskann {
       return 0;
     }
     size_t tag_bytes_written;
-    TagT * tag_data = new TagT[_nd + _num_frozen_pts];
+    TagT  *tag_data = new TagT[_nd + _num_frozen_pts];
     for (_u32 i = 0; i < _nd; i++) {
       TagT tag;
       if (_location_to_tag.try_get(i, tag)) {
@@ -226,7 +226,7 @@ namespace diskann {
       max_degree = _final_graph[i].size() > max_degree
                        ? (_u32) _final_graph[i].size()
                        : max_degree;
-      index_size += (_u64)(sizeof(unsigned) * (GK + 1));
+      index_size += (_u64) (sizeof(unsigned) * (GK + 1));
     }
     out.seekp(file_offset, out.beg);
     out.write((char *) &index_size, sizeof(uint64_t));
@@ -349,7 +349,7 @@ namespace diskann {
     }
 
     size_t file_dim, file_num_points;
-    TagT * tag_data;
+    TagT  *tag_data;
 #ifdef EXEC_ENV_OLS
     load_bin<TagT>(reader, tag_data, file_num_points, file_dim);
 #else
@@ -489,7 +489,7 @@ namespace diskann {
           std::istringstream iss(line);
           _u32               cnt = 0;
           _u32               medoid = 0;
-          label        label;
+          label              label;
           while (std::getline(iss, token, ',')) {
             token.erase(std::remove(token.begin(), token.end(), '\n'),
                         token.end());
@@ -512,7 +512,7 @@ namespace diskann {
       if (file_exists(universal_label_file)) {
         std::ifstream universal_label_reader(universal_label_file);
         universal_label_reader >> _universal_label;
-        _use_universal_label = true; // to check
+        _use_universal_label = true;  // to check
         universal_label_reader.close();
       }
     }
@@ -754,7 +754,7 @@ namespace diskann {
 #pragma omp parallel for schedule(static, 65536)
     for (_s64 i = 0; i < (_s64) _nd; i++) {
       // extract point and distance reference
-      float &  dist = distances[i];
+      float   &dist = distances[i];
       const T *cur_vec = _data + (i * (size_t) _aligned_dim);
       dist = 0;
       float diff = 0;
@@ -783,10 +783,10 @@ namespace diskann {
   std::pair<uint32_t, uint32_t> Index<T, TagT>::iterate_to_fixed_point(
       const T *query, const unsigned Lsize,
       const std::vector<unsigned> &init_ids, InMemQueryScratch<T> *scratch,
-      bool use_filter, const std::vector<label> &filter_label,
-      bool ret_frozen, bool search_invocation) {
-    std::vector<Neighbor> &   expanded_nodes = scratch->pool();
-    std::vector<Neighbor> &   best_L_nodes = scratch->best_l_nodes();
+      bool use_filter, const std::vector<label> &filter_label, bool ret_frozen,
+      bool search_invocation) {
+    std::vector<Neighbor>    &expanded_nodes = scratch->pool();
+    std::vector<Neighbor>    &best_L_nodes = scratch->best_l_nodes();
     tsl::robin_set<unsigned> &inserted_into_pool_rs =
         scratch->inserted_into_pool_rs();
     boost::dynamic_bitset<> &inserted_into_pool_bs =
@@ -803,7 +803,7 @@ namespace diskann {
     float *query_float;
     float *query_rotated;
     float *pq_dists;
-    _u8 *  pq_coord_scratch;
+    _u8   *pq_coord_scratch;
     // Intialize PQ related scratch to use PQ based distances
     if (_pq_dist) {
       // Get scratch spaces
@@ -878,7 +878,7 @@ namespace diskann {
 
       if (use_filter) {
         std::vector<label> common_filters;
-        auto &                   x = _pts_to_labels[id];
+        auto              &x = _pts_to_labels[id];
         std::set_intersection(filter_label.begin(), filter_label.end(),
                               x.begin(), x.end(),
                               std::back_inserter(common_filters));
@@ -957,7 +957,7 @@ namespace diskann {
                                // NEW LOCKS.
               //              _u32                     id = _final_graph[n][m];
               std::vector<label> common_filters;
-              auto &                   x = _pts_to_labels[id];
+              auto              &x = _pts_to_labels[id];
               std::set_intersection(filter_label.begin(), filter_label.end(),
                                     x.begin(), x.end(),
                                     std::back_inserter(common_filters));
@@ -1085,7 +1085,7 @@ namespace diskann {
       _final_graph[location].clear();
       _final_graph[location].shrink_to_fit();
       _final_graph[location].reserve(
-          (_u64)(_indexingRange * GRAPH_SLACK_FACTOR * 1.05));
+          (_u64) (_indexingRange * GRAPH_SLACK_FACTOR * 1.05));
 
       for (auto link : pruned_list) {
         if (_conc_consolidate)
@@ -1107,7 +1107,7 @@ namespace diskann {
                                     const float alpha, const unsigned degree,
                                     const unsigned         maxc,
                                     std::vector<Neighbor> &result,
-                                    InMemQueryScratch<T> * scratch) {
+                                    InMemQueryScratch<T>  *scratch) {
     if (pool.size() == 0)
       return;
 
@@ -1181,7 +1181,7 @@ namespace diskann {
   void Index<T, TagT>::prune_neighbors(const unsigned         location,
                                        std::vector<Neighbor> &pool,
                                        std::vector<unsigned> &pruned_list,
-                                       InMemQueryScratch<T> * scratch) {
+                                       InMemQueryScratch<T>  *scratch) {
     prune_neighbors(location, pool, _indexingRange, _indexingMaxC,
                     _indexingAlpha, pruned_list, scratch);
   }
@@ -1235,7 +1235,7 @@ namespace diskann {
   void Index<T, TagT>::inter_insert(unsigned               n,
                                     std::vector<unsigned> &pruned_list,
                                     const _u32             range,
-                                    InMemQueryScratch<T> * scratch) {
+                                    InMemQueryScratch<T>  *scratch) {
     const auto &src_pool = pruned_list;
 
     assert(!src_pool.empty());
@@ -1248,9 +1248,9 @@ namespace diskann {
       bool                  prune_needed = false;
       {
         LockGuard guard(_locks[des]);
-        auto &    des_pool = _final_graph[des];
+        auto     &des_pool = _final_graph[des];
         if (std::find(des_pool.begin(), des_pool.end(), n) == des_pool.end()) {
-          if (des_pool.size() < (_u64)(GRAPH_SLACK_FACTOR * range)) {
+          if (des_pool.size() < (_u64) (GRAPH_SLACK_FACTOR * range)) {
             des_pool.emplace_back(n);
             prune_needed = false;
           } else {
@@ -1266,7 +1266,7 @@ namespace diskann {
         std::vector<Neighbor>    dummy_pool(0);
 
         size_t reserveSize =
-            (size_t)(std::ceil(1.05 * GRAPH_SLACK_FACTOR * range));
+            (size_t) (std::ceil(1.05 * GRAPH_SLACK_FACTOR * range));
         dummy_visited.reserve(reserveSize);
         dummy_pool.reserve(reserveSize);
 
@@ -1298,7 +1298,7 @@ namespace diskann {
   template<typename T, typename TagT>
   void Index<T, TagT>::inter_insert(unsigned               n,
                                     std::vector<unsigned> &pruned_list,
-                                    InMemQueryScratch<T> * scratch) {
+                                    InMemQueryScratch<T>  *scratch) {
     inter_insert(n, pruned_list, _indexingRange, scratch);
   }
 
@@ -1343,7 +1343,7 @@ namespace diskann {
 
     for (uint64_t p = 0; p < _nd; p++) {
       _final_graph[p].reserve(
-          (size_t)(std::ceil(_indexingRange * GRAPH_SLACK_FACTOR * 1.05)));
+          (size_t) (std::ceil(_indexingRange * GRAPH_SLACK_FACTOR * 1.05)));
     }
 
     std::vector<unsigned> init_ids;
@@ -1352,7 +1352,8 @@ namespace diskann {
     diskann::Timer link_timer;
 
 #pragma omp parallel for schedule(dynamic, 2048)
-    for (_s64 node_ctr = 0; node_ctr < (_s64)(visit_order.size()); node_ctr++) {
+    for (_s64 node_ctr = 0; node_ctr < (_s64) (visit_order.size());
+         node_ctr++) {
       auto node = visit_order[node_ctr];
 
       ScratchStoreManager<InMemQueryScratch<T>> manager(_query_scratch);
@@ -1370,7 +1371,8 @@ namespace diskann {
       diskann::cout << "Starting final cleanup.." << std::flush;
     }
 #pragma omp parallel for schedule(dynamic, 2048)
-    for (_s64 node_ctr = 0; node_ctr < (_s64)(visit_order.size()); node_ctr++) {
+    for (_s64 node_ctr = 0; node_ctr < (_s64) (visit_order.size());
+         node_ctr++) {
       auto node = visit_order[node_ctr];
       if (_final_graph[node].size() > _indexingRange) {
         ScratchStoreManager<InMemQueryScratch<T>> manager(_query_scratch);
@@ -1498,7 +1500,7 @@ namespace diskann {
 
   template<typename T, typename TagT>
   void Index<T, TagT>::build(const T *data, const size_t num_points_to_load,
-                             Parameters &             parameters,
+                             Parameters              &parameters,
                              const std::vector<TagT> &tags) {
     if (num_points_to_load == 0) {
       throw ANNException("Do not call build with 0 points", -1, __FUNCSIG__,
@@ -1524,9 +1526,9 @@ namespace diskann {
   }
 
   template<typename T, typename TagT>
-  void Index<T, TagT>::build(const char *             filename,
+  void Index<T, TagT>::build(const char              *filename,
                              const size_t             num_points_to_load,
-                             Parameters &             parameters,
+                             Parameters              &parameters,
                              const std::vector<TagT> &tags) {
     if (num_points_to_load == 0)
       throw ANNException("Do not call build with 0 points", -1, __FUNCSIG__,
@@ -1626,7 +1628,7 @@ namespace diskann {
   }
 
   template<typename T, typename TagT>
-  void Index<T, TagT>::build(const char * filename,
+  void Index<T, TagT>::build(const char  *filename,
                              const size_t num_points_to_load,
                              Parameters &parameters, const char *tag_filename) {
     std::vector<TagT> tags;
@@ -1639,7 +1641,7 @@ namespace diskann {
         if (file_exists(tag_filename)) {
           diskann::cout << "Loading tags from " << tag_filename
                         << " for vamana index build" << std::endl;
-          TagT * tag_data = nullptr;
+          TagT  *tag_data = nullptr;
           size_t npts, ndim;
           diskann::load_bin(tag_filename, tag_data, npts, ndim);
           if (npts < num_points_to_load) {
@@ -1681,7 +1683,7 @@ namespace diskann {
     infile.seekg(0, std::ios::beg);
     line_cnt = 0;
     while (std::getline(infile, line)) {
-      std::istringstream       iss(line);
+      std::istringstream iss(line);
       std::vector<label> lbls(0);
       getline(iss, token, '\t');
       std::istringstream new_iss(token);
@@ -1711,10 +1713,10 @@ namespace diskann {
   }
 
   template<typename T, typename TagT>
-  void Index<T, TagT>::build_filtered_index(const char *       filename,
+  void Index<T, TagT>::build_filtered_index(const char        *filename,
                                             const std::string &label_file,
                                             const size_t num_points_to_load,
-                                            Parameters & parameters,
+                                            Parameters  &parameters,
                                             const std::vector<TagT> &tags) {
     _labels_file = label_file;
     _filtered_index = true;
@@ -1727,7 +1729,7 @@ namespace diskann {
     for (int lbl = 0; lbl < _labels.size(); lbl++) {
       auto itr = _labels.begin();
       std::advance(itr, lbl);
-      auto &            x = *itr;
+      auto             &x = *itr;
       std::vector<_u32> filtered_points;
       for (_u32 i = 0; i < num_points_to_load; i++) {
         if (std::find(_pts_to_labels[i].begin(), _pts_to_labels[i].end(), x) !=
@@ -1777,10 +1779,10 @@ namespace diskann {
 
   template<typename T, typename TagT>
   template<typename IdType>
-  std::pair<uint32_t, uint32_t> Index<T, TagT>::search(const T *      query,
+  std::pair<uint32_t, uint32_t> Index<T, TagT>::search(const T       *query,
                                                        const size_t   K,
                                                        const unsigned L,
-                                                       IdType *       indices,
+                                                       IdType        *indices,
                                                        float *distances) {
     ScratchStoreManager<InMemQueryScratch<T>> manager(_query_scratch);
     auto                                      scratch = manager.scratch_space();
@@ -1794,8 +1796,8 @@ namespace diskann {
       const T *query, const size_t K, const unsigned L, IdType *indices,
       float *distances, InMemQueryScratch<T> *scratch, bool use_filters,
       const label &filter_label) {
-    std::vector<unsigned>    init_ids;
-    std::vector<label> filter_vec;
+    std::vector<unsigned> init_ids;
+    std::vector<label>    filter_vec;
 
     std::shared_lock<std::shared_timed_mutex> lock(_update_lock);
 
@@ -1859,7 +1861,7 @@ namespace diskann {
   template<typename T, typename TagT>
   size_t Index<T, TagT>::search_with_tags(const T *query, const uint64_t K,
                                           const unsigned L, TagT *tags,
-                                          float *           distances,
+                                          float            *distances,
                                           std::vector<T *> &res_vectors) {
     ScratchStoreManager<InMemQueryScratch<T>> manager(_query_scratch);
     auto                                      scratch = manager.scratch_space();
@@ -1870,7 +1872,7 @@ namespace diskann {
                     << scratch->search_l << " but search L is: " << L
                     << std::endl;
     }
-    _u32 * indices = scratch->indices();
+    _u32  *indices = scratch->indices();
     float *dist_interim = scratch->interim_dists();
     search_impl(query, L, L, indices, dist_interim, scratch);
 
@@ -2094,7 +2096,7 @@ namespace diskann {
         }
       }
     }
-    for (_s64 loc = _max_points; loc < (_s64)(_max_points + _num_frozen_pts);
+    for (_s64 loc = _max_points; loc < (_s64) (_max_points + _num_frozen_pts);
          loc++) {
       LockGuard                                 adj_list_lock(_locks[loc]);
       ScratchStoreManager<InMemQueryScratch<T>> manager(_query_scratch);
@@ -2426,7 +2428,7 @@ namespace diskann {
         tl.lock();
 
         if (_nd >= _max_points) {
-          auto new_max_points = (size_t)(_max_points * INDEX_GROWTH_FACTOR);
+          auto new_max_points = (size_t) (_max_points * INDEX_GROWTH_FACTOR);
           resize(new_max_points);
         }
 
@@ -2502,7 +2504,7 @@ namespace diskann {
 
   template<typename T, typename TagT>
   void Index<T, TagT>::lazy_delete(const std::vector<TagT> &tags,
-                                   std::vector<TagT> &      failed_tags) {
+                                   std::vector<TagT>       &failed_tags) {
     if (failed_tags.size() > 0) {
       throw ANNException("failed_tags should be passed as an empty list", -1,
                          __FUNCSIG__, __FILE__, __LINE__);
@@ -2635,7 +2637,7 @@ namespace diskann {
 
     boost::dynamic_bitset<> flags{_nd, 0};
     unsigned                tmp_l = 0;
-    unsigned *              neighbors =
+    unsigned               *neighbors =
         (unsigned *) (_opt_graph + _node_size * _start + _data_len);
     unsigned MaxM_ep = *neighbors;
     neighbors++;
@@ -2665,7 +2667,7 @@ namespace diskann {
       unsigned id = init_ids[i];
       if (id >= _nd)
         continue;
-      T *   x = (T *) (_opt_graph + _node_size * id);
+      T    *x = (T *) (_opt_graph + _node_size * id);
       float norm_x = *x;
       x++;
       float dist =
@@ -2696,7 +2698,7 @@ namespace diskann {
           if (flags[id])
             continue;
           flags[id] = 1;
-          T *   data = (T *) (_opt_graph + _node_size * id);
+          T    *data = (T *) (_opt_graph + _node_size * id);
           float norm = *data;
           data++;
           float dist =
@@ -2740,106 +2742,106 @@ namespace diskann {
   template DISKANN_DLLEXPORT class Index<uint8_t, uint64_t>;
 
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<float, uint64_t>::search<uint64_t>(const float *query, const size_t K,
+  Index<float, uint64_t>::search<uint64_t>(const float *query, const size_t K,
                                            const unsigned L, uint64_t *indices,
                                            float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<float, uint64_t>::search<uint32_t>(const float *query, const size_t K,
+  Index<float, uint64_t>::search<uint32_t>(const float *query, const size_t K,
                                            const unsigned L, uint32_t *indices,
                                            float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<uint8_t, uint64_t>::search<uint64_t>(const uint8_t *query,
+  Index<uint8_t, uint64_t>::search<uint64_t>(const uint8_t *query,
                                              const size_t K, const unsigned L,
                                              uint64_t *indices,
-                                             float *   distances);
+                                             float    *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<uint8_t, uint64_t>::search<uint32_t>(const uint8_t *query,
+  Index<uint8_t, uint64_t>::search<uint32_t>(const uint8_t *query,
                                              const size_t K, const unsigned L,
                                              uint32_t *indices,
-                                             float *   distances);
+                                             float    *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<int8_t, uint64_t>::search<uint64_t>(const int8_t *query, const size_t K,
+  Index<int8_t, uint64_t>::search<uint64_t>(const int8_t *query, const size_t K,
                                             const unsigned L, uint64_t *indices,
                                             float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<int8_t, uint64_t>::search<uint32_t>(const int8_t *query, const size_t K,
+  Index<int8_t, uint64_t>::search<uint32_t>(const int8_t *query, const size_t K,
                                             const unsigned L, uint32_t *indices,
                                             float *distances);
   // TagT==uint32_t
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<float, uint32_t>::search<uint64_t>(const float *query, const size_t K,
+  Index<float, uint32_t>::search<uint64_t>(const float *query, const size_t K,
                                            const unsigned L, uint64_t *indices,
                                            float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<float, uint32_t>::search<uint32_t>(const float *query, const size_t K,
+  Index<float, uint32_t>::search<uint32_t>(const float *query, const size_t K,
                                            const unsigned L, uint32_t *indices,
                                            float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<uint8_t, uint32_t>::search<uint64_t>(const uint8_t *query,
+  Index<uint8_t, uint32_t>::search<uint64_t>(const uint8_t *query,
                                              const size_t K, const unsigned L,
                                              uint64_t *indices,
-                                             float *   distances);
+                                             float    *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<uint8_t, uint32_t>::search<uint32_t>(const uint8_t *query,
+  Index<uint8_t, uint32_t>::search<uint32_t>(const uint8_t *query,
                                              const size_t K, const unsigned L,
                                              uint32_t *indices,
-                                             float *   distances);
+                                             float    *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<int8_t, uint32_t>::search<uint64_t>(const int8_t *query, const size_t K,
+  Index<int8_t, uint32_t>::search<uint64_t>(const int8_t *query, const size_t K,
                                             const unsigned L, uint64_t *indices,
                                             float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<int8_t, uint32_t>::search<uint32_t>(const int8_t *query, const size_t K,
+  Index<int8_t, uint32_t>::search<uint32_t>(const int8_t *query, const size_t K,
                                             const unsigned L, uint32_t *indices,
                                             float *distances);
 
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<float, uint64_t>::search_with_filters<uint64_t>(
+  Index<float, uint64_t>::search_with_filters<uint64_t>(
       const float *query, const label &filter_label, const size_t K,
       const unsigned L, uint64_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<float, uint64_t>::search_with_filters<uint32_t>(
+  Index<float, uint64_t>::search_with_filters<uint32_t>(
       const float *query, const label &filter_label, const size_t K,
       const unsigned L, uint32_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<uint8_t, uint64_t>::search_with_filters<uint64_t>(
+  Index<uint8_t, uint64_t>::search_with_filters<uint64_t>(
       const uint8_t *query, const label &filter_label, const size_t K,
       const unsigned L, uint64_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<uint8_t, uint64_t>::search_with_filters<uint32_t>(
+  Index<uint8_t, uint64_t>::search_with_filters<uint32_t>(
       const uint8_t *query, const label &filter_label, const size_t K,
       const unsigned L, uint32_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<int8_t, uint64_t>::search_with_filters<uint64_t>(
+  Index<int8_t, uint64_t>::search_with_filters<uint64_t>(
       const int8_t *query, const label &filter_label, const size_t K,
       const unsigned L, uint64_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<int8_t, uint64_t>::search_with_filters<uint32_t>(
+  Index<int8_t, uint64_t>::search_with_filters<uint32_t>(
       const int8_t *query, const label &filter_label, const size_t K,
       const unsigned L, uint32_t *indices, float *distances);
   // TagT==uint32_t
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<float, uint32_t>::search_with_filters<uint64_t>(
+  Index<float, uint32_t>::search_with_filters<uint64_t>(
       const float *query, const label &filter_label, const size_t K,
       const unsigned L, uint64_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<float, uint32_t>::search_with_filters<uint32_t>(
+  Index<float, uint32_t>::search_with_filters<uint32_t>(
       const float *query, const label &filter_label, const size_t K,
       const unsigned L, uint32_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<uint8_t, uint32_t>::search_with_filters<uint64_t>(
+  Index<uint8_t, uint32_t>::search_with_filters<uint64_t>(
       const uint8_t *query, const label &filter_label, const size_t K,
       const unsigned L, uint64_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<uint8_t, uint32_t>::search_with_filters<uint32_t>(
+  Index<uint8_t, uint32_t>::search_with_filters<uint32_t>(
       const uint8_t *query, const label &filter_label, const size_t K,
       const unsigned L, uint32_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<int8_t, uint32_t>::search_with_filters<uint64_t>(
+  Index<int8_t, uint32_t>::search_with_filters<uint64_t>(
       const int8_t *query, const label &filter_label, const size_t K,
       const unsigned L, uint64_t *indices, float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-                             Index<int8_t, uint32_t>::search_with_filters<uint32_t>(
+  Index<int8_t, uint32_t>::search_with_filters<uint32_t>(
       const int8_t *query, const label &filter_label, const size_t K,
       const unsigned L, uint32_t *indices, float *distances);
 

--- a/tests/build_memory_index.cpp
+++ b/tests/build_memory_index.cpp
@@ -49,7 +49,7 @@ int build_in_memory_index(const diskann::Metric& metric,
     index.build(data_path.c_str(), data_num, paras);
   } else {
     if (universal_label != "") {
-      index.set_universal_label(universal_label);
+      index.set_universal_label(std::stoul(universal_label));
     }
     index.build_filtered_index(data_path.c_str(), label_file, data_num, paras);
   }

--- a/tests/build_memory_index.cpp
+++ b/tests/build_memory_index.cpp
@@ -65,9 +65,9 @@ int build_in_memory_index(const diskann::Metric& metric,
 int main(int argc, char** argv) {
   std::string data_type, dist_fn, data_path, index_path_prefix, label_file,
       universal_label;
-  unsigned    num_threads, R, L, Lf, build_PQ_bytes;
-  float       alpha;
-  bool        use_pq_build, use_opq;
+  unsigned num_threads, R, L, Lf, build_PQ_bytes;
+  float    alpha;
+  bool     use_pq_build, use_opq;
 
   po::options_description desc{"Arguments"};
   try {
@@ -99,13 +99,14 @@ int main(int argc, char** argv) {
         "Number of threads used for building index (defaults to "
         "omp_get_num_procs())");
     desc.add_options()(
-        "build_PQ_bytes", po::value<uint32_t>(&build_PQ_bytes)->default_value(0),
+        "build_PQ_bytes",
+        po::value<uint32_t>(&build_PQ_bytes)->default_value(0),
         "Number of PQ bytes to build the index; 0 for full precision build");
     desc.add_options()(
         "use_opq", po::bool_switch()->default_value(false),
         "Set true for OPQ compression while using PQ distance comparisons for "
         "building the index, and false for PQ compression");
-   desc.add_options()("label_file",
+    desc.add_options()("label_file",
                        po::value<std::string>(&label_file)->default_value(""),
                        "Input label file in txt format if present");
     desc.add_options()(
@@ -115,7 +116,7 @@ int main(int argc, char** argv) {
     desc.add_options()("FilteredLbuild,Lf",
                        po::value<uint32_t>(&Lf)->default_value(0),
                        "Build complexity for filtered points, higher value "
-                       "results in better graphs");        
+                       "results in better graphs");
 
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
@@ -150,20 +151,20 @@ int main(int argc, char** argv) {
                   << "  alpha: " << alpha << "  #threads: " << num_threads
                   << std::endl;
     if (data_type == std::string("int8"))
-      return build_in_memory_index<int8_t>(metric, data_path, R, L, alpha,
-                                           index_path_prefix, num_threads,
-                                           use_pq_build, build_PQ_bytes, use_opq,
-                                           label_file, universal_label, Lf);
+      return build_in_memory_index<int8_t>(
+          metric, data_path, R, L, alpha, index_path_prefix, num_threads,
+          use_pq_build, build_PQ_bytes, use_opq, label_file, universal_label,
+          Lf);
     else if (data_type == std::string("uint8"))
       return build_in_memory_index<uint8_t>(
           metric, data_path, R, L, alpha, index_path_prefix, num_threads,
-          use_pq_build, build_PQ_bytes, use_opq,
-                                           label_file, universal_label, Lf);
+          use_pq_build, build_PQ_bytes, use_opq, label_file, universal_label,
+          Lf);
     else if (data_type == std::string("float"))
       return build_in_memory_index<float>(metric, data_path, R, L, alpha,
                                           index_path_prefix, num_threads,
                                           use_pq_build, build_PQ_bytes, use_opq,
-                                           label_file, universal_label, Lf);
+                                          label_file, universal_label, Lf);
     else {
       std::cout << "Unsupported type. Use one of int8, uint8 or float."
                 << std::endl;

--- a/tests/search_memory_index.cpp
+++ b/tests/search_memory_index.cpp
@@ -55,9 +55,9 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
                   << " not found. Not computing recall." << std::endl;
   }
 
-  bool filtered_search = false;
-  diskann::label filter_label_as_num = -1;
-  if (filter_label != ""){
+  bool  filtered_search = false;
+  label filter_label_as_num = UINT_MAX;
+  if (filter_label != "") {
     filter_label_as_num = std::stoul(filter_label);
     filtered_search = true;
   }
@@ -191,12 +191,12 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
     if (tags) {
       std::cout << std::setw(4) << L << std::setw(12) << displayed_qps
                 << std::setw(20) << (float) mean_latency << std::setw(15)
-                << (float) latency_stats[(_u64)(0.999 * query_num)];
+                << (float) latency_stats[(_u64) (0.999 * query_num)];
     } else {
       std::cout << std::setw(4) << L << std::setw(12) << displayed_qps
                 << std::setw(18) << avg_cmps << std::setw(20)
                 << (float) mean_latency << std::setw(15)
-                << (float) latency_stats[(_u64)(0.999 * query_num)];
+                << (float) latency_stats[(_u64) (0.999 * query_num)];
     }
     for (float recall : recalls) {
       std::cout << std::setw(12) << recall;

--- a/tests/search_memory_index.cpp
+++ b/tests/search_memory_index.cpp
@@ -56,8 +56,11 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
   }
 
   bool filtered_search = false;
-  if (filter_label != "")
+  diskann::label filter_label_as_num = -1;
+  if (filter_label != ""){
+    filter_label_as_num = std::stoul(filter_label);
     filtered_search = true;
+  }
 
   using TagT = uint32_t;
   diskann::Index<T, TagT> index(metric, query_dim, 0, dynamic, tags);
@@ -130,7 +133,7 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
       auto qs = std::chrono::high_resolution_clock::now();
       if (filtered_search) {
         auto retval = index.search_with_filters(
-            query + i * query_aligned_dim, filter_label, recall_at, L,
+            query + i * query_aligned_dim, filter_label_as_num, recall_at, L,
             query_result_ids[test_id].data() + i * recall_at,
             query_result_dists[test_id].data() + i * recall_at);
         cmp_stats[i] = retval.second;


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
For in-memory build, this PR changes how labels are processed internally from strings to ints. This increases the speed of checking label set intersections between two points, resulting in faster build time and higher QPS at search time.

#### Any other comments?
Code also written by Siddharth Gollapudi
