### PR TITLE
Turn prune_neighbors into a no-op if pool input is empty

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1157,8 +1157,9 @@ namespace diskann {
       const _u32 max_candidate_size, const float alpha,
       std::vector<unsigned> &pruned_list, InMemQueryScratch<T> *scratch) {
     if (pool.size() == 0) {
-      throw diskann::ANNException("Pool passed to prune_neighbors is empty", -1,
-                                  __FUNCSIG__, __FILE__, __LINE__);
+      // if the pool is empty, behave like a noop
+      pruned_list.clear();
+      return;
     }
 
     _max_observed_degree = (std::max)(_max_observed_degree, range);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
Previously, `prune_neighbors` would do nothing if the input pool consisted solely of the node itself. However, the logic for verifying if the pool was a singleton was moved to be right before `prune_neighbors`: this would cause the pool passed to `prune_neighbors` to be empty, leading to an exception. 

We remove the exception from prune_neighbors, turning it into a noop in the case of an empty pool.

#### Any other comments?

