### PR TITLE
[EXEC_ENV_OLS only] Handle exception early and return error code during load.

### DIFF
--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -738,7 +738,16 @@ int PQFlashIndex<T, LabelT>::load_from_separate_paths(uint32_t num_threads, cons
 
     size_t pq_file_dim, pq_file_num_centroids;
 #ifdef EXEC_ENV_OLS
-    get_bin_metadata(files, pq_table_bin, pq_file_num_centroids, pq_file_dim, METADATA_SIZE);
+    try
+    {
+        get_bin_metadata(files, pq_table_bin, pq_file_num_centroids, pq_file_dim, METADATA_SIZE);
+    }
+    catch (ANNException &exp)
+    {
+        diskann::cout << "Exception when getting metadata from " << pq_table_bin << ":" << exp.what()
+                      << std::endl;
+        return -1;
+    }
 #else
     get_bin_metadata(pq_table_bin, pq_file_num_centroids, pq_file_dim, METADATA_SIZE);
 #endif


### PR DESCRIPTION
During index load, for the DLVS implementation (EXEC_ENV_OLS enabled), handle the `ANNException` thrown from the `get_bin_metadata` method early and return error code. 

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes? No
- [ ] Does this PR add any new dependencies? No
- [ ] Does this PR modify any existing APIs? No
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones? No
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
During index load, for the DLVS implementation (EXEC_ENV_OLS enabled), handle the `ANNException `thrown from the `get_bin_metadata `method early and return error code. 
#### Any other comments?
The ANNException thrown from the `MemoryMappedFiles::getContent` method becomes unhandled at DLVS side as it's thrown from a separate DLL and somehow cannot be caught even we have the [code ](https://github.com/microsoft/BANN/blob/main/src/legacy/diskann/bulk_ssd_wrapper/BulkSSDDiskANNIndex.cpp#L354-L358) to handle it, and we saw crashes due to this (e.g., when the file "index__pq_pivots.bin" doesn't exist in some index partition like below).

```
000000fa`806f9bd0 00007ffc`8366fadd     mscoreei!GetXMLElementAttribute+0x24f4
000000fa`806f9c00 00007ffc`85ca91d5     KERNELBASE!UnhandledExceptionFilter+0x1bd
000000fa`806f9d20 00007ffc`85c8efb6     ntdll!memset+0x2455
000000fa`806f9d60 00007ffc`85ca4fcf     ntdll!_C_specific_handler+0x96
000000fa`806f9dd0 00007ffc`85c318fe     ntdll!_chkstk+0x12f
000000fa`806f9e00 00007ffc`85c4f761     ntdll!RtlVirtualUnwind2+0x35e
000000fa`806fa540 00007ffc`835ff1ac     ntdll!RtlRaiseException+0x1f1
000000fa`806fb3e0 00007ffc`79436720     KERNELBASE!RaiseException+0x6c
000000fa`806fb4c0 00000218`55951a44     VCRUNTIME140!CxxThrowException+0x90
000000fa`806fb520 00000218`5589d642     bann_diskann!diskann::MemoryMappedFiles::getContent(class std::basic_string<char,std::char_traits<char>,std::allocator<char> > * fileName = 0x000000fa`806fb6b0 "K:\DiskStoreBulk\0$ggbspacev$spacevgriffinfbv4$133351776581894989$29$ann\index__pq_pivots.bin")+0xf4 [D:\menghao\2-work\OAAS\19-DLVS\git-repo\BANN\src\legacy\diskann\bulk_ssd_wrapper\memory_mapped_files.cpp @ 14]
(Inline Function) --------`--------     bann_diskann!diskann::get_bin_metadata(void)+0x4c [D:\menghao\2-work\OAAS\19-DLVS\git-repo\BANN\src\legacy\diskann\DiskANN\include\utils.h @ 254]


```