### PR TITLE
Save function slow on VMs with remote disks #243

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -203,10 +203,16 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
     // No copy/assign.
     Index(const Index<T, TagT, LabelT> &) = delete;
     Index<T, TagT, LabelT> &operator=(const Index<T, TagT, LabelT> &) = delete;
+    bool _coalasce_writes = true;
+    // weighted average of records saved per save
+    int _avg_records_per_save = 0;  
 
     // Use after _data and _nd have been populated
     // Acquire exclusive _update_lock before calling
     void build_with_data_populated(Parameters &parameters, const std::vector<TagT> &tags);
+
+    // check if data going to be saved is small
+    inline void is_small_segment();
 
     // generates 1 frozen point that will never be deleted from the graph
     // This is not visible to the user

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -263,9 +263,30 @@ _u64 Index<T, TagT, LabelT>::save_delete_list(const std::string &filename)
 }
 
 template <typename T, typename TagT, typename LabelT>
+inline bool Index<T, TagT, LabelT>::is_small_segment()
+{
+    if(!_coalasce_writes)
+        return true;
+
+    if(_label_to_medoid_id.size() >= (_avg_records_per_save) / 2)
+    {
+        _avg_records_per_save = 
+                    (2 * _avg_records_per_save + _label_to_medoid_id.size()) / 3
+        return true;
+    }
+    return false;
+}
+
+template <typename T, typename TagT, typename LabelT>
 void Index<T, TagT, LabelT>::save(const char *filename, bool compact_before_save)
 {
     diskann::Timer timer;
+
+    if(is_small_segment())
+    {
+        diskann::cout << "Small Write, will be coalasced into next write" << std::endl;
+        return;
+    }
 
     std::unique_lock<std::shared_timed_mutex> ul(_update_lock);
     std::unique_lock<std::shared_timed_mutex> cl(_consolidate_lock);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [x] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
#243


#### What does this implement/fix? Briefly explain your changes.
added protected parameter _coalasce_writes which will coalesce writes if set to true
save() calls is_small write which decides if write should is too small (will be coalesced next time when write is called) 

#### Any other comments?

