### PR TITLE
Remove IndexWriteParams from build method.

### DIFF
--- a/apps/build_memory_index.cpp
+++ b/apps/build_memory_index.cpp
@@ -127,11 +127,11 @@ int main(int argc, char **argv)
                                       .with_num_threads(num_threads)
                                       .build();
 
-        auto build_params = diskann::IndexBuildParamsBuilder()
-                                .with_universal_label(universal_label)
-                                .with_label_file(label_file)
-                                .with_save_path_prefix(index_path_prefix)
-                                .build();
+        auto filter_params = diskann::IndexFilterParamsBuilder()
+                                 .with_universal_label(universal_label)
+                                 .with_label_file(label_file)
+                                 .with_save_path_prefix(index_path_prefix)
+                                 .build();
         auto config = diskann::IndexConfigBuilder()
                           .with_metric(metric)
                           .with_dimension(data_dim)
@@ -150,7 +150,7 @@ int main(int argc, char **argv)
 
         auto index_factory = diskann::IndexFactory(config);
         auto index = index_factory.create_instance();
-        index->build(data_path, data_num, build_params);
+        index->build(data_path, data_num, filter_params);
         index->save(index_path_prefix.c_str());
         index.reset();
         return 0;

--- a/apps/build_memory_index.cpp
+++ b/apps/build_memory_index.cpp
@@ -127,7 +127,7 @@ int main(int argc, char **argv)
                                       .with_num_threads(num_threads)
                                       .build();
 
-        auto build_params = diskann::IndexBuildParamsBuilder(index_build_params)
+        auto build_params = diskann::IndexBuildParamsBuilder()
                                 .with_universal_label(universal_label)
                                 .with_label_file(label_file)
                                 .with_save_path_prefix(index_path_prefix)

--- a/apps/test_insert_deletes_consolidate.cpp
+++ b/apps/test_insert_deletes_consolidate.cpp
@@ -216,7 +216,7 @@ void build_incremental_index(const std::string &data_path, diskann::IndexWritePa
 
     if (beginning_index_size > 0)
     {
-        index->build(data, beginning_index_size, params, tags);
+        index->build(data, beginning_index_size, tags);
     }
     else
     {

--- a/include/abstract_index.h
+++ b/include/abstract_index.h
@@ -42,7 +42,7 @@ class AbstractIndex
     virtual ~AbstractIndex() = default;
 
     virtual void build(const std::string &data_file, const size_t num_points_to_load,
-                       IndexBuildParams &build_params) = 0;
+                       IndexFilterParams &build_params) = 0;
 
     template <typename data_type, typename tag_type>
     void build(const data_type *data, const size_t num_points_to_load, const std::vector<tag_type> &tags);

--- a/include/abstract_index.h
+++ b/include/abstract_index.h
@@ -45,8 +45,7 @@ class AbstractIndex
                        IndexBuildParams &build_params) = 0;
 
     template <typename data_type, typename tag_type>
-    void build(const data_type *data, const size_t num_points_to_load, const IndexWriteParameters &parameters,
-               const std::vector<tag_type> &tags);
+    void build(const data_type *data, const size_t num_points_to_load, const std::vector<tag_type> &tags);
 
     virtual void save(const char *filename, bool compact_before_save = false) = 0;
 
@@ -98,8 +97,7 @@ class AbstractIndex
     template <typename tag_type, typename data_type> int get_vector_by_tag(tag_type &tag, data_type *vec);
 
   private:
