### PR TITLE
Refine custom logger, support early-return and expose more stats(memory usage, scratching wating time .etc)

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -146,6 +146,11 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
     DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t> search(const T *query, const size_t K, const uint32_t L,
                                                            IDType *indices, float *distances = nullptr);
 
+    template <typename IDType>
+    DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t> search(const T *query, const size_t K, const uint32_t L,
+                                                           IDType *indices, float *distances,
+                                                           IndexSearchContext<LabelT> &context);
+
     // Initialize space for res_vectors before calling.
     DISKANN_DLLEXPORT size_t search_with_tags(const T *query, const uint64_t K, const uint32_t L, TagT *tags,
                                               float *distances, std::vector<T *> &res_vectors);
@@ -235,7 +240,8 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
     std::pair<uint32_t, uint32_t> iterate_to_fixed_point(const T *node_coords, const uint32_t Lindex,
                                                          const std::vector<uint32_t> &init_ids,
                                                          InMemQueryScratch<T> *scratch, bool use_filter,
-                                                         const std::vector<LabelT> &filters, bool search_invocation);
+                                                         const std::vector<LabelT> &filters, bool search_invocation,
+                                                         IndexSearchContext<LabelT> *context = nullptr);
 
     void search_for_point_and_prune(int location, uint32_t Lindex, std::vector<uint32_t> &pruned_list,
                                     InMemQueryScratch<T> *scratch, bool use_filter = false,
@@ -308,6 +314,11 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
     DISKANN_DLLEXPORT size_t load_tags(const std::string tag_file_name);
     DISKANN_DLLEXPORT size_t load_delete_set(const std::string &filename);
 #endif
+
+    template <typename IndexType>
+    std::pair<uint32_t, uint32_t> search_with_filters(const T *query, const size_t K, const uint32_t L,
+                                                      IndexType *indices, float *distances,
+                                                      IndexSearchContext<LabelT> &context);
 
   private:
     // Distance functions

--- a/include/index.h
+++ b/include/index.h
@@ -102,6 +102,7 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
     // get some private variables
     DISKANN_DLLEXPORT size_t get_num_points();
     DISKANN_DLLEXPORT size_t get_max_points();
+    DISKANN_DLLEXPORT uint64_t get_memory_in_bytes();
 
     // Batch build from a file. Optionally pass tags vector.
     DISKANN_DLLEXPORT void build(const char *filename, const size_t num_points_to_load,
@@ -377,6 +378,8 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
     uint8_t *_pq_data = nullptr;
     bool _pq_generated = false;
     FixedChunkPQTable _pq_table;
+
+    uint64_t _memory_in_bytes;
 
     //
     // Data structures, locks and flags for dynamic indexing and tags

--- a/include/index.h
+++ b/include/index.h
@@ -390,8 +390,6 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
     bool _pq_generated = false;
     FixedChunkPQTable _pq_table;
 
-    uint64_t _memory_in_bytes;
-
     //
     // Data structures, locks and flags for dynamic indexing and tags
     //
@@ -424,6 +422,8 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
 
     // Per node lock, cardinality=_max_points
     std::vector<non_recursive_mutex> _locks;
+
+    uint64_t _memory_in_bytes;
 
     static const float INDEX_GROWTH_FACTOR;
 };

--- a/include/logger.h
+++ b/include/logger.h
@@ -6,6 +6,12 @@
 #include <iostream>
 #include "windows_customizations.h"
 
+#ifdef EXEC_ENV_OLS
+#ifndef ENABLE_CUSTOM_LOGGER
+#define ENABLE_CUSTOM_LOGGER
+#endif // !ENABLE_CUSTOM_LOGGER
+#endif // EXEC_ENV_OLS
+
 namespace diskann
 {
 DISKANN_DLLEXPORT extern std::basic_ostream<char> cout;
@@ -18,7 +24,7 @@ enum class DISKANN_DLLEXPORT LogLevel
     LL_Count
 };
 
-#ifdef EXEC_ENV_OLS
+#ifdef ENABLE_CUSTOM_LOGGER
 DISKANN_DLLEXPORT void SetCustomLogger(std::function<void(LogLevel, const char *)> logger);
 #endif
 } // namespace diskann

--- a/include/logger_impl.h
+++ b/include/logger_impl.h
@@ -50,7 +50,7 @@ class ANNStreamBuf : public std::basic_streambuf<char>
 // overflows/missing text are not a concern).
 // This implies calling code _must_ either print std::endl or std::flush
 // to ensure that the message is written immediately.
-#ifdef EXEC_ENV_OLS
+#ifdef ENABLE_CUSTOM_LOGGER
     static const int BUFFER_SIZE = 1024;
 #else
     // Allocating an arbitrarily small buffer here because the overflow() and

--- a/include/parameters.h
+++ b/include/parameters.h
@@ -214,11 +214,11 @@ template <typename LabelT = uint32_t> class IndexSearchContext
 
   private:
     uint32_t _time_limit_in_microseconds;
-    State _result_state;
-    Timer _timer;
     uint32_t _io_limit;
-    LabelT _label;
+    State _result_state;
     bool _use_filter;
+    LabelT _label;
+    Timer _timer;
 };
 
 } // namespace diskann

