### PR TITLE
Change "convert_labels_string_to_int" to use non-negative continuous integer(starts from 0)

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -172,7 +172,7 @@ inline void convert_labels_string_to_int(const std::string &inFileName, const st
             token.erase(std::remove(token.begin(), token.end(), '\r'), token.end());
             if (string_int_map.find(token) == string_int_map.end())
             {
-                uint32_t nextId = (uint32_t)string_int_map.size() + 1;
+                uint32_t nextId = (uint32_t)string_int_map.size();
                 string_int_map[token] = nextId;
             }
             lbls.push_back(string_int_map[token]);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
when unv_label == "", it does not use label Id "0";
when unv_label != "", it does not use label Id "1";

#### What does this implement/fix? Briefly explain your changes.
After my changing, the label ids always start from 0 and continuous.

#### Any other comments?

