### PR TITLE
PR340 (IndexFactory) hot fixes

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -366,6 +366,7 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
     bool _dynamic_index = false;
     bool _enable_tags = false;
     bool _normalize_vecs = false; // Using normalied L2 for cosine.
+    bool _deletes_enabled = false;
 
     // Filter Support
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2440,6 +2440,11 @@ template <typename T, typename TagT, typename LabelT> int Index<T, TagT, LabelT>
         return -2;
     }
 
+    if (this->_deletes_enabled)
+    {
+        return 0;
+    }
+
     std::unique_lock<std::shared_timed_mutex> ul(_update_lock);
     std::unique_lock<std::shared_timed_mutex> tl(_tag_lock);
     std::unique_lock<std::shared_timed_mutex> dl(_delete_lock);
@@ -2451,7 +2456,7 @@ template <typename T, typename TagT, typename LabelT> int Index<T, TagT, LabelT>
             _empty_slots.insert(slot);
         }
     }
-
+    this->_deletes_enabled = true;
     return 0;
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
Python build was wailing because _nd + empty_slots.size() != _max_points
This is due to the fact that enable_delete() is called twice. As we now default enable_delete() on a dynamic build.