-    virtual void _build(const DataType &data, const size_t num_points_to_load, const IndexWriteParameters &parameters,
-                        TagVector &tags) = 0;
+    virtual void _build(const DataType &data, const size_t num_points_to_load, TagVector &tags) = 0;
     virtual std::pair<uint32_t, uint32_t> _search(const DataType &query, const size_t K, const uint32_t L,
                                                   std::any &indices, float *distances = nullptr) = 0;
     virtual std::pair<uint32_t, uint32_t> _search_with_filters(const DataType &query, const std::string &filter_label,

--- a/include/index.h
+++ b/include/index.h
@@ -94,8 +94,9 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
     // Batch build from a data array, which must pad vectors to aligned_dim
     DISKANN_DLLEXPORT void build(const T *data, const size_t num_points_to_load, const std::vector<TagT> &tags);
 
+    // Based on filter params builds a filtered or unfiltered index
     DISKANN_DLLEXPORT void build(const std::string &data_file, const size_t num_points_to_load,
-                                 IndexBuildParams &build_params);
+                                 IndexFilterParams &build_params);
 
     // Filtered Support
     DISKANN_DLLEXPORT void build_filtered_index(const char *filename, const std::string &label_file,

--- a/include/index.h
+++ b/include/index.h
@@ -86,23 +86,20 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
 
     // Batch build from a file. Optionally pass tags vector.
     DISKANN_DLLEXPORT void build(const char *filename, const size_t num_points_to_load,
-                                 const IndexWriteParameters &parameters,
                                  const std::vector<TagT> &tags = std::vector<TagT>());
 
     // Batch build from a file. Optionally pass tags file.
-    DISKANN_DLLEXPORT void build(const char *filename, const size_t num_points_to_load,
-                                 const IndexWriteParameters &parameters, const char *tag_filename);
+    DISKANN_DLLEXPORT void build(const char *filename, const size_t num_points_to_load, const char *tag_filename);
 
     // Batch build from a data array, which must pad vectors to aligned_dim
-    DISKANN_DLLEXPORT void build(const T *data, const size_t num_points_to_load, const IndexWriteParameters &parameters,
-                                 const std::vector<TagT> &tags);
+    DISKANN_DLLEXPORT void build(const T *data, const size_t num_points_to_load, const std::vector<TagT> &tags);
 
     DISKANN_DLLEXPORT void build(const std::string &data_file, const size_t num_points_to_load,
                                  IndexBuildParams &build_params);
 
     // Filtered Support
     DISKANN_DLLEXPORT void build_filtered_index(const char *filename, const std::string &label_file,
-                                                const size_t num_points_to_load, IndexWriteParameters &parameters,
+                                                const size_t num_points_to_load,
                                                 const std::vector<TagT> &tags = std::vector<TagT>());
 
     DISKANN_DLLEXPORT void set_universal_label(const LabelT &label);
@@ -194,8 +191,7 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
 
   protected:
     // overload of abstract index virtual methods
-    virtual void _build(const DataType &data, const size_t num_points_to_load, const IndexWriteParameters &parameters,
-                        TagVector &tags) override;
+    virtual void _build(const DataType &data, const size_t num_points_to_load, TagVector &tags) override;
 
     virtual std::pair<uint32_t, uint32_t> _search(const DataType &query, const size_t K, const uint32_t L,
                                                   std::any &indices, float *distances = nullptr) override;
@@ -227,7 +223,7 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
 
     // Use after _data and _nd have been populated
     // Acquire exclusive _update_lock before calling
-    void build_with_data_populated(const IndexWriteParameters &parameters, const std::vector<TagT> &tags);
+    void build_with_data_populated(const std::vector<TagT> &tags);
 
     // generates 1 frozen point that will never be deleted from the graph
     // This is not visible to the user
@@ -273,7 +269,7 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
     void inter_insert(uint32_t n, std::vector<uint32_t> &pruned_list, InMemQueryScratch<T> *scratch);
 
     // Acquire exclusive _update_lock before calling
-    void link(const IndexWriteParameters &parameters);
+    void link();
 
     // Acquire exclusive _tag_lock and _delete_lock before calling
     int reserve_location();
@@ -380,6 +376,7 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
     uint32_t _indexingRange;
     uint32_t _indexingMaxC;
     float _indexingAlpha;
+    uint32_t _indexingThreads;
 
     // Query scratch data structures
     ConcurrentQueue<InMemQueryScratch<T> *> _query_scratch;

--- a/include/index_build_params.h
+++ b/include/index_build_params.h
@@ -3,7 +3,7 @@
 
 namespace diskann
 {
-struct IndexBuildParams
+struct IndexFilterParams
 {
   public:
     std::string save_path_prefix;
@@ -12,21 +12,21 @@ struct IndexBuildParams
     uint32_t filter_threshold = 0;
 
   private:
-    IndexBuildParams(const std::string &save_path_prefix, const std::string &label_file,
-                     const std::string &universal_label, uint32_t filter_threshold)
+    IndexFilterParams(const std::string &save_path_prefix, const std::string &label_file,
+                      const std::string &universal_label, uint32_t filter_threshold)
         : save_path_prefix(save_path_prefix), label_file(label_file), universal_label(universal_label),
           filter_threshold(filter_threshold)
     {
     }
 
-    friend class IndexBuildParamsBuilder;
+    friend class IndexFilterParamsBuilder;
 };
-class IndexBuildParamsBuilder
+class IndexFilterParamsBuilder
 {
   public:
-    IndexBuildParamsBuilder() = default;
+    IndexFilterParamsBuilder() = default;
 
-    IndexBuildParamsBuilder &with_save_path_prefix(const std::string &save_path_prefix)
+    IndexFilterParamsBuilder &with_save_path_prefix(const std::string &save_path_prefix)
     {
         if (save_path_prefix.empty() || save_path_prefix == "")
             throw ANNException("Error: save_path_prefix can't be empty", -1);
@@ -34,31 +34,31 @@ class IndexBuildParamsBuilder
         return *this;
     }
 
-    IndexBuildParamsBuilder &with_label_file(const std::string &label_file)
+    IndexFilterParamsBuilder &with_label_file(const std::string &label_file)
     {
         this->_label_file = label_file;
         return *this;
     }
 
-    IndexBuildParamsBuilder &with_universal_label(const std::string &univeral_label)
+    IndexFilterParamsBuilder &with_universal_label(const std::string &univeral_label)
     {
         this->_universal_label = univeral_label;
         return *this;
     }
 
-    IndexBuildParamsBuilder &with_filter_threshold(const std::uint32_t &filter_threshold)
+    IndexFilterParamsBuilder &with_filter_threshold(const std::uint32_t &filter_threshold)
     {
         this->_filter_threshold = filter_threshold;
         return *this;
     }
 
-    IndexBuildParams build()
+    IndexFilterParams build()
     {
-        return IndexBuildParams(_save_path_prefix, _label_file, _universal_label, _filter_threshold);
+        return IndexFilterParams(_save_path_prefix, _label_file, _universal_label, _filter_threshold);
     }
 
-    IndexBuildParamsBuilder(const IndexBuildParamsBuilder &) = delete;
-    IndexBuildParamsBuilder &operator=(const IndexBuildParamsBuilder &) = delete;
+    IndexFilterParamsBuilder(const IndexFilterParamsBuilder &) = delete;
+    IndexFilterParamsBuilder &operator=(const IndexFilterParamsBuilder &) = delete;
 
   private:
     std::string _save_path_prefix;

--- a/include/index_build_params.h
+++ b/include/index_build_params.h
@@ -6,17 +6,16 @@ namespace diskann
 struct IndexBuildParams
 {
   public:
-    diskann::IndexWriteParameters index_write_params;
     std::string save_path_prefix;
     std::string label_file;
     std::string universal_label;
     uint32_t filter_threshold = 0;
 
   private:
-    IndexBuildParams(const IndexWriteParameters &index_write_params, const std::string &save_path_prefix,
-                     const std::string &label_file, const std::string &universal_label, uint32_t filter_threshold)
-        : index_write_params(index_write_params), save_path_prefix(save_path_prefix), label_file(label_file),
-          universal_label(universal_label), filter_threshold(filter_threshold)
+    IndexBuildParams(const std::string &save_path_prefix, const std::string &label_file,
+                     const std::string &universal_label, uint32_t filter_threshold)
+        : save_path_prefix(save_path_prefix), label_file(label_file), universal_label(universal_label),
+          filter_threshold(filter_threshold)
     {
     }
 
@@ -25,7 +24,7 @@ struct IndexBuildParams
 class IndexBuildParamsBuilder
 {
   public:
-    IndexBuildParamsBuilder(const diskann::IndexWriteParameters &paras) : _index_write_params(paras){};
+    IndexBuildParamsBuilder() = default;
 
     IndexBuildParamsBuilder &with_save_path_prefix(const std::string &save_path_prefix)
     {
@@ -55,15 +54,13 @@ class IndexBuildParamsBuilder
 
     IndexBuildParams build()
     {
-        return IndexBuildParams(_index_write_params, _save_path_prefix, _label_file, _universal_label,
-                                _filter_threshold);
+        return IndexBuildParams(_save_path_prefix, _label_file, _universal_label, _filter_threshold);
     }
 
     IndexBuildParamsBuilder(const IndexBuildParamsBuilder &) = delete;
     IndexBuildParamsBuilder &operator=(const IndexBuildParamsBuilder &) = delete;
 
   private:
-    diskann::IndexWriteParameters _index_write_params;
     std::string _save_path_prefix;
     std::string _label_file;
     std::string _universal_label;

--- a/python/include/static_memory_index.h
+++ b/python/include/static_memory_index.h
@@ -14,21 +14,23 @@
 
 namespace py = pybind11;
 
-namespace diskannpy {
+namespace diskannpy
+{
 
-template <typename DT>
-class StaticMemoryIndex
+template <typename DT> class StaticMemoryIndex
 {
   public:
-    StaticMemoryIndex(diskann::Metric m, const std::string &index_prefix, size_t num_points,
-                     size_t dimensions, uint32_t num_threads, uint32_t initial_search_complexity);
+    StaticMemoryIndex(diskann::Metric m, const std::string &index_prefix, size_t num_points, size_t dimensions,
+                      uint32_t num_threads, uint32_t initial_search_complexity);
 
-    NeighborsAndDistances<StaticIdType> search(py::array_t<DT, py::array::c_style | py::array::forcecast> &query, uint64_t knn,
-                uint64_t complexity);
+    NeighborsAndDistances<StaticIdType> search(py::array_t<DT, py::array::c_style | py::array::forcecast> &query,
+                                               uint64_t knn, uint64_t complexity);
 
-    NeighborsAndDistances<StaticIdType> batch_search(py::array_t<DT, py::array::c_style | py::array::forcecast> &queries,
-                                           uint64_t num_queries, uint64_t knn, uint64_t complexity, uint32_t num_threads);
+    NeighborsAndDistances<StaticIdType> batch_search(
+        py::array_t<DT, py::array::c_style | py::array::forcecast> &queries, uint64_t num_queries, uint64_t knn,
+        uint64_t complexity, uint32_t num_threads);
+
   private:
     diskann::Index<DT, StaticIdType, filterT> _index;
 };
-}
+} // namespace diskannpy

--- a/python/src/builder.cpp
+++ b/python/src/builder.cpp
@@ -65,11 +65,11 @@ void build_memory_index(const diskann::Metric metric, const std::string &vector_
         size_t tag_dims = 1;
         diskann::load_bin(tags_file, tags_data, data_num, tag_dims);
         std::vector<TagT> tags(tags_data, tags_data + data_num);
-        index.build(vector_bin_path.c_str(), data_num, index_build_params, tags);
+        index.build(vector_bin_path.c_str(), data_num, tags);
     }
     else
     {
-        index.build(vector_bin_path.c_str(), data_num, index_build_params);
+        index.build(vector_bin_path.c_str(), data_num);
     }
 
     index.save(index_output_path.c_str());

--- a/src/abstract_index.cpp
+++ b/src/abstract_index.cpp
@@ -6,12 +6,11 @@ namespace diskann
 {
 
 template <typename data_type, typename tag_type>
-void AbstractIndex::build(const data_type *data, const size_t num_points_to_load,
-                          const IndexWriteParameters &parameters, const std::vector<tag_type> &tags)
+void AbstractIndex::build(const data_type *data, const size_t num_points_to_load, const std::vector<tag_type> &tags)
 {
     auto any_data = std::any(data);
     auto any_tags_vec = TagVector(tags);
-    this->_build(any_data, num_points_to_load, parameters, any_tags_vec);
+    this->_build(any_data, num_points_to_load, any_tags_vec);
 }
 
 template <typename data_type, typename IDType>
@@ -92,50 +91,38 @@ template <typename tag_type, typename data_type> int AbstractIndex::get_vector_b
 
 // exports
 template DISKANN_DLLEXPORT void AbstractIndex::build<float, int32_t>(const float *data, const size_t num_points_to_load,
-                                                                     const IndexWriteParameters &parameters,
                                                                      const std::vector<int32_t> &tags);
 template DISKANN_DLLEXPORT void AbstractIndex::build<int8_t, int32_t>(const int8_t *data,
                                                                       const size_t num_points_to_load,
-                                                                      const IndexWriteParameters &parameters,
                                                                       const std::vector<int32_t> &tags);
 template DISKANN_DLLEXPORT void AbstractIndex::build<uint8_t, int32_t>(const uint8_t *data,
                                                                        const size_t num_points_to_load,
-                                                                       const IndexWriteParameters &parameters,
                                                                        const std::vector<int32_t> &tags);
 template DISKANN_DLLEXPORT void AbstractIndex::build<float, uint32_t>(const float *data,
                                                                       const size_t num_points_to_load,
-                                                                      const IndexWriteParameters &parameters,
                                                                       const std::vector<uint32_t> &tags);
 template DISKANN_DLLEXPORT void AbstractIndex::build<int8_t, uint32_t>(const int8_t *data,
                                                                        const size_t num_points_to_load,
-                                                                       const IndexWriteParameters &parameters,
                                                                        const std::vector<uint32_t> &tags);
 template DISKANN_DLLEXPORT void AbstractIndex::build<uint8_t, uint32_t>(const uint8_t *data,
                                                                         const size_t num_points_to_load,
-                                                                        const IndexWriteParameters &parameters,
                                                                         const std::vector<uint32_t> &tags);
 template DISKANN_DLLEXPORT void AbstractIndex::build<float, int64_t>(const float *data, const size_t num_points_to_load,
-                                                                     const IndexWriteParameters &parameters,
                                                                      const std::vector<int64_t> &tags);
 template DISKANN_DLLEXPORT void AbstractIndex::build<int8_t, int64_t>(const int8_t *data,
                                                                       const size_t num_points_to_load,
-                                                                      const IndexWriteParameters &parameters,
                                                                       const std::vector<int64_t> &tags);
 template DISKANN_DLLEXPORT void AbstractIndex::build<uint8_t, int64_t>(const uint8_t *data,
                                                                        const size_t num_points_to_load,
-                                                                       const IndexWriteParameters &parameters,
                                                                        const std::vector<int64_t> &tags);
 template DISKANN_DLLEXPORT void AbstractIndex::build<float, uint64_t>(const float *data,
                                                                       const size_t num_points_to_load,
-                                                                      const IndexWriteParameters &parameters,
                                                                       const std::vector<uint64_t> &tags);
 template DISKANN_DLLEXPORT void AbstractIndex::build<int8_t, uint64_t>(const int8_t *data,
                                                                        const size_t num_points_to_load,
-                                                                       const IndexWriteParameters &parameters,
                                                                        const std::vector<uint64_t> &tags);
 template DISKANN_DLLEXPORT void AbstractIndex::build<uint8_t, uint64_t>(const uint8_t *data,
                                                                         const size_t num_points_to_load,
-                                                                        const IndexWriteParameters &parameters,
                                                                         const std::vector<uint64_t> &tags);
 
 template DISKANN_DLLEXPORT std::pair<uint32_t, uint32_t> AbstractIndex::search<float, uint32_t>(

--- a/src/disk_utils.cpp
+++ b/src/disk_utils.cpp
@@ -639,7 +639,7 @@ int build_merged_vamana_index(std::string base_file, diskann::Metric compareMetr
             compareMetric, base_dim, base_num, std::make_shared<diskann::IndexWriteParameters>(paras), nullptr,
             paras.num_frozen_points, false, false, false, build_pq_bytes > 0, build_pq_bytes, use_opq);
         if (!use_filters)
-            _index.build(base_file.c_str(), base_num, paras);
+            _index.build(base_file.c_str(), base_num);
         else
         {
             if (universal_label != "")
@@ -647,7 +647,7 @@ int build_merged_vamana_index(std::string base_file, diskann::Metric compareMetr
                 LabelT unv_label_as_num = 0;
                 _index.set_universal_label(unv_label_as_num);
             }
-            _index.build_filtered_index(base_file.c_str(), label_file, base_num, paras);
+            _index.build_filtered_index(base_file.c_str(), label_file, base_num);
         }
         _index.save(mem_index_path.c_str());
 
@@ -703,7 +703,7 @@ int build_merged_vamana_index(std::string base_file, diskann::Metric compareMetr
             nullptr, paras.num_frozen_points, false, false, false, build_pq_bytes > 0, build_pq_bytes, use_opq);
         if (!use_filters)
         {
-            _index.build(shard_base_file.c_str(), shard_base_pts, paras);
+            _index.build(shard_base_file.c_str(), shard_base_pts);
         }
         else
         {
@@ -713,7 +713,7 @@ int build_merged_vamana_index(std::string base_file, diskann::Metric compareMetr
                 LabelT unv_label_as_num = 0;
                 _index.set_universal_label(unv_label_as_num);
             }
-            _index.build_filtered_index(shard_base_file.c_str(), shard_labels_file, shard_base_pts, paras);
+            _index.build_filtered_index(shard_base_file.c_str(), shard_labels_file, shard_base_pts);
         }
         _index.save(shard_index_file.c_str());
         // copy universal label file from first shard to the final destination

--- a/src/filter_utils.cpp
+++ b/src/filter_utils.cpp
@@ -51,7 +51,7 @@ void generate_label_indices(path input_data_path, path final_index_path_prefix, 
                                 0, false, false);
 
         auto index_build_timer = std::chrono::high_resolution_clock::now();
-        index.build(curr_label_input_data_path.c_str(), number_of_label_points, label_index_build_parameters);
+        index.build(curr_label_input_data_path.c_str(), number_of_label_points);
         std::chrono::duration<double> current_indexing_time =
             std::chrono::high_resolution_clock::now() - index_build_timer;
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -1699,24 +1699,24 @@ void Index<T, TagT, LabelT>::build(const char *filename, const size_t num_points
 
 template <typename T, typename TagT, typename LabelT>
 void Index<T, TagT, LabelT>::build(const std::string &data_file, const size_t num_points_to_load,
-                                   IndexBuildParams &build_params)
+                                   IndexFilterParams &filter_params)
 {
-    std::string labels_file_to_use = build_params.save_path_prefix + "_label_formatted.txt";
-    std::string mem_labels_int_map_file = build_params.save_path_prefix + "_labels_map.txt";
+    std::string labels_file_to_use = filter_params.save_path_prefix + "_label_formatted.txt";
+    std::string mem_labels_int_map_file = filter_params.save_path_prefix + "_labels_map.txt";
 
     size_t points_to_load = num_points_to_load == 0 ? _max_points : num_points_to_load;
 
     auto s = std::chrono::high_resolution_clock::now();
-    if (build_params.label_file == "")
+    if (filter_params.label_file == "")
     {
         this->build(data_file.c_str(), points_to_load);
     }
     else
     {
         // TODO: this should ideally happen in save()
-        convert_labels_string_to_int(build_params.label_file, labels_file_to_use, mem_labels_int_map_file,
-                                     build_params.universal_label);
-        if (build_params.universal_label != "")
+        convert_labels_string_to_int(filter_params.label_file, labels_file_to_use, mem_labels_int_map_file,
+                                     filter_params.universal_label);
+        if (filter_params.universal_label != "")
         {
             LabelT unv_label_as_num = 0;
             this->set_universal_label(unv_label_as_num);
@@ -1725,11 +1725,6 @@ void Index<T, TagT, LabelT>::build(const std::string &data_file, const size_t nu
     }
     std::chrono::duration<double> diff = std::chrono::high_resolution_clock::now() - s;
     std::cout << "Indexing time: " << diff.count() << "\n";
-    // cleanup
-    if (build_params.label_file != "")
-    {
-        // clean_up_artifacts({labels_file_to_use, mem_labels_int_map_file}, {});
-    }
 }
 
 template <typename T, typename TagT, typename LabelT>

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -93,18 +93,21 @@ Index<T, TagT, LabelT>::Index(const IndexConfig &index_config, std::unique_ptr<A
     if (_dynamic_index)
     {
         this->enable_delete(); // enable delete by default for dynamic index
-        // if write params are not passed, it is inffered that ctor is called by
-        // search
-        if (index_config.index_write_params != nullptr && index_config.index_search_params != nullptr)
-        {
-            _indexingQueueSize = index_config.index_write_params->search_list_size;
-            _indexingRange = index_config.index_write_params->max_degree;
-            _indexingMaxC = index_config.index_write_params->max_occlusion_size;
-            _indexingAlpha = index_config.index_write_params->alpha;
-            _filterIndexingQueueSize = index_config.index_write_params->filter_list_size;
+    }
 
-            uint32_t num_threads_indx = index_config.index_write_params->num_threads;
-            uint32_t num_scratch_spaces = index_config.index_search_params->num_search_threads + num_threads_indx;
+    if (index_config.index_write_params != nullptr)
+    {
+        _indexingQueueSize = index_config.index_write_params->search_list_size;
+        _indexingRange = index_config.index_write_params->max_degree;
+        _indexingMaxC = index_config.index_write_params->max_occlusion_size;
+        _indexingAlpha = index_config.index_write_params->alpha;
+        _filterIndexingQueueSize = index_config.index_write_params->filter_list_size;
+        _indexingThreads = index_config.index_write_params->num_threads;
+        _saturate_graph = index_config.index_write_params->saturate_graph;
+
+        if (index_config.index_search_params != nullptr)
+        {
+            uint32_t num_scratch_spaces = index_config.index_search_params->num_search_threads + _indexingThreads;
 
             initialize_query_scratch(num_scratch_spaces, index_config.index_search_params->initial_search_list_size,
                                      _indexingQueueSize, _indexingRange, _indexingMaxC, _data_store->get_dims());
@@ -1227,20 +1230,11 @@ void Index<T, TagT, LabelT>::inter_insert(uint32_t n, std::vector<uint32_t> &pru
     inter_insert(n, pruned_list, _indexingRange, scratch);
 }
 
-template <typename T, typename TagT, typename LabelT>
-void Index<T, TagT, LabelT>::link(const IndexWriteParameters &parameters)
+template <typename T, typename TagT, typename LabelT> void Index<T, TagT, LabelT>::link()
 {
-    uint32_t num_threads = parameters.num_threads;
+    uint32_t num_threads = _indexingThreads;
     if (num_threads != 0)
         omp_set_num_threads(num_threads);
-
-    _saturate_graph = parameters.saturate_graph;
-
-    _indexingQueueSize = parameters.search_list_size;
-    _filterIndexingQueueSize = parameters.filter_list_size;
-    _indexingRange = parameters.max_degree;
-    _indexingMaxC = parameters.max_occlusion_size;
-    _indexingAlpha = parameters.alpha;
 
     /* visit_order is a vector that is initialized to the entire graph */
     std::vector<uint32_t> visit_order;
@@ -1473,8 +1467,7 @@ void Index<T, TagT, LabelT>::set_start_points_at_random(T radius, uint32_t rando
 }
 
 template <typename T, typename TagT, typename LabelT>
-void Index<T, TagT, LabelT>::build_with_data_populated(const IndexWriteParameters &parameters,
-                                                       const std::vector<TagT> &tags)
+void Index<T, TagT, LabelT>::build_with_data_populated(const std::vector<TagT> &tags)
 {
     diskann::cout << "Starting index build with " << _nd << " points... " << std::endl;
 
@@ -1498,10 +1491,10 @@ void Index<T, TagT, LabelT>::build_with_data_populated(const IndexWriteParameter
         }
     }
 
-    uint32_t index_R = parameters.max_degree;
-    uint32_t num_threads_index = parameters.num_threads;
-    uint32_t index_L = parameters.search_list_size;
-    uint32_t maxc = parameters.max_occlusion_size;
+    uint32_t index_R = _indexingRange;
+    uint32_t num_threads_index = _indexingThreads;
+    uint32_t index_L = _indexingQueueSize;
+    uint32_t maxc = _indexingMaxC;
 
     if (_query_scratch.size() == 0)
     {
@@ -1510,7 +1503,7 @@ void Index<T, TagT, LabelT>::build_with_data_populated(const IndexWriteParameter
     }
 
     generate_frozen_point();
-    link(parameters);
+    link();
 
     size_t max = 0, min = SIZE_MAX, total = 0, cnt = 0;
     for (size_t i = 0; i < _nd; i++)
@@ -1528,13 +1521,11 @@ void Index<T, TagT, LabelT>::build_with_data_populated(const IndexWriteParameter
     _has_built = true;
 }
 template <typename T, typename TagT, typename LabelT>
-void Index<T, TagT, LabelT>::_build(const DataType &data, const size_t num_points_to_load,
-                                    const IndexWriteParameters &parameters, TagVector &tags)
+void Index<T, TagT, LabelT>::_build(const DataType &data, const size_t num_points_to_load, TagVector &tags)
 {
     try
     {
-        this->build(std::any_cast<const T *>(data), num_points_to_load, parameters,
-                    tags.get<const std::vector<TagT>>());
+        this->build(std::any_cast<const T *>(data), num_points_to_load, tags.get<const std::vector<TagT>>());
     }
     catch (const std::bad_any_cast &e)
     {
@@ -1546,8 +1537,7 @@ void Index<T, TagT, LabelT>::_build(const DataType &data, const size_t num_point
     }
 }
 template <typename T, typename TagT, typename LabelT>
-void Index<T, TagT, LabelT>::build(const T *data, const size_t num_points_to_load,
-                                   const IndexWriteParameters &parameters, const std::vector<TagT> &tags)
+void Index<T, TagT, LabelT>::build(const T *data, const size_t num_points_to_load, const std::vector<TagT> &tags)
 {
     if (num_points_to_load == 0)
     {
@@ -1568,12 +1558,11 @@ void Index<T, TagT, LabelT>::build(const T *data, const size_t num_points_to_loa
         _data_store->populate_data(data, (location_t)num_points_to_load);
     }
 
-    build_with_data_populated(parameters, tags);
+    build_with_data_populated(tags);
 }
 
 template <typename T, typename TagT, typename LabelT>
-void Index<T, TagT, LabelT>::build(const char *filename, const size_t num_points_to_load,
-                                   const IndexWriteParameters &parameters, const std::vector<TagT> &tags)
+void Index<T, TagT, LabelT>::build(const char *filename, const size_t num_points_to_load, const std::vector<TagT> &tags)
 {
     // idealy this should call build_filtered_index based on params passed
 
@@ -1662,12 +1651,11 @@ void Index<T, TagT, LabelT>::build(const char *filename, const size_t num_points
         std::unique_lock<std::shared_timed_mutex> tl(_tag_lock);
         _nd = num_points_to_load;
     }
-    build_with_data_populated(parameters, tags);
+    build_with_data_populated(tags);
 }
 
 template <typename T, typename TagT, typename LabelT>
-void Index<T, TagT, LabelT>::build(const char *filename, const size_t num_points_to_load,
-                                   const IndexWriteParameters &parameters, const char *tag_filename)
+void Index<T, TagT, LabelT>::build(const char *filename, const size_t num_points_to_load, const char *tag_filename)
 {
     std::vector<TagT> tags;
 
@@ -1706,7 +1694,7 @@ void Index<T, TagT, LabelT>::build(const char *filename, const size_t num_points
             }
         }
     }
-    build(filename, num_points_to_load, parameters, tags);
+    build(filename, num_points_to_load, tags);
 }
 
 template <typename T, typename TagT, typename LabelT>
@@ -1721,7 +1709,7 @@ void Index<T, TagT, LabelT>::build(const std::string &data_file, const size_t nu
     auto s = std::chrono::high_resolution_clock::now();
     if (build_params.label_file == "")
     {
-        this->build(data_file.c_str(), points_to_load, build_params.index_write_params);
+        this->build(data_file.c_str(), points_to_load);
     }
     else
     {
@@ -1733,8 +1721,7 @@ void Index<T, TagT, LabelT>::build(const std::string &data_file, const size_t nu
             LabelT unv_label_as_num = 0;
             this->set_universal_label(unv_label_as_num);
         }
-        this->build_filtered_index(data_file.c_str(), labels_file_to_use, points_to_load,
-                                   build_params.index_write_params);
+        this->build_filtered_index(data_file.c_str(), labels_file_to_use, points_to_load);
     }
     std::chrono::duration<double> diff = std::chrono::high_resolution_clock::now() - s;
     std::cout << "Indexing time: " << diff.count() << "\n";
@@ -1838,8 +1825,7 @@ void Index<T, TagT, LabelT>::set_universal_label(const LabelT &label)
 
 template <typename T, typename TagT, typename LabelT>
 void Index<T, TagT, LabelT>::build_filtered_index(const char *filename, const std::string &label_file,
-                                                  const size_t num_points_to_load, IndexWriteParameters &parameters,
-                                                  const std::vector<TagT> &tags)
+                                                  const size_t num_points_to_load, const std::vector<TagT> &tags)
 {
     _labels_file = label_file; // original label file
     _filtered_index = true;
@@ -1903,7 +1889,7 @@ void Index<T, TagT, LabelT>::build_filtered_index(const char *filename, const st
         _medoid_counts[best_medoid]++;
     }
 
-    this->build(filename, num_points_to_load, parameters, tags);
+    this->build(filename, num_points_to_load, tags);
 }
 
 template <typename T, typename TagT, typename LabelT>


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [x] Should this result in any changes to our documentation, either updating existing docs or adding new ones?

#### What does this implement/fix? Briefly explain your changes.
removing index_write params from build method. 

Why? 
For dynamic index, we have to provide `write_params` upfront (as there is not build method). For `static_index`  however, we pass it in build method. 
Because of this we had two constructors (not good). So we just ask for these params upfront in the `index_config`. 

From the code behavior we also know that one index object is used to build only one index output(i.e the files).

We are **not** using it like following 
```
Index idx = new Index();
for (...){
     idx.build(...);
}
```


So taking the `write_params` upfront makes sense.


