### PR TITLE
Fixing index_prefix_path bug in python for StaticMemoryIndex

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "diskannpy"
-version = "0.7.0rc1"
+version = "0.7.0rc2"
 
 description = "DiskANN Python extension module"
 readme = "python/README.md"

--- a/python/src/_static_disk_index.py
+++ b/python/src/_static_disk_index.py
@@ -79,9 +79,9 @@ class StaticDiskIndex:
           does not exist, you are required to provide it.
         - **index_prefix**: The prefix of the index files. Defaults to "ann".
         """
-        index_prefix = _valid_index_prefix(index_directory, index_prefix)
+        index_prefix_path = _valid_index_prefix(index_directory, index_prefix)
         vector_dtype, metric, _, _ = _ensure_index_metadata(
-            index_prefix,
+            index_prefix_path,
             vector_dtype,
             distance_metric,
             1,  # it doesn't matter because we don't need it in this context anyway
@@ -101,7 +101,7 @@ class StaticDiskIndex:
             _index = _native_dap.StaticDiskFloatIndex
         self._index = _index(
             distance_metric=dap_metric,
-            index_path_prefix=index_prefix,
+            index_path_prefix=index_prefix_path,
             num_threads=num_threads,
             num_nodes_to_cache=num_nodes_to_cache,
             cache_mechanism=cache_mechanism,

--- a/python/src/_static_memory_index.py
+++ b/python/src/_static_memory_index.py
@@ -82,7 +82,7 @@ class StaticMemoryIndex:
         self._labels_metadata = {}
         if enable_filters:
             try:
-                with open(index_prefix_path + "_labels_map.txt", "r") as labels_map_if:
+                with open(f"{index_prefix_path}_labels_map.txt", "r") as labels_map_if:
                     for line in labels_map_if:
                         (key, val) = line.split("\t")
                         self._labels_map[key] = int(val)

--- a/python/src/_static_memory_index.py
+++ b/python/src/_static_memory_index.py
@@ -77,22 +77,22 @@ class StaticMemoryIndex:
           does not exist, you are required to provide it.
         - **enable_filters**: Indexes built with filters can also be used for filtered search.
         """
-        index_prefix = _valid_index_prefix(index_directory, index_prefix)
+        index_prefix_path = _valid_index_prefix(index_directory, index_prefix)
         self._labels_map = {}
         self._labels_metadata = {}
         if enable_filters:
             try:
-                with open(index_prefix + "_labels_map.txt", "r") as labels_map_if:
+                with open(index_prefix_path + "_labels_map.txt", "r") as labels_map_if:
                     for line in labels_map_if:
                         (key, val) = line.split("\t")
                         self._labels_map[key] = int(val)
-                with open(f"{index_prefix}_label_metadata.json", "r") as labels_metadata_if:
+                with open(f"{index_prefix_path}_label_metadata.json", "r") as labels_metadata_if:
                     self._labels_metadata = json.load(labels_metadata_if)
             except: # noqa: E722
                 # exceptions are basically presumed to be either file not found or file not formatted correctly
                 raise RuntimeException("Filter labels file was unable to be processed.")
         vector_dtype, metric, num_points, dims = _ensure_index_metadata(
-            index_prefix,
+            index_prefix_path,
             vector_dtype,
             distance_metric,
             1,  # it doesn't matter because we don't need it in this context anyway
@@ -119,7 +119,7 @@ class StaticMemoryIndex:
             distance_metric=dap_metric,
             num_points=num_points,
             dimensions=dims,
-            index_path=os.path.join(index_directory, index_prefix),
+            index_path=index_prefix_path,
             num_threads=num_threads,
             initial_search_complexity=initial_search_complexity,
         )


### PR DESCRIPTION
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
Identical to the bug fixed in #483 was a bug in StaticMemoryIndex, also loading the wrong index prefix path.

Both are fixed to what they always should have been.

