### PR TITLE
Added a max_dist_cmp parameter to in-memory search

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -146,13 +146,15 @@ namespace diskann {
     // can customize L on a per-query basis without tampering with "Parameters"
     template<typename IDType>
     DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t> search(
-        const T *query, const size_t K, const unsigned L, IDType *indices,
+        const T *query, const size_t K, const unsigned L,
+        const unsigned max_dist_cmp, IDType *indices,
         float *distances = nullptr);
 
     // Initialize space for res_vectors before calling.
     DISKANN_DLLEXPORT size_t search_with_tags(const T *query, const uint64_t K,
-                                              const unsigned L, TagT *tags,
-                                              float            *distances,
+                                              const unsigned L,
+                                              const unsigned max_dst_cmp,
+                                              TagT *tags, float *distances,
                                               std::vector<T *> &res_vectors);
 
     // Will fail if tag already in the index or if tag=0.
@@ -225,6 +227,7 @@ namespace diskann {
 
     std::pair<uint32_t, uint32_t> iterate_to_fixed_point(
         const T *node_coords, const unsigned Lindex,
+        const unsigned max_dist_cmp, 
         const std::vector<unsigned> &init_ids, InMemQueryScratch<T> *scratch,
         bool ret_frozen = true, bool search_invocation = false);
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ x] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ x] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
Adds a max_dist_cmp parameter to in-memory search to force early termination of iterate_to_fixed_point for queries that take too long to converge. Need to test if this can control 99.9pc latency.

#### Any other comments?