--- a/include/parameters.h
+++ b/include/parameters.h
@@ -9,6 +9,7 @@
 #include "defaults.h"
 #include "timer.h"
 #include "windows_customizations.h"
+#include "percentile_stats.h"
 
 namespace diskann
 {
@@ -160,14 +161,6 @@ template <typename LabelT = uint32_t> class IndexSearchContext
     }
 
     /// <summary>
-    /// Set stats(compare count, IO count, compare time, IO time .etc)
-    /// </summary>
-    /// <param name=""></param>
-    virtual void SetCounter(const std::string & /*name*/, uint64_t /*value*/)
-    {
-    }
-
-    /// <summary>
     /// Set the searching result
     /// </summary>
     /// <param name="status"></param>
@@ -212,6 +205,11 @@ template <typename LabelT = uint32_t> class IndexSearchContext
         return false;
     }
 
+    QueryStats &GetStats()
+    {
+        return _stats;
+    }
+
   private:
     uint32_t _time_limit_in_microseconds;
     uint32_t _io_limit;
@@ -219,6 +217,7 @@ template <typename LabelT = uint32_t> class IndexSearchContext
     bool _use_filter;
     LabelT _label;
     Timer _timer;
+    QueryStats _stats;
 };
 
 } // namespace diskann

--- a/include/parameters.h
+++ b/include/parameters.h
@@ -144,18 +144,19 @@ enum State : uint8_t
 template <typename LabelT = uint32_t> class IndexSearchContext
 {
   public:
-    IndexSearchContext(LabelT label, bool use_filter = false, uint32_t time_limit_in_microseconds = 0u,
+    IndexSearchContext(LabelT label, bool use_filter, uint32_t time_limit_in_microseconds = 0u,
                        uint32_t io_limit = UINT32_MAX)
         : IndexSearchContext(time_limit_in_microseconds, io_limit)
     {
-        _label = label;
         _use_filter = use_filter;
+        _label = label;
     }
 
     IndexSearchContext(uint32_t time_limit_in_microseconds = 0u, uint32_t io_limit = UINT32_MAX)
         : _time_limit_in_microseconds(time_limit_in_microseconds), _io_limit(io_limit), _result_state(State::Unknown)
     {
         _use_filter = false;
+        _label = (LabelT)0;
     }
 
     /// <summary>
@@ -220,5 +221,4 @@ template <typename LabelT = uint32_t> class IndexSearchContext
     bool _use_filter;
 };
 
-template DISKANN_DLLEXPORT class IndexSearchContext<UINT32>;
 } // namespace diskann

--- a/include/parameters.h
+++ b/include/parameters.h
@@ -139,20 +139,12 @@ enum State : uint8_t
 };
 
 /// <summary>
