### PR TITLE
Implements early loop breaking in L2 distance functions based on a di…

### DIFF
--- a/include/distance.h
+++ b/include/distance.h
@@ -7,41 +7,48 @@ namespace diskann {
   template<typename T>
   class Distance {
    public:
-    virtual float compare(const T *a, const T *b, uint32_t length) const = 0;
+    virtual float compare(
+        const T *a, const T *b, uint32_t length,
+        float break_distance = std::numeric_limits<float>::max()) const = 0;
     virtual ~Distance() {
     }
   };
 
   class DistanceCosineInt8 : public Distance<int8_t> {
    public:
-    DISKANN_DLLEXPORT virtual float compare(const int8_t *a, const int8_t *b,
-                                            uint32_t length) const;
+    DISKANN_DLLEXPORT virtual float compare(const int8_t *a, const int8_t *b, 
+        uint32_t length,
+        float break_distance = std::numeric_limits<float>::max()) const;
   };
 
   class DistanceL2Int8 : public Distance<int8_t> {
    public:
-    DISKANN_DLLEXPORT virtual float compare(const int8_t *a, const int8_t *b,
-                                            uint32_t size) const;
+    DISKANN_DLLEXPORT virtual float compare(const int8_t *a, const int8_t *b,                                   
+        uint32_t size,
+        float break_distance = std::numeric_limits<float>::max()) const;
   };
 
   // AVX implementations. Borrowed from HNSW code.
   class AVXDistanceL2Int8 : public Distance<int8_t> {
    public:
     DISKANN_DLLEXPORT virtual float compare(const int8_t *a, const int8_t *b,
-                                            uint32_t length) const;
+                                            uint32_t length,
+        float break_distance = std::numeric_limits<float>::max()) const;
   };
 
   class DistanceCosineFloat : public Distance<float> {
    public:
     DISKANN_DLLEXPORT virtual float compare(const float *a, const float *b,
-                                            uint32_t length) const;
+                                            uint32_t length,
+        float break_distance = std::numeric_limits<float>::max()) const;
   };
 
   class DistanceL2Float : public Distance<float> {
    public:
 #ifdef _WINDOWS
     DISKANN_DLLEXPORT virtual float compare(const float *a, const float *b,
-                                            uint32_t size) const;
+                                            uint32_t size,
+        float break_distance = std::numeric_limits<float>::max()) const;
 #else
     DISKANN_DLLEXPORT virtual float compare(const float *a, const float *b,
                                             uint32_t size) const
@@ -52,25 +59,29 @@ namespace diskann {
   class AVXDistanceL2Float : public Distance<float> {
    public:
     DISKANN_DLLEXPORT virtual float compare(const float *a, const float *b,
-                                            uint32_t length) const;
+                                            uint32_t length,
+        float break_distance = std::numeric_limits<float>::max()) const;
   };
 
   class SlowDistanceL2Float : public Distance<float> {
    public:
     DISKANN_DLLEXPORT virtual float compare(const float *a, const float *b,
-                                            uint32_t length) const;
+                                            uint32_t length,
+        float break_distance = std::numeric_limits<float>::max()) const;
   };
 
   class SlowDistanceCosineUInt8 : public Distance<uint8_t> {
    public:
     DISKANN_DLLEXPORT virtual float compare(const uint8_t *a, const uint8_t *b,
-                                            uint32_t length) const;
+                                            uint32_t length,
+        float break_distance = std::numeric_limits<float>::max()) const;
   };
 
   class DistanceL2UInt8 : public Distance<uint8_t> {
    public:
     DISKANN_DLLEXPORT virtual float compare(const uint8_t *a, const uint8_t *b,
-                                            uint32_t size) const;
+                                            uint32_t size,
+        float break_distance = std::numeric_limits<float>::max()) const;
   };
 
   // Simple implementations for non-AVX machines. Compiler can optimize.
