### PR TITLE
Preparing for 0.6.0 diskannpy release

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![DiskANN Paper](https://img.shields.io/badge/Paper-NeurIPS%3A_DiskANN-blue)](https://papers.nips.cc/paper/9527-rand-nsg-fast-accurate-billion-point-nearest-neighbor-search-on-a-single-node.pdf)
 [![DiskANN Paper](https://img.shields.io/badge/Paper-Arxiv%3A_Fresh--DiskANN-blue)](https://arxiv.org/abs/2105.09613)
 [![DiskANN Paper](https://img.shields.io/badge/Paper-Filtered--DiskANN-blue)](https://harsha-simhadri.org/pubs/Filtered-DiskANN23.pdf)
-[![DiskANN Main](https://github.com/microsoft/DiskANN/actions/workflows/pr-test.yml/badge.svg?branch=main)](https://github.com/microsoft/DiskANN/actions/workflows/pr-test.yml)
+[![DiskANN Main](https://github.com/microsoft/DiskANN/actions/workflows/push-test.yml/badge.svg?branch=main)](https://github.com/microsoft/DiskANN/actions/workflows/push-test.yml)
 [![PyPI version](https://img.shields.io/pypi/v/diskannpy.svg)](https://pypi.org/project/diskannpy/)
 [![Downloads shield](https://pepy.tech/badge/diskannpy)](https://pepy.tech/project/diskannpy)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # DiskANN
 
-[![DiskANN Pull Request Build and Test](https://github.com/microsoft/DiskANN/actions/workflows/pr-test.yml/badge.svg)](https://github.com/microsoft/DiskANN/actions/workflows/pr-test.yml)
+[![DiskANN Paper](https://img.shields.io/badge/Paper-NeurIPS%3A_DiskANN-blue)](https://papers.nips.cc/paper/9527-rand-nsg-fast-accurate-billion-point-nearest-neighbor-search-on-a-single-node.pdf)
+[![DiskANN Paper](https://img.shields.io/badge/Paper-Arxiv%3A_Fresh--DiskANN-blue)](https://arxiv.org/abs/2105.09613)
+[![DiskANN Paper](https://img.shields.io/badge/Paper-Filtered--DiskANN-blue)](https://harsha-simhadri.org/pubs/Filtered-DiskANN23.pdf)
+[![DiskANN Main](https://github.com/microsoft/DiskANN/actions/workflows/pr-test.yml/badge.svg?branch=main)](https://github.com/microsoft/DiskANN/actions/workflows/pr-test.yml)
+[![PyPI version](https://img.shields.io/pypi/v/diskannpy.svg)](https://pypi.org/project/diskannpy/)
+[![Downloads shield](https://pepy.tech/badge/diskannpy)](https://pepy.tech/project/diskannpy)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 DiskANN is a suite of scalable, accurate and cost-effective approximate nearest neighbor search algorithms for large-scale vector search that support real-time changes and simple filters.
 This code is based on ideas from the [DiskANN](https://papers.nips.cc/paper/9527-rand-nsg-fast-accurate-billion-point-nearest-neighbor-search-on-a-single-node.pdf), [Fresh-DiskANN](https://arxiv.org/abs/2105.09613) and the [Filtered-DiskANN](https://harsha-simhadri.org/pubs/Filtered-DiskANN23.pdf) papers with further improvements. 
@@ -11,8 +17,6 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
 See [guidelines](CONTRIBUTING.md) for contributing to this project.
-
-
 
 ## Linux build:
 
@@ -71,12 +75,16 @@ OR for Visual Studio 2017 and earlier:
 ```
 <full-path-to-installed-cmake>\cmake ..
 ```
-* This will create a diskann.sln solution. Open it from VisualStudio and build either Release or Debug configuration.
-    * Alternatively, use MSBuild:
+**This will create a diskann.sln solution**. Now you can:
+
+- Open it from VisualStudio and build either Release or Debug configuration.
+- `<full-path-to-installed-cmake>\cmake --build build`
+- Use MSBuild:
 ```
 msbuild.exe diskann.sln /m /nologo /t:Build /p:Configuration="Release" /property:Platform="x64"
 ```
-    * This will also build gperftools submodule for libtcmalloc_minimal dependency.
+
+* This will also build gperftools submodule for libtcmalloc_minimal dependency.
 * Generated binaries are stored in the x64/Release or x64/Debug directories.
 
 ## Usage:
@@ -88,7 +96,7 @@ Please see the following pages on using the compiled code:
 - [Commandline examples for using in-memory streaming indices](workflows/dynamic_index.md)
 - [Commandline interface for building and search in memory indices with label data and filters](workflows/filtered_in_memory.md)
 - [Commandline interface for building and search SSD based indices with label data and filters](workflows/filtered_ssd_index.md)
-- To be added: Python interfaces and docker files
+- [diskannpy - DiskANN as a python extension module](python/README.md)
 
 Please cite this software in your work as:
 
@@ -97,7 +105,7 @@ Please cite this software in your work as:
    author = {Simhadri, Harsha Vardhan and Krishnaswamy, Ravishankar and Srinivasa, Gopal and Subramanya, Suhas Jayaram and Antonijevic, Andrija and Pryce, Dax and Kaczynski, David and Williams, Shane and Gollapudi, Siddarth and Sivashankar, Varun and Karia, Neel and Singh, Aditi and Jaiswal, Shikhar and Mahapatro, Neelam and Adams, Philip and Tower, Bryan}},
    title = {{DiskANN: Graph-structured Indices for Scalable, Fast, Fresh and Filtered Approximate Nearest Neighbor Search}},
    url = {https://github.com/Microsoft/DiskANN},
-   version = {0.5},
+   version = {0.6.0},
    year = {2023}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# DiskANN
+_occlude_factor_occlude_factor# DiskANN
 
 [![DiskANN Paper](https://img.shields.io/badge/Paper-NeurIPS%3A_DiskANN-blue)](https://papers.nips.cc/paper/9527-rand-nsg-fast-accurate-billion-point-nearest-neighbor-search-on-a-single-node.pdf)
 [![DiskANN Paper](https://img.shields.io/badge/Paper-Arxiv%3A_Fresh--DiskANN-blue)](https://arxiv.org/abs/2105.09613)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,18 @@ authors = [
     {name = "Dax Pryce", email = "daxpryce@microsoft.com"}
 ]
 
+[project.optional-dependencies]
+dev = ["black", "isort", "mypy"]
+
 [tool.setuptools]
 package-dir = {"" = "python/src"}
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+
+[tool.mypy]
+plugins = "numpy.typing.mypy_plugin"
 
 [tool.cibuildwheel]
 manylinux-x86_64-image = "manylinux_2_28"
@@ -34,7 +44,6 @@ test-requires = ["scikit-learn~=1.2"]
 build-frontend = "build"
 skip = ["pp*", "*-win32", "*-manylinux_i686", "*-musllinux*"]
 test-command = "python -m unittest discover {project}/python/tests"
-
 
 [tool.cibuildwheel.linux]
 before-build = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "diskannpy"
-version = "0.5.0.rc5"
+version = "0.6.0"
 
 description = "DiskANN Python extension module"
 readme = "python/README.md"

--- a/python/README.md
+++ b/python/README.md
@@ -3,7 +3,7 @@
 [![DiskANN Paper](https://img.shields.io/badge/Paper-NeurIPS%3A_DiskANN-blue)](https://papers.nips.cc/paper/9527-rand-nsg-fast-accurate-billion-point-nearest-neighbor-search-on-a-single-node.pdf)
 [![DiskANN Paper](https://img.shields.io/badge/Paper-Arxiv%3A_Fresh--DiskANN-blue)](https://arxiv.org/abs/2105.09613)
 [![DiskANN Paper](https://img.shields.io/badge/Paper-Filtered--DiskANN-blue)](https://harsha-simhadri.org/pubs/Filtered-DiskANN23.pdf)
-[![DiskANN Main](https://github.com/microsoft/DiskANN/actions/workflows/pr-test.yml/badge.svg?branch=main)](https://github.com/microsoft/DiskANN/actions/workflows/pr-test.yml)
+[![DiskANN Main](https://github.com/microsoft/DiskANN/actions/workflows/push-test.yml/badge.svg?branch=main)](https://github.com/microsoft/DiskANN/actions/workflows/push-test.yml)
 [![PyPI version](https://img.shields.io/pypi/v/diskannpy.svg)](https://pypi.org/project/diskannpy/)
 [![Downloads shield](https://pepy.tech/badge/diskannpy)](https://pepy.tech/project/diskannpy)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/python/README.md
+++ b/python/README.md
@@ -1,9 +1,17 @@
 # diskannpy
 
+[![DiskANN Paper](https://img.shields.io/badge/Paper-NeurIPS%3A_DiskANN-blue)](https://papers.nips.cc/paper/9527-rand-nsg-fast-accurate-billion-point-nearest-neighbor-search-on-a-single-node.pdf)
+[![DiskANN Paper](https://img.shields.io/badge/Paper-Arxiv%3A_Fresh--DiskANN-blue)](https://arxiv.org/abs/2105.09613)
+[![DiskANN Paper](https://img.shields.io/badge/Paper-Filtered--DiskANN-blue)](https://harsha-simhadri.org/pubs/Filtered-DiskANN23.pdf)
+[![DiskANN Main](https://github.com/microsoft/DiskANN/actions/workflows/pr-test.yml/badge.svg?branch=main)](https://github.com/microsoft/DiskANN/actions/workflows/pr-test.yml)
+[![PyPI version](https://img.shields.io/pypi/v/diskannpy.svg)](https://pypi.org/project/diskannpy/)
+[![Downloads shield](https://pepy.tech/badge/diskannpy)](https://pepy.tech/project/diskannpy)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 ## Installation
 Packages published to PyPI will always be built using the latest numpy major.minor release (at this time, 1.25).
 
-Conda distributions for versions 1.19-1.25 will be completed as a future effort.  In the meantime, feel free to 
+Conda distributions for versions 1.19-1.25 will be completed as a future effort.  In the meantime, feel free to
 clone this repository and build it yourself.
 
 ## Local Build Instructions
@@ -16,11 +24,18 @@ build `diskannpy` with these additional instructions.
 In the root folder of DiskANN, there is a file `pyproject.toml`. You will need to edit the version of numpy in both the
 `[build-system.requires]` section, as well as the `[project.dependencies]` section.  The version numbers must match.
 
+#### Linux
 ```bash
-python3.11 -m venv venv # versions from python3.8 and up should work. on windows, you might need to use py -3.11 -m venv venv
-source venv/bin/activate # linux
-# or
-venv\Scripts\Activate.{ps1, bat} # windows
+python3.11 -m venv venv # versions from python3.9 and up should work
+source venv/bin/activate
+pip install build
+python -m build
+```
+
+#### Windows
+```powershell
+py -3.11 -m venv venv # versions from python3.9 and up should work
+venv\Scripts\Activate.ps1
 pip install build
 python -m build
 ```
@@ -34,7 +49,7 @@ Please cite this software in your work as:
    author = {Simhadri, Harsha Vardhan and Krishnaswamy, Ravishankar and Srinivasa, Gopal and Subramanya, Suhas Jayaram and Antonijevic, Andrija and Pryce, Dax and Kaczynski, David and Williams, Shane and Gollapudi, Siddarth and Sivashankar, Varun and Karia, Neel and Singh, Aditi and Jaiswal, Shikhar and Mahapatro, Neelam and Adams, Philip and Tower, Bryan}},
    title = {{DiskANN: Graph-structured Indices for Scalable, Fast, Fresh and Filtered Approximate Nearest Neighbor Search}},
    url = {https://github.com/Microsoft/DiskANN},
-   version = {0.5},
+   version = {0.6.0},
    year = {2023}
 }
 ```

--- a/python/src/__init__.py
+++ b/python/src/__init__.py
@@ -1,6 +1,43 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license.
 
+"""
+# Documentation Overview
+`diskannpy` is mostly structured around 2 distinct processes: [Building Functions](#index-builders) and [Search Classes](#search-classes)
+
+It also includes a few nascent [utilities](#utilities).
+
+And lastly, it makes substantial use of type hints, with various shorthand [type aliases](#parameter-and-response-type-aliases) documented. 
+When reading the `diskannpy` code we refer to the type aliases, though `pydoc` helpfully expands them. 
+
+## Index Builders
+- `build_disk_index` - To build an index that cannot fully fit into memory when searching
+- `build_memory_index` - To build an index that can fully fit into memory when searching
+
+## Search Classes
+- `StaticMemoryIndex` - for indices that can fully fit in memory and won't be changed during the search operations
+- `StaticDiskIndex` - for indices that cannot fully fit in memory, thus relying on disk IO to search, and also won't be changed during search operations
+- `DynamicMemoryIndex` - for indices that can fully fit in memory and will be mutated via insert/deletion operations as well as search operations
+
+## Parameter Defaults
+- `diskannpy.defaults` - Default values exported from the C++ extension for Python users
+
+## Parameter and Response Type Aliases
+- `DistanceMetric` - What distance metrics does `diskannpy` support?
+- `VectorDType` - What vector datatypes does `diskannpy` support?
+- `QueryResponse` - What can I expect as a response to my search?
+- `QueryResponseBatch` - What can I expect as a response to my batch search?
+- `VectorIdentifier` - What types do `diskannpy` support as vector identifiers? 
+- `VectorIdentifierBatch` - A batch of identifiers of the exact same type. The type can change, but they must **all** change.
+- `VectorLike` - How does a vector look to `diskannpy`, to be inserted or searched with.
+- `VectorLikeBatch` - A batch of those vectors, to be inserted or searched with.
+
+## Utilities
+- `numpy_to_diskann_file` - Turns a 2 dimensional `numpy.typing.NDArray[VectorDType]` with shape `(number_of_points, vector_dim)`
+- `vectors_from_binary` - Reads a `diskann` bin file representing stored vectors into a numpy ndarray.
+- `vector_file_metadata` - Reads a `diskannpy` metadata file, containing the index's distance metric, vector dtype, number of points, and vector dimensionality and returns them. Useful for inspecting what an index was saved with without loading the whole index. 
+"""
+
 from ._builder import (
     build_disk_index,
     build_memory_index,
@@ -17,8 +54,31 @@ from ._common import (
     VectorLikeBatch,
     valid_dtype
 )
-from ._diskannpy import defaults
+from . import defaults
 from ._dynamic_memory_index import DynamicMemoryIndex
 from ._files import vectors_from_binary, vector_file_metadata
 from ._static_disk_index import StaticDiskIndex
 from ._static_memory_index import StaticMemoryIndex
+
+
+__all__ = [
+    "build_disk_index", 
+    "build_memory_index",
+    "StaticDiskIndex",
+    "StaticMemoryIndex",
+    "DynamicMemoryIndex",
+    "defaults",
+    "DistanceMetric", 
+    "VectorDType",
+    "QueryResponse", 
+    "QueryResponseBatch", 
+    "VectorIdentifier",
+    "VectorIdentifierBatch",
+    "VectorLike",
+    "VectorLikeBatch",
+    "numpy_to_diskann_file", 
+    "valid_dtype",
+    "vectors_from_binary",
+    "vector_file_metadata",
+]
+

--- a/python/src/__init__.py
+++ b/python/src/__init__.py
@@ -3,12 +3,12 @@
 
 """
 # Documentation Overview
-`diskannpy` is mostly structured around 2 distinct processes: [Building Functions](#index-builders) and [Search Classes](#search-classes)
+`diskannpy` is mostly structured around 2 distinct processes: [Index Builder Functions](#index-builders) and [Search Classes](#search-classes)
 
 It also includes a few nascent [utilities](#utilities).
 
 And lastly, it makes substantial use of type hints, with various shorthand [type aliases](#parameter-and-response-type-aliases) documented. 
-When reading the `diskannpy` code we refer to the type aliases, though `pydoc` helpfully expands them. 
+When reading the `diskannpy` code we refer to the type aliases, though `pdoc` helpfully expands them.
 
 ## Index Builders
 - `build_disk_index` - To build an index that cannot fully fit into memory when searching
@@ -31,17 +31,20 @@ When reading the `diskannpy` code we refer to the type aliases, though `pydoc` h
 - `VectorIdentifierBatch` - A batch of identifiers of the exact same type. The type can change, but they must **all** change.
 - `VectorLike` - How does a vector look to `diskannpy`, to be inserted or searched with.
 - `VectorLikeBatch` - A batch of those vectors, to be inserted or searched with.
+- `Metadata` - DiskANN vector binary file metadata (num_points, vector_dim)
 
 ## Utilities
-- `numpy_to_diskann_file` - Turns a 2 dimensional `numpy.typing.NDArray[VectorDType]` with shape `(number_of_points, vector_dim)`
-- `vectors_from_binary` - Reads a `diskann` bin file representing stored vectors into a numpy ndarray.
-- `vector_file_metadata` - Reads a `diskannpy` metadata file, containing the index's distance metric, vector dtype, number of points, and vector dimensionality and returns them. Useful for inspecting what an index was saved with without loading the whole index. 
+- `vectors_to_file` - Turns a 2 dimensional `numpy.typing.NDArray[VectorDType]` with shape `(number_of_points, vector_dim)` into a DiskANN vector bin file.
+- `vectors_from_file` - Reads a DiskANN vector bin file representing stored vectors into a numpy ndarray.
+- `vectors_metadata_from_file` - Reads metadata stored in a DiskANN vector bin file without reading the entire file
+- `tags_to_file` - Turns a 1 dimensional `numpy.typing.NDArray[VectorIdentifier]` into a DiskANN tags bin file.
+- `tags_from_file` - Reads a DiskANN tags bin file representing stored tags into a numpy ndarray.
+- `valid_dtype` - Checks if a given vector dtype is supported by `diskannpy`
 """
 
 from ._builder import (
     build_disk_index,
     build_memory_index,
-    numpy_to_diskann_file,
 )
 from ._common import (
     DistanceMetric,
@@ -56,7 +59,7 @@ from ._common import (
 )
 from . import defaults
 from ._dynamic_memory_index import DynamicMemoryIndex
-from ._files import vectors_from_binary, vector_file_metadata
+from ._files import vectors_from_file, vectors_metadata_from_file, Metadata, vectors_to_file, tags_from_file, tags_to_file
 from ._static_disk_index import StaticDiskIndex
 from ._static_memory_index import StaticMemoryIndex
 
@@ -76,9 +79,12 @@ __all__ = [
     "VectorIdentifierBatch",
     "VectorLike",
     "VectorLikeBatch",
-    "numpy_to_diskann_file", 
+    "Metadata",
+    "vectors_metadata_from_file",
+    "vectors_to_file",
+    "vectors_from_file",
+    "tags_to_file",
+    "tags_from_file",
     "valid_dtype",
-    "vectors_from_binary",
-    "vector_file_metadata",
 ]
 

--- a/python/src/__init__.py
+++ b/python/src/__init__.py
@@ -27,7 +27,7 @@ When reading the `diskannpy` code we refer to the type aliases, though `pdoc` he
 - `VectorDType` - What vector datatypes does `diskannpy` support?
 - `QueryResponse` - What can I expect as a response to my search?
 - `QueryResponseBatch` - What can I expect as a response to my batch search?
-- `VectorIdentifier` - What types do `diskannpy` support as vector identifiers? 
+- `VectorIdentifier` - What types do `diskannpy` support as vector identifiers?
 - `VectorIdentifierBatch` - A batch of identifiers of the exact same type. The type can change, but they must **all** change.
 - `VectorLike` - How does a vector look to `diskannpy`, to be inserted or searched with.
 - `VectorLikeBatch` - A batch of those vectors, to be inserted or searched with.
@@ -42,39 +42,88 @@ When reading the `diskannpy` code we refer to the type aliases, though `pdoc` he
 - `valid_dtype` - Checks if a given vector dtype is supported by `diskannpy`
 """
 
-from ._builder import (
-    build_disk_index,
-    build_memory_index,
-)
-from ._common import (
-    DistanceMetric,
-    QueryResponse,
-    QueryResponseBatch,
-    VectorDType,
-    VectorIdentifier,
-    VectorIdentifierBatch,
-    VectorLike,
-    VectorLikeBatch,
-    valid_dtype
-)
+from typing import Any, Literal, NamedTuple, Type, Union
+
+import numpy as np
+from numpy import typing as npt
+
+DistanceMetric = Literal["l2", "mips", "cosine"]
+""" Type alias for one of {"l2", "mips", "cosine"} """
+VectorDType = Union[Type[np.float32], Type[np.int8], Type[np.uint8]]
+""" Type alias for one of {`numpy.float32`, `numpy.int8`, `numpy.uint8`} """
+VectorLike = npt.NDArray[VectorDType]
+""" Type alias for something that can be treated as a vector """
+VectorLikeBatch = npt.NDArray[VectorDType]
+""" Type alias for a batch of VectorLikes """
+VectorIdentifier = Union[int, np.uint32]
+""" 
+Type alias for a vector identifier, whether it be an implicit array index identifier from StaticMemoryIndex or 
+StaticDiskIndex, or an explicit tag identifier from DynamicMemoryIndex 
+"""
+VectorIdentifierBatch = npt.NDArray[np.uint32]
+""" Type alias for a batch of VectorIdentifiers """
+
+
+class QueryResponse(NamedTuple):
+    """
+    Tuple with two values, identifiers and distances. Both are 1d arrays, positionally correspond, and will contain the
+    nearest neighbors from [0..k_neighbors)
+    """
+
+    identifiers: npt.NDArray[VectorIdentifier]
+    """ A `numpy.typing.NDArray[VectorIdentifier]` array of vector identifiers, 1 dimensional """
+    distances: npt.NDArray[np.float32]
+    """
+    A `numpy.typing.NDAarray[numpy.float32]` of distances as calculated by the distance metric function,  1 dimensional
+    """
+
+
+class QueryResponseBatch(NamedTuple):
+    """
+    Tuple with two values, identifiers and distances. Both are 2d arrays, with dimensionality determined by the
+    rows corresponding to the number of queries made, and the columns corresponding to the k neighbors
+    requested. The two 2d arrays have an implicit, position-based relationship
+    """
+
+    identifiers: npt.NDArray[VectorIdentifier]
+    """ 
+    A `numpy.typing.NDArray[VectorIdentifier]` array of vector identifiers, 2 dimensional. The row corresponds to index 
+    of the query, and the column corresponds to the k neighbors requested 
+    """
+    distances: np.ndarray[np.float32]
+    """  
+    A `numpy.typing.NDAarray[numpy.float32]` of distances as calculated by the distance metric function, 2 dimensional. 
+    The row corresponds to the index of the query, and the column corresponds to the distance of the query to the 
+    *k-th* neighbor 
+    """
+
+
 from . import defaults
+from ._builder import build_disk_index, build_memory_index
+from ._common import valid_dtype
 from ._dynamic_memory_index import DynamicMemoryIndex
-from ._files import vectors_from_file, vectors_metadata_from_file, Metadata, vectors_to_file, tags_from_file, tags_to_file
+from ._files import (
+    Metadata,
+    tags_from_file,
+    tags_to_file,
+    vectors_from_file,
+    vectors_metadata_from_file,
+    vectors_to_file,
+)
 from ._static_disk_index import StaticDiskIndex
 from ._static_memory_index import StaticMemoryIndex
 
-
 __all__ = [
-    "build_disk_index", 
+    "build_disk_index",
     "build_memory_index",
     "StaticDiskIndex",
     "StaticMemoryIndex",
     "DynamicMemoryIndex",
     "defaults",
-    "DistanceMetric", 
+    "DistanceMetric",
     "VectorDType",
-    "QueryResponse", 
-    "QueryResponseBatch", 
+    "QueryResponse",
+    "QueryResponseBatch",
     "VectorIdentifier",
     "VectorIdentifierBatch",
     "VectorLike",
@@ -87,4 +136,3 @@ __all__ = [
     "tags_from_file",
     "valid_dtype",
 ]
-

--- a/python/src/_builder.pyi
+++ b/python/src/_builder.pyi
@@ -21,7 +21,7 @@ def build_disk_index(
     pq_disk_bytes: int,
     vector_dtype: VectorDType,
     index_prefix: str,
-): ...
+) -> None: ...
 @overload
 def build_disk_index(
     data: VectorLikeBatch,
@@ -34,7 +34,7 @@ def build_disk_index(
     num_threads: int,
     pq_disk_bytes: int,
     index_prefix: str,
-): ...
+) -> None: ...
 @overload
 def build_memory_index(
     data: VectorLikeBatch,
@@ -52,7 +52,7 @@ def build_memory_index(
     filter_complexity: int,
     tags: Optional[VectorIdentifierBatch],
     index_prefix: str,
-): ...
+) -> None: ...
 @overload
 def build_memory_index(
     data: str,
@@ -71,5 +71,5 @@ def build_memory_index(
     filter_complexity: int,
     tags: Optional[str],
     index_prefix: str,
-): ...
+) -> None: ...
 

--- a/python/src/_builder.pyi
+++ b/python/src/_builder.pyi
@@ -1,11 +1,11 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license.
 
-from typing import BinaryIO, overload, Optional
+from typing import BinaryIO, Optional, overload
 
 import numpy as np
 
-from ._common import DistanceMetric, VectorDType, VectorLikeBatch, VectorIdentifierBatch
+from . import DistanceMetric, VectorDType, VectorIdentifierBatch, VectorLikeBatch
 
 def numpy_to_diskann_file(vectors: np.ndarray, file_handler: BinaryIO): ...
 @overload
@@ -72,4 +72,3 @@ def build_memory_index(
     tags: Optional[str],
     index_prefix: str,
 ) -> None: ...
-

--- a/python/src/_common.py
+++ b/python/src/_common.py
@@ -27,32 +27,48 @@ __ALL__ = [
 _VALID_DTYPES = [np.float32, np.int8, np.uint8]
 
 DistanceMetric = Literal["l2", "mips", "cosine"]
+""" Type alias for one of {"l2", "mips", "cosine"} """
 VectorDType = Union[Type[np.float32], Type[np.int8], Type[np.uint8]]
+""" Type alias for one of {`numpy.float32`, `numpy.int8`, `numpy.uint8`} """
 VectorLike = Union[List[int], List[float], npt.NDArray[VectorDType]]
+""" Type alias for something that can be treated as a vector, whether it be a `List[int]`, `List[float]`, or `numpy.typing.NDArray[VectorDType]` """
 VectorLikeBatch = Union[List[List[int]], List[List[float]], npt.NDArray[VectorDType]]
+""" Type alias for a batch of VectorLikes """
 VectorIdentifier = Union[int, np.uintc]
+""" Type alias for a vector identifier, whether it be an implicit array index identifier from StaticMemoryIndex or StaticDiskIndex, or an explicit tag identifier from DynamicMemoryIndex """
 VectorIdentifierBatch = Union[List[int], List[np.uintc], npt.NDArray[np.uintc]]
+""" Type alias for a batch of VectorIdentifiers """
 
 
 class QueryResponse(NamedTuple):
     """
-    Tuple with two values, distances and indices. Both are 1d arrays and positionally correspond
+    Tuple with two values, identifiers and distances. Both are 1d arrays, positionally correspond, and will contain the nearest neighbors from [0..k_neighbors)
     """
-    distances: np.ndarray
-    indices: np.ndarray
+    identifiers: npt.NDArray[VectorIdentifier]
+    """ A `numpy.typing.NDArray[VectorIdentifier]` array of vector identifiers, 1 dimensional """
+    distances: npt.NDArray[np.single]
+    """ A `numpy.typing.NDAarray[numpy.float32]` of distances as calculated by the distance metric function, 1 dimensional """
 
 
 class QueryResponseBatch(NamedTuple):
     """
-    Tuple with two values, distances and indices. Both are 2d arrays, with dimensionality determined by the
+    Tuple with two values, identifiers and distances. Both are 2d arrays, with dimensionality determined by the
     rows corresponding to the number of queries made, and the columns corresponding to the k neighbors
     requested. The two 2d arrays have an implicit, position-based relationship
     """
-    distances: np.ndarray
-    indices: np.ndarray
+    identifiers: npt.NDArray[VectorIdentifier]
+    """ A `numpy.typing.NDArray[VectorIdentifier]` array of vector identifiers, 2 dimensional. The row corresponds to 
+     index of the query, and the column corresponds to the k neighbors requested """
+    distances: np.ndarray[np.single]
+    """  A `numpy.typing.NDAarray[numpy.float32]` of distances as calculated by the distance metric function, 2 
+    dimensional. The row corresponds to the index of the query, and the column corresponds to the distance of the query 
+    to the *k-th* neighbor """
 
 
 def valid_dtype(dtype: Type) -> VectorDType:
+    """
+    Utility method to determine whether the provided dtype is supported by `diskannpy`
+    """
     _assert_dtype(dtype)
     if np.can_cast(dtype, np.uint8):
         return np.uint8

--- a/python/src/_files.py
+++ b/python/src/_files.py
@@ -2,25 +2,18 @@
 # Licensed under the MIT license.
 
 import warnings
+from typing import BinaryIO, NamedTuple
 
 import numpy as np
 import numpy.typing as npt
 
-from typing import BinaryIO, NamedTuple
-
-from ._common import (
-    VectorDType,
-    VectorIdentifierBatch,
-    VectorLikeBatch,
-    _assert,
-    _assert_2d,
-    _assert_dtype,
-    _assert_existing_file
-)
+from . import VectorDType, VectorIdentifierBatch, VectorLikeBatch
+from ._common import _assert, _assert_2d, _assert_dtype, _assert_existing_file
 
 
 class Metadata(NamedTuple):
-    """ DiskANN binary vector files contain a small stanza containing some metadata about them. """
+    """DiskANN binary vector files contain a small stanza containing some metadata about them."""
+
     num_vectors: int
     """ The number of vectors in the file. """
     dimensions: int
@@ -90,10 +83,15 @@ def tags_to_file(tags_file: str, tags: VectorIdentifierBatch) -> None:
 
     """
     _assert(np.can_cast(tags.dtype, np.uint32), "valid tags must be uint32")
-    _assert(len(tags.shape) == 1 or tags.shape[1] == 1, "tags must be 1d or 2d with 1 column")
+    _assert(
+        len(tags.shape) == 1 or tags.shape[1] == 1,
+        "tags must be 1d or 2d with 1 column",
+    )
     if len(tags.shape) == 2:
-        warnings.warn("Tags in 2d with one column will be reshaped and copied to a new array. "
-                      "It is more efficient for you to reshape without copying first.")
+        warnings.warn(
+            "Tags in 2d with one column will be reshaped and copied to a new array. "
+            "It is more efficient for you to reshape without copying first."
+        )
         tags = tags.reshape(tags.shape[0], copy=True)
     with open(tags_file, "wb") as fh:
         _write_bin(tags.astype(np.uint32), fh)
@@ -107,7 +105,7 @@ def tags_from_file(tags_file: str) -> VectorIdentifierBatch:
     - **tags_file**: The path to the tag file to read the tags from.
     """
     _assert_existing_file(tags_file, "tags_file")
-    points, dims = vectors_metadata_from_file(tags_file)  # tag files contain the same metadata stanza
+    points, dims = vectors_metadata_from_file(
+        tags_file
+    )  # tag files contain the same metadata stanza
     return np.fromfile(file=tags_file, dtype=np.uint32, offset=8).reshape(points)
-
-

--- a/python/src/_files.py
+++ b/python/src/_files.py
@@ -1,26 +1,113 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT license.
 
+import warnings
+
 import numpy as np
 import numpy.typing as npt
 
-from typing import NamedTuple
+from typing import BinaryIO, NamedTuple
 
-from ._common import VectorDType, _assert_existing_file
+from ._common import (
+    VectorDType,
+    VectorIdentifierBatch,
+    VectorLikeBatch,
+    _assert,
+    _assert_2d,
+    _assert_dtype,
+    _assert_existing_file
+)
 
 
 class Metadata(NamedTuple):
+    """ DiskANN binary vector files contain a small stanza containing some metadata about them. """
     num_vectors: int
+    """ The number of vectors in the file. """
     dimensions: int
+    """ The dimensionality of the vectors in the file. """
 
 
-def vector_file_metadata(vector_file: str) -> Metadata:
+def vectors_metadata_from_file(vector_file: str) -> Metadata:
+    """
+    Read the metadata from a DiskANN binary vector file.
+    ### Parameters
+    - **vector_file**: The path to the vector file to read the metadata from.
+
+    ### Returns
+    `diskannpy.Metadata`
+    """
     _assert_existing_file(vector_file, "vector_file")
-    points, dims = np.fromfile(file=vector_file, dtype=np.uintc, count=2)
+    points, dims = np.fromfile(file=vector_file, dtype=np.int32, count=2)
     return Metadata(points, dims)
 
 
-def vectors_from_binary(vector_file: str, dtype: VectorDType) -> npt.NDArray[VectorDType]:
-    points, dims = vector_file_metadata(vector_file)
+def _write_bin(data: np.ndarray, file_handler: BinaryIO):
+    if len(data.shape) == 1:
+        _ = file_handler.write(np.array([data.shape[0], 1], dtype=np.int32).tobytes())
+    else:
+        _ = file_handler.write(np.array(data.shape, dtype=np.int32).tobytes())
+    _ = file_handler.write(data.tobytes())
+
+
+def vectors_to_file(vector_file: str, vectors: VectorLikeBatch) -> None:
+    """
+    Utility function that writes a DiskANN binary vector formatted file to the location of your choosing.
+
+    ### Parameters
+    - **vector_file**: The path to the vector file to write the vectors to.
+    - **vectors**: A 2d array of dtype `numpy.float32`, `numpy.uint8`, or `numpy.int8`
+    """
+    _assert_dtype(vectors.dtype)
+    _assert_2d(vectors, "vectors")
+    with open(vector_file, "wb") as fh:
+        _write_bin(vectors, fh)
+
+
+def vectors_from_file(vector_file: str, dtype: VectorDType) -> npt.NDArray[VectorDType]:
+    """
+    Read vectors from a DiskANN binary vector file.
+
+    ### Parameters
+    - **vector_file**: The path to the vector file to read the vectors from.
+    - **dtype**: The data type of the vectors in the file. Ensure you match the data types exactly
+
+    ### Returns
+    `numpy.typing.NDArray[dtype]`
+    """
+    points, dims = vectors_metadata_from_file(vector_file)
     return np.fromfile(file=vector_file, dtype=dtype, offset=8).reshape(points, dims)
+
+
+def tags_to_file(tags_file: str, tags: VectorIdentifierBatch) -> None:
+    """
+    Write tags to a DiskANN binary tag file.
+
+    ### Parameters
+    - **tags_file**: The path to the tag file to write the tags to.
+    - **tags**: A 1d array of dtype `numpy.uint32` containing the tags to write. If you have a 2d array of tags with
+      one column, you can pass it here and it will be reshaped and copied to a new array. It is more efficient for you
+      to reshape on your own without copying it first, as it should be a constant time operation vs. linear time
+
+    """
+    _assert(np.can_cast(tags.dtype, np.uint32), "valid tags must be uint32")
+    _assert(len(tags.shape) == 1 or tags.shape[1] == 1, "tags must be 1d or 2d with 1 column")
+    if len(tags.shape) == 2:
+        warnings.warn("Tags in 2d with one column will be reshaped and copied to a new array. "
+                      "It is more efficient for you to reshape without copying first.")
+        tags = tags.reshape(tags.shape[0], copy=True)
+    with open(tags_file, "wb") as fh:
+        _write_bin(tags.astype(np.uint32), fh)
+
+
+def tags_from_file(tags_file: str) -> VectorIdentifierBatch:
+    """
+    Read tags from a DiskANN binary tag file and return them as a 1d array of dtype `numpy.uint32`.
+
+    ### Parameters
+    - **tags_file**: The path to the tag file to read the tags from.
+    """
+    _assert_existing_file(tags_file, "tags_file")
+    points, dims = vectors_metadata_from_file(tags_file)  # tag files contain the same metadata stanza
+    return np.fromfile(file=tags_file, dtype=np.uint32, offset=8).reshape(points)
+
 

--- a/python/src/_static_disk_index.py
+++ b/python/src/_static_disk_index.py
@@ -29,6 +29,9 @@ __ALL__ = ["StaticDiskIndex"]
 
 
 class StaticDiskIndex:
+    """
+    A StaticDiskIndex is a disk-backed index that is not mutable.
+    """
     def __init__(
         self,
         index_directory: str,
@@ -41,29 +44,37 @@ class StaticDiskIndex:
         index_prefix: str = "ann",
     ):
         """
-        The diskannpy.DiskIndex represents our python API into the DiskANN Product Quantization Flash Index library.
+        ### Parameters
+        - **index_directory**: The directory containing the index files. This directory must contain the following
+            files:
+            - `{index_prefix}_sample_data.bin`
+            - `{index_prefix}_mem.index.data`
+            - `{index_prefix}_pq_compressed.bin`
+            - `{index_prefix}_pq_pivots.bin`
+            - `{index_prefix}_sample_ids.bin`
+            - `{index_prefix}_disk.index`
 
-        This class is responsible for searching a DiskANN disk index.
-
-        :param metric: One of {"l2", "mips"}. L2 is supported for all 3 vector dtypes, but MIPS is only
-            available for single point floating numbers (numpy.single)
-        :type metric: str
-        :param vector_dtype: The vector dtype this index will be exposing.
-        :type vector_dtype: Type[numpy.single], Type[numpy.byte], Type[numpy.ubyte]
-        :param index_directory: Path on disk where the disk index is stored
-        :type index_directory: str
-        :param num_threads: Number of threads used to load the index (>= 0)
-        :type num_threads: int
-        :param num_nodes_to_cache: Number of nodes to cache in memory (> -1)
-        :type num_nodes_to_cache: int
-        :param cache_mechanism: 1 -> use the generated sample_data.bin file for
-            the index to initialize a set of cached nodes, up to ``num_nodes_to_cache``, 2 -> ready the cache for up to
-            ``num_nodes_to_cache``, but do not initialize it with any nodes. Any other value disables node caching.
-        :param index_prefix: A shared prefix that all files in this index will use. Default is "ann".
-        :type index_prefix: str
-        :raises ValueError: If metric is not a valid metric
-        :raises ValueError: If vector dtype is not a supported dtype
-        :raises ValueError: If num_threads or num_nodes_to_cache is an invalid range.
+          It may also include the following optional files:
+            - `{index_prefix}_vectors.bin`: Optional. `diskannpy` builder functions may create this file in the
+              `index_directory` if the index was created from a numpy array
+            - `{index_prefix}_metadata.bin`: Optional. `diskannpy` builder functions create this file to store metadata
+            about the index, such as vector dtype, distance metric, number of vectors and vector dimensionality.
+            If an index is built from the `diskann` cli tools, this file will not exist.
+        - **num_threads**: Number of threads to use when searching this index. (>= 0), 0 = num_threads in system
+        - **num_nodes_to_cache**: Number of nodes to cache in memory (> -1)
+        - **cache_mechanism**: 1 -> use the generated sample_data.bin file for
+            the index to initialize a set of cached nodes, up to `num_nodes_to_cache`, 2 -> ready the cache for up to
+            `num_nodes_to_cache`, but do not initialize it with any nodes. Any other value disables node caching.
+        - **distance_metric**: A `str`, strictly one of {"l2", "mips", "cosine"}. `l2` and `cosine` are supported for all 3
+          vector dtypes, but `mips` is only available for single precision floats. Default is `None`. **This
+          value is only used if a `{index_prefix}_metadata.bin` file does not exist.** If it does not exist,
+          you are required to provide it.
+        - **vector_dtype**: The vector dtype this index has been built with. **This value is only used if a
+          `{index_prefix}_metadata.bin` file does not exist.** If it does not exist, you are required to provide it.
+        - **dimensions**: The vector dimensionality of this index. All new vectors inserted must be the same
+          dimensionality. **This value is only used if a `{index_prefix}_metadata.bin` file does not exist.** If it
+          does not exist, you are required to provide it.
+        - **index_prefix**: The prefix of the index files. Defaults to "ann".
         """
         index_prefix = _valid_index_prefix(index_directory, index_prefix)
         vector_dtype, metric, _, _ = _ensure_index_metadata(
@@ -79,12 +90,12 @@ class StaticDiskIndex:
         _assert_is_nonnegative_uint32(num_nodes_to_cache, "num_nodes_to_cache")
 
         self._vector_dtype = vector_dtype
-        if vector_dtype == np.single:
-            _index = _native_dap.StaticDiskFloatIndex
-        elif vector_dtype == np.ubyte:
+        if vector_dtype == np.uint8:
             _index = _native_dap.StaticDiskUInt8Index
-        else:
+        elif vector_dtype == np.int8:
             _index = _native_dap.StaticDiskInt8Index
+        else:
+            _index = _native_dap.StaticDiskFloatIndex
         self._index = _index(
             distance_metric=dap_metric,
             index_path_prefix=os.path.join(index_directory, index_prefix),
@@ -97,32 +108,24 @@ class StaticDiskIndex:
         self, query: VectorLike, k_neighbors: int, complexity: int, beam_width: int = 2
     ) -> QueryResponse:
         """
-        Searches the disk index by a single query vector in a 1d numpy array.
+        Searches the index by a single query vector.
 
-        numpy array dtype must match index.
-
-        :param query: 1d numpy array of the same dimensionality and dtype of the index.
-        :type query: numpy.ndarray
-        :param k_neighbors: Number of neighbors to be returned. If query vector exists in index, it almost definitely
-            will be returned as well, so adjust your ``k_neighbors`` as appropriate. (> 0)
-        :type k_neighbors: int
-        :param complexity: Size of list to use while searching. List size increases accuracy at the cost of latency. Must
-            be at least k_neighbors in size.
-        :type complexity: int
-        :param beam_width: The beamwidth to be used for search. This is the maximum number of IO requests each query
-            will issue per iteration of search code. Larger beamwidth will result in fewer IO round-trips per query,
-            but might result in slightly higher total number of IO requests to SSD per query. For the highest query
-            throughput with a fixed SSD IOps rating, use W=1. For best latency, use W=4,8 or higher complexity search.
-            Specifying 0 will optimize the beamwidth depending on the number of threads performing search, but will
-            involve some tuning overhead.
-        :type beam_width: int
-        :return: Returns a tuple of 1-d numpy ndarrays; the first including the indices of the approximate nearest
-            neighbors, the second their distances. These are aligned arrays.
+        ### Parameters
+        - **query**: 1d numpy array of the same dimensionality and dtype of the index.
+        - **k_neighbors**: Number of neighbors to be returned. If query vector exists in index, it almost definitely
+          will be returned as well, so adjust your ``k_neighbors`` as appropriate. Must be > 0.
+        - **complexity**: Size of distance ordered list of candidate neighbors to use while searching. List size
+          increases accuracy at the cost of latency. Must be at least k_neighbors in size.
+        - **beam_width**: The beamwidth to be used for search. This is the maximum number of IO requests each query
+          will issue per iteration of search code. Larger beamwidth will result in fewer IO round-trips per query,
+          but might result in slightly higher total number of IO requests to SSD per query. For the highest query
+          throughput with a fixed SSD IOps rating, use W=1. For best latency, use W=4,8 or higher complexity search.
+          Specifying 0 will optimize the beamwidth depending on the number of threads performing search, but will
+          involve some tuning overhead.
         """
         _query = _castable_dtype_or_raise(
             query,
-            expected=self._vector_dtype,
-            message=f"DiskIndex expected a query vector of dtype of {self._vector_dtype}"
+            expected=self._vector_dtype
         )
         _assert(len(_query.shape) == 1, "query vector must be 1-d")
         _assert_is_positive_uint32(k_neighbors, "k_neighbors")
@@ -151,39 +154,28 @@ class StaticDiskIndex:
         beam_width: int = 2,
     ) -> QueryResponseBatch:
         """
-        Searches the disk index for many query vectors in a 2d numpy array.
+       Searches the index by a batch of query vectors.
 
-        numpy array dtype must match index.
+       This search is parallelized and far more efficient than searching for each vector individually.
 
-        This search is parallelized and far more efficient than searching for each vector individually.
-
-        :param queries: 2d numpy array, with column dimensionality matching the index and row dimensionality being the
-            number of queries intended to search for in parallel. Dtype must match dtype of the index.
-        :type queries: numpy.ndarray
-        :param k_neighbors: Number of neighbors to be returned. If query vector exists in index, it almost definitely
-            will be returned as well, so adjust your ``k_neighbors`` as appropriate. (> 0)
-        :type k_neighbors: int
-        :param complexity: Size of list to use while searching. List size increases accuracy at the cost of latency. Must
-            be at least k_neighbors in size.
-        :type complexity: int
-        :param num_threads: Number of threads to use when searching this index. (>= 0), 0 = num_threads in system
-        :type num_threads: int
-        :param beam_width: The beamwidth to be used for search. This is the maximum number of IO requests each query
-            will issue per iteration of search code. Larger beamwidth will result in fewer IO round-trips per query,
-            but might result in slightly higher total number of IO requests to SSD per query. For the highest query
-            throughput with a fixed SSD IOps rating, use W=1. For best latency, use W=4,8 or higher complexity search.
-            Specifying 0 will optimize the beamwidth depending on the number of threads performing search, but will
-            involve some tuning overhead.
-        :type beam_width: int
-        :return: Returns a tuple of 2-d numpy ndarrays; each row corresponds to the query vector in the same index,
-            and elements in row corresponding from 1..k_neighbors approximate nearest neighbors. The second ndarray
-            contains the distances, of the same form: row index will match query index, column index refers to
-            1..k_neighbors distance. These are aligned arrays.
-        """
+       ### Parameters
+       - **queries**: 2d numpy array, with column dimensionality matching the index and row dimensionality being the
+         number of queries intended to search for in parallel. Dtype must match dtype of the index.
+       - **k_neighbors**: Number of neighbors to be returned. If query vector exists in index, it almost definitely
+         will be returned as well, so adjust your ``k_neighbors`` as appropriate. Must be > 0.
+       - **complexity**: Size of distance ordered list of candidate neighbors to use while searching. List size
+         increases accuracy at the cost of latency. Must be at least k_neighbors in size.
+       - **num_threads**: Number of threads to use when searching this index. (>= 0), 0 = num_threads in system
+       - **beam_width**: The beamwidth to be used for search. This is the maximum number of IO requests each query
+         will issue per iteration of search code. Larger beamwidth will result in fewer IO round-trips per query,
+         but might result in slightly higher total number of IO requests to SSD per query. For the highest query
+         throughput with a fixed SSD IOps rating, use W=1. For best latency, use W=4,8 or higher complexity search.
+         Specifying 0 will optimize the beamwidth depending on the number of threads performing search, but will
+         involve some tuning overhead.
+       """
         _queries = _castable_dtype_or_raise(
             queries,
-            expected=self._vector_dtype,
-            message=f"DiskIndex expected a query vector of dtype of {self._vector_dtype}"
+            expected=self._vector_dtype
         )
         _assert_2d(_queries, "queries")
         _assert_is_positive_uint32(k_neighbors, "k_neighbors")

--- a/python/src/_static_disk_index.py
+++ b/python/src/_static_disk_index.py
@@ -7,14 +7,16 @@ from typing import Optional
 
 import numpy as np
 
-from . import _diskannpy as _native_dap
-from ._common import (
+from . import (
     DistanceMetric,
     QueryResponse,
     QueryResponseBatch,
     VectorDType,
     VectorLike,
     VectorLikeBatch,
+)
+from . import _diskannpy as _native_dap
+from ._common import (
     _assert,
     _assert_2d,
     _assert_is_nonnegative_uint32,
@@ -32,6 +34,7 @@ class StaticDiskIndex:
     """
     A StaticDiskIndex is a disk-backed index that is not mutable.
     """
+
     def __init__(
         self,
         index_directory: str,
@@ -82,7 +85,7 @@ class StaticDiskIndex:
             vector_dtype,
             distance_metric,
             1,  # it doesn't matter because we don't need it in this context anyway
-            dimensions
+            dimensions,
         )
         dap_metric = _valid_metric(metric)
 
@@ -123,10 +126,7 @@ class StaticDiskIndex:
           Specifying 0 will optimize the beamwidth depending on the number of threads performing search, but will
           involve some tuning overhead.
         """
-        _query = _castable_dtype_or_raise(
-            query,
-            expected=self._vector_dtype
-        )
+        _query = _castable_dtype_or_raise(query, expected=self._vector_dtype)
         _assert(len(_query.shape) == 1, "query vector must be 1-d")
         _assert_is_positive_uint32(k_neighbors, "k_neighbors")
         _assert_is_positive_uint32(complexity, "complexity")
@@ -154,29 +154,26 @@ class StaticDiskIndex:
         beam_width: int = 2,
     ) -> QueryResponseBatch:
         """
-       Searches the index by a batch of query vectors.
+        Searches the index by a batch of query vectors.
 
-       This search is parallelized and far more efficient than searching for each vector individually.
+        This search is parallelized and far more efficient than searching for each vector individually.
 
-       ### Parameters
-       - **queries**: 2d numpy array, with column dimensionality matching the index and row dimensionality being the
-         number of queries intended to search for in parallel. Dtype must match dtype of the index.
-       - **k_neighbors**: Number of neighbors to be returned. If query vector exists in index, it almost definitely
-         will be returned as well, so adjust your ``k_neighbors`` as appropriate. Must be > 0.
-       - **complexity**: Size of distance ordered list of candidate neighbors to use while searching. List size
-         increases accuracy at the cost of latency. Must be at least k_neighbors in size.
-       - **num_threads**: Number of threads to use when searching this index. (>= 0), 0 = num_threads in system
-       - **beam_width**: The beamwidth to be used for search. This is the maximum number of IO requests each query
-         will issue per iteration of search code. Larger beamwidth will result in fewer IO round-trips per query,
-         but might result in slightly higher total number of IO requests to SSD per query. For the highest query
-         throughput with a fixed SSD IOps rating, use W=1. For best latency, use W=4,8 or higher complexity search.
-         Specifying 0 will optimize the beamwidth depending on the number of threads performing search, but will
-         involve some tuning overhead.
-       """
-        _queries = _castable_dtype_or_raise(
-            queries,
-            expected=self._vector_dtype
-        )
+        ### Parameters
+        - **queries**: 2d numpy array, with column dimensionality matching the index and row dimensionality being the
+          number of queries intended to search for in parallel. Dtype must match dtype of the index.
+        - **k_neighbors**: Number of neighbors to be returned. If query vector exists in index, it almost definitely
+          will be returned as well, so adjust your ``k_neighbors`` as appropriate. Must be > 0.
+        - **complexity**: Size of distance ordered list of candidate neighbors to use while searching. List size
+          increases accuracy at the cost of latency. Must be at least k_neighbors in size.
+        - **num_threads**: Number of threads to use when searching this index. (>= 0), 0 = num_threads in system
+        - **beam_width**: The beamwidth to be used for search. This is the maximum number of IO requests each query
+          will issue per iteration of search code. Larger beamwidth will result in fewer IO round-trips per query,
+          but might result in slightly higher total number of IO requests to SSD per query. For the highest query
+          throughput with a fixed SSD IOps rating, use W=1. For best latency, use W=4,8 or higher complexity search.
+          Specifying 0 will optimize the beamwidth depending on the number of threads performing search, but will
+          involve some tuning overhead.
+        """
+        _queries = _castable_dtype_or_raise(queries, expected=self._vector_dtype)
         _assert_2d(_queries, "queries")
         _assert_is_positive_uint32(k_neighbors, "k_neighbors")
         _assert_is_positive_uint32(complexity, "complexity")

--- a/python/src/_static_memory_index.py
+++ b/python/src/_static_memory_index.py
@@ -29,6 +29,9 @@ __ALL__ = ["StaticMemoryIndex"]
 
 
 class StaticMemoryIndex:
+    """
+    A StaticMemoryIndex is an immutable in-memory DiskANN index.
+    """
     def __init__(
         self,
         index_directory: str,
@@ -40,19 +43,34 @@ class StaticMemoryIndex:
         dimensions: Optional[int] = None,
     ):
         """
-        The diskannpy.StaticMemoryIndex represents our python API into a static DiskANN InMemory Index library.
+        ### Parameters
+        - **index_directory**: The directory containing the index files. This directory must contain the following
+          files:
+            - `{index_prefix}.data`
+            - `{index_prefix}`
 
-        This static index is intended for searching.
 
-        :param index_directory: The directory the index files reside in
-        :type index_directory: str
-        :param initial_search_complexity: A positive integer that tunes how much work should be completed in the
-            conduct of a search. This can be overridden on a per search basis, but this initial value allows us
-            to pre-allocate a search scratch space. It is suggested that you set this value to the P95 of your
-            search complexity values.
-        :type initial_search_complexity: int
-        :param index_prefix: A shared prefix that all files in this index will use. Default is "ann".
-        :type index_prefix: str
+          It may also include the following optional files:
+            - `{index_prefix}_vectors.bin`: Optional. `diskannpy` builder functions may create this file in the
+              `index_directory` if the index was created from a numpy array
+            - `{index_prefix}_metadata.bin`: Optional. `diskannpy` builder functions create this file to store metadata
+            about the index, such as vector dtype, distance metric, number of vectors and vector dimensionality.
+            If an index is built from the `diskann` cli tools, this file will not exist.
+        - **num_threads**: Number of threads to use when searching this index. (>= 0), 0 = num_threads in system
+        - **initial_search_complexity**: Should be set to the most common `complexity` expected to be used during the
+          life of this `diskannpy.DynamicMemoryIndex` object. The working scratch memory allocated is based off of
+          `initial_search_complexity` * `search_threads`. Note that it may be resized if a `search` or `batch_search`
+          operation requests a space larger than can be accommodated by these values.
+        - **index_prefix**: The prefix of the index files. Defaults to "ann".
+        - **distance_metric**: A `str`, strictly one of {"l2", "mips", "cosine"}. `l2` and `cosine` are supported for all 3
+          vector dtypes, but `mips` is only available for single precision floats. Default is `None`. **This
+          value is only used if a `{index_prefix}_metadata.bin` file does not exist.** If it does not exist,
+          you are required to provide it.
+        - **vector_dtype**: The vector dtype this index has been built with. **This value is only used if a
+          `{index_prefix}_metadata.bin` file does not exist.** If it does not exist, you are required to provide it.
+        - **dimensions**: The vector dimensionality of this index. All new vectors inserted must be the same
+          dimensionality. **This value is only used if a `{index_prefix}_metadata.bin` file does not exist.** If it
+          does not exist, you are required to provide it.
         """
         index_prefix = _valid_index_prefix(index_directory, index_prefix)
         vector_dtype, metric, num_points, dims = _ensure_index_metadata(
@@ -72,12 +90,13 @@ class StaticMemoryIndex:
         self._vector_dtype = vector_dtype
         self._dimensions = dims
 
-        if vector_dtype == np.single:
-            _index = _native_dap.StaticMemoryFloatIndex
-        elif vector_dtype == np.ubyte:
+        if vector_dtype == np.uint8:
             _index = _native_dap.StaticMemoryUInt8Index
-        else:
+        elif vector_dtype == np.int8:
             _index = _native_dap.StaticMemoryInt8Index
+        else:
+            _index = _native_dap.StaticMemoryFloatIndex
+
         self._index = _index(
             distance_metric=dap_metric,
             num_points=num_points,
@@ -89,32 +108,18 @@ class StaticMemoryIndex:
 
     def search(self, query: VectorLike, k_neighbors: int, complexity: int) -> QueryResponse:
         """
-        Searches the static in memory index by a single query vector in a 1d numpy array.
+        Searches the index by a single query vector.
 
-        numpy array dtype must match index.
-
-        :param query: 1d numpy array of the same dimensionality and dtype of the index.
-        :type query: numpy.ndarray
-        :param k_neighbors: Number of neighbors to be returned. If query vector exists in index, it almost definitely
-            will be returned as well, so adjust your ``k_neighbors`` as appropriate. (> 0)
-        :type k_neighbors: int
-        :param complexity: Size of list to use while searching. List size increases accuracy at the cost of latency. Must
-            be at least k_neighbors in size.
-        :type complexity: int
-        :param beam_width: The beamwidth to be used for search. This is the maximum number of IO requests each query
-            will issue per iteration of search code. Larger beamwidth will result in fewer IO round-trips per query,
-            but might result in slightly higher total number of IO requests to SSD per query. For the highest query
-            throughput with a fixed SSD IOps rating, use W=1. For best latency, use W=4,8 or higher complexity search.
-            Specifying 0 will optimize the beamwidth depending on the number of threads performing search, but will
-            involve some tuning overhead.
-        :type beam_width: int
-        :return: Returns a tuple of 1-d numpy ndarrays; the first including the indices of the approximate nearest
-            neighbors, the second their distances. These are aligned arrays.
+        ### Parameters
+        - **query**: 1d numpy array of the same dimensionality and dtype of the index.
+        - **k_neighbors**: Number of neighbors to be returned. If query vector exists in index, it almost definitely
+          will be returned as well, so adjust your ``k_neighbors`` as appropriate. Must be > 0.
+        - **complexity**: Size of distance ordered list of candidate neighbors to use while searching. List size
+          increases accuracy at the cost of latency. Must be at least k_neighbors in size.
         """
         _query = _castable_dtype_or_raise(
             query,
-            expected=self._vector_dtype,
-            message=f"StaticMemoryIndex expected a query vector of dtype of {self._vector_dtype}"
+            expected=self._vector_dtype
         )
         _assert(len(_query.shape) == 1, "query vector must be 1-d")
         _assert(
@@ -136,30 +141,21 @@ class StaticMemoryIndex:
         self, queries: VectorLikeBatch, k_neighbors: int, complexity: int, num_threads: int
     ) -> QueryResponseBatch:
         """
-        Searches the static, in memory index for many query vectors in a 2d numpy array.
-
-        numpy array dtype must match index.
+        Searches the index by a batch of query vectors.
 
         This search is parallelized and far more efficient than searching for each vector individually.
 
-        :param queries: 2d numpy array, with column dimensionality matching the index and row dimensionality being the
-            number of queries intended to search for in parallel. Dtype must match dtype of the index.
-        :type queries: numpy.ndarray
-        :param k_neighbors: Number of neighbors to be returned. If query vector exists in index, it almost definitely
-            will be returned as well, so adjust your ``k_neighbors`` as appropriate. (> 0)
-        :type k_neighbors: int
-        :param complexity: Size of list to use while searching. List size increases accuracy at the cost of latency. Must
-            be at least k_neighbors in size.
-        :type complexity: int
-        :param num_threads: Number of threads to use when searching this index. (>= 0), 0 = num_threads in system
-        :type num_threads: int
-        :return: Returns a tuple of 2-d numpy ndarrays; each row corresponds to the query vector in the same index,
-            and elements in row corresponding from 1..k_neighbors approximate nearest neighbors. The second ndarray
-            contains the distances, of the same form: row index will match query index, column index refers to
-            1..k_neighbors distance. These are aligned arrays.
+        ### Parameters
+        - **queries**: 2d numpy array, with column dimensionality matching the index and row dimensionality being the
+          number of queries intended to search for in parallel. Dtype must match dtype of the index.
+        - **k_neighbors**: Number of neighbors to be returned. If query vector exists in index, it almost definitely
+          will be returned as well, so adjust your ``k_neighbors`` as appropriate. Must be > 0.
+        - **complexity**: Size of distance ordered list of candidate neighbors to use while searching. List size
+          increases accuracy at the cost of latency. Must be at least k_neighbors in size.
+        - **num_threads**: Number of threads to use when searching this index. (>= 0), 0 = num_threads in system
         """
 
-        _queries = _castable_dtype_or_raise(queries, expected=self._vector_dtype, message=f"StaticMemoryIndex expected a query vector of dtype of {self._vector_dtype}")
+        _queries = _castable_dtype_or_raise(queries, expected=self._vector_dtype)
         _assert(len(_queries.shape) == 2, "queries must must be 2-d np array")
         _assert(
             _queries.shape[1] == self._dimensions,

--- a/python/src/_static_memory_index.py
+++ b/python/src/_static_memory_index.py
@@ -3,26 +3,27 @@
 
 import os
 import warnings
+from typing import Optional
 
 import numpy as np
 
-from typing import Optional
-
-from . import _diskannpy as _native_dap
-from ._common import (
+from . import (
     DistanceMetric,
     QueryResponse,
     QueryResponseBatch,
     VectorDType,
     VectorLike,
     VectorLikeBatch,
+)
+from . import _diskannpy as _native_dap
+from ._common import (
     _assert,
     _assert_is_nonnegative_uint32,
     _assert_is_positive_uint32,
     _castable_dtype_or_raise,
     _ensure_index_metadata,
     _valid_index_prefix,
-    _valid_metric
+    _valid_metric,
 )
 
 __ALL__ = ["StaticMemoryIndex"]
@@ -32,6 +33,7 @@ class StaticMemoryIndex:
     """
     A StaticMemoryIndex is an immutable in-memory DiskANN index.
     """
+
     def __init__(
         self,
         index_directory: str,
@@ -78,7 +80,7 @@ class StaticMemoryIndex:
             vector_dtype,
             distance_metric,
             1,  # it doesn't matter because we don't need it in this context anyway
-            dimensions
+            dimensions,
         )
         dap_metric = _valid_metric(metric)
 
@@ -106,7 +108,9 @@ class StaticMemoryIndex:
             initial_search_complexity=initial_search_complexity,
         )
 
-    def search(self, query: VectorLike, k_neighbors: int, complexity: int) -> QueryResponse:
+    def search(
+        self, query: VectorLike, k_neighbors: int, complexity: int
+    ) -> QueryResponse:
         """
         Searches the index by a single query vector.
 
@@ -117,15 +121,12 @@ class StaticMemoryIndex:
         - **complexity**: Size of distance ordered list of candidate neighbors to use while searching. List size
           increases accuracy at the cost of latency. Must be at least k_neighbors in size.
         """
-        _query = _castable_dtype_or_raise(
-            query,
-            expected=self._vector_dtype
-        )
+        _query = _castable_dtype_or_raise(query, expected=self._vector_dtype)
         _assert(len(_query.shape) == 1, "query vector must be 1-d")
         _assert(
             _query.shape[0] == self._dimensions,
             f"query vector must have the same dimensionality as the index; index dimensionality: {self._dimensions}, "
-            f"query dimensionality: {_query.shape[0]}"
+            f"query dimensionality: {_query.shape[0]}",
         )
         _assert_is_positive_uint32(k_neighbors, "k_neighbors")
         _assert_is_nonnegative_uint32(complexity, "complexity")
@@ -138,7 +139,11 @@ class StaticMemoryIndex:
         return self._index.search(query=_query, knn=k_neighbors, complexity=complexity)
 
     def batch_search(
-        self, queries: VectorLikeBatch, k_neighbors: int, complexity: int, num_threads: int
+        self,
+        queries: VectorLikeBatch,
+        k_neighbors: int,
+        complexity: int,
+        num_threads: int,
     ) -> QueryResponseBatch:
         """
         Searches the index by a batch of query vectors.
@@ -160,7 +165,7 @@ class StaticMemoryIndex:
         _assert(
             _queries.shape[1] == self._dimensions,
             f"query vectors must have the same dimensionality as the index; index dimensionality: {self._dimensions}, "
-            f"query dimensionality: {_queries.shape[1]}"
+            f"query dimensionality: {_queries.shape[1]}",
         )
         _assert_is_positive_uint32(k_neighbors, "k_neighbors")
         _assert_is_positive_uint32(complexity, "complexity")

--- a/python/src/defaults.py
+++ b/python/src/defaults.py
@@ -45,4 +45,3 @@ NUM_PQ_BYTES = _defaults.NUM_PQ_BYTES
 """ The number of product quantization bytes to use. More bytes requires more resources in both memory and time, but is like to result in better approximations. """
 USE_OPQ = _defaults.USE_OPQ
 """ Whether to use Optimized Product Quantization or not. """
-

--- a/python/src/defaults.py
+++ b/python/src/defaults.py
@@ -1,0 +1,44 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+
+"""
+# Parameter Defaults
+These parameter defaults are re-exported from the C++ extension module, and used to keep the pythonic wrapper in sync with the C++.
+"""
+from ._diskannpy import defaults as _defaults
+
+ALPHA = _defaults.ALPHA
+""" Alpha is <help>. Note that, as ALPHA is a `float32` (single precision float) in C++, when converted into Python it becomes a `float64` (double precision float). The actual value is 1.2f. """
+NUM_THREADS = _defaults.NUM_THREADS
+""" Number of threads to use. `0` will use all available detected logical processors """
+MAX_OCCLUSION_SIZE = _defaults.MAX_OCCLUSION_SIZE
+""" The maximum number of points that can be occluded by a single point. This is used to  prevent a single point from 
+dominating the graph structure. If a point has more than `max_occlusion_size` neighbors closer to it than the current 
+point, it will not be added to the graph. This is a tradeoff between index build time and search quality. """
+FILTER_COMPLEXITY = _defaults.FILTER_COMPLEXITY
+""" Complexity (a.k.a. `L`) references the size of the list we store candidate approximate neighbors in while doing a filtered search. This value must be larger than `k_neighbors`, and larger values tend toward higher recall in the resultant ANN search at the cost of more time. """
+NUM_FROZEN_POINTS_STATIC = _defaults.NUM_FROZEN_POINTS_STATIC
+""" Num Frozen Points Static """
+NUM_FROZEN_POINTS_DYNAMIC = _defaults.NUM_FROZEN_POINTS_DYNAMIC
+""" Num Frozen Points Dynamic """
+SATURATE_GRAPH = _defaults.SATURATE_GRAPH
+""" Whether to saturate the graph or not. Default is `True` """
+GRAPH_DEGREE = _defaults.GRAPH_DEGREE
+""" Graph degree (a.k.a. `R`) is the maximum degree allowed for a node in the index's graph structure. This degree will be pruned throughout the course of the index build, but it will never grow beyond this value. Higher R values require longer index build times, but may result in an index showing excellent recall and latency characteristics. """
+COMPLEXITY = _defaults.COMPLEXITY
+""" Complexity (a.k.a `L`) references the size of the list we store candidate approximate neighbors in while doing a number of tasks. It's used during index build as part of the index optimization processes. It's used in index search classes both to help mitigate poor latencies during cold start, as well as on subsequent queries to conduct the search. Large values will likely increase latency but also may improve recall, and tuning these values for your particular index is certainly a reasonable choice."""
+PQ_DISK_BYTES = _defaults.PQ_DISK_BYTES
+""" Use `0` to store uncompressed data on SSD. This allows the index to asymptote to 100% recall. If your vectors are 
+too large to store in SSD, this parameter provides the option to compress the vectors using PQ for storing on SSD. 
+This will trade off recall. You would also want this to be greater than the number of bytes used for the PQ 
+compressed data stored in-memory. Default is `0`. """
+USE_PQ_BUILD = _defaults.USE_PQ_BUILD
+""" Whether to use product quantization in the index building process. Product quantization is an approximation 
+technique that can vastly speed up vector computations and comparisons in a spatial neighborhood, but it is still an 
+approximation technique. It should be preferred when index creation times take longer than you can afford for your 
+use case."""
+NUM_PQ_BYTES = _defaults.NUM_PQ_BYTES
+""" The number of product quantization bytes to use. More bytes requires more resources in both memory and time, but is like to result in better approximations. """
+USE_OPQ = _defaults.USE_OPQ
+""" Whether to use Optimized Product Quantization or not. """
+

--- a/python/src/defaults.py
+++ b/python/src/defaults.py
@@ -8,7 +8,11 @@ These parameter defaults are re-exported from the C++ extension module, and used
 from ._diskannpy import defaults as _defaults
 
 ALPHA = _defaults.ALPHA
-""" Alpha is <help>. Note that, as ALPHA is a `float32` (single precision float) in C++, when converted into Python it becomes a `float64` (double precision float). The actual value is 1.2f. """
+""" Note that, as ALPHA is a `float32` (single precision float) in C++, when converted into Python it becomes a `float64` (double precision float). The actual value is 1.2f. 
+The alpha parameter (>=1) is used to control the nature and number of points that are added to the
+graph. A higher alpha value (e.g., 1.4) will result in fewer hops (and IOs) to convergence, but probably more
+distance comparisons.
+"""
 NUM_THREADS = _defaults.NUM_THREADS
 """ Number of threads to use. `0` will use all available detected logical processors """
 MAX_OCCLUSION_SIZE = _defaults.MAX_OCCLUSION_SIZE
@@ -18,9 +22,9 @@ point, it will not be added to the graph. This is a tradeoff between index build
 FILTER_COMPLEXITY = _defaults.FILTER_COMPLEXITY
 """ Complexity (a.k.a. `L`) references the size of the list we store candidate approximate neighbors in while doing a filtered search. This value must be larger than `k_neighbors`, and larger values tend toward higher recall in the resultant ANN search at the cost of more time. """
 NUM_FROZEN_POINTS_STATIC = _defaults.NUM_FROZEN_POINTS_STATIC
-""" Num Frozen Points Static """
+""" Number of points frozen by default in a StaticMemoryIndex """
 NUM_FROZEN_POINTS_DYNAMIC = _defaults.NUM_FROZEN_POINTS_DYNAMIC
-""" Num Frozen Points Dynamic """
+""" Number of points frozen by default in a DynamicMemoryIndex """
 SATURATE_GRAPH = _defaults.SATURATE_GRAPH
 """ Whether to saturate the graph or not. Default is `True` """
 GRAPH_DEGREE = _defaults.GRAPH_DEGREE

--- a/python/tests/fixtures/build_memory_index.py
+++ b/python/tests/fixtures/build_memory_index.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 
 import os
-
 from tempfile import mkdtemp
 
 import diskannpy as dap
@@ -12,11 +11,7 @@ from .create_test_data import random_vectors
 
 
 def build_random_vectors_and_memory_index(
-        dtype,
-        metric,
-        with_tags: bool = False,
-        index_prefix: str = "ann",
-        seed: int = 12345
+    dtype, metric, with_tags: bool = False, index_prefix: str = "ann", seed: int = 12345
 ):
     query_vectors: np.ndarray = random_vectors(1000, 10, dtype=dtype, seed=seed)
     index_vectors: np.ndarray = random_vectors(10000, 10, dtype=dtype, seed=seed)
@@ -42,7 +37,7 @@ def build_random_vectors_and_memory_index(
         use_opq=False,
         filter_complexity=32,
         tags=tags,
-        index_prefix=index_prefix
+        index_prefix=index_prefix,
     )
 
     return (
@@ -52,5 +47,5 @@ def build_random_vectors_and_memory_index(
         index_vectors,
         ann_dir,
         os.path.join(ann_dir, "vectors.bin"),
-        tags
+        tags,
     )

--- a/python/tests/fixtures/build_memory_index.py
+++ b/python/tests/fixtures/build_memory_index.py
@@ -24,7 +24,7 @@ def build_random_vectors_and_memory_index(
 
     if with_tags:
         rng = np.random.default_rng(seed)
-        tags = np.arange(start=1, stop=10001, dtype=np.uintc)
+        tags = np.arange(start=1, stop=10001, dtype=np.uint32)
         rng.shuffle(tags)
     else:
         tags = ""

--- a/python/tests/fixtures/create_test_data.py
+++ b/python/tests/fixtures/create_test_data.py
@@ -11,18 +11,18 @@ import numpy as np
 
 def random_vectors(rows: int, dimensions: int, dtype, seed: int = 12345) -> np.ndarray:
     rng = np.random.default_rng(seed)
-    if dtype == np.single:
+    if dtype == np.float32:
         vectors = rng.random((rows, dimensions), dtype=dtype)
-    elif dtype == np.ubyte:
+    elif dtype == np.uint8:
         vectors = rng.integers(
             low=0, high=256, size=(rows, dimensions), dtype=dtype
         )  # low is inclusive, high is exclusive
-    elif dtype == np.byte:
+    elif dtype == np.int8:
         vectors = rng.integers(
             low=-128, high=128, size=(rows, dimensions), dtype=dtype
         )  # low is inclusive, high is exclusive
     else:
-        raise RuntimeError("Only np.single, np.byte, and np.ubyte are supported")
+        raise RuntimeError("Only np.float32, np.int8, and np.uint8 are supported")
     return vectors
 
 

--- a/python/tests/test_dynamic_memory_index.py
+++ b/python/tests/test_dynamic_memory_index.py
@@ -32,12 +32,12 @@ class TestDynamicMemoryIndex(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls._test_matrix = [
-            build_random_vectors_and_memory_index(np.single, "l2", with_tags=True),
-            build_random_vectors_and_memory_index(np.ubyte, "l2", with_tags=True),
-            build_random_vectors_and_memory_index(np.byte, "l2", with_tags=True),
-            build_random_vectors_and_memory_index(np.single, "cosine", with_tags=True),
-            build_random_vectors_and_memory_index(np.ubyte, "cosine", with_tags=True),
-            build_random_vectors_and_memory_index(np.byte, "cosine", with_tags=True),
+            build_random_vectors_and_memory_index(np.float32, "l2", with_tags=True),
+            build_random_vectors_and_memory_index(np.uint8, "l2", with_tags=True),
+            build_random_vectors_and_memory_index(np.int8, "l2", with_tags=True),
+            build_random_vectors_and_memory_index(np.float32, "cosine", with_tags=True),
+            build_random_vectors_and_memory_index(np.uint8, "cosine", with_tags=True),
+            build_random_vectors_and_memory_index(np.int8, "cosine", with_tags=True),
         ]
         cls._example_ann_dir = cls._test_matrix[0][4]
 
@@ -60,7 +60,7 @@ class TestDynamicMemoryIndex(unittest.TestCase):
             vector_bin_file,
             generated_tags
         ) in self._test_matrix:
-            with self.subTest():
+            with self.subTest(msg=f"Testing dtype {dtype}"):
                 index = dap.DynamicMemoryIndex.from_file(
                     index_directory=ann_dir,
                     max_vectors=11_000,
@@ -98,7 +98,7 @@ class TestDynamicMemoryIndex(unittest.TestCase):
             vector_bin_file,
             generated_tags
         ) in self._test_matrix:
-            with self.subTest():
+            with self.subTest(msg=f"Testing dtype {dtype}"):
                 index = dap.DynamicMemoryIndex(
                     distance_metric="l2",
                     vector_dtype=dtype,
@@ -112,9 +112,6 @@ class TestDynamicMemoryIndex(unittest.TestCase):
 
                 k = 5
                 ids, dists = index.search(query_vectors[0], k_neighbors=k, complexity=5)
-                self.assertEqual(ids.shape[0], k)
-                self.assertEqual(dists.shape[0], k)
-                ids, dists = index.search(query_vectors[0].tolist(), k_neighbors=k, complexity=5)
                 self.assertEqual(ids.shape[0], k)
                 self.assertEqual(dists.shape[0], k)
 

--- a/python/tests/test_static_disk_index.py
+++ b/python/tests/test_static_disk_index.py
@@ -35,9 +35,9 @@ class TestStaticDiskIndex(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls._test_matrix = [
-            _build_random_vectors_and_index(np.single, "l2"),
-            _build_random_vectors_and_index(np.ubyte, "l2"),
-            _build_random_vectors_and_index(np.byte, "l2"),
+            _build_random_vectors_and_index(np.float32, "l2"),
+            _build_random_vectors_and_index(np.uint8, "l2"),
+            _build_random_vectors_and_index(np.int8, "l2"),
         ]
         cls._example_ann_dir = cls._test_matrix[0][4]
 
@@ -52,7 +52,7 @@ class TestStaticDiskIndex(unittest.TestCase):
 
     def test_recall_and_batch(self):
         for metric, dtype, query_vectors, index_vectors, ann_dir in self._test_matrix:
-            with self.subTest():
+            with self.subTest(msg=f"Testing dtype {dtype}"):
                 index = dap.StaticDiskIndex(
                     distance_metric="l2",
                     vector_dtype=dtype,
@@ -83,7 +83,7 @@ class TestStaticDiskIndex(unittest.TestCase):
 
     def test_single(self):
         for metric, dtype, query_vectors, index_vectors, ann_dir in self._test_matrix:
-            with self.subTest():
+            with self.subTest(msg=f"Testing dtype {dtype}"):
                 index = dap.StaticDiskIndex(
                     distance_metric="l2",
                     vector_dtype=dtype,

--- a/python/tests/test_static_memory_index.py
+++ b/python/tests/test_static_memory_index.py
@@ -42,7 +42,7 @@ class TestStaticMemoryIndex(unittest.TestCase):
             vector_bin_file,
             _
         ) in self._test_matrix:
-            with self.subTest():
+            with self.subTest(msg=f"Testing dtype {dtype}"):
                 index = dap.StaticMemoryIndex(
                     index_directory=ann_dir,
                     num_threads=16,
@@ -78,7 +78,7 @@ class TestStaticMemoryIndex(unittest.TestCase):
             vector_bin_file,
             _
         ) in self._test_matrix:
-            with self.subTest():
+            with self.subTest(msg=f"Testing dtype {dtype}"):
                 index = dap.StaticMemoryIndex(
                     index_directory=ann_dir,
                     num_threads=16,

--- a/python/tests/test_static_memory_index.py
+++ b/python/tests/test_static_memory_index.py
@@ -40,7 +40,7 @@ class TestStaticMemoryIndex(unittest.TestCase):
             index_vectors,
             ann_dir,
             vector_bin_file,
-            _
+            _,
         ) in self._test_matrix:
             with self.subTest(msg=f"Testing dtype {dtype}"):
                 index = dap.StaticMemoryIndex(
@@ -66,7 +66,7 @@ class TestStaticMemoryIndex(unittest.TestCase):
                     self.assertTrue(
                         recall > 0.70,
                         f"Recall [{recall}] was not over 0.7",
-                        )
+                    )
 
     def test_single(self):
         for (
@@ -76,7 +76,7 @@ class TestStaticMemoryIndex(unittest.TestCase):
             index_vectors,
             ann_dir,
             vector_bin_file,
-            _
+            _,
         ) in self._test_matrix:
             with self.subTest(msg=f"Testing dtype {dtype}"):
                 index = dap.StaticMemoryIndex(
@@ -98,7 +98,7 @@ class TestStaticMemoryIndex(unittest.TestCase):
             index_vectors,
             ann_dir,
             vector_bin_file,
-            _
+            _,
         ) = build_random_vectors_and_memory_index(np.single, "l2", "not_ann")
         good_ranges = {
             "index_directory": ann_dir,


### PR DESCRIPTION
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?

Changes in 0.6.0 include:
- updated documentation
- consistent naming in utility functions
- simplification of api (trying to coerce lists of longs or doubles into strict np arrays of our supported dtypes is too prone to silently swallowing errors in the downcast, and would be completely opaque to the user).  we support numpy arrays *only*.

Docs should be generated via `pdoc` in the style of `pdoc -o build/docs diskannpy` after building and installing diskannpy and pdoc. For the 0.6.0 release I will manually push this to a gh-pages branch and folder, and work on the automation to do this in github actions in a later PR.

