### PR TITLE
Allow documentation to be published to our gh-pages branch (redux)

### DIFF
--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -7,6 +7,8 @@ jobs:
     name: DiskANN Common Build Checks
     uses: ./.github/workflows/common.yml
   build-documentation:
+    permissions:
+      contents: write
     strategy:
       fail-fast: true
     name: DiskANN Build Documentation


### PR DESCRIPTION
I hate testing CICD on main.