@@ -78,8 +89,9 @@ namespace diskann {
   class SlowDistanceL2Int : public Distance<T> {
    public:
     // Implementing here because this is a template function
-    DISKANN_DLLEXPORT virtual float compare(const T *a, const T *b,
-                                            uint32_t length) const {
+    DISKANN_DLLEXPORT virtual float compare(
+        const T *a, const T *b, uint32_t length,
+        float break_distance = std::numeric_limits<float>::max()) const {
       uint32_t result = 0;
       for (uint32_t i = 0; i < length; i++) {
         result += ((int32_t) ((int16_t) a[i] - (int16_t) b[i])) *
@@ -94,7 +106,9 @@ namespace diskann {
    public:
     inline float inner_product(const T *a, const T *b, unsigned size) const;
 
-    inline float compare(const T *a, const T *b, unsigned size) const {
+    inline float compare(
+        const T *a, const T *b, unsigned size,
+        float break_distance = std::numeric_limits<float>::max()) const {
       float result = inner_product(a, b, size);
       //      if (result < 0)
       //      return std::numeric_limits<float>::max();
@@ -109,13 +123,16 @@ namespace diskann {
                                           // templated for future use.
    public:
     float norm(const T *a, unsigned size) const;
-    float compare(const T *a, const T *b, float norm, unsigned size) const;
+    float compare(
+        const T *a, const T *b, float norm, unsigned size,
+        float break_distance = std::numeric_limits<float>::max()) const;
   };
 
   class AVXDistanceInnerProductFloat : public Distance<float> {
    public:
-    DISKANN_DLLEXPORT virtual float compare(const float *a, const float *b,
-                                            uint32_t length) const;
+    DISKANN_DLLEXPORT virtual float compare(
+        const float *a, const float *b, uint32_t length,
+        float break_distance = std::numeric_limits<float>::max()) const;
   };
 
   class AVXNormalizedCosineDistanceFloat : public Distance<float> {
@@ -123,8 +140,9 @@ namespace diskann {
     AVXDistanceInnerProductFloat _innerProduct;
 
    public:
-    DISKANN_DLLEXPORT virtual float compare(const float *a, const float *b,
-                                            uint32_t length) const {
+    DISKANN_DLLEXPORT virtual float compare(
+        const float *a, const float *b, uint32_t length,
+        float break_distance = std::numeric_limits<float>::max()) const {
       // Inner product returns negative values to indicate distance.
       // This will ensure that cosine is between -1 and 1.
       return 1.0f + _innerProduct.compare(a, b, length);

--- a/include/neighbor.h
+++ b/include/neighbor.h
@@ -100,6 +100,11 @@ namespace diskann {
       return _capacity;
     }
 
+    float max_distance() {
+      return _size < _capacity ? (std::numeric_limits<float>::max)()
+                               : _data[_size - 1].distance;
+    }
+
     void reserve(size_t capacity) {
       if (capacity + 1 > _data.size()) {
         _data.resize(capacity + 1);

--- a/include/pq.h
+++ b/include/pq.h
@@ -97,7 +97,7 @@ namespace diskann {
 
   void pq_dist_lookup(const _u8* pq_ids, const _u64 n_pts,
                       const _u64 pq_nchunks, const float* pq_dists,
-                      std::vector<float>& dists_out);
+                      std::vector<float>& dists_out, float break_distance);
 
   // Need to replace calls to these with calls to vector& based functions above
   void aggregate_coords(const unsigned* ids, const _u64 n_ids,
@@ -105,7 +105,7 @@ namespace diskann {
 
   void pq_dist_lookup(const _u8* pq_ids, const _u64 n_pts,
                       const _u64 pq_nchunks, const float* pq_dists,
-                      float* dists_out);
+                      float* dists_out, float break_distance);
 
   DISKANN_DLLEXPORT int generate_pq_pivots(
       const float* const train_data, size_t num_train, unsigned dim,

--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -21,12 +21,79 @@
 
 namespace diskann {
 
+  // This function was taken from: https://github.com/microsoft/SPTAG/blob/main/AnnService/src/Core/Common/DistanceUtils.cpp
+  inline __m128 _mm_sqdf_epu8(__m128i X, __m128i Y) {
+    __m128i zero = _mm_setzero_si128();
+
+    __m128i xlo = _mm_unpacklo_epi8(X, zero);
+    __m128i xhi = _mm_unpackhi_epi8(X, zero);
+    __m128i ylo = _mm_unpacklo_epi8(Y, zero);
+    __m128i yhi = _mm_unpackhi_epi8(Y, zero);
+
+    __m128i dlo = _mm_sub_epi16(xlo, ylo);
+    __m128i dhi = _mm_sub_epi16(xhi, yhi);
+
+    return _mm_cvtepi32_ps(
+        _mm_add_epi32(_mm_madd_epi16(dlo, dlo), _mm_madd_epi16(dhi, dhi)));
+  }
+
+  // This function was taken from:
+  // https://github.com/microsoft/SPTAG/blob/main/AnnService/src/Core/Common/DistanceUtils.cpp
+  inline __m128 _mm_sqdf_epi8(__m128i X, __m128i Y) {
+    __m128i zero = _mm_setzero_si128();
+
+    __m128i sign_x = _mm_cmplt_epi8(X, zero);
+    __m128i sign_y = _mm_cmplt_epi8(Y, zero);
+
+    __m128i xlo = _mm_unpacklo_epi8(X, sign_x);
+    __m128i xhi = _mm_unpackhi_epi8(X, sign_x);
+    __m128i ylo = _mm_unpacklo_epi8(Y, sign_y);
+    __m128i yhi = _mm_unpackhi_epi8(Y, sign_y);
+
+    __m128i dlo = _mm_sub_epi16(xlo, ylo);
+    __m128i dhi = _mm_sub_epi16(xhi, yhi);
+
+    return _mm_cvtepi32_ps(
+        _mm_add_epi32(_mm_madd_epi16(dlo, dlo), _mm_madd_epi16(dhi, dhi)));
+  }
+
+  // This function was taken from:
+  // https://github.com/microsoft/SPTAG/blob/main/AnnService/src/Core/Common/DistanceUtils.cpp
+  inline __m256 _mm256_sqdf_epi8(__m256i X, __m256i Y) {
+    __m256i zero = _mm256_setzero_si256();
+
+    __m256i sign_x = _mm256_cmpgt_epi8(zero, X);
+    __m256i sign_y = _mm256_cmpgt_epi8(zero, Y);
+
+    __m256i xlo = _mm256_unpacklo_epi8(X, sign_x);
+    __m256i xhi = _mm256_unpackhi_epi8(X, sign_x);
+    __m256i ylo = _mm256_unpacklo_epi8(Y, sign_y);
+    __m256i yhi = _mm256_unpackhi_epi8(Y, sign_y);
+
+    __m256i dlo = _mm256_sub_epi16(xlo, ylo);
+    __m256i dhi = _mm256_sub_epi16(xhi, yhi);
+
+    return _mm256_cvtepi32_ps(_mm256_add_epi32(_mm256_madd_epi16(dlo, dlo),
+                                               _mm256_madd_epi16(dhi, dhi)));
+  }
+
+  // This was taken from:
+  // https://github.com/microsoft/SPTAG/blob/main/AnnService/src/Core/Common/DistanceUtils.cpp
+#define REPEAT(type, ctype, delta, load, exec, acc, result) \
+  {                                                         \
+    type c1 = load((ctype *) (a));                         \
+    type c2 = load((ctype *) (b));                         \
+    a += delta;                                            \
+    b += delta;                                            \
+    result = acc(result, exec(c1, c2));                     \
+  }
+
   //
   // Cosine distance functions.
   //
 
-  float DistanceCosineInt8::compare(const int8_t *a, const int8_t *b,
-                                    uint32_t length) const {
+  float DistanceCosineInt8::compare(
+      const int8_t *a, const int8_t *b, uint32_t length, float break_distance) const {
 #ifdef _WINDOWS
     return diskann::CosineSimilarity2<int8_t>(a, b, length);
 #else
@@ -42,7 +109,8 @@ namespace diskann {
   }
 
   float DistanceCosineFloat::compare(const float *a, const float *b,
-                                     uint32_t length) const {
+                                     uint32_t length,
+                                     float    break_distance) const {
 #ifdef _WINDOWS
     return diskann::CosineSimilarity2<float>(a, b, length);
 #else
@@ -58,7 +126,8 @@ namespace diskann {
   }
 
   float SlowDistanceCosineUInt8::compare(const uint8_t *a, const uint8_t *b,
-                                         uint32_t length) const {
+                                         uint32_t length,
+                                         float    break_distance) const {
     int magA = 0, magB = 0, scalarProduct = 0;
     for (uint32_t i = 0; i < length; i++) {
       magA += ((uint32_t) a[i]) * ((uint32_t) a[i]);
@@ -73,32 +142,46 @@ namespace diskann {
   // L2 distance functions.
   //
 
-  float DistanceL2Int8::compare(const int8_t *a, const int8_t *b,
-                                uint32_t size) const {
+  float DistanceL2Int8::compare(const int8_t *a, const int8_t *b, 
+                                uint32_t size, float break_distance) const {
     int32_t result = 0;
 
 #ifdef _WINDOWS
 #ifdef USE_AVX2
-    __m256 r = _mm256_setzero_ps();
-    char  *pX = (char *) a, *pY = (char *) b;
-    while (size >= 32) {
-      __m256i r1 = _mm256_subs_epi8(_mm256_loadu_si256((__m256i *) pX),
-                                    _mm256_loadu_si256((__m256i *) pY));
-      r = _mm256_add_ps(r, _mm256_mul_epi8(r1, r1));
-      pX += 32;
-      pY += 32;
-      size -= 32;
+
+    const int8_t *pEnd32 = a + ((size >> 5) << 5);
+    const int8_t *pEnd1 = a + size;
+
+    __m256        diff256 = _mm256_setzero_ps();
+    const int8_t *testdist = size / 2 + a;
+    float         diff = 0;
+
+    while (a < pEnd32) {
+      REPEAT(__m256i, __m256i, 32, _mm256_loadu_si256, _mm256_sqdf_epi8,
+             _mm256_add_ps, diff256)
+
+      if (a >= testdist) {
+        __m128 diff128 = _mm_add_ps(_mm256_castps256_ps128(diff256),
+                                    _mm256_extractf128_ps(diff256, 1));
+        diff = diff128.m128_f32[0] + diff128.m128_f32[1] + 
+            diff128.m128_f32[2] + diff128.m128_f32[3];
+
+        if (diff > break_distance)
+          return diff;
+
+        testdist += (pEnd32 - a) / 2;
+      }
     }
-    while (size > 0) {
-      __m128i r2 = _mm_subs_epi8(_mm_loadu_si128((__m128i *) pX),
-                                 _mm_loadu_si128((__m128i *) pY));
-      r = _mm256_add_ps(r, _mm256_mul32_pi8(r2, r2));
-      pX += 4;
-      pY += 4;
-      size -= 4;
+
+    while (a < pEnd1) {
+      float c1 = ((float) (*a++) - (float) (*b++));
+      diff += c1 * c1;
+
+      if (diff > break_distance)
+        return diff;
     }
-    r = _mm256_hadd_ps(_mm256_hadd_ps(r, r), r);
-    return r.m256_f32[0] + r.m256_f32[4];
+    return diff;
+
 #else
 #pragma omp simd reduction(+ : result) aligned(a, b : 8)
     for (_s32 i = 0; i < (_s32) size; i++) {
@@ -117,33 +200,68 @@ namespace diskann {
 #endif
   }
 
+  // This function implementation was adapted from:
+  // https://github.com/microsoft/SPTAG/blob/main/AnnService/src/Core/Common/DistanceUtils.cpp
+
   float DistanceL2UInt8::compare(const uint8_t *a, const uint8_t *b,
-                                 uint32_t size) const {
+                                 uint32_t length, float break_distance) const {
+#ifdef _WINDOWS
+    const uint8_t *end16 = a + ((length >> 4) << 4);
+    const uint8_t *end1 = a + length;
+ 
+     __m128 diff128 = _mm_setzero_ps();
+    const uint8_t *testdist = length / 2 + a;
+     float diff = 0;
+ 
+     while (a < end16) {
+       REPEAT(__m128i, __m128i, 16, _mm_loadu_si128, _mm_sqdf_epu8,
+       _mm_add_ps, diff128)
+
+       if (a >= testdist) {
+         diff = diff128.m128_f32[0] + diff128.m128_f32[1] +
+                diff128.m128_f32[2] + diff128.m128_f32[3];
+         if (diff > break_distance)
+           return diff;
+
+         testdist += (end16 - a) / 2;
+       }
+     }
+ 
+     while (a < end1) {
+       float c1 = ((float) (*a++) - (float) (*b++));
+         diff += c1 * c1;
+ 
+         if (diff > break_distance)
+           return diff;
+     }
+     return diff;
+#else
     uint32_t result = 0;
-#ifndef _WINDOWS
 #pragma omp simd reduction(+ : result) aligned(a, b : 8)
-#endif
     for (int32_t i = 0; i < (int32_t) size; i++) {
       result += ((int32_t) ((int16_t) a[i] - (int16_t) b[i])) *
                 ((int32_t) ((int16_t) a[i] - (int16_t) b[i]));
     }
     return (float) result;
+#endif
   }
 
 #ifndef _WINDOWS
-  float DistanceL2Float::compare(const float *a, const float *b,
-                                 uint32_t size) const {
+  float DistanceL2Float::compare(const float *a, const float *b, uint32_t size,
+                                 float break_distance) const {
     a = (const float *) __builtin_assume_aligned(a, 32);
     b = (const float *) __builtin_assume_aligned(b, 32);
 #else
-  float DistanceL2Float::compare(const float *a, const float *b,
-                                 uint32_t size) const {
+  float DistanceL2Float::compare(const float *a, const float *b, uint32_t size,
+                                 float break_distance) const {
 #endif
 
     float result = 0;
 #ifdef USE_AVX2
     // assume size is divisible by 8
     uint16_t niters = (uint16_t) (size / 8);
+    //test for break_distance at the halfway point
+    uint16_t testidx = niters / 2;
     __m256   sum = _mm256_setzero_ps();
     for (uint16_t j = 0; j < niters; j++) {
       // scope is a[8j:8j+7], b[8j:8j+7]
@@ -159,10 +277,22 @@ namespace diskann {
       __m256 tmp_vec = _mm256_sub_ps(a_vec, b_vec);
 
       sum = _mm256_fmadd_ps(tmp_vec, tmp_vec, sum);
+
+      if (j >= testidx) {
+        // horizontal add sum
+        result = _mm256_reduce_add_ps(sum);
+        if (result > break_distance)
+           break;
+        //test for break_distance at the next halfway point
+        testidx += (niters - j) / 2;
+      }
     }
 
-    // horizontal add sum
-    result = _mm256_reduce_add_ps(sum);
+    //complete remaining dimensions
+    for (uint32_t i = niters * 8; i < size; i++) {
+      result += (a[i] - b[i]) * (a[i] - b[i]);
+    }
+
 #else
 #ifndef _WINDOWS
 #pragma omp simd reduction(+ : result) aligned(a, b : 32)
@@ -175,7 +305,8 @@ namespace diskann {
   }
 
   float SlowDistanceL2Float::compare(const float *a, const float *b,
-                                     uint32_t length) const {
+                                     uint32_t length,
+                                     float    break_distance) const {
     float result = 0.0f;
     for (uint32_t i = 0; i < length; i++) {
       result += (a[i] - b[i]) * (a[i] - b[i]);
@@ -184,46 +315,47 @@ namespace diskann {
   }
 
 #ifdef _WINDOWS
+
+  // This function implementation was adapted from:
+  // https://github.com/microsoft/SPTAG/blob/main/AnnService/src/Core/Common/DistanceUtils.cpp
+
   float AVXDistanceL2Int8::compare(const int8_t *a, const int8_t *b,
-                                   uint32_t length) const {
-    __m128  r = _mm_setzero_ps();
-    __m128i r1;
-    while (length >= 16) {
-      r1 = _mm_subs_epi8(_mm_load_si128((__m128i *) a),
-                         _mm_load_si128((__m128i *) b));
-      r = _mm_add_ps(r, _mm_mul_epi8(r1));
-      a += 16;
-      b += 16;
-      length -= 16;
-    }
-    r = _mm_hadd_ps(_mm_hadd_ps(r, r), r);
-    float res = r.m128_f32[0];
+                                   uint32_t length,
+                                   float    break_distance) const {
+    const int8_t *pEnd16 = a + ((length >> 4) << 4);
+    const int8_t *pEnd1 = a + length;
 
-    if (length >= 8) {
-      __m128  r2 = _mm_setzero_ps();
-      __m128i r3 = _mm_subs_epi8(_mm_load_si128((__m128i *) (a - 8)),
-                                 _mm_load_si128((__m128i *) (b - 8)));
-      r2 = _mm_add_ps(r2, _mm_mulhi_epi8(r3));
-      a += 8;
-      b += 8;
-      length -= 8;
-      r2 = _mm_hadd_ps(_mm_hadd_ps(r2, r2), r2);
-      res += r2.m128_f32[0];
+    __m128 diff128 = _mm_setzero_ps();
+    const int8_t *testdist = length / 2 + a;
+    float   diff = 0;
+
+    while (a < pEnd16) {
+      REPEAT(__m128i, __m128i, 16, _mm_loadu_si128, _mm_sqdf_epi8, _mm_add_ps,
+             diff128)
+
+      if (a >= testdist) {
+        diff = diff128.m128_f32[0] + diff128.m128_f32[1] + diff128.m128_f32[2] +
+               diff128.m128_f32[3];
+        if (diff > break_distance)
+           return diff;
+
+        testdist += (pEnd16 - a) / 2;
+      }
     }
 
-    if (length >= 4) {
-      __m128  r2 = _mm_setzero_ps();
-      __m128i r3 = _mm_subs_epi8(_mm_load_si128((__m128i *) (a - 12)),
-                                 _mm_load_si128((__m128i *) (b - 12)));
-      r2 = _mm_add_ps(r2, _mm_mulhi_epi8_shift32(r3));
-      res += r2.m128_f32[0] + r2.m128_f32[1];
-    }
+    while (a < pEnd1) {
+      float c1 = ((float) (*a++) - (float) (*b++));
+      diff += c1 * c1;
 
-    return res;
+      if (diff > break_distance)
+        return diff;
+    }
+    return diff;
   }
 
   float AVXDistanceL2Float::compare(const float *a, const float *b,
-                                    uint32_t length) const {
+                                    uint32_t length,
+                                    float    break_distance) const {
     __m128 diff, v1, v2;
     __m128 sum = _mm_set1_ps(0);
 
@@ -241,12 +373,12 @@ namespace diskann {
            sum.m128_f32[3];
   }
 #else
-  float AVXDistanceL2Int8::compare(const int8_t *, const int8_t *,
-                                   uint32_t) const {
+  float AVXDistanceL2Int8::compare(const int8_t *, const int8_t *, uint32_t,
+                                   float break_distance) const {
     return 0;
   }
   float AVXDistanceL2Float::compare(const float *, const float *,
-                                    uint32_t) const {
+                                    uint32_t, float) const {
     return 0;
   }
 #endif
@@ -363,7 +495,7 @@ namespace diskann {
 
   template<typename T>
   float DistanceFastL2<T>::compare(const T *a, const T *b, float norm,
-                                   unsigned size) const {
+                                   unsigned size, float break_distance) const {
     float result = -2 * DistanceInnerProduct<T>::inner_product(a, b, size);
     result += norm;
     return result;
@@ -467,7 +599,8 @@ namespace diskann {
   }
 
   float AVXDistanceInnerProductFloat::compare(const float *a, const float *b,
-                                              uint32_t size) const {
+                                              uint32_t size,
+                                              float    break_distance) const {
     float result = 0.0f;
 #define AVX_DOT(addr1, addr2, dest, tmp1, tmp2) \
   tmp1 = _mm256_loadu_ps(addr1);                \


### PR DESCRIPTION
…stance threshold from the current candidate nearest vector list.

AXV versions of the L2 distance functions were updated to allow these loop breaks. Changes were based on SPTAG distance implementations. This change also includes early loop breaking in the pq_dist_lookup functions.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [N] Does this PR have a descriptive title that could go in our release notes?
- [N] Does this PR add any new dependencies?
- [N] Does this PR modify any existing APIs?
- [N] Is the change to the API backwards compatible?
- [N] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
none

#### What does this implement/fix? Briefly explain your changes.
Performance optimization in distance comparisons
#### Any other comments?

