### PR TITLE
Fix major bug with current membranne

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -116,18 +116,18 @@ namespace diskann {
     // Batch build from a file. Optionally pass tags vector.
     DISKANN_DLLEXPORT void build(
         const char *filename, const size_t num_points_to_load,
-        Parameters              &parameters,
+        Parameters &             parameters,
         const std::vector<TagT> &tags = std::vector<TagT>());
 
     // Batch build from a file. Optionally pass tags file.
-    DISKANN_DLLEXPORT void build(const char  *filename,
+    DISKANN_DLLEXPORT void build(const char * filename,
                                  const size_t num_points_to_load,
-                                 Parameters  &parameters,
-                                 const char  *tag_filename);
+                                 Parameters & parameters,
+                                 const char * tag_filename);
 
     // Batch build from a data array, which must pad vectors to aligned_dim
     DISKANN_DLLEXPORT void build(const T *data, const size_t num_points_to_load,
-                                 Parameters              &parameters,
+                                 Parameters &             parameters,
                                  const std::vector<TagT> &tags);
 
     // Filtered Support
@@ -161,7 +161,7 @@ namespace diskann {
     // Initialize space for res_vectors before calling.
     DISKANN_DLLEXPORT size_t search_with_tags(const T *query, const uint64_t K,
                                               const unsigned L, TagT *tags,
-                                              float            *distances,
+                                              float *           distances,
                                               std::vector<T *> &res_vectors);
 
     // Filter support search
@@ -183,7 +183,7 @@ namespace diskann {
     // Record deleted points now and restructure graph later. Add to failed_tags
     // if tag not found.
     DISKANN_DLLEXPORT void lazy_delete(const std::vector<TagT> &tags,
-                                       std::vector<TagT>       &failed_tags);
+                                       std::vector<TagT> &      failed_tags);
 
     // Call after a series of lazy deletions
     // Returns number of live points left after consolidation
@@ -228,7 +228,7 @@ namespace diskann {
 
     // Use after _data and _nd have been populated
     // Acquire exclusive _update_lock before calling
-    void build_with_data_populated(Parameters              &parameters,
+    void build_with_data_populated(Parameters &             parameters,
                                    const std::vector<TagT> &tags);
 
     // generates 1 frozen point that will never be deleted from the graph
@@ -238,7 +238,7 @@ namespace diskann {
     // determines navigating node of the graph by calculating medoid of datafopt
     unsigned calculate_entry_point();
 
-    void parse_label_file(const std::string& map_file);
+    void parse_label_file(const std::string &map_file);
 
     std::pair<uint32_t, uint32_t> iterate_to_fixed_point(
         const T *node_coords, const unsigned Lindex,
@@ -246,16 +246,15 @@ namespace diskann {
         bool use_filter, const std::vector<label> &filters,
         bool ret_frozen = true, bool search_invocation = false);
 
-    void search_for_point_and_prune(int location, _u32 Lindex,
-        std::vector<unsigned>& pruned_list,
-        InMemQueryScratch<T>* scratch,
-        bool                      use_filter = false,
-        const std::vector<label>& filters = std::vector<label>(),
+    void search_for_point_and_prune(
+        int location, _u32 Lindex, std::vector<unsigned> &pruned_list,
+        InMemQueryScratch<T> *scratch, bool use_filter = false,
+        const std::vector<label> &filters = std::vector<label>(),
         _u32                      filteredLindex = 0);
 
     void prune_neighbors(const unsigned location, std::vector<Neighbor> &pool,
                          std::vector<unsigned> &pruned_list,
-                         InMemQueryScratch<T>  *scratch);
+                         InMemQueryScratch<T> * scratch);
 
     void prune_neighbors(const unsigned location, std::vector<Neighbor> &pool,
                          const _u32 range, const _u32 max_candidate_size,
@@ -336,7 +335,7 @@ namespace diskann {
     Distance<T> *_distance = nullptr;
 
     // Data
-    T    *_data = nullptr;
+    T *   _data = nullptr;
     char *_opt_graph = nullptr;
 
     // Graph related data structures
@@ -373,6 +372,7 @@ namespace diskann {
     std::unordered_map<_u32, _u32>  _medoid_counts;
     bool                            _use_universal_label = false;
     label                           _universal_label = 0;
+    uint32_t                        _filterIndexingQueueSize;
 
     // Indexing parameters
     uint32_t _indexingQueueSize;
@@ -388,7 +388,7 @@ namespace diskann {
     bool              _pq_dist = false;
     bool              _use_opq = false;
     size_t            _num_pq_chunks = 0;
-    _u8              *_pq_data = nullptr;
+    _u8 *             _pq_data = nullptr;
     bool              _pq_generated = false;
     FixedChunkPQTable _pq_table;
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
Currently, calls to `search_for_points_and_prune()` in `index.cpp` do not use filters or the `FilteredLBuild` parameter, even if the build in question is a filtered build. This means that even if a filtered build is requested, the corresponding logic in `iterate_to_fixed_point` is currently never used. This PR fixes this issue by introducing some basic logic to ensure that if the index being built is a filtered index, then calls to  `search_for_points_and_prune()` will use filters.

#### Any other comments?
I'm not sure why, but running clang-format fixed way more style issues than I expected.
