### PR TITLE
Handle io_setup error properly

### DIFF
--- a/src/linux_aligned_file_reader.cpp
+++ b/src/linux_aligned_file_reader.cpp
@@ -147,10 +147,14 @@ void LinuxAlignedFileReader::register_thread()
     if (ret != 0)
     {
         lk.unlock();
-        assert(errno != EAGAIN);
-        assert(errno != ENOMEM);
-        std::cerr << "io_setup() failed; returned " << ret << ", errno=" << errno << ":" << ::strerror(errno)
-                  << std::endl;
+        if (ret == -EAGAIN)
+        {
+            std::cerr << "io_setup() failed with EAGAIN: Consider increasing /proc/sys/fs/aio-max-nr" << std::endl;
+        }
+        else
+        {
+            std::cerr << "io_setup() failed; returned " << ret << ": " << ::strerror(-ret) << std::endl;
+        }
     }
     else
     {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #456

#### What does this implement/fix? Briefly explain your changes.

Quoting from  #456

> io_setup() is part of a system library for asynchronous io called libaio https://man7.org/linux/man-pages/man2/io_setup.2.html . io_setup returns -11 to indicate: EAGAIN (try again) which is used to indicate the limit set in /proc/sys/fs/aio-max-nr has been exceeded.

#### Any other comments?

