### PR TITLE
Allow documentation to be published to our gh-pages branch

### DIFF
--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -2,6 +2,8 @@ name: DiskANN Build PDoc Documentation
 on: [workflow_call]
 jobs:
   build-reference-documentation:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
The publication of diskannpy documentation is foiled by the default RO scoping of GITHUB_TOKEN. Adding write permissions to the job that builds/publishes our documentation to our gh-pages branch.
