### PR TITLE
GT computation with individual labels for queries

### DIFF
--- a/tests/search_memory_index.cpp
+++ b/tests/search_memory_index.cpp
@@ -134,6 +134,7 @@ int search_memory_index(diskann::Metric& metric, const std::string& index_path,
         }
 
     query_result_ids[test_id].resize(recall_at * query_num);
+    query_result_dists[test_id].resize(recall_at * query_num);
     std::vector<T*> res = std::vector<T*>();
 
         auto s = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Addresses #265. This PR adds support for computing ground truths when every query in the query file appears with its own label. 
-->

#### What does this implement/fix? Briefly explain your changes.
Based on the queries that appear in the query label file, both the base bin file and the query bin file are split into label specific ones. Then individual searches are run for each label, and then finally the label specific results are combined. Some bookkeeping was required to combine the label specific ground truth files.

#### Any other comments?

