### PR TITLE
Pass nullptr as nullT when creating thread_data to avoid crash

### DIFF
--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -41,7 +41,7 @@ namespace diskann
 
 template <typename T, typename LabelT>
 PQFlashIndex<T, LabelT>::PQFlashIndex(std::shared_ptr<AlignedFileReader> &fileReader, diskann::Metric m)
-    : reader(fileReader), metric(m)
+    : reader(fileReader), metric(m), thread_data(nullptr)
 {
     if (m == diskann::Metric::COSINE || m == diskann::Metric::INNER_PRODUCT)
     {


### PR DESCRIPTION
Pass `nullptr` as "nullT" parameter when creating thread_data that's of `ConcurrentQueue<SSDThreadData*>` type, otherwise, the default `null_T `is uninitialized and may point to arbitrary memory and causes crash when it is returned by `ScratchStoreManager` since it thinks it's not `nullptr` and valid.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes? No
- [ ] Does this PR add any new dependencies? No
- [ ] Does this PR modify any existing APIs? No
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones? No
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
Pass `nullptr` as "nullT" parameter when creating thread_data that's of `ConcurrentQueue<SSDThreadData*>` type, otherwise, the default `null_T `is uninitialized and may point to arbitrary memory and caused crash when it is returned by `ScratchStoreManager` since it thinks it's not `nullptr` and valid.

#### Any other comments?
We detected crashes in production in our Bing serving stack where it crashed on `query_scratch->reset()` as the `query_scratch` pointing to garbage. In high concurrent scenario (many search requests), the ConcurrentQueue is already empty when a thread tries to get a scratch it will use an uninitialized `null_T` that survived `nullptr` check.