### PR TITLE
fix: use the passed in io_limit

### DIFF
--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -1123,7 +1123,7 @@ void PQFlashIndex<T, LabelT>::cached_beam_search(const T *query1, const uint64_t
 {
     LabelT dummy_filter = 0;
     cached_beam_search(query1, k_search, l_search, indices, distances, beam_width, false, dummy_filter,
-                       std::numeric_limits<uint32_t>::max(), use_reorder_data, stats);
+                       io_limit, use_reorder_data, stats);
 }
 
 template <typename T, typename LabelT>

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -1122,8 +1122,8 @@ void PQFlashIndex<T, LabelT>::cached_beam_search(const T *query1, const uint64_t
                                                  QueryStats *stats)
 {
     LabelT dummy_filter = 0;
-    cached_beam_search(query1, k_search, l_search, indices, distances, beam_width, false, dummy_filter,
-                       io_limit, use_reorder_data, stats);
+    cached_beam_search(query1, k_search, l_search, indices, distances, beam_width, false, dummy_filter, io_limit,
+                       use_reorder_data, stats);
 }
 
 template <typename T, typename LabelT>


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes? No
- [ ] Does this PR add any new dependencies? No
- [ ] Does this PR modify any existing APIs? No
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones? No.
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
The io_limit passed to one of the cached_beam_search overload was ignored and uint32 max was used instead. We should use the passed in  io_limit.
#### Any other comments?
We detect this issue when using the latest DiskANN library version in another repo.