### PR TITLE
Fix BANN build failure after adding streamingDiskANN.

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1427,9 +1427,9 @@ namespace diskann {
 #ifdef EXEC_ENV_OLS
       throw ANNException("load_pq_centroid_bin should not be called when EXEC_ENV_OLS is defined.",
                          -1, __FUNCSIG__, __FILE__, __LINE__);
-      //pq_table.load_pq_centroid_bin(files, pq_pivots_file.c_str(), _num_pq_chunks);
+      //_pq_table.load_pq_centroid_bin(files, pq_pivots_file.c_str(), _num_pq_chunks);
 #else
-      pq_table.load_pq_centroid_bin(pq_pivots_file.c_str(), _num_pq_chunks);
+      _pq_table.load_pq_centroid_bin(pq_pivots_file.c_str(), _num_pq_chunks);
 #endif
     }
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1427,7 +1427,6 @@ namespace diskann {
 #ifdef EXEC_ENV_OLS
       throw ANNException("load_pq_centroid_bin should not be called when EXEC_ENV_OLS is defined.",
                          -1, __FUNCSIG__, __FILE__, __LINE__);
-      //_pq_table.load_pq_centroid_bin(files, pq_pivots_file.c_str(), _num_pq_chunks);
 #else
       _pq_table.load_pq_centroid_bin(pq_pivots_file.c_str(), _num_pq_chunks);
 #endif

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1424,7 +1424,11 @@ namespace diskann {
       copy_aligned_data_from_file<_u8>(pq_compressed_file.c_str(), _pq_data,
                                        file_num_points, _num_pq_chunks,
                                        _num_pq_chunks);
-      _pq_table.load_pq_centroid_bin(pq_pivots_file.c_str(), _num_pq_chunks);
+#ifdef EXEC_ENV_OLS
+      //pq_table.load_pq_centroid_bin(files, pq_pivots_file.c_str(), _num_pq_chunks);
+#else
+      pq_table.load_pq_centroid_bin(pq_pivots_file.c_str(), _num_pq_chunks);
+#endif
     }
 
     copy_aligned_data_from_file<T>(filename, _data, file_num_points, file_dim,

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1425,6 +1425,8 @@ namespace diskann {
                                        file_num_points, _num_pq_chunks,
                                        _num_pq_chunks);
 #ifdef EXEC_ENV_OLS
+      throw ANNException("load_pq_centroid_bin should not be called when EXEC_ENV_OLS is defined.",
+                         -1, __FUNCSIG__, __FILE__, __LINE__);
       //pq_table.load_pq_centroid_bin(files, pq_pivots_file.c_str(), _num_pq_chunks);
 #else
       pq_table.load_pq_centroid_bin(pq_pivots_file.c_str(), _num_pq_chunks);


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Briefly explain your changes.
When EXEC_ENV_OLS is defined, build will fail because of load_pq_centroid_bin function signature mismatch.

#### Any other comments?

