### PR TITLE
only move the queue items if the new item index is less than size

### DIFF
--- a/include/neighbor.h
+++ b/include/neighbor.h
@@ -78,7 +78,7 @@ class NeighborPriorityQueue
             }
         }
 
-        if (lo < _capacity)
+        if (lo < _size)
         {
             std::memmove(&_data[lo + 1], &_data[lo], (_size - lo) * sizeof(Neighbor));
         }


### PR DESCRIPTION

- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
- [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?

#### What does this implement/fix? Briefly explain your changes.
Before, it used to always move the queue items, but that is not necessary if the item to add is at the end of the queue (and queue still has capacity).

