### PR TITLE
remove the distance 0 warning in prune candidate the list

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1293,10 +1293,6 @@ void Index<T, TagT, LabelT>::prune_neighbors(const uint32_t location, std::vecto
     pruned_list.clear();
     pruned_list.reserve(range);
 
-    if (pool.begin()->distance == 0)
-    {
-        diskann::cerr << "Warning: a candidate with distance 0 found in prune_neighbors" << std::endl;
-    }
     occlude_list(location, pool, alpha, range, max_candidate_size, pruned_list, scratch);
     assert(pruned_list.size() <= range);
 


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
remove the distance 0 warning in prune candidate the list, since diskann::cerr does not seem thread safe.  See issue #329 

#### Any other comments?

