### PR TITLE
Fix the disparity between disk and memory search for Universal label

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -104,8 +104,8 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
     DISKANN_DLLEXPORT size_t get_num_points();
     DISKANN_DLLEXPORT size_t get_max_points();
 
-    DISKANN_DLLEXPORT const std::vector<LabelT> find_common_filters(uint32_t point_id, bool search_invocation,
-                                                                    const std::vector<LabelT> &incoming_labels);
+    DISKANN_DLLEXPORT size_t find_common_filters(uint32_t point_id, bool search_invocation,
+                                                 const std::vector<LabelT> &incoming_labels);
 
     // Batch build from a file. Optionally pass tags vector.
     DISKANN_DLLEXPORT void build(const char *filename, const size_t num_points_to_load,

--- a/include/index.h
+++ b/include/index.h
@@ -104,6 +104,9 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
     DISKANN_DLLEXPORT size_t get_num_points();
     DISKANN_DLLEXPORT size_t get_max_points();
 
+    DISKANN_DLLEXPORT const std::vector<LabelT> find_common_filters(uint32_t point_id, bool search_invocation,
+                                                                    const std::vector<LabelT> &incoming_labels);
+
     // Batch build from a file. Optionally pass tags vector.
     DISKANN_DLLEXPORT void build(const char *filename, const size_t num_points_to_load,
                                  const IndexWriteParameters &parameters,

--- a/include/index.h
+++ b/include/index.h
@@ -104,7 +104,7 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
     DISKANN_DLLEXPORT size_t get_num_points();
     DISKANN_DLLEXPORT size_t get_max_points();
 
-    DISKANN_DLLEXPORT size_t find_common_filters(uint32_t point_id, bool search_invocation,
+    DISKANN_DLLEXPORT bool detect_common_filters(uint32_t point_id, bool search_invocation,
                                                  const std::vector<LabelT> &incoming_labels);
 
     // Batch build from a file. Optionally pass tags vector.

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -837,9 +837,9 @@ template <typename T, typename TagT, typename LabelT> std::vector<uint32_t> Inde
     return init_ids;
 }
 
-// Find common filter between 2 nodes
+// Find common filter between a node's labels and a given set of labels, while taking into account universal label
 template <typename T, typename TagT, typename LabelT>
-size_t Index<T, TagT, LabelT>::find_common_filters(uint32_t point_id, bool search_invocation,
+bool Index<T, TagT, LabelT>::detect_common_filters(uint32_t point_id, bool search_invocation,
                                                    const std::vector<LabelT> &incoming_labels)
 {
     auto &curr_node_labels = _pts_to_labels[point_id];
@@ -850,7 +850,7 @@ size_t Index<T, TagT, LabelT>::find_common_filters(uint32_t point_id, bool searc
     {
         // This is to reduce the repetitive calls. If common_filters size is > 0 , we dont need to check further for
         // universal label
-        return common_filters.size();
+        return true;
     }
     if (_use_universal_label)
     {
@@ -866,7 +866,7 @@ size_t Index<T, TagT, LabelT>::find_common_filters(uint32_t point_id, bool searc
                 common_filters.push_back(_universal_label);
         }
     }
-    return common_filters.size();
+    return (common_filters.size() > 0);
 }
 
 template <typename T, typename TagT, typename LabelT>
@@ -965,7 +965,7 @@ std::pair<uint32_t, uint32_t> Index<T, TagT, LabelT>::iterate_to_fixed_point(
 
         if (use_filter)
         {
-            if (find_common_filters(id, search_invocation, filter_label) == 0)
+            if (!detect_common_filters(id, search_invocation, filter_label))
                 continue;
         }
 
@@ -1033,7 +1033,7 @@ std::pair<uint32_t, uint32_t> Index<T, TagT, LabelT>::iterate_to_fixed_point(
                 if (use_filter)
                 {
                     // NOTE: NEED TO CHECK IF THIS CORRECT WITH NEW LOCKS.
-                    if (find_common_filters(id, search_invocation, filter_label) == 0)
+                    if (!detect_common_filters(id, search_invocation, filter_label))
                         continue;
                 }
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -846,6 +846,12 @@ size_t Index<T, TagT, LabelT>::find_common_filters(uint32_t point_id, bool searc
     std::vector<LabelT> common_filters;
     std::set_intersection(incoming_labels.begin(), incoming_labels.end(), curr_node_labels.begin(),
                           curr_node_labels.end(), std::back_inserter(common_filters));
+    if (common_filters.size() > 0)
+    {
+        // This is to reduce the repetitive calls. If common_filters size is > 0 , we dont need to check further for
+        // universal label
+        return common_filters.size();
+    }
     if (_use_universal_label)
     {
         if (!search_invocation)

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1026,10 +1026,17 @@ std::pair<uint32_t, uint32_t> Index<T, TagT, LabelT>::iterate_to_fixed_point(
                                           std::back_inserter(common_filters));
                     if (_use_universal_label)
                     {
-                        if (std::find(filter_label.begin(), filter_label.end(), _universal_label) !=
-                                filter_label.end() ||
-                            std::find(x.begin(), x.end(), _universal_label) != x.end())
-                            common_filters.emplace_back(_universal_label);
+                        if (!search_invocation)
+                        {
+                            if (std::find(filter_label.begin(), filter_label.end(), _universal_label) !=
+                                    filter_label.end() ||
+                                std::find(x.begin(), x.end(), _universal_label) != x.end())
+                                common_filters.emplace_back(_universal_label);
+                        }
+                        else{
+                            if(std::find(x.begin(), x.end(), _universal_label) != x.end())
+                                common_filters.emplace_back(_universal_label);
+                        }
                     }
 
                     if (common_filters.size() == 0)

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -939,9 +939,17 @@ std::pair<uint32_t, uint32_t> Index<T, TagT, LabelT>::iterate_to_fixed_point(
                                   std::back_inserter(common_filters));
             if (_use_universal_label)
             {
-                if (std::find(filter_label.begin(), filter_label.end(), _universal_label) != filter_label.end() ||
-                    std::find(x.begin(), x.end(), _universal_label) != x.end())
-                    common_filters.emplace_back(_universal_label);
+                if (!search_invocation)
+                {
+                    if (std::find(filter_label.begin(), filter_label.end(), _universal_label) != filter_label.end() ||
+                        std::find(x.begin(), x.end(), _universal_label) != x.end())
+                        common_filters.emplace_back(_universal_label);
+                }
+                else
+                {
+                    if (std::find(x.begin(), x.end(), _universal_label) != x.end())
+                        common_filters.emplace_back(_universal_label);
+                }
             }
 
             if (common_filters.size() == 0)

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -838,11 +838,11 @@ template <typename T, typename TagT, typename LabelT> std::vector<uint32_t> Inde
 }
 
 template <typename T, typename TagT, typename LabelT>
-const std::vector<LabelT> Index<T, TagT, LabelT>::find_common_filters(uint32_t point_id, bool search_invocation,
-                                                                      const std::vector<LabelT> &incoming_labels)
+size_t Index<T, TagT, LabelT>::find_common_filters(uint32_t point_id, bool search_invocation,
+                                                   const std::vector<LabelT> &incoming_labels)
 {
-    std::vector<LabelT> common_filters;
     auto &curr_node_labels = _pts_to_labels[point_id];
+    std::vector<LabelT> common_filters;
     std::set_intersection(incoming_labels.begin(), incoming_labels.end(), curr_node_labels.begin(),
                           curr_node_labels.end(), std::back_inserter(common_filters));
     if (_use_universal_label)
@@ -859,7 +859,7 @@ const std::vector<LabelT> Index<T, TagT, LabelT>::find_common_filters(uint32_t p
                 common_filters.push_back(_universal_label);
         }
     }
-    return common_filters;
+    return common_filters.size();
 }
 
 template <typename T, typename TagT, typename LabelT>
@@ -958,8 +958,7 @@ std::pair<uint32_t, uint32_t> Index<T, TagT, LabelT>::iterate_to_fixed_point(
 
         if (use_filter)
         {
-            std::vector<LabelT> common_filters = find_common_filters(id, search_invocation, filter_label);
-            if (common_filters.size() == 0)
+            if (find_common_filters(id, search_invocation, filter_label) == 0)
                 continue;
         }
 
@@ -1027,8 +1026,7 @@ std::pair<uint32_t, uint32_t> Index<T, TagT, LabelT>::iterate_to_fixed_point(
                 if (use_filter)
                 {
                     // NOTE: NEED TO CHECK IF THIS CORRECT WITH NEW LOCKS.
-                    std::vector<LabelT> common_filters = find_common_filters(id, search_invocation, filter_label);
-                    if (common_filters.size() == 0)
+                    if (find_common_filters(id, search_invocation, filter_label) == 0)
                         continue;
                 }
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1033,8 +1033,9 @@ std::pair<uint32_t, uint32_t> Index<T, TagT, LabelT>::iterate_to_fixed_point(
                                 std::find(x.begin(), x.end(), _universal_label) != x.end())
                                 common_filters.emplace_back(_universal_label);
                         }
-                        else{
-                            if(std::find(x.begin(), x.end(), _universal_label) != x.end())
+                        else
+                        {
+                            if (std::find(x.begin(), x.end(), _universal_label) != x.end())
                                 common_filters.emplace_back(_universal_label);
                         }
                     }

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -837,6 +837,7 @@ template <typename T, typename TagT, typename LabelT> std::vector<uint32_t> Inde
     return init_ids;
 }
 
+//Find common filter between 2 nodes
 template <typename T, typename TagT, typename LabelT>
 size_t Index<T, TagT, LabelT>::find_common_filters(uint32_t point_id, bool search_invocation,
                                                    const std::vector<LabelT> &incoming_labels)

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -837,7 +837,7 @@ template <typename T, typename TagT, typename LabelT> std::vector<uint32_t> Inde
     return init_ids;
 }
 
-//Find common filter between 2 nodes
+// Find common filter between 2 nodes
 template <typename T, typename TagT, typename LabelT>
 size_t Index<T, TagT, LabelT>::find_common_filters(uint32_t point_id, bool search_invocation,
                                                    const std::vector<LabelT> &incoming_labels)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
**Fix the disparity between disk and memory search for Universal label**
Issue - If query label is UNV, memory search currently do unfiltered search over the graph without checking what is the label of current node. However, disk search returns the points corresponding to UNV label only

- Used the search_invocation flag inside iterate_to_fixed_point method and changed the logic for filtered memory search to check the current point's label and push to the output result accordingly.

#### Any other comments?

