### PR TITLE
Added PDoc workflow to publish github pages documentation

### DIFF
--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -4,7 +4,10 @@ jobs:
   build-reference-documentation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -17,12 +17,12 @@ jobs:
           pdoc -o docs/python/html diskannpy
       - name: Create version environment variable
         run: |
-          echo "DISKANN_VERSION=`$(python <<EOF
-            from importlib.metadata import version
-            v = version('diskannpy')
-            print(v)
-            EOF
-            )`" >> $GITHUB_ENV
+          echo "DISKANN_VERSION=$(python <<EOF
+          from importlib.metadata import version
+          v = version('diskannpy')
+          print(v)
+          EOF
+          )" >> $GITHUB_ENV
       - name: Archive documentation version artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -12,12 +12,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Build wheel for documentation
-        uses: ./.github/actions/build
+      - name: Install python build
+        run: python -m pip install build
+        shell: bash
+      - name: Building Python Wheel for documentation generation
+        run: python -m build --wheel --outdir documentation_dist
+        shell: bash
       - name: "Run Reference Documentation Generation"
         run: |
           pip install pdoc pipdeptree
-          pip install dist/*.whl 
+          pip install documentation_dist/*.whl 
           echo "documentation" > dependencies_documentation.txt
           pipdeptree >> dependencies_documentation.txt
           pdoc -o docs/python/html diskannpy

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -20,7 +20,7 @@ jobs:
           echo "DISKANN_VERSION=`$(python <<EOF
             from importlib.metadata import version
             v = version('diskannpy')
-            print(f"$v")
+            print(v)
             EOF
             )`" >> $GITHUB_ENV
       - name: Archive documentation version artifact

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -1,0 +1,29 @@
+name: DiskANN Build PDoc Documentation
+on: [workflow_call]
+jobs:
+  build-reference-documentation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: "Run Reference Documentation Generation"
+        run: |
+          pip install pdoc pipdeptree
+          echo "documentation" > dependencies_documentation.txt
+          pipdeptree >> dependencies_documentation.txt
+          pdoc -o docs/python/html diskannpy
+      - name: Archive documentation version artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: dependencies
+          path: |
+            dependencies_documentation.txt
+      - name: Archive documentation artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: documentation-site
+          path: |
+            docs/python/html

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -15,6 +15,9 @@ jobs:
           echo "documentation" > dependencies_documentation.txt
           pipdeptree >> dependencies_documentation.txt
           pdoc -o docs/python/html diskannpy
+      - name: Create version environment variable
+        run: |
+          echo "DISKANN_VERSION=`python setup.py --version`" >> $GITHUB_ENV
       - name: Archive documentation version artifact
         uses: actions/upload-artifact@v2
         with:
@@ -27,3 +30,17 @@ jobs:
           name: documentation-site
           path: |
             docs/python/html
+      - name: Publish reference docs (main branch)
+        uses: peaceiris/actions-gh-pages@v3
+        #if: github.ref=='refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/python/html
+          destination_dir: ${{ env.DISKANN_VERSION }}-test
+      - name: Publish latest reference docs (main branch)
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.ref=='refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/python/html
+          destination_dir: latest

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -38,7 +38,7 @@ jobs:
             docs/python/html
       - name: Publish reference docs for latest development version (main branch)
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref == 'refs/heads/main'
+        #if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/python/html

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -12,16 +12,12 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
-      - name: Install python build
-        run: python -m pip install build
-        shell: bash
-      - name: Building Python Wheel for documentation generation
-        run: python -m build --wheel --outdir documentation_dist
-        shell: bash
+      - name: Build wheel for documentation
+        uses: ./.github/actions/build
       - name: "Run Reference Documentation Generation"
         run: |
           pip install pdoc pipdeptree
-          pip install documentation_dist/*.whl 
+          pip install dist/*.whl 
           echo "documentation" > dependencies_documentation.txt
           pipdeptree >> dependencies_documentation.txt
           pdoc -o docs/python/html diskannpy

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -35,16 +35,23 @@ jobs:
           name: documentation-site
           path: |
             docs/python/html
-      - name: Publish reference docs (main branch)
+      - name: Publish reference docs for latest development version (main branch)
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref=='refs/heads/main'
+        if: github.ref == 'refs/heads/main'
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/python/html
+          destination_dir: docs/python/dev
+      - name: Publish reference docs by version (main branch)
+        uses: peaceiris/actions-gh-pages@v3
+        if: github.event_name == 'release' && github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/python/html
           destination_dir: docs/python/${{ env.DISKANN_VERSION }}
       - name: Publish latest reference docs (main branch)
         uses: peaceiris/actions-gh-pages@v3
-        if: github.ref=='refs/heads/main'
+        if: github.event_name == 'release' && github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/python/html

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -15,10 +15,13 @@ jobs:
       - name: Install python build
         run: python -m pip install build
         shell: bash
+      # Install required dependencies
       - name: Prepare Linux environment
         run: |
           sudo scripts/dev/install-dev-deps-ubuntu.bash
         shell: bash
+      # We need to build the wheel in order to run pdoc.  pdoc does not seem to work if you just point it at
+      # our source directory.
       - name: Building Python Wheel for documentation generation
         run: python -m build --wheel --outdir documentation_dist
         shell: bash
@@ -49,13 +52,15 @@ jobs:
           name: documentation-site
           path: |
             docs/python/html
+      # Publish to /dev if we are on the "main" branch
       - name: Publish reference docs for latest development version (main branch)
         uses: peaceiris/actions-gh-pages@v3
-        #if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/python/html
           destination_dir: docs/python/dev
+      # Publish to /<version> if we are on the "main" branch and releasing
       - name: Publish reference docs by version (main branch)
         uses: peaceiris/actions-gh-pages@v3
         if: github.event_name == 'release' && github.ref == 'refs/heads/main'
@@ -63,6 +68,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/python/html
           destination_dir: docs/python/${{ env.DISKANN_VERSION }}
+      # Publish to /latest if we are on the "main" branch and releasing
       - name: Publish latest reference docs (main branch)
         uses: peaceiris/actions-gh-pages@v3
         if: github.event_name == 'release' && github.ref == 'refs/heads/main'

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -9,10 +9,16 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.9
+      - name: Install python build
+        run: python -m pip install build
+        shell: bash
+      - name: Building Python Wheel for documentation generation
+        run: python3 -m build --wheel --outdir documentation_dist
+        shell: bash
       - name: "Run Reference Documentation Generation"
         run: |
           pip install pdoc pipdeptree
-          pip install -e .
+          pip install documentation_dist/*.whl 
           echo "documentation" > dependencies_documentation.txt
           pipdeptree >> dependencies_documentation.txt
           pdoc -o docs/python/html diskannpy

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -41,11 +41,11 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/python/html
-          destination_dir: ${{ env.DISKANN_VERSION }}-test
+          destination_dir: docs/python/${{ env.DISKANN_VERSION }}-test
       - name: Publish latest reference docs (main branch)
         uses: peaceiris/actions-gh-pages@v3
         if: github.ref=='refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/python/html
-          destination_dir: latest
+          destination_dir: docs/python/latest

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -13,7 +13,7 @@ jobs:
         run: python -m pip install build
         shell: bash
       - name: Building Python Wheel for documentation generation
-        run: python3 -m build --wheel --outdir documentation_dist
+        run: python -m build --wheel --outdir documentation_dist
         shell: bash
       - name: "Run Reference Documentation Generation"
         run: |

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -11,7 +11,7 @@ jobs:
           python-version: 3.9
       - name: "Run Reference Documentation Generation"
         run: |
-          pip install pdoc pipdeptree
+          pip install diskannpy pdoc pipdeptree
           echo "documentation" > dependencies_documentation.txt
           pipdeptree >> dependencies_documentation.txt
           pdoc -o docs/python/html diskannpy

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -11,7 +11,8 @@ jobs:
           python-version: 3.9
       - name: "Run Reference Documentation Generation"
         run: |
-          pip install diskannpy pdoc pipdeptree
+          pip install pdoc pipdeptree
+          pip install -e .
           echo "documentation" > dependencies_documentation.txt
           pipdeptree >> dependencies_documentation.txt
           pdoc -o docs/python/html diskannpy

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -17,7 +17,12 @@ jobs:
           pdoc -o docs/python/html diskannpy
       - name: Create version environment variable
         run: |
-          echo "DISKANN_VERSION=`python setup.py --version`" >> $GITHUB_ENV
+          echo "DISKANN_VERSION=`$(python <<EOF
+            from importlib.metadata import version
+            v = version('diskannpy')
+            print(f"$v")
+            EOF
+            )`" >> $GITHUB_ENV
       - name: Archive documentation version artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -37,11 +37,11 @@ jobs:
             docs/python/html
       - name: Publish reference docs (main branch)
         uses: peaceiris/actions-gh-pages@v3
-        #if: github.ref=='refs/heads/main'
+        if: github.ref=='refs/heads/main'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/python/html
-          destination_dir: docs/python/${{ env.DISKANN_VERSION }}-test
+          destination_dir: docs/python/${{ env.DISKANN_VERSION }}
       - name: Publish latest reference docs (main branch)
         uses: peaceiris/actions-gh-pages@v3
         if: github.ref=='refs/heads/main'

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -15,6 +15,10 @@ jobs:
       - name: Install python build
         run: python -m pip install build
         shell: bash
+      - name: Prepare Linux environment
+        run: |
+          sudo scripts/dev/install-dev-deps-ubuntu.bash
+        shell: bash
       - name: Building Python Wheel for documentation generation
         run: python -m build --wheel --outdir documentation_dist
         shell: bash

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -20,17 +20,6 @@ jobs:
         uses: ./.github/actions/python-wheel
         with:
           cibw-identifier: ${{matrix.cibw-identifier}}
-      - name: Build dependency tree
-        run: |
-          pip install pipdeptree
-          echo "documentation" > dependencies_documentation.txt
-          pipdeptree >> dependencies_${{matrix.cibw-identifier}.txt
-      - name: Archive dependencies artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: dependencies
-          path: |
-            dependencies_${{matrix.cibw-identifier}.txt
   windows-build:
     name: Python - Windows - ${{matrix.cibw-identifier}}
     strategy:
@@ -51,14 +40,3 @@ jobs:
         uses: ./.github/actions/python-wheel
         with:
           cibw-identifier: ${{matrix.cibw-identifier}}
-      - name: Build dependency tree
-        run: |
-          pip install pipdeptree
-          echo "documentation" > dependencies_documentation.txt
-          pipdeptree >> dependencies_${{matrix.cibw-identifier}.txt
-      - name: Archive dependencies artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: dependencies
-          path: |
-            dependencies_${{matrix.cibw-identifier}.txt

--- a/.github/workflows/build-python.yml
+++ b/.github/workflows/build-python.yml
@@ -20,6 +20,17 @@ jobs:
         uses: ./.github/actions/python-wheel
         with:
           cibw-identifier: ${{matrix.cibw-identifier}}
+      - name: Build dependency tree
+        run: |
+          pip install pipdeptree
+          echo "documentation" > dependencies_documentation.txt
+          pipdeptree >> dependencies_${{matrix.cibw-identifier}.txt
+      - name: Archive dependencies artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: dependencies
+          path: |
+            dependencies_${{matrix.cibw-identifier}.txt
   windows-build:
     name: Python - Windows - ${{matrix.cibw-identifier}}
     strategy:
@@ -40,3 +51,14 @@ jobs:
         uses: ./.github/actions/python-wheel
         with:
           cibw-identifier: ${{matrix.cibw-identifier}}
+      - name: Build dependency tree
+        run: |
+          pip install pipdeptree
+          echo "documentation" > dependencies_documentation.txt
+          pipdeptree >> dependencies_${{matrix.cibw-identifier}.txt
+      - name: Archive dependencies artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: dependencies
+          path: |
+            dependencies_${{matrix.cibw-identifier}.txt

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -6,6 +6,11 @@ jobs:
       fail-fast: true
     name: DiskANN Common Build Checks
     uses: ./.github/workflows/common.yml
+  build-documentation:
+    strategy:
+      fail-fast: true
+    name: DiskANN Build Documentation
+    uses: ./.github/workflows/build-python-pdoc.yml
   build:
     strategy:
       fail-fast: false

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -31,14 +31,14 @@ jobs:
       - name: Build dispannpy dependency tree
         run: |
           pip install diskannpy pipdeptree
-          echo "dependencies" > dependencies_${{ runner.os }}.txt
-          pipdeptree >> dependencies_${{ runner.os }}_${{ runner.labels.label_name }}.txt
+          echo "dependencies" > dependencies_${{ matrix.os }}.txt
+          pipdeptree >> dependencies_${{ matrix.os }}.txt
       - name: Archive dispannpy dependencies artifact
         uses: actions/upload-artifact@v3
         with:
           name: dependencies
           path: |
-            dependencies_${{ runner.os }}_${{ runner.labels.label_name }}.txt
+            dependencies_${{ matrix.os }}.txt
       - name: DiskANN Build CLI Applications
         uses: ./.github/actions/build
   build-documentation:

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -32,13 +32,13 @@ jobs:
         run: |
           pip install diskannpy pipdeptree
           echo "dependencies" > dependencies_${{ runner.os }}.txt
-          pipdeptree >> dependencies_${{ runner.os }}.txt
+          pipdeptree >> dependencies_${{ runner.os }}_${{ runner.labels.label_name }}.txt
       - name: Archive dispannpy dependencies artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: dependencies
           path: |
-            dependencies_${{ runner.os }}.txt
+            dependencies_${{ runner.os }}_${{ runner.labels.label_name }}.txt
       - name: DiskANN Build CLI Applications
         uses: ./.github/actions/build
   build-documentation:

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -41,11 +41,6 @@ jobs:
             dependencies_${{ matrix.os }}.txt
       - name: DiskANN Build CLI Applications
         uses: ./.github/actions/build
-  build-documentation:
-      strategy:
-        fail-fast: true
-      name: DiskANN Build Documentation
-      uses: ./.github/workflows/build-python-pdoc.yml
 #  python:
 #    name: DiskANN Build Python Wheel
 #    uses: ./.github/workflows/build-python.yml

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -28,6 +28,17 @@ jobs:
         with:
           fetch-depth: 1
           submodules: true
+      - name: Build dispannpy dependency tree
+        run: |
+          pip install diskannpy pipdeptree
+          echo "dependencies" > dependencies_${{ runner.os }}.txt
+          pipdeptree >> dependencies_${{ runner.os }}.txt
+      - name: Archive dispannpy dependencies artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: dependencies
+          path: |
+            dependencies_${{ runner.os }}.txt
       - name: DiskANN Build CLI Applications
         uses: ./.github/actions/build
   build-documentation:

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -30,6 +30,11 @@ jobs:
           submodules: true
       - name: DiskANN Build CLI Applications
         uses: ./.github/actions/build
+  build-documentation:
+      strategy:
+        fail-fast: true
+      name: DiskANN Build Documentation
+      uses: ./.github/workflows/build-python-pdoc.yml
 #  python:
 #    name: DiskANN Build Python Wheel
 #    uses: ./.github/workflows/build-python.yml

--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -6,6 +6,11 @@ jobs:
   python-release-wheels:
     name: Python
     uses: ./.github/workflows/build-python.yml
+  build-documentation:
+    strategy:
+      fail-fast: true
+    name: DiskANN Build Documentation
+    uses: ./.github/workflows/build-python-pdoc.yml
   release:
     runs-on: ubuntu-latest
     needs: python-release-wheels


### PR DESCRIPTION
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [x] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### What does this implement/fix? Briefly explain your changes.

Make GitHub publish pdoc documentation to gh-pages as part of the release.  Create documentation as a ZIP as part of each build.

#### Any other comments?

