### PR TITLE
Disabling Python builds

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -303,25 +303,25 @@ jobs:
         ${{ env.diskann_built_tests }}/build_stitched_index --num_threads 48 --data_type uint8 --data_path ./rand_uint8_10D_10K_norm50.0.bin --label_file ./zipf_labels_50_10K.txt -R 32 -L 100 --alpha 1.2 --stitched_R 64 --index_path_prefix ./stit_zipf_32_100_64_new --universal_label 0
         ${{ env.diskann_built_tests }}/search_memory_index --num_threads 48 --data_type uint8 --dist_fn l2 --filter_label 10 --index_path_prefix ./stit_rand_32_100_64_new --query_file ./rand_uint8_10D_1K_norm50.0.bin --result_path ./rand_stit_96_10_90_new --gt_file ./l2_rand_uint8_10D_10K_norm50.0_10D_1K_norm50.0_gt100_wlabel -K 10 -L 16 32 150
         ${{ env.diskann_built_tests }}/search_memory_index --num_threads 48 --data_type uint8 --dist_fn l2 --filter_label 5 --index_path_prefix ./stit_zipf_32_100_64_new --query_file ./rand_uint8_10D_1K_norm50.0.bin --result_path ./zipf_stit_96_10_90_new --gt_file ./l2_zipf_uint8_10D_10K_norm50.0_10D_1K_norm50.0_gt100_wlabel -K 10 -L 16 32 150
-    - uses: actions/setup-python@v3
-      with:
-        python-version: "3.10"
-    - name: Install cibuildwheel
-      run: python -m pip install cibuildwheel==2.11.3
-    - name: build wheels
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: python -m cibuildwheel --output-dir wheelhouse
-      env:
-        CIBW_ARCHS_WINDOWS: AMD64
-        CIBW_ARCHS_LINUX: x86_64
-    - name: Run Python Unit tests
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: |
-        pip install wheelhouse/diskannpy-*-cp310-cp310-manylinux_2_24_x86_64.whl
-        pip install scikit-learn
-        LD_PRELOAD="/lib/x86_64-linux-gnu/libmkl_intel_thread.so:/lib/x86_64-linux-gnu/libmkl_intel_ilp64.so:/lib/x86_64-linux-gnu/libmkl_core.so:/lib/x86_64-linux-gnu/libiomp5.so:/lib/x86_64-linux-gnu/libmkl_avx2.so:/lib/x86_64-linux-gnu/libmkl_def.so" python -m unittest discover python/tests
-    - uses: actions/upload-artifact@v3
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      with:
-        name: wheelhouse
-        path: ./wheelhouse/*.whl
+#     - uses: actions/setup-python@v3
+#       with:
+#         python-version: "3.10"
+#     - name: Install cibuildwheel
+#       run: python -m pip install cibuildwheel==2.11.3
+#     - name: build wheels
+#       if: ${{ matrix.os == 'ubuntu-latest' }}
+#       run: python -m cibuildwheel --output-dir wheelhouse
+#       env:
+#         CIBW_ARCHS_WINDOWS: AMD64
+#         CIBW_ARCHS_LINUX: x86_64
+#     - name: Run Python Unit tests
+#       if: ${{ matrix.os == 'ubuntu-latest' }}
+#       run: |
+#         pip install wheelhouse/diskannpy-*-cp310-cp310-manylinux_2_24_x86_64.whl
+#         pip install scikit-learn
+#         LD_PRELOAD="/lib/x86_64-linux-gnu/libmkl_intel_thread.so:/lib/x86_64-linux-gnu/libmkl_intel_ilp64.so:/lib/x86_64-linux-gnu/libmkl_core.so:/lib/x86_64-linux-gnu/libiomp5.so:/lib/x86_64-linux-gnu/libmkl_avx2.so:/lib/x86_64-linux-gnu/libmkl_def.so" python -m unittest discover python/tests
+#     - uses: actions/upload-artifact@v3
+#       if: ${{ matrix.os == 'ubuntu-latest' }}
+#       with:
+#         name: wheelhouse
+#         path: ./wheelhouse/*.whl

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -13,25 +13,25 @@ jobs:
       run: |
         mkdir build && cd build && cmake -DRESTAPI=True -DCMAKE_BUILD_TYPE=Release ..
         make checkformat
-    - name: build
-      run: |
-        cd build && make -j
-    - uses: actions/setup-python@v3
-      with:
-        python-version: "3.10"
-    - name: Install Python Build Module
-      run: python -m pip install build
-    - name: Python Build
-      run: python -m build
-    - name: Run Python Unit tests
-      run: |
-        pip install scikit-learn
-        pip install dist/*.whl
-        LD_PRELOAD="/lib/x86_64-linux-gnu/libmkl_intel_thread.so:/lib/x86_64-linux-gnu/libmkl_intel_ilp64.so:/lib/x86_64-linux-gnu/libmkl_core.so:/lib/x86_64-linux-gnu/libiomp5.so:/lib/x86_64-linux-gnu/libmkl_avx2.so:/lib/x86_64-linux-gnu/libmkl_def.so" python -m unittest discover python/tests
-    - uses: actions/upload-artifact@v3
-      with:
-        name: wheelhouse
-        path: dist/*.whl
+#     - name: build
+#       run: |
+#         cd build && make -j
+#     - uses: actions/setup-python@v3
+#       with:
+#         python-version: "3.10"
+#     - name: Install Python Build Module
+#       run: python -m pip install build
+#     - name: Python Build
+#       run: python -m build
+#     - name: Run Python Unit tests
+#       run: |
+#         pip install scikit-learn
+#         pip install dist/*.whl
+#         LD_PRELOAD="/lib/x86_64-linux-gnu/libmkl_intel_thread.so:/lib/x86_64-linux-gnu/libmkl_intel_ilp64.so:/lib/x86_64-linux-gnu/libmkl_core.so:/lib/x86_64-linux-gnu/libiomp5.so:/lib/x86_64-linux-gnu/libmkl_avx2.so:/lib/x86_64-linux-gnu/libmkl_def.so" python -m unittest discover python/tests
+#     - uses: actions/upload-artifact@v3
+#       with:
+#         name: wheelhouse
+#         path: dist/*.whl
 
   docker-container-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Debian stretch no longer seems to have valid apt repos - or at least not ones that we can access in our github actions - which means our cibuildwheel is failing, and making it impossible for anyone to complete a merge.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.

#### Any other comments?

