### PR TITLE
Add convenience functions for parsing the PQ index

### DIFF
--- a/include/pq_flash_index.h
+++ b/include/pq_flash_index.h
@@ -105,7 +105,7 @@ template <typename T, typename LabelT = uint32_t> class PQFlashIndex
                                                    std::vector<T *> &coord_buffers,
                                                    std::vector<std::pair<uint32_t, uint32_t *>> &nbr_buffers);
 
-    DISKANN_DLLEXPORT std::vector<std::uint8_t> get_pq_vector(std::uint64_t VID);
+    DISKANN_DLLEXPORT std::vector<std::uint8_t> get_pq_vector(std::uint64_t vid);
     DISKANN_DLLEXPORT uint64_t get_num_points();
 
   protected:

--- a/include/pq_flash_index.h
+++ b/include/pq_flash_index.h
@@ -135,8 +135,6 @@ template <typename T, typename LabelT = uint32_t> class PQFlashIndex
     // returns region of `node_buf` containing [COORD(T)]
     DISKANN_DLLEXPORT T *offset_to_node_coords(char *node_buf);
 
-
-
     // index info for multi-node sectors
     // nhood of node `i` is in sector: [i / nnodes_per_sector]
     // offset in sector: [(i % nnodes_per_sector) * max_node_len]

--- a/include/pq_flash_index.h
+++ b/include/pq_flash_index.h
@@ -94,6 +94,20 @@ template <typename T, typename LabelT = uint32_t> class PQFlashIndex
 
     DISKANN_DLLEXPORT diskann::Metric get_metric();
 
+    //
+    // node_ids: input list of node_ids to be read
+    // coord_buffers: pointers to pre-allocated buffers that coords need to copied to. If null, dont copy.
+    // nbr_buffers: pre-allocated buffers to copy neighbors into
+    //
+    // returns a vector of bool one for each node_id: true if read is success, else false
+    //
+    DISKANN_DLLEXPORT std::vector<bool> read_nodes(const std::vector<uint32_t> &node_ids,
+                                                   std::vector<T *> &coord_buffers,
+                                                   std::vector<std::pair<uint32_t, uint32_t *>> &nbr_buffers);
+
+    DISKANN_DLLEXPORT std::vector<std::uint8_t> get_pq_vector(std::uint64_t VID);
+    DISKANN_DLLEXPORT uint64_t get_num_points();
+
   protected:
     DISKANN_DLLEXPORT void use_medoids_data_as_centroids();
     DISKANN_DLLEXPORT void setup_thread_data(uint64_t nthreads, uint64_t visited_reserve = 4096);
@@ -121,16 +135,7 @@ template <typename T, typename LabelT = uint32_t> class PQFlashIndex
     // returns region of `node_buf` containing [COORD(T)]
     DISKANN_DLLEXPORT T *offset_to_node_coords(char *node_buf);
 
-    //
-    // node_ids: input list of node_ids to be read
-    // coord_buffers: pointers to pre-allocated buffers that coords need to copied to. If null, dont copy.
-    // nbr_buffers: pre-allocated buffers to copy neighbors into
-    //
-    // returns a vector of bool one for each node_id: true if read is success, else false
-    //
-    DISKANN_DLLEXPORT std::vector<bool> read_nodes(const std::vector<uint32_t> &node_ids,
-                                                   std::vector<T *> &coord_buffers,
-                                                   std::vector<std::pair<uint32_t, uint32_t *>> &nbr_buffers);
+
 
     // index info for multi-node sectors
     // nhood of node `i` is in sector: [i / nnodes_per_sector]

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -1689,9 +1689,9 @@ template <typename T, typename LabelT> char *PQFlashIndex<T, LabelT>::getHeaderB
 #endif
 
 template <typename T, typename LabelT>
-std::vector<std::uint8_t> PQFlashIndex<T, LabelT>::get_pq_vector(std::uint64_t VID)
+std::vector<std::uint8_t> PQFlashIndex<T, LabelT>::get_pq_vector(std::uint64_t vid)
 {
-    std::uint8_t *pqVec = &this->data[VID * this->_n_chunks];
+    std::uint8_t *pqVec = &this->data[vid * this->_n_chunks];
     return std::vector<std::uint8_t>(pqVec, pqVec + this->_n_chunks);
 }
 

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -1697,7 +1697,7 @@ std::vector<std::uint8_t> PQFlashIndex<T, LabelT>::get_pq_vector(std::uint64_t V
 
 template <typename T, typename LabelT> std::uint64_t PQFlashIndex<T, LabelT>::get_num_points()
 {
-    return num_points;
+    return _num_points;
 }
 
 // instantiations

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -1688,6 +1688,20 @@ template <typename T, typename LabelT> char *PQFlashIndex<T, LabelT>::getHeaderB
 }
 #endif
 
+template <typename T, typename LabelT>
+std::vector<std::uint8_t> PQFlashIndex<T, LabelT>::get_pq_vector(std::uint64_t VID)
+{
+    std::uint8_t* pqVec = &this->data[VID * this->n_chunks];
+    return std::vector<std::uint8_t>(pqVec, pqVec +n_chunks);
+}
+
+template <typename T, typename LabelT>
+std::uint64_t PQFlashIndex<T, LabelT>::get_num_points()
+{
+    return num_points;
+}
+
+
 // instantiations
 template class PQFlashIndex<uint8_t>;
 template class PQFlashIndex<int8_t>;

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -1691,16 +1691,14 @@ template <typename T, typename LabelT> char *PQFlashIndex<T, LabelT>::getHeaderB
 template <typename T, typename LabelT>
 std::vector<std::uint8_t> PQFlashIndex<T, LabelT>::get_pq_vector(std::uint64_t VID)
 {
-    std::uint8_t* pqVec = &this->data[VID * this->n_chunks];
-    return std::vector<std::uint8_t>(pqVec, pqVec +n_chunks);
+    std::uint8_t *pqVec = &this->data[VID * this->n_chunks];
+    return std::vector<std::uint8_t>(pqVec, pqVec + n_chunks);
 }
 
-template <typename T, typename LabelT>
-std::uint64_t PQFlashIndex<T, LabelT>::get_num_points()
+template <typename T, typename LabelT> std::uint64_t PQFlashIndex<T, LabelT>::get_num_points()
 {
     return num_points;
 }
-
 
 // instantiations
 template class PQFlashIndex<uint8_t>;

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -1691,8 +1691,8 @@ template <typename T, typename LabelT> char *PQFlashIndex<T, LabelT>::getHeaderB
 template <typename T, typename LabelT>
 std::vector<std::uint8_t> PQFlashIndex<T, LabelT>::get_pq_vector(std::uint64_t VID)
 {
-    std::uint8_t *pqVec = &this->data[VID * this->n_chunks];
-    return std::vector<std::uint8_t>(pqVec, pqVec + n_chunks);
+    std::uint8_t *pqVec = &this->data[VID * this->_n_chunks];
+    return std::vector<std::uint8_t>(pqVec, pqVec + this->_n_chunks);
 }
 
 template <typename T, typename LabelT> std::uint64_t PQFlashIndex<T, LabelT>::get_num_points()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?

#### What does this implement/fix? Briefly explain your changes.
User may need to parse index graph information into different format for different applications. This PR gives an API for getting the neighborhood of a given vector, and that vector's PQ and full-dimensional data.

#### Any other comments?

