### PR TITLE
fixed a bug with loading medoids for sharded filtered index, and adde…

### DIFF
--- a/include/pq_flash_index.h
+++ b/include/pq_flash_index.h
@@ -106,6 +106,8 @@ template <typename T, typename LabelT = uint32_t> class PQFlashIndex
     DISKANN_DLLEXPORT void parse_label_file(const std::string &map_file, size_t &num_pts_labels);
     DISKANN_DLLEXPORT void get_label_file_metadata(std::string map_file, uint32_t &num_pts, uint32_t &num_total_labels);
     DISKANN_DLLEXPORT inline int32_t get_filter_number(const LabelT &filter_label);
+    DISKANN_DLLEXPORT void generate_random_labels(std::vector<LabelT> &labels, const uint32_t num_labels,
+                                                  const uint32_t nthreads);
 
     // index info
     // nhood of node `i` is in sector: [i / nnodes_per_sector]
@@ -187,7 +189,7 @@ template <typename T, typename LabelT = uint32_t> class PQFlashIndex
     uint32_t *_pts_to_label_offsets = nullptr;
     uint32_t *_pts_to_labels = nullptr;
     tsl::robin_set<LabelT> _labels;
-    std::unordered_map<LabelT, uint32_t> _filter_to_medoid_id;
+    std::unordered_map<LabelT, std::vector<uint32_t>> _filter_to_medoid_ids;
     bool _use_universal_label;
     uint32_t _universal_filter_num;
     std::vector<LabelT> _filter_list;

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -1247,7 +1247,7 @@ void PQFlashIndex<T, LabelT>::cached_beam_search(const T *query1, const uint64_t
     {
         if (_filter_to_medoid_ids.find(filter_label) != _filter_to_medoid_ids.end())
         {
-            const auto& medoid_ids = _filter_to_medoid_ids[filter_label];
+            const auto &medoid_ids = _filter_to_medoid_ids[filter_label];
             for (uint64_t cur_m = 0; cur_m < medoid_ids.size(); cur_m++)
             {
                 // for filtered index, we dont store global centroid data as for unfiltered index, so we use PQ distance

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -1247,15 +1247,16 @@ void PQFlashIndex<T, LabelT>::cached_beam_search(const T *query1, const uint64_t
     {
         if (_filter_to_medoid_ids.find(filter_label) != _filter_to_medoid_ids.end())
         {
-            for (uint64_t cur_m = 0; cur_m < _filter_to_medoid_ids[filter_label].size(); cur_m++)
+            const auto& medoid_ids = _filter_to_medoid_ids[filter_label];
+            for (uint64_t cur_m = 0; cur_m < medoid_ids.size(); cur_m++)
             {
                 // for filtered index, we dont store global centroid data as for unfiltered index, so we use PQ distance
                 // as approximation to decide closest medoid matching the query filter.
-                compute_dists(&_filter_to_medoid_ids[filter_label][cur_m], 1, dist_scratch);
+                compute_dists(&medoid_ids[cur_m], 1, dist_scratch);
                 float cur_expanded_dist = dist_scratch[0];
                 if (cur_expanded_dist < best_dist)
                 {
-                    best_medoid = _filter_to_medoid_ids[filter_label][cur_m];
+                    best_medoid = medoid_ids[cur_m];
                     best_dist = cur_expanded_dist;
                 }
             }

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -252,11 +252,23 @@ void PQFlashIndex<T, LabelT>::generate_cache_list_from_sample_queries(std::strin
     std::vector<uint64_t> tmp_result_ids_64(sample_num, 0);
     std::vector<float> tmp_result_dists(sample_num, 0);
 
+    bool filtered_search = false;
+    std::vector<LabelT> random_query_filters(sample_num);
+    if (_filter_to_medoid_ids.size() != 0)
+    {
+        filtered_search = true;
+        generate_random_labels(random_query_filters, (uint32_t)sample_num, nthreads);
+    }
+
 #pragma omp parallel for schedule(dynamic, 1) num_threads(nthreads)
     for (int64_t i = 0; i < (int64_t)sample_num; i++)
     {
+        auto &label_for_search = random_query_filters[i];
+        // run a search on the sample query with a random label (sampled from base label distribution), and it will
+        // concurrently update the node_visit_counter to track most visited nodes. The last false is to not use the
+        // "use_reorder_data" option which enables a final reranking if the disk index itself contains only PQ data.
         cached_beam_search(samples + (i * sample_aligned_dim), 1, l_search, tmp_result_ids_64.data() + i,
-                           tmp_result_dists.data() + i, beamwidth);
+                           tmp_result_dists.data() + i, beamwidth, filtered_search, label_for_search, false);
     }
 
     std::sort(this->node_visit_counter.begin(), node_visit_counter.end(),
@@ -304,9 +316,24 @@ void PQFlashIndex<T, LabelT>::cache_bfs_levels(uint64_t num_nodes_to_cache, std:
     cur_level = std::make_unique<tsl::robin_set<uint32_t>>();
     prev_level = std::make_unique<tsl::robin_set<uint32_t>>();
 
-    for (uint64_t miter = 0; miter < num_medoids; miter++)
+    for (uint64_t miter = 0; miter < num_medoids && cur_level->size() < num_nodes_to_cache; miter++)
     {
         cur_level->insert(medoids[miter]);
+    }
+
+    if ((_filter_to_medoid_ids.size() > 0) && (cur_level->size() < num_nodes_to_cache))
+    {
+        for (auto &x : _filter_to_medoid_ids)
+        {
+            for (auto &y : x.second)
+            {
+                cur_level->insert(y);
+                if (cur_level->size() == num_nodes_to_cache)
+                    break;
+            }
+            if (cur_level->size() == num_nodes_to_cache)
+                break;
+        }
     }
 
     uint64_t lvl = 1;
@@ -396,7 +423,7 @@ void PQFlashIndex<T, LabelT>::cache_bfs_levels(uint64_t num_nodes_to_cache, std:
         }
 
         diskann::cout << ". #nodes: " << node_set.size() - prev_node_set_size
-                      << ", #nodes thus far: " << node_list.size() << std::endl;
+                      << ", #nodes thus far: " << node_set.size() << std::endl;
         prev_node_set_size = node_set.size();
         lvl++;
     }
@@ -476,6 +503,41 @@ inline int32_t PQFlashIndex<T, LabelT>::get_filter_number(const LabelT &filter_l
         }
     }
     return idx;
+}
+
+template <typename T, typename LabelT>
+void PQFlashIndex<T, LabelT>::generate_random_labels(std::vector<LabelT> &labels, const uint32_t num_labels,
+                                                     const uint32_t nthreads)
+{
+    std::random_device rd;
+    labels.clear();
+    labels.resize(num_labels);
+
+    uint64_t num_total_labels =
+        _pts_to_label_offsets[num_points - 1] + _pts_to_labels[_pts_to_label_offsets[num_points - 1]];
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<uint64_t> dis(0, num_total_labels);
+
+    tsl::robin_set<uint64_t> skip_locs;
+    for (uint32_t i = 0; i < num_points; i++)
+    {
+        skip_locs.insert(_pts_to_label_offsets[i]);
+    }
+
+#pragma omp parallel for schedule(dynamic, 1) num_threads(nthreads)
+    for (int64_t i = 0; i < num_labels; i++)
+    {
+        bool found_flag = false;
+        while (!found_flag)
+        {
+            uint64_t rnd_loc = dis(gen);
+            if (skip_locs.find(rnd_loc) == skip_locs.end())
+            {
+                found_flag = true;
+                labels[i] = _filter_list[_pts_to_labels[rnd_loc]];
+            }
+        }
+    }
 }
 
 template <typename T, typename LabelT>
@@ -717,24 +779,24 @@ int PQFlashIndex<T, LabelT>::load_from_separate_paths(uint32_t num_threads, cons
             assert(medoid_stream.is_open());
             std::string line, token;
 
-            _filter_to_medoid_id.clear();
+            _filter_to_medoid_ids.clear();
             try
             {
                 while (std::getline(medoid_stream, line))
                 {
                     std::istringstream iss(line);
                     uint32_t cnt = 0;
-                    uint32_t medoid = 0;
+                    std::vector<uint32_t> medoids;
                     LabelT label;
                     while (std::getline(iss, token, ','))
                     {
                         if (cnt == 0)
                             label = (LabelT)std::stoul(token);
                         else
-                            medoid = (uint32_t)stoul(token);
+                            medoids.push_back((uint32_t)stoul(token));
                         cnt++;
                     }
-                    _filter_to_medoid_id[label] = medoid;
+                    _filter_to_medoid_ids[label].swap(medoids);
                 }
             }
             catch (std::system_error &e)
@@ -1181,13 +1243,27 @@ void PQFlashIndex<T, LabelT>::cached_beam_search(const T *query1, const uint64_t
             }
         }
     }
-    else if (_filter_to_medoid_id.find(filter_label) != _filter_to_medoid_id.end())
-    {
-        best_medoid = _filter_to_medoid_id[filter_label];
-    }
     else
     {
-        throw ANNException("Cannot find medoid for specified filter.", -1, __FUNCSIG__, __FILE__, __LINE__);
+        if (_filter_to_medoid_ids.find(filter_label) != _filter_to_medoid_ids.end())
+        {
+            for (uint64_t cur_m = 0; cur_m < _filter_to_medoid_ids[filter_label].size(); cur_m++)
+            {
+                // for filtered index, we dont store global centroid data as for unfiltered index, so we use PQ distance
+                // as approximation to decide closest medoid matching the query filter.
+                compute_dists(&_filter_to_medoid_ids[filter_label][cur_m], 1, dist_scratch);
+                float cur_expanded_dist = dist_scratch[0];
+                if (cur_expanded_dist < best_dist)
+                {
+                    best_medoid = _filter_to_medoid_ids[filter_label][cur_m];
+                    best_dist = cur_expanded_dist;
+                }
+            }
+        }
+        else
+        {
+            throw ANNException("Cannot find medoid for specified filter.", -1, __FUNCSIG__, __FILE__, __LINE__);
+        }
     }
 
     compute_dists(&best_medoid, 1, dist_scratch);


### PR DESCRIPTION
…d better caching for filtered index

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
This PR does two things:
(i) if the index is a sharded build, there will be multiple medoids for each filter, so we have changed filter_to_medoid_id to filter_to_medoid_ids, one per shard. 
(ii) for filtered index, we now do smarter "filter-aware" caching by sampling filter labels according to base distribution and running filtered searches to identify most visited nodes to cache.

#### Any other comments?

