### PR TITLE
Python Packaging README

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ name = "diskannpy"
 version = "0.5.0.rc4"
 
 description = "DiskANN Python extension module"
-readme = "README.md"
+readme = "python/README.md"
 requires-python = ">=3.9"
 license = {text = "MIT License"}
 dependencies = [


### PR DESCRIPTION
Using the correct README for our publication to pypi.

This is just a documentation path change where we want to link to the `diskannpy` specific README, which in turn links back to the main project README.

