### PR TITLE
Refactored Parameters class.

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -118,7 +118,6 @@ jobs:
 
     - name: Generate 10K random int8 index vectors, 1K query vectors, in 10 dims and compute GT
       run: |
-      run: |
         ${{ env.diskann_built_utils }}/rand_data_gen --data_type int8 --output_file ./rand_int8_10D_10K_norm50.0.bin -D 10 -N 10000 --norm 50.0
         ${{ env.diskann_built_utils }}/rand_data_gen --data_type int8 --output_file ./rand_int8_10D_1K_norm50.0.bin -D 10 -N 1000 --norm 50.0
         ${{ env.diskann_built_utils }}/compute_groundtruth  --data_type int8 --dist_fn l2 --base_file ./rand_int8_10D_10K_norm50.0.bin --query_file ./rand_int8_10D_1K_norm50.0.bin --gt_file ./l2_rand_int8_10D_10K_norm50.0_10D_1K_norm50.0_gt100 --K 100

--- a/include/defaults.h
+++ b/include/defaults.h
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+#pragma once
+#include <stdint.h>
+
+namespace diskann {
+  namespace defaults {
+    const float    ALPHA = 1.2f;
+    const uint32_t NUM_THREADS = 0;
+    const uint32_t NUM_ROUNDS = 2;
+    const uint32_t MAX_OCCLUSION_SIZE = 750;
+    // following constants should always be specified, but are useful as a
+    // sensible default at cli / python boundaries
+    const uint32_t MAX_DEGREE = 64;
+    const uint32_t BUILD_LIST_SIZE = 100;
+    const uint32_t SEARCH_LIST_SIZE = 100;
+  }  // namespace defaults
+}  // namespace diskann

--- a/include/index.h
+++ b/include/index.h
@@ -84,14 +84,14 @@ namespace diskann {
 
     // Constructor for incremental index
     DISKANN_DLLEXPORT Index(Metric m, const size_t dim, const size_t max_points,
-                            const bool        dynamic_index,
-                            const Parameters &indexParameters,
-                            const Parameters &searchParameters,
-                            const bool        enable_tags = false,
-                            const bool        concurrent_consolidate = false,
-                            const bool        pq_dist_build = false,
-                            const size_t      num_pq_chunks = 0,
-                            const bool        use_opq = false);
+                            const bool                dynamic_index,
+                            const MutationParameters &indexParameters,
+                            const SearchParameters &  searchParameters,
+                            const bool                enable_tags = false,
+                            const bool   concurrent_consolidate = false,
+                            const bool   pq_dist_build = false,
+                            const size_t num_pq_chunks = 0,
+                            const bool   use_opq = false);
 
     DISKANN_DLLEXPORT ~Index();
 
@@ -115,19 +115,19 @@ namespace diskann {
     // Batch build from a file. Optionally pass tags vector.
     DISKANN_DLLEXPORT void build(
         const char *filename, const size_t num_points_to_load,
-        Parameters              &parameters,
-        const std::vector<TagT> &tags = std::vector<TagT>());
+        const MutationParameters &parameters,
+        const std::vector<TagT> & tags = std::vector<TagT>());
 
     // Batch build from a file. Optionally pass tags file.
-    DISKANN_DLLEXPORT void build(const char  *filename,
-                                 const size_t num_points_to_load,
-                                 Parameters  &parameters,
-                                 const char  *tag_filename);
+    DISKANN_DLLEXPORT void build(const char *              filename,
+                                 const size_t              num_points_to_load,
+                                 const MutationParameters &parameters,
+                                 const char *              tag_filename);
 
     // Batch build from a data array, which must pad vectors to aligned_dim
     DISKANN_DLLEXPORT void build(const T *data, const size_t num_points_to_load,
-                                 Parameters              &parameters,
-                                 const std::vector<TagT> &tags);
+                                 const MutationParameters &parameters,
+                                 const std::vector<TagT> & tags);
 
     // Set starting point of an index before inserting any points incrementally
     DISKANN_DLLEXPORT void set_start_point(T *data);
