### PR TITLE
Release documentation from the release tag instead of main

### DIFF
--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -60,18 +60,18 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/python/html
           destination_dir: docs/python/dev
-      # Publish to /<version> if we are on the "main" branch and releasing
+      # Publish to /<version> if we are releasing
       - name: Publish reference docs by version (main branch)
         uses: peaceiris/actions-gh-pages@v3
-        if: github.event_name == 'release' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'release'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/python/html
           destination_dir: docs/python/${{ env.DISKANN_VERSION }}
-      # Publish to /latest if we are on the "main" branch and releasing
+      # Publish to /latest if we are releasing
       - name: Publish latest reference docs (main branch)
         uses: peaceiris/actions-gh-pages@v3
-        if: github.event_name == 'release' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'release'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/python/html


### PR DESCRIPTION
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs

#### What does this implement/fix? Briefly explain your changes.
Releases happen from tags so the documentation needs to be released from the release tag and not main.  Release docs were not getting pushed to github-pages because the build always failed the branch check.

#### Any other comments?

