### PR TITLE
Fix inefficiency in constructing reverse label map

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1923,44 +1923,19 @@ void Index<T, TagT, LabelT>::build_filtered_index(const char *filename, const st
     {
         for (auto label : _pts_to_labels[point_id])
         {
-            label_to_points[label].emplace_back(point_id);
-            // if (label != _universal_label){
-            //     label_to_points[label].emplace_back(point_id);
-            // }
-            // else{
-            //     for (typename tsl::robin_set<LabelT>::size_type lbl = 0; lbl < _labels.size(); lbl++){
-            //         auto itr = _labels.begin();
-            //         std::advance(itr, lbl);
-            //         auto &x = *itr;
-            //         label_to_points[x].emplace_back(point_id);
-            //     }
-            // }
+            if (label != _universal_label){
+                label_to_points[label].emplace_back(point_id);
+            }
+            else{
+                for (typename tsl::robin_set<LabelT>::size_type lbl = 0; lbl < _labels.size(); lbl++){
+                    auto itr = _labels.begin();
+                    std::advance(itr, lbl);
+                    auto &x = *itr;
+                    label_to_points[x].emplace_back(point_id);
+                }
+            }
         }
     }
-
-    // for (typename tsl::robin_set<LabelT>::size_type lbl = 0; lbl < _labels.size(); lbl++)
-    // {
-    //     auto itr = _labels.begin();
-    //     std::advance(itr, lbl);
-    //     auto &x = *itr;
-
-    //     std::vector<uint32_t> labeled_points;
-    //     for (uint32_t point_id = 0; point_id < num_points_to_load; point_id++)
-    //     {
-    //         bool pt_has_lbl = std::find(_pts_to_labels[point_id].begin(), _pts_to_labels[point_id].end(), x) !=
-    //                           _pts_to_labels[point_id].end();
-
-    //         bool pt_has_univ_lbl =
-    //             (_use_universal_label && (std::find(_pts_to_labels[point_id].begin(), _pts_to_labels[point_id].end(),
-    //                                                 _universal_label) != _pts_to_labels[point_id].end()));
-
-    //         if (pt_has_lbl || pt_has_univ_lbl)
-    //         {
-    //             labeled_points.emplace_back(point_id);
-    //         }
-    //     }
-    //     label_to_points[x] = labeled_points;
-    // }
 
     uint32_t num_cands = 25;
     for (auto itr = _labels.begin(); itr != _labels.end(); itr++)

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1923,11 +1923,14 @@ void Index<T, TagT, LabelT>::build_filtered_index(const char *filename, const st
     {
         for (auto label : _pts_to_labels[point_id])
         {
-            if (label != _universal_label){
+            if (label != _universal_label)
+            {
                 label_to_points[label].emplace_back(point_id);
             }
-            else{
-                for (typename tsl::robin_set<LabelT>::size_type lbl = 0; lbl < _labels.size(); lbl++){
+            else
+            {
+                for (typename tsl::robin_set<LabelT>::size_type lbl = 0; lbl < _labels.size(); lbl++)
+                {
                     auto itr = _labels.begin();
                     std::advance(itr, lbl);
                     auto &x = *itr;

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1919,19 +1919,22 @@ void Index<T, TagT, LabelT>::build_filtered_index(const char *filename, const st
 
     std::unordered_map<LabelT, std::vector<uint32_t>> label_to_points;
 
-    for (uint32_t point_id = 0; point_id < num_points_to_load; point_id++){
-        for (auto label : _pts_to_labels[point_id]){
-            if (label != _universal_label){
-                label_to_points[label].emplace_back(point_id);
-            }
-            else{
-                for (typename tsl::robin_set<LabelT>::size_type lbl = 0; lbl < _labels.size(); lbl++){
-                    auto itr = _labels.begin();
-                    std::advance(itr, lbl);
-                    auto &x = *itr;
-                    label_to_points[x].emplace_back(point_id);
-                }
-            }
+    for (uint32_t point_id = 0; point_id < num_points_to_load; point_id++)
+    {
+        for (auto label : _pts_to_labels[point_id])
+        {
+            label_to_points[label].emplace_back(point_id);
+            // if (label != _universal_label){
+            //     label_to_points[label].emplace_back(point_id);
+            // }
+            // else{
+            //     for (typename tsl::robin_set<LabelT>::size_type lbl = 0; lbl < _labels.size(); lbl++){
+            //         auto itr = _labels.begin();
+            //         std::advance(itr, lbl);
+            //         auto &x = *itr;
+            //         label_to_points[x].emplace_back(point_id);
+            //     }
+            // }
         }
     }
 
@@ -1958,8 +1961,6 @@ void Index<T, TagT, LabelT>::build_filtered_index(const char *filename, const st
     //     }
     //     label_to_points[x] = labeled_points;
     // }
-
-
 
     uint32_t num_cands = 25;
     for (auto itr = _labels.begin(); itr != _labels.end(); itr++)

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1919,29 +1919,47 @@ void Index<T, TagT, LabelT>::build_filtered_index(const char *filename, const st
 
     std::unordered_map<LabelT, std::vector<uint32_t>> label_to_points;
 
-    for (typename tsl::robin_set<LabelT>::size_type lbl = 0; lbl < _labels.size(); lbl++)
-    {
-        auto itr = _labels.begin();
-        std::advance(itr, lbl);
-        auto &x = *itr;
-
-        std::vector<uint32_t> labeled_points;
-        for (uint32_t point_id = 0; point_id < num_points_to_load; point_id++)
-        {
-            bool pt_has_lbl = std::find(_pts_to_labels[point_id].begin(), _pts_to_labels[point_id].end(), x) !=
-                              _pts_to_labels[point_id].end();
-
-            bool pt_has_univ_lbl =
-                (_use_universal_label && (std::find(_pts_to_labels[point_id].begin(), _pts_to_labels[point_id].end(),
-                                                    _universal_label) != _pts_to_labels[point_id].end()));
-
-            if (pt_has_lbl || pt_has_univ_lbl)
-            {
-                labeled_points.emplace_back(point_id);
+    for (uint32_t point_id = 0; point_id < num_points_to_load; point_id++){
+        for (auto label : _pts_to_labels[point_id]){
+            if (label != _universal_label){
+                label_to_points[label].emplace_back(point_id);
+            }
+            else{
+                for (typename tsl::robin_set<LabelT>::size_type lbl = 0; lbl < _labels.size(); lbl++){
+                    auto itr = _labels.begin();
+                    std::advance(itr, lbl);
+                    auto &x = *itr;
+                    label_to_points[x].emplace_back(point_id);
+                }
             }
         }
-        label_to_points[x] = labeled_points;
     }
+
+    // for (typename tsl::robin_set<LabelT>::size_type lbl = 0; lbl < _labels.size(); lbl++)
+    // {
+    //     auto itr = _labels.begin();
+    //     std::advance(itr, lbl);
+    //     auto &x = *itr;
+
+    //     std::vector<uint32_t> labeled_points;
+    //     for (uint32_t point_id = 0; point_id < num_points_to_load; point_id++)
+    //     {
+    //         bool pt_has_lbl = std::find(_pts_to_labels[point_id].begin(), _pts_to_labels[point_id].end(), x) !=
+    //                           _pts_to_labels[point_id].end();
+
+    //         bool pt_has_univ_lbl =
+    //             (_use_universal_label && (std::find(_pts_to_labels[point_id].begin(), _pts_to_labels[point_id].end(),
+    //                                                 _universal_label) != _pts_to_labels[point_id].end()));
+
+    //         if (pt_has_lbl || pt_has_univ_lbl)
+    //         {
+    //             labeled_points.emplace_back(point_id);
+    //         }
+    //     }
+    //     label_to_points[x] = labeled_points;
+    // }
+
+
 
     uint32_t num_cands = 25;
     for (auto itr = _labels.begin(); itr != _labels.end(); itr++)


### PR DESCRIPTION
#### What does this implement/fix? Briefly explain your changes.

In the function build_filtered_index, label_to_points was getting populated with a double loop over number of points and number of labels, which is very inefficient for a large number of labels. Instead, we can just do a single pass through the data to populate label_to_points, which makes the filtered build faster.

#### Any other comments?
It's a very local change, and I checked that build/search performance is not affected.