-/// Use this class to pass in/out searching parameters/result
+/// Use this class to pass in searching parameters and pass out searching result
 /// </summary>
 
 template <typename LabelT = uint32_t> class IndexSearchContext
 {
   public:
-    IndexSearchContext(LabelT label, bool use_filter, uint32_t time_limit_in_microseconds = 0u,
-                       uint32_t io_limit = UINT32_MAX)
-        : IndexSearchContext(time_limit_in_microseconds, io_limit)
-    {
-        _use_filter = use_filter;
-        _label = label;
-    }
-
     IndexSearchContext(uint32_t time_limit_in_microseconds = 0u, uint32_t io_limit = UINT32_MAX)
         : _time_limit_in_microseconds(time_limit_in_microseconds), _io_limit(io_limit), _result_state(State::Unknown)
     {
@@ -160,11 +152,13 @@ template <typename LabelT = uint32_t> class IndexSearchContext
         _label = (LabelT)0;
     }
 
-    /// <summary>
-    /// Set the searching result
-    /// </summary>
-    /// <param name="status"></param>
-    virtual void SetState(State state)
+    void SetLabel(LabelT label, bool use_filter)
+    {
+        _label = label;
+        _use_filter = use_filter;
+    }
+
+    void SetState(State state)
     {
         _result_state = state;
     }

--- a/include/percentile_stats.h
+++ b/include/percentile_stats.h
@@ -20,9 +20,10 @@ namespace diskann
 {
 struct QueryStats
 {
-    float total_us = 0; // total time to process query in micros
-    float io_us = 0;    // total time spent in IO
-    float cpu_us = 0;   // total time spent in CPU
+    float total_us = 0;   // total time to process query in micros
+    float io_us = 0;      // total time spent in IO
+    float cpu_us = 0;     // total time spent in CPU
+    float scratch_us = 0; // time spent to allocate scratch
 
     unsigned n_4k = 0;         // # of 4kB reads
     unsigned n_8k = 0;         // # of 8kB reads

--- a/include/pq.h
+++ b/include/pq.h
@@ -65,10 +65,9 @@ template <typename T> struct PQScratch
     PQScratch(size_t graph_degree, size_t aligned_dim)
     {
         memory_in_bytes = diskann::alloc_aligned((void **)&aligned_pq_coord_scratch,
-                               (size_t)graph_degree * (size_t)MAX_PQ_CHUNKS * sizeof(uint8_t), 256);
+                                                 (size_t)graph_degree * (size_t)MAX_PQ_CHUNKS * sizeof(uint8_t), 256);
         memory_in_bytes += diskann::alloc_aligned((void **)&aligned_pqtable_dist_scratch,
-                                                 256 * (size_t)MAX_PQ_CHUNKS * sizeof(float),
-                               256);
+                                                  256 * (size_t)MAX_PQ_CHUNKS * sizeof(float), 256);
         memory_in_bytes +=
             diskann::alloc_aligned((void **)&aligned_dist_scratch, (size_t)graph_degree * sizeof(float), 256);
         memory_in_bytes +=

--- a/include/pq.h
+++ b/include/pq.h
@@ -31,9 +31,9 @@ class FixedChunkPQTable
     virtual ~FixedChunkPQTable();
 
 #ifdef EXEC_ENV_OLS
-    void load_pq_centroid_bin(MemoryMappedFiles &files, const char *pq_table_file, size_t num_chunks);
+    uint64_t load_pq_centroid_bin(MemoryMappedFiles &files, const char *pq_table_file, size_t num_chunks);
 #else
-    void load_pq_centroid_bin(const char *pq_table_file, size_t num_chunks);
+    uint64_t load_pq_centroid_bin(const char *pq_table_file, size_t num_chunks);
 #endif
 
     uint32_t get_num_chunks();
@@ -60,16 +60,21 @@ template <typename T> struct PQScratch
     uint8_t *aligned_pq_coord_scratch = nullptr;   // MUST BE AT LEAST  [N_CHUNKS * MAX_DEGREE]
     float *rotated_query = nullptr;
     float *aligned_query_float = nullptr;
+    uint64_t memory_in_bytes = 0;
 
     PQScratch(size_t graph_degree, size_t aligned_dim)
     {
-        diskann::alloc_aligned((void **)&aligned_pq_coord_scratch,
+        memory_in_bytes = diskann::alloc_aligned((void **)&aligned_pq_coord_scratch,
                                (size_t)graph_degree * (size_t)MAX_PQ_CHUNKS * sizeof(uint8_t), 256);
-        diskann::alloc_aligned((void **)&aligned_pqtable_dist_scratch, 256 * (size_t)MAX_PQ_CHUNKS * sizeof(float),
+        memory_in_bytes += diskann::alloc_aligned((void **)&aligned_pqtable_dist_scratch,
+                                                 256 * (size_t)MAX_PQ_CHUNKS * sizeof(float),
                                256);
-        diskann::alloc_aligned((void **)&aligned_dist_scratch, (size_t)graph_degree * sizeof(float), 256);
-        diskann::alloc_aligned((void **)&aligned_query_float, aligned_dim * sizeof(float), 8 * sizeof(float));
-        diskann::alloc_aligned((void **)&rotated_query, aligned_dim * sizeof(float), 8 * sizeof(float));
+        memory_in_bytes +=
+            diskann::alloc_aligned((void **)&aligned_dist_scratch, (size_t)graph_degree * sizeof(float), 256);
+        memory_in_bytes +=
+            diskann::alloc_aligned((void **)&aligned_query_float, aligned_dim * sizeof(float), 8 * sizeof(float));
+        memory_in_bytes +=
+            diskann::alloc_aligned((void **)&rotated_query, aligned_dim * sizeof(float), 8 * sizeof(float));
 
         memset(aligned_query_float, 0, aligned_dim * sizeof(float));
         memset(rotated_query, 0, aligned_dim * sizeof(float));

--- a/include/pq_flash_index.h
+++ b/include/pq_flash_index.h
@@ -94,6 +94,8 @@ template <typename T, typename LabelT = uint32_t> class PQFlashIndex
 
     DISKANN_DLLEXPORT diskann::Metric get_metric();
 
+    DISKANN_DLLEXPORT uint64_t get_memory_in_bytes();
+
   protected:
     DISKANN_DLLEXPORT void use_medoids_data_as_centroids();
     DISKANN_DLLEXPORT void setup_thread_data(uint64_t nthreads, uint64_t visited_reserve = 4096);
@@ -133,6 +135,7 @@ template <typename T, typename LabelT = uint32_t> class PQFlashIndex
                                 // PQ for disk data (very large dimensionality)
     uint64_t aligned_dim = 0;
     uint64_t disk_bytes_per_point = 0;
+    uint64_t memory_in_bytes = 0;
 
     std::string disk_index_file;
     std::vector<std::pair<uint32_t, uint32_t>> node_visit_counter;

--- a/include/pq_flash_index.h
+++ b/include/pq_flash_index.h
@@ -81,6 +81,11 @@ template <typename T, typename LabelT = uint32_t> class PQFlashIndex
                                               const uint32_t io_limit, const bool use_reorder_data = false,
                                               QueryStats *stats = nullptr);
 
+    DISKANN_DLLEXPORT void cached_beam_search(const T *query, const uint64_t k_search, const uint64_t l_search,
+                                              uint64_t *res_ids, float *res_dists, const uint64_t beam_width,
+                                              IndexSearchContext<LabelT> &context, const bool use_reorder_data = false,
+                                              QueryStats *stats = nullptr);
+
     DISKANN_DLLEXPORT LabelT get_converted_label(const std::string &filter_label);
 
     DISKANN_DLLEXPORT uint32_t range_search(const T *query1, const double range, const uint64_t min_l_search,

--- a/include/timer.h
+++ b/include/timer.h
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
-
+#pragma once
 #include <chrono>
 
 namespace diskann

--- a/include/utils.h
+++ b/include/utils.h
@@ -227,7 +227,7 @@ inline void report_misalignment_of_requested_size(size_t align)
     print_error_and_terminate(stream);
 }
 
-inline void alloc_aligned(void **ptr, size_t size, size_t align)
+inline uint64_t alloc_aligned(void **ptr, size_t size, size_t align)
 {
     *ptr = nullptr;
     if (IS_ALIGNED(size, align) == 0)
@@ -238,7 +238,14 @@ inline void alloc_aligned(void **ptr, size_t size, size_t align)
     *ptr = ::_aligned_malloc(size, align); // note the swapped arguments!
 #endif
     if (*ptr == nullptr)
+    {
         report_memory_allocation_failure();
+        return 0;
+    }
+    else
+    {
+        return size;
+    }
 }
 
 inline void realloc_aligned(void **ptr, size_t size, size_t align)
@@ -352,7 +359,7 @@ template <typename T> inline std::string getValues(T *data, size_t num)
 
 // load_bin functions START
 template <typename T>
-inline void load_bin_impl(std::basic_istream<char> &reader, T *&data, size_t &npts, size_t &dim, size_t file_offset = 0)
+inline uint64_t load_bin_impl(std::basic_istream<char> &reader, T *&data, size_t &npts, size_t &dim, size_t file_offset = 0)
 {
     int npts_i32, dim_i32;
 
@@ -364,8 +371,10 @@ inline void load_bin_impl(std::basic_istream<char> &reader, T *&data, size_t &np
 
     std::cout << "Metadata: #pts = " << npts << ", #dims = " << dim << "..." << std::endl;
 
-    data = new T[npts * dim];
-    reader.read((char *)data, npts * dim * sizeof(T));
+    auto size = npts * dim;
+    data = new T[size];
+    reader.read((char *)data, size * sizeof(T));
+    return size * sizeof(T);
 }
 
 #ifdef EXEC_ENV_OLS
@@ -406,7 +415,7 @@ template <typename T> DISKANN_DLLEXPORT void read_value(AlignedFileReader &reade
 #endif
 
 template <typename T>
-inline void load_bin(const std::string &bin_file, T *&data, size_t &npts, size_t &dim, size_t offset = 0)
+inline uint64_t load_bin(const std::string &bin_file, T *&data, size_t &npts, size_t &dim, size_t offset = 0)
 {
     diskann::cout << "Reading bin file " << bin_file.c_str() << " ..." << std::endl;
     std::ifstream reader;
@@ -417,7 +426,7 @@ inline void load_bin(const std::string &bin_file, T *&data, size_t &npts, size_t
         diskann::cout << "Opening bin file " << bin_file.c_str() << "... " << std::endl;
         reader.open(bin_file, std::ios::binary | std::ios::ate);
         reader.seekg(0);
-        load_bin_impl<T>(reader, data, npts, dim, offset);
+        return load_bin_impl<T>(reader, data, npts, dim, offset);
     }
     catch (std::system_error &e)
     {

--- a/include/utils.h
+++ b/include/utils.h
@@ -359,7 +359,8 @@ template <typename T> inline std::string getValues(T *data, size_t num)
 
 // load_bin functions START
 template <typename T>
-inline uint64_t load_bin_impl(std::basic_istream<char> &reader, T *&data, size_t &npts, size_t &dim, size_t file_offset = 0)
+inline uint64_t load_bin_impl(std::basic_istream<char> &reader, T *&data, size_t &npts, size_t &dim,
+                              size_t file_offset = 0)
 {
     int npts_i32, dim_i32;
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -93,7 +93,8 @@ Index<T, TagT, LabelT>::Index(Metric m, const size_t dim, const size_t max_point
     {
         if (_num_pq_chunks > _dim)
             throw diskann::ANNException("ERROR: num_pq_chunks > dim", -1, __FUNCSIG__, __FILE__, __LINE__);
-        _memory_in_bytes += alloc_aligned(((void **)&_pq_data), total_internal_points * _num_pq_chunks * sizeof(char), 8 * sizeof(char));
+        _memory_in_bytes += alloc_aligned(((void **)&_pq_data), total_internal_points * _num_pq_chunks * sizeof(char),
+                                          8 * sizeof(char));
         std::memset(_pq_data, 0, total_internal_points * _num_pq_chunks * sizeof(char));
     }
     _memory_in_bytes +=
@@ -886,7 +887,8 @@ template <typename T, typename TagT, typename LabelT> std::vector<uint32_t> Inde
 template <typename T, typename TagT, typename LabelT>
 std::pair<uint32_t, uint32_t> Index<T, TagT, LabelT>::iterate_to_fixed_point(
     const T *query, const uint32_t Lsize, const std::vector<uint32_t> &init_ids, InMemQueryScratch<T> *scratch,
-    bool use_filter, const std::vector<LabelT> &filter_label, bool search_invocation, IndexSearchContext<LabelT>* context)
+    bool use_filter, const std::vector<LabelT> &filter_label, bool search_invocation,
+    IndexSearchContext<LabelT> *context)
 {
     if (context != nullptr && context->CheckTimeout())
     {
@@ -2128,15 +2130,16 @@ std::pair<uint32_t, uint32_t> Index<T, TagT, LabelT>::search_with_filters(const 
                                                                           const size_t K, const uint32_t L,
                                                                           IdType *indices, float *distances)
 {
-    IndexSearchContext<LabelT> context(filter_label, /*use_filter*/true);
+    IndexSearchContext<LabelT> context(filter_label, /*use_filter*/ true);
     return search_with_filters(query, K, L, indices, distances, context);
 }
 
 template <typename T, typename TagT, typename LabelT>
 template <typename IdType>
-std::pair<uint32_t, uint32_t> Index<T, TagT, LabelT>::search_with_filters(
-    const T *query, const size_t K, const uint32_t L, IdType *indices, float *distances,
-    IndexSearchContext<LabelT> &context)
+std::pair<uint32_t, uint32_t> Index<T, TagT, LabelT>::search_with_filters(const T *query, const size_t K,
+                                                                          const uint32_t L, IdType *indices,
+                                                                          float *distances,
+                                                                          IndexSearchContext<LabelT> &context)
 {
     if (context.CheckTimeout())
     {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1147,8 +1147,12 @@ std::pair<uint32_t, uint32_t> Index<T, TagT, LabelT>::iterate_to_fixed_point(
         return std::make_pair(hops, cmps);
     }
 
-    context->GetStats().n_hops = hops;
-    context->GetStats().n_cmps = cmps;
+    if (context != nullptr)
+    {
+        context->GetStats().n_hops = hops;
+        context->GetStats().n_cmps = cmps;
+    }
+
     return std::make_pair(hops, cmps);
 }
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -54,7 +54,7 @@ Index<T, TagT, LabelT>::Index(Metric m, const size_t dim, const size_t max_point
     : _dist_metric(m), _dim(dim), _max_points(max_points), _num_frozen_pts(num_frozen_pts),
       _dynamic_index(dynamic_index), _enable_tags(enable_tags), _indexingMaxC(DEFAULT_MAXC), _query_scratch(nullptr),
       _pq_dist(pq_dist_build), _use_opq(use_opq), _num_pq_chunks(num_pq_chunks),
-      _delete_set(new tsl::robin_set<uint32_t>), _conc_consolidate(concurrent_consolidate)
+      _delete_set(new tsl::robin_set<uint32_t>), _conc_consolidate(concurrent_consolidate), _memory_in_bytes(0)
 {
     if (dynamic_index && !enable_tags)
     {
@@ -93,10 +93,11 @@ Index<T, TagT, LabelT>::Index(Metric m, const size_t dim, const size_t max_point
     {
         if (_num_pq_chunks > _dim)
             throw diskann::ANNException("ERROR: num_pq_chunks > dim", -1, __FUNCSIG__, __FILE__, __LINE__);
-        alloc_aligned(((void **)&_pq_data), total_internal_points * _num_pq_chunks * sizeof(char), 8 * sizeof(char));
+        _memory_in_bytes += alloc_aligned(((void **)&_pq_data), total_internal_points * _num_pq_chunks * sizeof(char), 8 * sizeof(char));
         std::memset(_pq_data, 0, total_internal_points * _num_pq_chunks * sizeof(char));
     }
-    alloc_aligned(((void **)&_data), total_internal_points * _aligned_dim * sizeof(T), 8 * sizeof(T));
+    _memory_in_bytes +=
+        alloc_aligned(((void **)&_data), total_internal_points * _aligned_dim * sizeof(T), 8 * sizeof(T));
     std::memset(_data, 0, total_internal_points * _aligned_dim * sizeof(T));
 
     _start = (uint32_t)_max_points;
@@ -596,6 +597,8 @@ void Index<T, TagT, LabelT>::load(const char *filename, uint32_t num_threads, ui
                 _label_to_medoid_id[label] = medoid;
                 line_cnt++;
             }
+
+            _memory_in_bytes += (sizeof(LabelT) + sizeof(uint32_t)) * _label_to_medoid_id.size();
         }
 
         std::string universal_label_file(filename);
@@ -788,6 +791,7 @@ size_t Index<T, TagT, LabelT>::load_graph(std::string filename, size_t expected_
     }
 #endif
 
+    _memory_in_bytes += cc * sizeof(uint32_t);
     diskann::cout << "done. Index has " << nodes_read << " nodes and " << cc << " out-edges, _start is set to "
                   << _start << std::endl;
     return nodes_read;
@@ -2220,6 +2224,11 @@ template <typename T, typename TagT, typename LabelT> size_t Index<T, TagT, Labe
 {
     std::shared_lock<std::shared_timed_mutex> tl(_tag_lock);
     return _max_points;
+}
+
+template <typename T, typename TagT, typename LabelT> uint64_t Index<T, TagT, LabelT>::get_memory_in_bytes()
+{
+    return _memory_in_bytes;
 }
 
 template <typename T, typename TagT, typename LabelT> void Index<T, TagT, LabelT>::generate_frozen_point()

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2132,7 +2132,8 @@ std::pair<uint32_t, uint32_t> Index<T, TagT, LabelT>::search_with_filters(const 
                                                                           const size_t K, const uint32_t L,
                                                                           IdType *indices, float *distances)
 {
-    IndexSearchContext<LabelT> context(filter_label, /*use_filter*/ true);
+    IndexSearchContext<LabelT> context;
+    context.SetLabel(filter_label, /*use_filter*/ true);
     return search_with_filters(query, K, L, indices, distances, context);
 }
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -16,7 +16,7 @@ DISKANN_DLLEXPORT ANNStreamBuf cerrBuff(stderr);
 DISKANN_DLLEXPORT std::basic_ostream<char> cout(&coutBuff);
 DISKANN_DLLEXPORT std::basic_ostream<char> cerr(&cerrBuff);
 
-#ifdef EXEC_ENV_OLS
+#if defined(EXEC_ENV_OLS) || defined(ENABLE_CUSTOM_LOGGER)
 std::function<void(LogLevel, const char *)> g_logger;
 
 void SetCustomLogger(std::function<void(LogLevel, const char *)> logger)
@@ -37,7 +37,7 @@ ANNStreamBuf::ANNStreamBuf(FILE *fp)
     }
     _fp = fp;
     _logLevel = (_fp == stdout) ? LogLevel::LL_Info : LogLevel::LL_Error;
-#ifdef EXEC_ENV_OLS
+#ifdef ENABLE_CUSTOM_LOGGER
     _buf = new char[BUFFER_SIZE + 1]; // See comment in the header
 #else
     _buf = new char[BUFFER_SIZE]; // See comment in the header
@@ -87,7 +87,7 @@ int ANNStreamBuf::flush()
 }
 void ANNStreamBuf::logImpl(char *str, int num)
 {
-#ifdef EXEC_ENV_OLS
+#ifdef ENABLE_CUSTOM_LOGGER
     str[num] = '\0'; // Safe. See the c'tor.
     // Invoke the OLS custom logging function.
     if (g_logger)

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -16,7 +16,7 @@ DISKANN_DLLEXPORT ANNStreamBuf cerrBuff(stderr);
 DISKANN_DLLEXPORT std::basic_ostream<char> cout(&coutBuff);
 DISKANN_DLLEXPORT std::basic_ostream<char> cerr(&cerrBuff);
 
-#if defined(EXEC_ENV_OLS) || defined(ENABLE_CUSTOM_LOGGER)
+#ifdef ENABLE_CUSTOM_LOGGER
 std::function<void(LogLevel, const char *)> g_logger;
 
 void SetCustomLogger(std::function<void(LogLevel, const char *)> logger)

--- a/src/pq.cpp
+++ b/src/pq.cpp
@@ -34,13 +34,13 @@ FixedChunkPQTable::~FixedChunkPQTable()
 }
 
 #ifdef EXEC_ENV_OLS
-void FixedChunkPQTable::load_pq_centroid_bin(MemoryMappedFiles &files, const char *pq_table_file, size_t num_chunks)
+uint64_t FixedChunkPQTable::load_pq_centroid_bin(MemoryMappedFiles &files, const char *pq_table_file, size_t num_chunks)
 {
 #else
-void FixedChunkPQTable::load_pq_centroid_bin(const char *pq_table_file, size_t num_chunks)
+uint64_t FixedChunkPQTable::load_pq_centroid_bin(const char *pq_table_file, size_t num_chunks)
 {
 #endif
-
+    uint64_t memory_in_bytes = 0;
     uint64_t nr, nc;
     std::string rotmat_file = std::string(pq_table_file) + "_rotation_matrix.bin";
 
@@ -82,9 +82,9 @@ void FixedChunkPQTable::load_pq_centroid_bin(const char *pq_table_file, size_t n
 
 #ifdef EXEC_ENV_OLS
 
-    diskann::load_bin<float>(files, pq_table_file, tables, nr, nc, file_offset_data[0]);
+    memory_in_bytes += diskann::load_bin<float>(files, pq_table_file, tables, nr, nc, file_offset_data[0]);
 #else
-    diskann::load_bin<float>(pq_table_file, tables, nr, nc, file_offset_data[0]);
+    memory_in_bytes += diskann::load_bin<float>(pq_table_file, tables, nr, nc, file_offset_data[0]);
 #endif
 
     if ((nr != NUM_PQ_CENTROIDS))
@@ -98,9 +98,9 @@ void FixedChunkPQTable::load_pq_centroid_bin(const char *pq_table_file, size_t n
     this->ndims = nc;
 
 #ifdef EXEC_ENV_OLS
-    diskann::load_bin<float>(files, pq_table_file, centroid, nr, nc, file_offset_data[1]);
+    memory_in_bytes += diskann::load_bin<float>(files, pq_table_file, centroid, nr, nc, file_offset_data[1]);
 #else
-    diskann::load_bin<float>(pq_table_file, centroid, nr, nc, file_offset_data[1]);
+    memory_in_bytes += diskann::load_bin<float>(pq_table_file, centroid, nr, nc, file_offset_data[1]);
 #endif
 
     if ((nr != this->ndims) || (nc != 1))
@@ -117,9 +117,11 @@ void FixedChunkPQTable::load_pq_centroid_bin(const char *pq_table_file, size_t n
         chunk_offsets_index = 3;
     }
 #ifdef EXEC_ENV_OLS
-    diskann::load_bin<uint32_t>(files, pq_table_file, chunk_offsets, nr, nc, file_offset_data[chunk_offsets_index]);
+    memory_in_bytes +=
+        diskann::load_bin<uint32_t>(files, pq_table_file, chunk_offsets, nr, nc, file_offset_data[chunk_offsets_index]);
 #else
-    diskann::load_bin<uint32_t>(pq_table_file, chunk_offsets, nr, nc, file_offset_data[chunk_offsets_index]);
+    memory_in_bytes +=
+        diskann::load_bin<uint32_t>(pq_table_file, chunk_offsets, nr, nc, file_offset_data[chunk_offsets_index]);
 #endif
 
     if (nc != 1 || (nr != num_chunks + 1 && num_chunks != 0))
@@ -136,9 +138,9 @@ void FixedChunkPQTable::load_pq_centroid_bin(const char *pq_table_file, size_t n
     if (file_exists(rotmat_file))
     {
 #ifdef EXEC_ENV_OLS
-        diskann::load_bin<float>(files, rotmat_file, (float *&)rotmat_tr, nr, nc);
+        memory_in_bytes += diskann::load_bin<float>(files, rotmat_file, (float *&)rotmat_tr, nr, nc);
 #else
-        diskann::load_bin<float>(rotmat_file, rotmat_tr, nr, nc);
+        memory_in_bytes += diskann::load_bin<float>(rotmat_file, rotmat_tr, nr, nc);
 #endif
         if (nr != this->ndims || nc != this->ndims)
         {
@@ -150,6 +152,7 @@ void FixedChunkPQTable::load_pq_centroid_bin(const char *pq_table_file, size_t n
 
     // alloc and compute transpose
     tables_tr = new float[256 * this->ndims];
+    memory_in_bytes += sizeof(float) * 256 * this->ndims;
     for (size_t i = 0; i < 256; i++)
     {
         for (size_t j = 0; j < this->ndims; j++)
@@ -157,6 +160,8 @@ void FixedChunkPQTable::load_pq_centroid_bin(const char *pq_table_file, size_t n
             tables_tr[j * 256 + i] = tables[i * this->ndims + j];
         }
     }
+
+    return memory_in_bytes;
 }
 
 uint32_t FixedChunkPQTable::get_num_chunks()

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -136,7 +136,8 @@ template <typename T, typename LabelT> void PQFlashIndex<T, LabelT>::load_cache_
     memory_in_bytes += sizeof(uint32_t) * nhood_cache_buf_size;
 
     size_t coord_cache_buf_len = num_cached_nodes * aligned_dim;
-    memory_in_bytes += diskann::alloc_aligned((void **)&coord_cache_buf, coord_cache_buf_len * sizeof(T), 8 * sizeof(T));
+    memory_in_bytes +=
+        diskann::alloc_aligned((void **)&coord_cache_buf, coord_cache_buf_len * sizeof(T), 8 * sizeof(T));
     memset(coord_cache_buf, 0, coord_cache_buf_len * sizeof(T));
 
     size_t BLOCK_SIZE = 8;

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -41,7 +41,7 @@ namespace diskann
 
 template <typename T, typename LabelT>
 PQFlashIndex<T, LabelT>::PQFlashIndex(std::shared_ptr<AlignedFileReader> &fileReader, diskann::Metric m)
-    : reader(fileReader), metric(m)
+    : reader(fileReader), metric(m), memory_in_bytes(0)
 {
     if (m == diskann::Metric::COSINE || m == diskann::Metric::INNER_PRODUCT)
     {
@@ -130,11 +130,13 @@ template <typename T, typename LabelT> void PQFlashIndex<T, LabelT>::load_cache_
     auto this_thread_data = manager.scratch_space();
     IOContext &ctx = this_thread_data->ctx;
 
-    nhood_cache_buf = new uint32_t[num_cached_nodes * (max_degree + 1)];
-    memset(nhood_cache_buf, 0, num_cached_nodes * (max_degree + 1));
+    auto nhood_cache_buf_size = num_cached_nodes * (max_degree + 1);
+    nhood_cache_buf = new uint32_t[nhood_cache_buf_size];
+    memset(nhood_cache_buf, 0, nhood_cache_buf_size);
+    memory_in_bytes += sizeof(uint32_t) * nhood_cache_buf_size;
 
     size_t coord_cache_buf_len = num_cached_nodes * aligned_dim;
-    diskann::alloc_aligned((void **)&coord_cache_buf, coord_cache_buf_len * sizeof(T), 8 * sizeof(T));
+    memory_in_bytes += diskann::alloc_aligned((void **)&coord_cache_buf, coord_cache_buf_len * sizeof(T), 8 * sizeof(T));
     memset(coord_cache_buf, 0, coord_cache_buf_len * sizeof(T));
 
     size_t BLOCK_SIZE = 8;
@@ -176,6 +178,7 @@ template <typename T, typename LabelT> void PQFlashIndex<T, LabelT>::load_cache_
             T *cached_coords = coord_cache_buf + node_idx * aligned_dim;
             memcpy(cached_coords, node_coords, disk_bytes_per_point);
             coord_cache.insert(std::make_pair(nhood.first, cached_coords));
+            memory_in_bytes += disk_bytes_per_point;
 
             // insert node nhood into nhood_cache
             uint32_t *node_nhood = OFFSET_TO_NODE_NHOOD(node_buf);
@@ -187,6 +190,7 @@ template <typename T, typename LabelT> void PQFlashIndex<T, LabelT>::load_cache_
             cnhood.second = nhood_cache_buf + node_idx * (max_degree + 1);
             memcpy(cnhood.second, nbrs, nnbrs * sizeof(uint32_t));
             nhood_cache.insert(std::make_pair(nhood.first, cnhood));
+            memory_in_bytes += nnbrs * sizeof(uint32_t);
             aligned_free(nhood.second);
             node_idx++;
         }
@@ -408,7 +412,7 @@ template <typename T, typename LabelT> void PQFlashIndex<T, LabelT>::use_medoids
 {
     if (centroid_data != nullptr)
         aligned_free(centroid_data);
-    alloc_aligned(((void **)&centroid_data), num_medoids * aligned_dim * sizeof(float), 32);
+    memory_in_bytes += alloc_aligned(((void **)&centroid_data), num_medoids * aligned_dim * sizeof(float), 32);
     std::memset(centroid_data, 0, num_medoids * aligned_dim * sizeof(float));
 
     // borrow ctx
@@ -694,6 +698,7 @@ int PQFlashIndex<T, LabelT>::load_from_separate_paths(uint32_t num_threads, cons
 
     this->num_points = npts_u64;
     this->n_chunks = nchunks_u64;
+    memory_in_bytes += npts_u64 * nchunks_u64;
     if (file_exists(labels_file))
     {
         parse_label_file(labels_file, num_pts_in_label_file);
@@ -776,11 +781,10 @@ int PQFlashIndex<T, LabelT>::load_from_separate_paths(uint32_t num_threads, cons
     }
 
 #ifdef EXEC_ENV_OLS
-    pq_table.load_pq_centroid_bin(files, pq_table_bin.c_str(), nchunks_u64);
+    memory_in_bytes += pq_table.load_pq_centroid_bin(files, pq_table_bin.c_str(), nchunks_u64);
 #else
-    pq_table.load_pq_centroid_bin(pq_table_bin.c_str(), nchunks_u64);
+    memory_in_bytes += pq_table.load_pq_centroid_bin(pq_table_bin.c_str(), nchunks_u64);
 #endif
-
     diskann::cout << "Loaded PQ centroids and in-memory compressed vectors. #points: " << num_points
                   << " #dim: " << data_dim << " #aligned_dim: " << aligned_dim << " #chunks: " << n_chunks << std::endl;
 
@@ -951,6 +955,7 @@ int PQFlashIndex<T, LabelT>::load_from_separate_paths(uint32_t num_threads, cons
 #else
             diskann::load_aligned_bin<float>(centroids_file, centroid_data, num_centroids, tmp_dim, aligned_tmp_dim);
 #endif
+            memory_in_bytes += sizeof(float) * num_centroids * aligned_tmp_dim;
             if (aligned_tmp_dim != aligned_dim || num_centroids != num_medoids)
             {
                 std::stringstream stream;
@@ -1534,6 +1539,11 @@ template <typename T, typename LabelT> uint64_t PQFlashIndex<T, LabelT>::get_dat
 template <typename T, typename LabelT> diskann::Metric PQFlashIndex<T, LabelT>::get_metric()
 {
     return this->metric;
+}
+
+template <typename T, typename LabelT> uint64_t PQFlashIndex<T, LabelT>::get_memory_in_bytes()
+{
+    return this->memory_in_bytes;
 }
 
 #ifdef EXEC_ENV_OLS

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -1065,7 +1065,8 @@ void PQFlashIndex<T, LabelT>::cached_beam_search(const T *query1, const uint64_t
                                                  const uint32_t io_limit, const bool use_reorder_data,
                                                  QueryStats *stats)
 {
-    IndexSearchContext<LabelT> context(filter_label, use_filter);
+    IndexSearchContext<LabelT> context;
+    context.SetLabel(filter_label, use_filter);
     return cached_beam_search(query1, k_search, l_search, indices, distances, beam_width, context, use_reorder_data,
                               stats);
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
   - [ ] Add new APIs
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
1. Track major memory usage to load index
2. Use class IndexSearchContext to pass in new parameters or pass out results for searching index.
Using this way to avoid creating new "search" functions to support new features
3. Use new macro(ENABLE_CUSTOM_LOGGER) to turn on Custom logger since we also wants to enable the logger feature
4. Support to set searching time limit to return early when the searching is time out
5. Track the time to wait for the available scratch(pre-allocated objects)

