### PR TITLE
Fix calculation of current_point_offset in test_insert_consolidate_deletes

### DIFF
--- a/apps/test_insert_deletes_consolidate.cpp
+++ b/apps/test_insert_deletes_consolidate.cpp
@@ -246,7 +246,7 @@ void build_incremental_index(const std::string &data_path, diskann::IndexWritePa
     std::cout << "Initial non-incremental index build time for " << beginning_index_size << " points took "
               << elapsedSeconds << " seconds (" << beginning_index_size / elapsedSeconds << " points/second)\n ";
 
-    current_point_offset = beginning_index_size;
+    current_point_offset += beginning_index_size;
 
     if (points_to_delete_from_beginning > max_points_to_insert)
     {


### PR DESCRIPTION
The program builds the streaming index after two optional steps: 1) skipping S points from the input file and 2) batch building of initial index using B points from the input file.

After these two steps, the offset to the input file should be S + B, but the current code first sets it to S in line 163 then overwrites it to B in line 249, instead of adding B to the offset. The tool which `test_insert_deletes_consolidate` was based on was using `+=` in the modified line.