@@ -152,7 +152,7 @@ namespace diskann {
     // Initialize space for res_vectors before calling.
     DISKANN_DLLEXPORT size_t search_with_tags(const T *query, const uint64_t K,
                                               const unsigned L, TagT *tags,
-                                              float            *distances,
+                                              float *           distances,
                                               std::vector<T *> &res_vectors);
 
     // Will fail if tag already in the index or if tag=0.
@@ -168,14 +168,14 @@ namespace diskann {
     // Record deleted points now and restructure graph later. Add to failed_tags
     // if tag not found.
     DISKANN_DLLEXPORT void lazy_delete(const std::vector<TagT> &tags,
-                                       std::vector<TagT>       &failed_tags);
+                                       std::vector<TagT> &      failed_tags);
 
     // Call after a series of lazy deletions
     // Returns number of live points left after consolidation
     // If _conc_consolidates is set in the ctor, then this call can be invoked
     // alongside inserts and lazy deletes, else it acquires _update_lock
     DISKANN_DLLEXPORT consolidation_report
-    consolidate_deletes(const Parameters &parameters);
+    consolidate_deletes(const MutationParameters &parameters);
 
     DISKANN_DLLEXPORT bool is_index_saved();
 
@@ -213,8 +213,8 @@ namespace diskann {
 
     // Use after _data and _nd have been populated
     // Acquire exclusive _update_lock before calling
-    void build_with_data_populated(Parameters              &parameters,
-                                   const std::vector<TagT> &tags);
+    void build_with_data_populated(const MutationParameters &parameters,
+                                   const std::vector<TagT> & tags);
 
     // generates 1 frozen point that will never be deleted from the graph
     // This is not visible to the user
@@ -230,11 +230,11 @@ namespace diskann {
 
     void search_for_point_and_prune(int location, _u32 Lindex,
                                     std::vector<unsigned> &pruned_list,
-                                    InMemQueryScratch<T>  *scratch);
+                                    InMemQueryScratch<T> * scratch);
 
     void prune_neighbors(const unsigned location, std::vector<Neighbor> &pool,
                          std::vector<unsigned> &pruned_list,
-                         InMemQueryScratch<T>  *scratch);
+                         InMemQueryScratch<T> * scratch);
 
     void prune_neighbors(const unsigned location, std::vector<Neighbor> &pool,
                          const _u32 range, const _u32 max_candidate_size,
@@ -257,7 +257,7 @@ namespace diskann {
                       InMemQueryScratch<T> *scratch);
 
     // Acquire exclusive _update_lock before calling
-    void link(Parameters &parameters);
+    void link(const MutationParameters &parameters);
 
     // Acquire exclusive _tag_lock and _delete_lock before calling
     int reserve_location();
@@ -315,7 +315,7 @@ namespace diskann {
     Distance<T> *_distance = nullptr;
 
     // Data
-    T    *_data = nullptr;
+    T *   _data = nullptr;
     char *_opt_graph = nullptr;
 
     // Graph related data structures
@@ -356,7 +356,7 @@ namespace diskann {
     bool              _pq_dist = false;
     bool              _use_opq = false;
     size_t            _num_pq_chunks = 0;
-    _u8              *_pq_data = nullptr;
+    _u8 *             _pq_data = nullptr;
     bool              _pq_generated = false;
     FixedChunkPQTable _pq_table;
 

--- a/include/parameters.h
+++ b/include/parameters.h
@@ -2,82 +2,79 @@
 // Licensed under the MIT license.
 
 #pragma once
-#include <sstream>
+
 #include <typeinfo>
-#include <unordered_map>
+#include "defaults.h"
 
 namespace diskann {
-
-  class Parameters {
+  class MutationParameters {
    public:
-    Parameters() {
-      int *p = new int;
-      *p = 0;
-      params["num_threads"] = p;
-    }
+    MutationParameters(
+        const uint32_t list_size, const uint32_t max_degree,
+        const bool     saturate_graph,
+        const uint32_t max_occlusion_size = defaults::MAX_OCCLUSION_SIZE,
+        const float    alpha = defaults::ALPHA,
+        const uint32_t num_rounds = defaults::NUM_ROUNDS,
+        const uint32_t num_threads = defaults::NUM_THREADS)
+        : _list_size(list_size), _max_degree(max_degree),
+          _saturate_graph(saturate_graph),
+          _max_occlusion_size(max_occlusion_size), _alpha(alpha),
+          _num_rounds(num_rounds), _num_threads(num_threads){};
 
-    template<typename ParamType>
-    inline void Set(const std::string &name, const ParamType &value) {
-      //      ParamType *ptr = (ParamType *) malloc(sizeof(ParamType));
-      if (params.find(name) != params.end()) {
-        free(params[name]);
-      }
-      ParamType *ptr = new ParamType;
-      *ptr = value;
-      params[name] = (void *) ptr;
-    }
+    MutationParameters(const MutationParameters &) = delete;
+    MutationParameters &operator=(const MutationParameters &) = delete;
 
-    template<typename ParamType>
-    inline ParamType Get(const std::string &name) const {
-      auto item = params.find(name);
-      if (item == params.end()) {
-        throw std::invalid_argument("Invalid parameter name.");
-      } else {
-        // return ConvertStrToValue<ParamType>(item->second);
-        if (item->second == nullptr) {
-          throw std::invalid_argument(std::string("Parameter ") + name +
-                                      " has value null.");
-        } else {
-          return *(static_cast<ParamType *>(item->second));
-        }
-      }
+    uint32_t get_max_degree() const {
+      return _max_degree;
     }
-
-    template<typename ParamType>
-    inline ParamType Get(const std::string &name,
-                         const ParamType   &default_value) {
-      try {
-        return Get<ParamType>(name);
-      } catch (std::invalid_argument e) {
-        return default_value;
-      }
+    uint32_t get_search_list_size() const {
+      return _list_size;
     }
-
-    ~Parameters() {
-      for (auto iter = params.begin(); iter != params.end(); iter++) {
-        if (iter->second != nullptr)
-          free(iter->second);
-        // delete iter->second;
-      }
+    uint32_t get_max_occlusion_size() const {
+      return _max_occlusion_size;
+    }
+    float get_alpha() const {
+      return _alpha;
+    }
+    uint32_t get_num_rounds() const {
+      return _num_rounds;
+    }
+    bool is_saturate_graph() const {
+      return _saturate_graph;
+    }
+    uint32_t get_num_threads() const {
+      return _num_threads;
     }
 
    private:
-    std::unordered_map<std::string, void *> params;
+    uint32_t _list_size;
+    uint32_t _max_degree;
+    bool     _saturate_graph;
+    uint32_t _max_occlusion_size;
+    float    _alpha;
+    uint32_t _num_rounds;
+    uint32_t _num_threads;
+  };
 
-    Parameters(const Parameters &);
-    Parameters &operator=(const Parameters &);
+  class SearchParameters {
+   public:
+    SearchParameters(const uint32_t list_size,
+                     const uint32_t num_threads = defaults::NUM_THREADS)
+        : _list_size(list_size), _num_threads(num_threads){};
 
-    template<typename ParamType>
-    inline ParamType ConvertStrToValue(const std::string &str) const {
-      std::stringstream sstream(str);
-      ParamType         value;
-      if (!(sstream >> value) || !sstream.eof()) {
-        std::stringstream err;
-        err << "Failed to convert value '" << str
-            << "' to type: " << typeid(value).name();
-        throw std::runtime_error(err.str());
-      }
-      return value;
+    SearchParameters(const SearchParameters &) = delete;
+    SearchParameters &operator=(const SearchParameters &) = delete;
+
+    uint32_t get_search_list_size() const {
+      return _list_size;
     }
+
+    uint32_t get_num_threads() const {
+      return _num_threads;
+    }
+
+   private:
+    uint32_t _list_size;
+    uint32_t _num_threads;
   };
 }  // namespace diskann

--- a/python/src/diskann_bindings.cpp
+++ b/python/src/diskann_bindings.cpp
@@ -25,7 +25,6 @@ PYBIND11_MAKE_OPAQUE(std::vector<float>);
 PYBIND11_MAKE_OPAQUE(std::vector<int8_t>);
 PYBIND11_MAKE_OPAQUE(std::vector<uint8_t>);
 
-
 namespace py = pybind11;
 using namespace diskann;
 
@@ -74,8 +73,7 @@ struct DiskANNIndex {
                  const size_t num_nodes_to_cache, int cache_mechanism) {
     const std::string index_path =
         index_path_prefix + std::string("_disk.index");
-    int load_success =
-        pq_flash_index->load(num_threads, index_path.c_str());
+    int load_success = pq_flash_index->load(num_threads, index_path.c_str());
     if (load_success != 0) {
       return load_success;
     }
@@ -197,8 +195,8 @@ struct DiskANNIndex {
       const int num_threads) {
     py::array_t<unsigned> offsets(num_queries + 1);
 
-    std::vector<std::vector<_u64> >  u64_ids(num_queries);
-    std::vector<std::vector<float> > dists(num_queries);
+    std::vector<std::vector<_u64>>  u64_ids(num_queries);
+    std::vector<std::vector<float>> dists(num_queries);
 
     auto offsets_mutable = offsets.mutable_unchecked();
     offsets_mutable(0) = 0;
@@ -246,8 +244,9 @@ struct DiskANNIndex {
         stats, num_queries,
         [](const diskann::QueryStats &stats) { return stats.n_cmps; });
     delete[] stats;
-    return std::make_pair(std::make_pair(offsets, std::make_pair(ids, res_dists)),
-                          collective_stats);
+    return std::make_pair(
+        std::make_pair(offsets, std::make_pair(ids, res_dists)),
+        collective_stats);
   }
 };
 
@@ -259,31 +258,15 @@ PYBIND11_MODULE(diskannpy, m) {
   m.attr("__version__") = "dev";
 #endif
 
-  py::bind_vector<std::vector<unsigned> >(m, "VectorUnsigned");
-  py::bind_vector<std::vector<float> >(m, "VectorFloat");
-  py::bind_vector<std::vector<int8_t> >(m, "VectorInt8");
-  py::bind_vector<std::vector<uint8_t> >(m, "VectorUInt8");
-
+  py::bind_vector<std::vector<unsigned>>(m, "VectorUnsigned");
+  py::bind_vector<std::vector<float>>(m, "VectorFloat");
+  py::bind_vector<std::vector<int8_t>>(m, "VectorInt8");
+  py::bind_vector<std::vector<uint8_t>>(m, "VectorUInt8");
 
   py::enum_<Metric>(m, "Metric")
-    .value("L2", Metric::L2)
-    .value("INNER_PRODUCT", Metric::INNER_PRODUCT)
-    .export_values();
-
-  py::class_<Parameters>(m, "Parameters")
-      .def(py::init<>())
-      .def(
-          "set",
-          [](Parameters &self, const std::string &name, py::object value) {
-            if (py::isinstance<py::bool_>(value)) {
-              return self.Set(name, py::cast<bool>(value));
-            } else if (py::isinstance<py::int_>(value)) {
-              return self.Set(name, py::cast<unsigned>(value));
-            } else if (py::isinstance<py::float_>(value)) {
-              return self.Set(name, py::cast<float>(value));
-            }
-          },
-          py::arg("name"), py::arg("value"));
+      .value("L2", Metric::L2)
+      .value("INNER_PRODUCT", Metric::INNER_PRODUCT)
+      .export_values();
 
   py::class_<Neighbor>(m, "Neighbor")
       .def(py::init<>())
@@ -294,9 +277,11 @@ PYBIND11_MODULE(diskannpy, m) {
   py::class_<AlignedFileReader>(m, "AlignedFileReader");
 
 #ifdef _WINDOWS
-  py::class_<WindowsAlignedFileReader>(m, "WindowsAlignedFileReader").def(py::init<>());
+  py::class_<WindowsAlignedFileReader>(m, "WindowsAlignedFileReader")
+      .def(py::init<>());
 #else
-  py::class_<LinuxAlignedFileReader>(m, "LinuxAlignedFileReader").def(py::init<>());
+  py::class_<LinuxAlignedFileReader>(m, "LinuxAlignedFileReader")
+      .def(py::init<>());
 #endif
 
   m.def(
@@ -434,9 +419,9 @@ PYBIND11_MODULE(diskannpy, m) {
          size_t dims) { save_bin<_u32>(file_name, data.data(), npts, dims); },
       py::arg("file_name"), py::arg("data"), py::arg("npts"), py::arg("dims"));
 
-  py::class_<DiskANNIndex<float> >(m, "DiskANNFloatIndex")
+  py::class_<DiskANNIndex<float>>(m, "DiskANNFloatIndex")
       .def(py::init([](diskann::Metric metric) {
-        return std::unique_ptr<DiskANNIndex<float> >(
+        return std::unique_ptr<DiskANNIndex<float>>(
             new DiskANNIndex<float>(metric));
       }))
       .def("cache_bfs_levels", &DiskANNIndex<float>::cache_bfs_levels,
@@ -462,8 +447,8 @@ PYBIND11_MODULE(diskannpy, m) {
       .def("batch_range_search_numpy_input",
            &DiskANNIndex<float>::batch_range_search_numpy_input,
            py::arg("queries"), py::arg("dim"), py::arg("num_queries"),
-           py::arg("range"), py::arg("min_list_size"), py::arg("max_list_size"), py::arg("beam_width"),
-           py::arg("num_threads"))
+           py::arg("range"), py::arg("min_list_size"), py::arg("max_list_size"),
+           py::arg("beam_width"), py::arg("num_threads"))
       .def(
           "build",
           [](DiskANNIndex<float> &self, const char *data_file_path,
@@ -485,13 +470,13 @@ PYBIND11_MODULE(diskannpy, m) {
           py::arg("indexing_ram_limit"), py::arg("num_threads"),
           py::arg("pq_disk_bytes") = 0);
 
-  py::class_<DiskANNIndex<int8_t> >(m, "DiskANNInt8Index")
+  py::class_<DiskANNIndex<int8_t>>(m, "DiskANNInt8Index")
       .def(py::init([](diskann::Metric metric) {
-        return std::unique_ptr<DiskANNIndex<int8_t> >(
+        return std::unique_ptr<DiskANNIndex<int8_t>>(
             new DiskANNIndex<int8_t>(metric));
       }))
       .def("cache_bfs_levels", &DiskANNIndex<int8_t>::cache_bfs_levels,
-        py::arg("num_nodes_to_cache"))
+           py::arg("num_nodes_to_cache"))
       .def("load_index", &DiskANNIndex<int8_t>::load_index,
            py::arg("index_path_prefix"), py::arg("num_threads"),
            py::arg("num_nodes_to_cache"), py::arg("cache_mechanism") = 1)
@@ -513,8 +498,8 @@ PYBIND11_MODULE(diskannpy, m) {
       .def("batch_range_search_numpy_input",
            &DiskANNIndex<int8_t>::batch_range_search_numpy_input,
            py::arg("queries"), py::arg("dim"), py::arg("num_queries"),
-           py::arg("range"), py::arg("min_list_size"), py::arg("max_list_size"), py::arg("beam_width"),
-           py::arg("num_threads"))
+           py::arg("range"), py::arg("min_list_size"), py::arg("max_list_size"),
+           py::arg("beam_width"), py::arg("num_threads"))
       .def(
           "build",
           [](DiskANNIndex<int8_t> &self, const char *data_file_path,
@@ -536,10 +521,9 @@ PYBIND11_MODULE(diskannpy, m) {
           py::arg("indexing_ram_limit"), py::arg("num_threads"),
           py::arg("pq_disk_bytes") = 0);
 
-  
-  py::class_<DiskANNIndex<uint8_t> >(m, "DiskANNUInt8Index")
+  py::class_<DiskANNIndex<uint8_t>>(m, "DiskANNUInt8Index")
       .def(py::init([](diskann::Metric metric) {
-        return std::unique_ptr<DiskANNIndex<uint8_t> >(
+        return std::unique_ptr<DiskANNIndex<uint8_t>>(
             new DiskANNIndex<uint8_t>(metric));
       }))
       .def("cache_bfs_levels", &DiskANNIndex<uint8_t>::cache_bfs_levels,
@@ -565,8 +549,8 @@ PYBIND11_MODULE(diskannpy, m) {
       .def("batch_range_search_numpy_input",
            &DiskANNIndex<uint8_t>::batch_range_search_numpy_input,
            py::arg("queries"), py::arg("dim"), py::arg("num_queries"),
-           py::arg("range"), py::arg("min_list_size"), py::arg("max_list_size"), py::arg("beam_width"),
-           py::arg("num_threads"))
+           py::arg("range"), py::arg("min_list_size"), py::arg("max_list_size"),
+           py::arg("beam_width"), py::arg("num_threads"))
       .def(
           "build",
           [](DiskANNIndex<uint8_t> &self, const char *data_file_path,

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1424,7 +1424,12 @@ namespace diskann {
       copy_aligned_data_from_file<_u8>(pq_compressed_file.c_str(), _pq_data,
                                        file_num_points, _num_pq_chunks,
                                        _num_pq_chunks);
+#ifdef EXEC_ENV_OLS
+      throw ANNException("load_pq_centroid_bin should not be called when EXEC_ENV_OLS is defined.",
+                         -1, __FUNCSIG__, __FILE__, __LINE__);
+#else
       _pq_table.load_pq_centroid_bin(pq_pivots_file.c_str(), _num_pq_chunks);
+#endif
     }
 
     copy_aligned_data_from_file<T>(filename, _data, file_num_points, file_dim,

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -28,22 +28,24 @@ namespace diskann {
   // (bin), and initialize max_points
   template<typename T, typename TagT>
   Index<T, TagT>::Index(Metric m, const size_t dim, const size_t max_points,
-                        const bool dynamic_index, const Parameters &indexParams,
-                        const Parameters &searchParams, const bool enable_tags,
-                        const bool concurrent_consolidate,
+                        const bool                dynamic_index,
+                        const MutationParameters &indexParams,
+                        const SearchParameters &  searchParams,
+                        const bool                enable_tags,
+                        const bool                concurrent_consolidate,
                         const bool pq_dist_build, const size_t num_pq_chunks,
                         const bool use_opq)
       : Index(m, dim, max_points, dynamic_index, enable_tags,
               concurrent_consolidate) {
-    _indexingQueueSize = indexParams.Get<uint32_t>("L");
-    _indexingRange = indexParams.Get<uint32_t>("R");
-    _indexingMaxC = indexParams.Get<uint32_t>("C");
-    _indexingAlpha = indexParams.Get<float>("alpha");
+    _indexingQueueSize = indexParams.get_search_list_size();
+    _indexingRange = indexParams.get_max_degree();
+    _indexingMaxC = indexParams.get_max_occlusion_size();
+    _indexingAlpha = indexParams.get_alpha();
 
-    uint32_t num_threads_srch = searchParams.Get<uint32_t>("num_threads");
-    uint32_t num_threads_indx = indexParams.Get<uint32_t>("num_threads");
+    uint32_t num_threads_srch = searchParams.get_num_threads();
+    uint32_t num_threads_indx = indexParams.get_num_threads();
     uint32_t num_scratch_spaces = num_threads_srch + num_threads_indx;
-    uint32_t search_l = searchParams.Get<uint32_t>("L");
+    uint32_t search_l = searchParams.get_search_list_size();
 
     initialize_query_scratch(num_scratch_spaces, search_l, _indexingQueueSize,
                              _indexingRange, _indexingMaxC, dim);
@@ -177,7 +179,7 @@ namespace diskann {
       return 0;
     }
     size_t tag_bytes_written;
-    TagT  *tag_data = new TagT[_nd + _num_frozen_pts];
+    TagT * tag_data = new TagT[_nd + _num_frozen_pts];
     for (_u32 i = 0; i < _nd; i++) {
       TagT tag;
       if (_location_to_tag.try_get(i, tag)) {
@@ -230,7 +232,7 @@ namespace diskann {
       max_degree = _final_graph[i].size() > max_degree
                        ? (_u32) _final_graph[i].size()
                        : max_degree;
-      index_size += (_u64) (sizeof(unsigned) * (GK + 1));
+      index_size += (_u64)(sizeof(unsigned) * (GK + 1));
     }
     out.seekp(file_offset, out.beg);
     out.write((char *) &index_size, sizeof(uint64_t));
@@ -321,7 +323,7 @@ namespace diskann {
     }
 
     size_t file_dim, file_num_points;
-    TagT  *tag_data;
+    TagT * tag_data;
 #ifdef EXEC_ENV_OLS
     load_bin<TagT>(reader, tag_data, file_num_points, file_dim);
 #else
@@ -681,7 +683,7 @@ namespace diskann {
 #pragma omp parallel for schedule(static, 65536)
     for (_s64 i = 0; i < (_s64) _nd; i++) {
       // extract point and distance reference
-      float   &dist = distances[i];
+      float &  dist = distances[i];
       const T *cur_vec = _data + (i * (size_t) _aligned_dim);
       dist = 0;
       float diff = 0;
@@ -719,7 +721,7 @@ namespace diskann {
     boost::dynamic_bitset<> &inserted_into_pool_bs =
         scratch->inserted_into_pool_bs();
     std::vector<unsigned> &id_scratch = scratch->id_scratch();
-    std::vector<float> &dist_scratch = scratch->dist_scratch();
+    std::vector<float> &   dist_scratch = scratch->dist_scratch();
     assert(id_scratch.size() == 0);
     T *aligned_query = scratch->aligned_query();
     memcpy(aligned_query, query, _dim * sizeof(T));
@@ -730,7 +732,7 @@ namespace diskann {
     float *query_float;
     float *query_rotated;
     float *pq_dists;
-    _u8   *pq_coord_scratch;
+    _u8 *  pq_coord_scratch;
     // Intialize PQ related scratch to use PQ based distances
     if (_pq_dist) {
       // Get scratch spaces
@@ -782,7 +784,7 @@ namespace diskann {
     // Lambda to batch compute query<-> node distances in PQ space
     auto compute_dists = [this, pq_coord_scratch, pq_dists](
                              const std::vector<unsigned> &ids,
-                             std::vector<float>          &dists_out) {
+                             std::vector<float> &         dists_out) {
       diskann::aggregate_coords(ids, this->_pq_data, this->_num_pq_chunks,
                                 pq_coord_scratch);
       diskann::pq_dist_lookup(pq_coord_scratch, ids.size(),
@@ -822,7 +824,7 @@ namespace diskann {
     uint32_t cmps = 0;
 
     while (best_L_nodes.has_unexpanded_node()) {
-      auto nbr = best_L_nodes.closest_unexpanded();   
+      auto nbr = best_L_nodes.closest_unexpanded();
       auto n = nbr.id;
       // Add node to expanded nodes to create pool for prune later
       if (!search_invocation &&
@@ -871,7 +873,7 @@ namespace diskann {
                 sizeof(T) * _aligned_dim);
           }
 
-          dist_scratch.push_back( _distance->compare(
+          dist_scratch.push_back(_distance->compare(
               aligned_query, _data + _aligned_dim * (size_t) id,
               (unsigned) _aligned_dim));
         }
@@ -920,7 +922,7 @@ namespace diskann {
   void Index<T, TagT>::occlude_list(
       const unsigned location, std::vector<Neighbor> &pool, const float alpha,
       const unsigned degree, const unsigned maxc, std::vector<unsigned> &result,
-      InMemQueryScratch<T>                 *scratch,
+      InMemQueryScratch<T> *                scratch,
       const tsl::robin_set<unsigned> *const delete_set_ptr) {
     if (pool.size() == 0)
       return;
@@ -937,7 +939,6 @@ namespace diskann {
     // Initialize occlude_factor to pool.size() many 0.0f values for correctness
     occlude_factor.insert(occlude_factor.end(), pool.size(), 0.0f);
 
-
     float cur_alpha = 1;
     while (cur_alpha <= alpha && result.size() < degree) {
       // used for MIPS, where we store a value of eps in cur_alpha to
@@ -951,7 +952,8 @@ namespace diskann {
         }
         // Set the entry to float::max so that is not considered again
         occlude_factor[iter - pool.begin()] = std::numeric_limits<float>::max();
-        // Add the entry to the result if its not been deleted, and doesn't add a self loop
+        // Add the entry to the result if its not been deleted, and doesn't add
+        // a self loop
         if (delete_set_ptr == nullptr ||
             delete_set_ptr->find(iter->id) == delete_set_ptr->end()) {
           if (iter->id != location) {
@@ -991,7 +993,7 @@ namespace diskann {
   void Index<T, TagT>::prune_neighbors(const unsigned         location,
                                        std::vector<Neighbor> &pool,
                                        std::vector<unsigned> &pruned_list,
-                                       InMemQueryScratch<T>  *scratch) {
+                                       InMemQueryScratch<T> * scratch) {
     prune_neighbors(location, pool, _indexingRange, _indexingMaxC,
                     _indexingAlpha, pruned_list, scratch);
   }
@@ -1010,7 +1012,7 @@ namespace diskann {
 
     // If using _pq_build, over-write the PQ distances with actual distances
     if (_pq_dist) {
-      for (auto& ngh : pool)
+      for (auto &ngh : pool)
         ngh.distance = _distance->compare(
             _data + _aligned_dim * (size_t) ngh.id,
             _data + _aligned_dim * (size_t) location, (unsigned) _aligned_dim);
@@ -1040,7 +1042,7 @@ namespace diskann {
   void Index<T, TagT>::inter_insert(unsigned               n,
                                     std::vector<unsigned> &pruned_list,
                                     const _u32             range,
-                                    InMemQueryScratch<T>  *scratch) {
+                                    InMemQueryScratch<T> * scratch) {
     const auto &src_pool = pruned_list;
 
     assert(!src_pool.empty());
@@ -1053,9 +1055,9 @@ namespace diskann {
       bool                  prune_needed = false;
       {
         LockGuard guard(_locks[des]);
-        auto     &des_pool = _final_graph[des];
+        auto &    des_pool = _final_graph[des];
         if (std::find(des_pool.begin(), des_pool.end(), n) == des_pool.end()) {
-          if (des_pool.size() < (_u64) (GRAPH_SLACK_FACTOR * range)) {
+          if (des_pool.size() < (_u64)(GRAPH_SLACK_FACTOR * range)) {
             des_pool.emplace_back(n);
             prune_needed = false;
           } else {
@@ -1072,7 +1074,7 @@ namespace diskann {
         std::vector<Neighbor>    dummy_pool(0);
 
         size_t reserveSize =
-            (size_t) (std::ceil(1.05 * GRAPH_SLACK_FACTOR * range));
+            (size_t)(std::ceil(1.05 * GRAPH_SLACK_FACTOR * range));
         dummy_visited.reserve(reserveSize);
         dummy_pool.reserve(reserveSize);
 
@@ -1101,25 +1103,25 @@ namespace diskann {
   template<typename T, typename TagT>
   void Index<T, TagT>::inter_insert(unsigned               n,
                                     std::vector<unsigned> &pruned_list,
-                                    InMemQueryScratch<T>  *scratch) {
+                                    InMemQueryScratch<T> * scratch) {
     inter_insert(n, pruned_list, _indexingRange, scratch);
   }
 
   template<typename T, typename TagT>
-  void Index<T, TagT>::link(Parameters &parameters) {
-    unsigned num_threads = parameters.Get<unsigned>("num_threads");
+  void Index<T, TagT>::link(const MutationParameters &parameters) {
+    uint32_t num_threads = parameters.get_num_threads();
     if (num_threads != 0)
       omp_set_num_threads(num_threads);
 
-    _saturate_graph = parameters.Get<bool>("saturate_graph");
+    _saturate_graph = parameters.is_saturate_graph();
 
     if (num_threads != 0)
       omp_set_num_threads(num_threads);
 
-    _indexingQueueSize = parameters.Get<unsigned>("L");  // Search list size
-    _indexingRange = parameters.Get<unsigned>("R");
-    _indexingMaxC = parameters.Get<unsigned>("C");
-    _indexingAlpha = parameters.Get<float>("alpha");
+    _indexingQueueSize = parameters.get_search_list_size();  // Search list size
+    _indexingRange = parameters.get_max_degree();
+    _indexingMaxC = parameters.get_max_occlusion_size();
+    _indexingAlpha = parameters.get_alpha();
 
     /* visit_order is a vector that is initialized to the entire graph */
     std::vector<unsigned>          visit_order;
@@ -1141,7 +1143,7 @@ namespace diskann {
 
     for (uint64_t p = 0; p < _nd; p++) {
       _final_graph[p].reserve(
-          (size_t) (std::ceil(_indexingRange * GRAPH_SLACK_FACTOR * 1.05)));
+          (size_t)(std::ceil(_indexingRange * GRAPH_SLACK_FACTOR * 1.05)));
     }
 
     std::vector<unsigned> init_ids;
@@ -1150,8 +1152,7 @@ namespace diskann {
     diskann::Timer link_timer;
 
 #pragma omp parallel for schedule(dynamic, 2048)
-    for (_s64 node_ctr = 0; node_ctr < (_s64) (visit_order.size());
-         node_ctr++) {
+    for (_s64 node_ctr = 0; node_ctr < (_s64)(visit_order.size()); node_ctr++) {
       auto node = visit_order[node_ctr];
 
       ScratchStoreManager<InMemQueryScratch<T>> manager(_query_scratch);
@@ -1163,7 +1164,7 @@ namespace diskann {
       {
         LockGuard guard(_locks[node]);
         _final_graph[node].reserve(
-            (_u64) (_indexingRange * GRAPH_SLACK_FACTOR * 1.05));
+            (_u64)(_indexingRange * GRAPH_SLACK_FACTOR * 1.05));
         _final_graph[node] = pruned_list;
         assert(_final_graph[node].size() <= _indexingRange);
       }
@@ -1180,8 +1181,7 @@ namespace diskann {
       diskann::cout << "Starting final cleanup.." << std::flush;
     }
 #pragma omp parallel for schedule(dynamic, 2048)
-    for (_s64 node_ctr = 0; node_ctr < (_s64) (visit_order.size());
-         node_ctr++) {
+    for (_s64 node_ctr = 0; node_ctr < (_s64)(visit_order.size()); node_ctr++) {
       auto node = visit_order[node_ctr];
       if (_final_graph[node].size() > _indexingRange) {
         ScratchStoreManager<InMemQueryScratch<T>> manager(_query_scratch);
@@ -1252,7 +1252,7 @@ namespace diskann {
 
   template<typename T, typename TagT>
   void Index<T, TagT>::build_with_data_populated(
-      Parameters &parameters, const std::vector<TagT> &tags) {
+      const MutationParameters &parameters, const std::vector<TagT> &tags) {
     diskann::cout << "Starting index build with " << _nd << " points... "
                   << std::endl;
 
@@ -1277,10 +1277,10 @@ namespace diskann {
       }
     }
 
-    uint32_t index_R = parameters.Get<uint32_t>("R");
-    uint32_t num_threads_index = parameters.Get<uint32_t>("num_threads");
-    uint32_t index_L = parameters.Get<uint32_t>("L");
-    uint32_t maxc = parameters.Get<uint32_t>("C");
+    uint32_t index_R = parameters.get_max_degree();
+    uint32_t num_threads_index = parameters.get_num_threads();
+    uint32_t index_L = parameters.get_search_list_size();
+    uint32_t maxc = parameters.get_max_occlusion_size();
 
     if (_query_scratch.size() == 0) {
       initialize_query_scratch(5 + num_threads_index, index_L, index_L, index_R,
@@ -1309,8 +1309,8 @@ namespace diskann {
 
   template<typename T, typename TagT>
   void Index<T, TagT>::build(const T *data, const size_t num_points_to_load,
-                             Parameters              &parameters,
-                             const std::vector<TagT> &tags) {
+                             const MutationParameters &parameters,
+                             const std::vector<TagT> & tags) {
     if (num_points_to_load == 0) {
       throw ANNException("Do not call build with 0 points", -1, __FUNCSIG__,
                          __FILE__, __LINE__);
@@ -1322,7 +1322,7 @@ namespace diskann {
     }
 
     std::unique_lock<std::shared_timed_mutex> ul(_update_lock);
-    
+
     {
       std::unique_lock<std::shared_timed_mutex> tl(_tag_lock);
       _nd = num_points_to_load;
@@ -1340,10 +1340,10 @@ namespace diskann {
   }
 
   template<typename T, typename TagT>
-  void Index<T, TagT>::build(const char              *filename,
-                             const size_t             num_points_to_load,
-                             Parameters              &parameters,
-                             const std::vector<TagT> &tags) {
+  void Index<T, TagT>::build(const char *              filename,
+                             const size_t              num_points_to_load,
+                             const MutationParameters &parameters,
+                             const std::vector<TagT> & tags) {
     std::unique_lock<std::shared_timed_mutex> ul(_update_lock);
     if (num_points_to_load == 0)
       throw ANNException("Do not call build with 0 points", -1, __FUNCSIG__,
@@ -1451,9 +1451,10 @@ namespace diskann {
   }
 
   template<typename T, typename TagT>
-  void Index<T, TagT>::build(const char  *filename,
-                             const size_t num_points_to_load,
-                             Parameters &parameters, const char *tag_filename) {
+  void Index<T, TagT>::build(const char *              filename,
+                             const size_t              num_points_to_load,
+                             const MutationParameters &parameters,
+                             const char *              tag_filename) {
     std::vector<TagT> tags;
 
     if (_enable_tags) {
@@ -1465,7 +1466,7 @@ namespace diskann {
         if (file_exists(tag_filename)) {
           diskann::cout << "Loading tags from " << tag_filename
                         << " for vamana index build" << std::endl;
-          TagT  *tag_data = nullptr;
+          TagT * tag_data = nullptr;
           size_t npts, ndim;
           diskann::load_bin(tag_filename, tag_data, npts, ndim);
           if (npts < num_points_to_load) {
@@ -1492,10 +1493,10 @@ namespace diskann {
 
   template<typename T, typename TagT>
   template<typename IdType>
-  std::pair<uint32_t, uint32_t> Index<T, TagT>::search(const T       *query,
+  std::pair<uint32_t, uint32_t> Index<T, TagT>::search(const T *      query,
                                                        const size_t   K,
                                                        const unsigned L,
-                                                       IdType        *indices,
+                                                       IdType *       indices,
                                                        float *distances) {
     if (K > (uint64_t) L) {
       throw ANNException("Set L to a value of at least K", -1, __FUNCSIG__,
@@ -1517,14 +1518,14 @@ namespace diskann {
     std::vector<unsigned> init_ids;
     init_ids.push_back(_start);
     std::shared_lock<std::shared_timed_mutex> lock(_update_lock);
-    auto retval =
+    auto                                      retval =
         iterate_to_fixed_point(query, L, init_ids, scratch, true, true);
     NeighborPriorityQueue &best_L_nodes = scratch->best_l_nodes();
 
     size_t pos = 0;
     for (int i = 0; i < best_L_nodes.size(); ++i) {
       if (best_L_nodes[i].id < _max_points) {
-        // safe because Index uses uint32_t ids internally 
+        // safe because Index uses uint32_t ids internally
         // and IDType will be uint32_t or uint64_t
         indices[pos] = (IdType) best_L_nodes[i].id;
         if (distances != nullptr) {
@@ -1552,7 +1553,7 @@ namespace diskann {
   template<typename T, typename TagT>
   size_t Index<T, TagT>::search_with_tags(const T *query, const uint64_t K,
                                           const unsigned L, TagT *tags,
-                                          float            *distances,
+                                          float *           distances,
                                           std::vector<T *> &res_vectors) {
     if (K > (uint64_t) L) {
       throw ANNException("Set L to a value of at least K", -1, __FUNCSIG__,
@@ -1731,12 +1732,11 @@ namespace diskann {
       }
     }
   }
-  
-   
+
   // Returns number of live points left after consolidation
   template<typename T, typename TagT>
   consolidation_report Index<T, TagT>::consolidate_deletes(
-      const Parameters &params) {
+      const MutationParameters &params) {
     if (!_enable_tags)
       throw diskann::ANNException("Point tag array not instantiated", -1,
                                   __FUNCSIG__, __FILE__, __LINE__);
@@ -1797,12 +1797,12 @@ namespace diskann {
                                   __FUNCSIG__, __FILE__, __LINE__);
     }
 
-    const unsigned range = params.Get<unsigned>("R");
-    const unsigned maxc = params.Get<unsigned>("C");
-    const float    alpha = params.Get<float>("alpha");
-    const unsigned num_threads = params.Get<unsigned>("num_threads") == 0
+    const unsigned range = params.get_max_degree();
+    const unsigned maxc = params.get_max_occlusion_size();
+    const float    alpha = params.get_alpha();
+    const unsigned num_threads = params.get_num_threads() == 0
                                      ? omp_get_num_threads()
-                                     : params.Get<unsigned>("num_threads");
+                                     : params.get_num_threads();
 
     unsigned       num_calls_to_process_delete = 0;
     diskann::Timer timer;
@@ -1817,7 +1817,7 @@ namespace diskann {
         num_calls_to_process_delete += 1;
       }
     }
-    for (_s64 loc = _max_points; loc < (_s64) (_max_points + _num_frozen_pts);
+    for (_s64 loc = _max_points; loc < (_s64)(_max_points + _num_frozen_pts);
          loc++) {
       ScratchStoreManager<InMemQueryScratch<T>> manager(_query_scratch);
       auto scratch = manager.scratch_space();
@@ -1982,7 +1982,7 @@ namespace diskann {
                   << timer.elapsed() / 1000000. << "s." << std::endl;
   }
 
-  // 
+  //
   // Caller must hold unique _tag_lock and _delete_lock before calling this
   //
   template<typename T, typename TagT>
@@ -2141,7 +2141,7 @@ namespace diskann {
         dl.lock();
 
         if (_nd >= _max_points) {
-          auto new_max_points = (size_t) (_max_points * INDEX_GROWTH_FACTOR);
+          auto new_max_points = (size_t)(_max_points * INDEX_GROWTH_FACTOR);
           resize(new_max_points);
         }
 
@@ -2202,7 +2202,7 @@ namespace diskann {
       LockGuard guard(_locks[location]);
       _final_graph[location].clear();
       _final_graph[location].reserve(
-          (_u64) (_indexingRange * GRAPH_SLACK_FACTOR * 1.05));
+          (_u64)(_indexingRange * GRAPH_SLACK_FACTOR * 1.05));
 
       for (auto link : pruned_list) {
         if (_conc_consolidate)
@@ -2244,7 +2244,7 @@ namespace diskann {
 
   template<typename T, typename TagT>
   void Index<T, TagT>::lazy_delete(const std::vector<TagT> &tags,
-                                   std::vector<TagT>       &failed_tags) {
+                                   std::vector<TagT> &      failed_tags) {
     if (failed_tags.size() > 0) {
       throw ANNException("failed_tags should be passed as an empty list", -1,
                          __FUNCSIG__, __FILE__, __LINE__);
@@ -2383,7 +2383,7 @@ namespace diskann {
 
     boost::dynamic_bitset<> flags{_nd, 0};
     unsigned                tmp_l = 0;
-    unsigned               *neighbors =
+    unsigned *              neighbors =
         (unsigned *) (_opt_graph + _node_size * _start + _data_len);
     unsigned MaxM_ep = *neighbors;
     neighbors++;
@@ -2413,7 +2413,7 @@ namespace diskann {
       unsigned id = init_ids[i];
       if (id >= _nd)
         continue;
-      T    *x = (T *) (_opt_graph + _node_size * id);
+      T *   x = (T *) (_opt_graph + _node_size * id);
       float norm_x = *x;
       x++;
       float dist =
@@ -2438,7 +2438,7 @@ namespace diskann {
         if (flags[id])
           continue;
         flags[id] = 1;
-        T    *data = (T *) (_opt_graph + _node_size * id);
+        T *   data = (T *) (_opt_graph + _node_size * id);
         float norm = *data;
         data++;
         float dist =
@@ -2472,56 +2472,56 @@ namespace diskann {
   template DISKANN_DLLEXPORT class Index<uint8_t, uint64_t>;
 
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<float, uint64_t>::search<uint64_t>(const float *query, const size_t K,
+                             Index<float, uint64_t>::search<uint64_t>(const float *query, const size_t K,
                                            const unsigned L, uint64_t *indices,
                                            float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<float, uint64_t>::search<uint32_t>(const float *query, const size_t K,
+                             Index<float, uint64_t>::search<uint32_t>(const float *query, const size_t K,
                                            const unsigned L, uint32_t *indices,
                                            float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<uint8_t, uint64_t>::search<uint64_t>(const uint8_t *query,
+                             Index<uint8_t, uint64_t>::search<uint64_t>(const uint8_t *query,
                                              const size_t K, const unsigned L,
                                              uint64_t *indices,
-                                             float    *distances);
+                                             float *   distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<uint8_t, uint64_t>::search<uint32_t>(const uint8_t *query,
+                             Index<uint8_t, uint64_t>::search<uint32_t>(const uint8_t *query,
                                              const size_t K, const unsigned L,
                                              uint32_t *indices,
-                                             float    *distances);
+                                             float *   distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<int8_t, uint64_t>::search<uint64_t>(const int8_t *query, const size_t K,
+                             Index<int8_t, uint64_t>::search<uint64_t>(const int8_t *query, const size_t K,
                                             const unsigned L, uint64_t *indices,
                                             float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<int8_t, uint64_t>::search<uint32_t>(const int8_t *query, const size_t K,
+                             Index<int8_t, uint64_t>::search<uint32_t>(const int8_t *query, const size_t K,
                                             const unsigned L, uint32_t *indices,
                                             float *distances);
   // TagT==uint32_t
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<float, uint32_t>::search<uint64_t>(const float *query, const size_t K,
+                             Index<float, uint32_t>::search<uint64_t>(const float *query, const size_t K,
                                            const unsigned L, uint64_t *indices,
                                            float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<float, uint32_t>::search<uint32_t>(const float *query, const size_t K,
+                             Index<float, uint32_t>::search<uint32_t>(const float *query, const size_t K,
                                            const unsigned L, uint32_t *indices,
                                            float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<uint8_t, uint32_t>::search<uint64_t>(const uint8_t *query,
+                             Index<uint8_t, uint32_t>::search<uint64_t>(const uint8_t *query,
                                              const size_t K, const unsigned L,
                                              uint64_t *indices,
-                                             float    *distances);
+                                             float *   distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<uint8_t, uint32_t>::search<uint32_t>(const uint8_t *query,
+                             Index<uint8_t, uint32_t>::search<uint32_t>(const uint8_t *query,
                                              const size_t K, const unsigned L,
                                              uint32_t *indices,
-                                             float    *distances);
+                                             float *   distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<int8_t, uint32_t>::search<uint64_t>(const int8_t *query, const size_t K,
+                             Index<int8_t, uint32_t>::search<uint64_t>(const int8_t *query, const size_t K,
                                             const unsigned L, uint64_t *indices,
                                             float *distances);
   template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t>
-  Index<int8_t, uint32_t>::search<uint32_t>(const int8_t *query, const size_t K,
+                             Index<int8_t, uint32_t>::search<uint32_t>(const int8_t *query, const size_t K,
                                             const unsigned L, uint32_t *indices,
                                             float *distances);
 

--- a/tests/build_memory_index.cpp
+++ b/tests/build_memory_index.cpp
@@ -27,14 +27,9 @@ int build_in_memory_index(const diskann::Metric& metric,
                           const std::string& save_path,
                           const unsigned num_threads, const bool use_pq_build,
                           const size_t num_pq_bytes, const bool use_opq) {
-  diskann::Parameters paras;
-  paras.Set<unsigned>("R", R);
-  paras.Set<unsigned>("L", L);
-  paras.Set<unsigned>(
-      "C", 750);  // maximum candidate set size during pruning procedure
-  paras.Set<float>("alpha", alpha);
-  paras.Set<bool>("saturate_graph", 0);
-  paras.Set<unsigned>("num_threads", num_threads);
+  diskann::MutationParameters paras(
+      L, R, false, diskann::defaults::MAX_OCCLUSION_SIZE,
+      diskann::defaults::ALPHA, diskann::defaults::NUM_ROUNDS, num_threads);
 
   _u64 data_num, data_dim;
   diskann::get_bin_metadata(data_path, data_num, data_dim);
@@ -89,7 +84,8 @@ int main(int argc, char** argv) {
         "Number of threads used for building index (defaults to "
         "omp_get_num_procs())");
     desc.add_options()(
-        "build_PQ_bytes", po::value<uint32_t>(&build_PQ_bytes)->default_value(0),
+        "build_PQ_bytes",
+        po::value<uint32_t>(&build_PQ_bytes)->default_value(0),
         "Number of PQ bytes to build the index; 0 for full precision build");
     desc.add_options()(
         "use_opq", po::bool_switch()->default_value(false),
@@ -129,17 +125,17 @@ int main(int argc, char** argv) {
                   << "  alpha: " << alpha << "  #threads: " << num_threads
                   << std::endl;
     if (data_type == std::string("int8"))
-      return build_in_memory_index<int8_t>(metric, data_path, R, L, alpha,
-                                           index_path_prefix, num_threads,
-                                           use_pq_build, build_PQ_bytes, use_opq);
+      return build_in_memory_index<int8_t>(
+          metric, data_path, R, L, alpha, index_path_prefix, num_threads,
+          use_pq_build, build_PQ_bytes, use_opq);
     else if (data_type == std::string("uint8"))
       return build_in_memory_index<uint8_t>(
           metric, data_path, R, L, alpha, index_path_prefix, num_threads,
           use_pq_build, build_PQ_bytes, use_opq);
     else if (data_type == std::string("float"))
-      return build_in_memory_index<float>(metric, data_path, R, L, alpha,
-                                          index_path_prefix, num_threads,
-                                          use_pq_build, build_PQ_bytes, use_opq);
+      return build_in_memory_index<float>(
+          metric, data_path, R, L, alpha, index_path_prefix, num_threads,
+          use_pq_build, build_PQ_bytes, use_opq);
     else {
       std::cout << "Unsupported type. Use one of int8, uint8 or float."
                 << std::endl;

--- a/tests/search_memory_index.cpp
+++ b/tests/search_memory_index.cpp
@@ -64,7 +64,6 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
     index.optimize_index_layout();
 
   std::cout << "Using " << num_threads << " threads to search" << std::endl;
-  diskann::Parameters paras;
   std::cout.setf(std::ios_base::fixed, std::ios_base::floatfield);
   std::cout.precision(2);
   const std::string qps_title = show_qps_per_thread ? "QPS/thread" : "QPS";
@@ -178,12 +177,12 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
     if (tags) {
       std::cout << std::setw(4) << L << std::setw(12) << displayed_qps
                 << std::setw(20) << (float) mean_latency << std::setw(15)
-                << (float) latency_stats[(_u64) (0.999 * query_num)];
+                << (float) latency_stats[(_u64)(0.999 * query_num)];
     } else {
       std::cout << std::setw(4) << L << std::setw(12) << displayed_qps
                 << std::setw(18) << avg_cmps << std::setw(20)
                 << (float) mean_latency << std::setw(15)
-                << (float) latency_stats[(_u64) (0.999 * query_num)];
+                << (float) latency_stats[(_u64)(0.999 * query_num)];
     }
     for (float recall : recalls) {
       std::cout << std::setw(12) << recall;
@@ -211,7 +210,6 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
 
   return best_recall >= fail_if_recall_below ? 0 : -1;
 }
-
 
 int main(int argc, char** argv) {
   std::string data_type, dist_fn, index_path_prefix, result_path, query_file,


### PR DESCRIPTION
The existing Parameters class tried to make for a generic, type-agnostic configuration class.

After finding a double free bug rooted in the destructor of Parameters and not being able to satisfactorily rectify it as is, we decided a simple refactor and a very simple set of configuration objects would help sanitize things and unblock us from using this in Python, which invariably resulted in either a munmap: invalid pointer, free: invalid size, double free (!prev), or segfault



