### PR TITLE
Version bump 0.7.0rc2->0.7.0

### DIFF
--- a/.github/workflows/python-release.yml
+++ b/.github/workflows/python-release.yml
@@ -12,6 +12,8 @@ jobs:
     name: DiskANN Build Documentation
     uses: ./.github/workflows/build-python-pdoc.yml
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: python-release-wheels
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "diskannpy"
-version = "0.7.0rc2"
+version = "0.7.0"
 
 description = "DiskANN Python extension module"
 readme = "python/README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ test-command = "python -m unittest discover {project}/python/tests"
 [tool.cibuildwheel.linux]
 before-build = [
     "dnf makecache --refresh",
+    "dnf upgrade -y almalinux-release",
     "dnf install -y epel-release",
     "dnf config-manager -y --add-repo https://yum.repos.intel.com/mkl/setup/intel-mkl.repo",
     "rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ before-build = [
     "dnf makecache --refresh",
     "dnf install -y epel-release",
     "dnf config-manager -y --add-repo https://yum.repos.intel.com/mkl/setup/intel-mkl.repo",
-    "rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2019.PUB",
+    "rpm --import https://yum.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB",
     "dnf makecache --refresh -y",
     "dnf install -y wget make cmake gcc-c++ libaio-devel gperftools-libs libunwind-devel clang-tools-extra boost-devel boost-program-options intel-mkl-2020.4-912"
 ]


### PR DESCRIPTION
Preparing diskannpy for 0.7.0 release (filter support, static memory indices only)

- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [x] Does this PR modify any existing APIs?
   - [x] Is the change to the API backwards compatible?
- [x] Should this result in any changes to our documentation, either updating existing docs or adding new ones?

#### What does this implement/fix? Briefly explain your changes.

0.7.0rc2 has been published on PyPI as a pre-release for a while. I'm using it pretty frequently without any troubles, so we should just release it as a final 0.7.0 cut.

