### PR TITLE
Add simplified functions for product quantization

### DIFF
--- a/include/pq.h
+++ b/include/pq.h
@@ -67,10 +67,19 @@ DISKANN_DLLEXPORT int generate_opq_pivots(const float *train_data, size_t num_tr
                                           unsigned num_pq_chunks, std::string opq_pivots_path,
                                           bool make_zero_mean = false);
 
+DISKANN_DLLEXPORT int generate_pq_pivots_simplified(const float *train_data, size_t num_train, 
+                                                    size_t dim, size_t num_pq_chunks,
+                                                    std::vector<float> &pivot_data_vector);
+
 template <typename T>
 int generate_pq_data_from_pivots(const std::string &data_file, unsigned num_centers, unsigned num_pq_chunks,
                                  const std::string &pq_pivots_path, const std::string &pq_compressed_vectors_path,
                                  bool use_opq = false);
+
+DISKANN_DLLEXPORT int generate_pq_data_from_pivots_simplified(const float *data, const size_t num, 
+                                                              const float *pivot_data, const size_t pivots_num, 
+                                                              const size_t dim, const size_t num_pq_chunks,
+                                                              std::vector<uint8_t> &pq);
 
 template <typename T>
 void generate_disk_quantized_data(const std::string &data_file_to_use, const std::string &disk_pq_pivots_path,

--- a/include/pq.h
+++ b/include/pq.h
@@ -67,9 +67,8 @@ DISKANN_DLLEXPORT int generate_opq_pivots(const float *train_data, size_t num_tr
                                           unsigned num_pq_chunks, std::string opq_pivots_path,
                                           bool make_zero_mean = false);
 
-DISKANN_DLLEXPORT int generate_pq_pivots_simplified(const float *train_data, size_t num_train,
-                                                    size_t dim, size_t num_pq_chunks,
-                                                    std::vector<float> &pivot_data_vector);
+DISKANN_DLLEXPORT int generate_pq_pivots_simplified(const float *train_data, size_t num_train, size_t dim,
+                                                    size_t num_pq_chunks, std::vector<float> &pivot_data_vector);
 
 template <typename T>
 int generate_pq_data_from_pivots(const std::string &data_file, unsigned num_centers, unsigned num_pq_chunks,

--- a/include/pq.h
+++ b/include/pq.h
@@ -67,7 +67,7 @@ DISKANN_DLLEXPORT int generate_opq_pivots(const float *train_data, size_t num_tr
                                           unsigned num_pq_chunks, std::string opq_pivots_path,
                                           bool make_zero_mean = false);
 
-DISKANN_DLLEXPORT int generate_pq_pivots_simplified(const float *train_data, size_t num_train, 
+DISKANN_DLLEXPORT int generate_pq_pivots_simplified(const float *train_data, size_t num_train,
                                                     size_t dim, size_t num_pq_chunks,
                                                     std::vector<float> &pivot_data_vector);
 
@@ -76,8 +76,8 @@ int generate_pq_data_from_pivots(const std::string &data_file, unsigned num_cent
                                  const std::string &pq_pivots_path, const std::string &pq_compressed_vectors_path,
                                  bool use_opq = false);
 
-DISKANN_DLLEXPORT int generate_pq_data_from_pivots_simplified(const float *data, const size_t num, 
-                                                              const float *pivot_data, const size_t pivots_num, 
+DISKANN_DLLEXPORT int generate_pq_data_from_pivots_simplified(const float *data, const size_t num,
+                                                              const float *pivot_data, const size_t pivots_num,
                                                               const size_t dim, const size_t num_pq_chunks,
                                                               std::vector<uint8_t> &pq);
 

--- a/src/pq.cpp
+++ b/src/pq.cpp
@@ -356,8 +356,7 @@ void pq_dist_lookup(const uint8_t *pq_ids, const size_t n_pts, const size_t pq_n
 // array of chunk_offsets and centroids.
 // The compiler pragma for multi-threading support is removed from this implementation
 // for the purpose of integration into systems that strictly control resource allocation.
-int generate_pq_pivots_simplified(const float *train_data, size_t num_train, 
-                                  size_t dim, size_t num_pq_chunks,
+int generate_pq_pivots_simplified(const float *train_data, size_t num_train, size_t dim, size_t num_pq_chunks,
                                   std::vector<float> &pivot_data_vector)
 {
     if (num_pq_chunks > dim || dim % num_pq_chunks != 0)
@@ -385,7 +384,8 @@ int generate_pq_pivots_simplified(const float *train_data, size_t num_train,
 
         for (int32_t j = 0; j < num_train; j++)
         {
-            std::memcpy(cur_data + j * cur_chunk_size, train_data + j * dim + chunk_offset, cur_chunk_size * sizeof(float));
+            std::memcpy(cur_data + j * cur_chunk_size, train_data + j * dim + chunk_offset,
+                        cur_chunk_size * sizeof(float));
         }
 
         kmeans::kmeanspp_selecting_pivots(cur_data, num_train, cur_chunk_size, cur_pivot_data, num_centers);
@@ -783,9 +783,8 @@ int generate_opq_pivots(const float *passed_train_data, size_t num_train, uint32
 // array of chunk_offsets and centroids.
 // The compiler pragma for multi-threading support is removed from this implementation
 // for the purpose of integration into systems that strictly control resource allocation.
-int generate_pq_data_from_pivots_simplified(const float *data, const size_t num,
-                                            const float *pivot_data, const size_t pivots_num,
-                                            const size_t dim, const size_t num_pq_chunks,
+int generate_pq_data_from_pivots_simplified(const float *data, const size_t num, const float *pivot_data,
+                                            const size_t pivots_num, const size_t dim, const size_t num_pq_chunks,
                                             std::vector<uint8_t> &pq)
 {
     if (num_pq_chunks == 0 || num_pq_chunks > dim || dim % num_pq_chunks != 0)

--- a/src/pq.cpp
+++ b/src/pq.cpp
@@ -344,6 +344,65 @@ void pq_dist_lookup(const uint8_t *pq_ids, const size_t n_pts, const size_t pq_n
     }
 }
 
+// generate_pq_pivots_simplified is a simplified version of generate_pq_pivots.
+// Input is provided in the in-memory buffer train_data.
+// Output is stored in the in-memory buffer pivot_data_vector.
+// Simplification is based on the following assumptions:
+//   dim % num_pq_chunks == 0
+//   num_centers == 256 by default
+//   KMEANS_ITERS_FOR_PQ == 15 by default
+//   make_zero_mean is false by default.
+// These assumptions allow to make the function much simpler and avoid storing
+// array of chunk_offsets and centroids.
+// The compiler pragma for multi-threading support is removed from this implementation
+// for the purpose of integration into systems that strictly control resource allocation.
+int generate_pq_pivots_simplified(const float *train_data, size_t num_train, 
+                                  size_t dim, size_t num_pq_chunks,
+                                  std::vector<float> &pivot_data_vector)
+{
+    if (num_pq_chunks > dim || dim % num_pq_chunks != 0)
+    {
+        return -1;
+    }
+
+    const size_t num_centers = 256;
+    const size_t cur_chunk_size = dim / num_pq_chunks;
+    const uint32_t KMEANS_ITERS_FOR_PQ = 15;
+
+    pivot_data_vector.resize(num_centers * dim);
+    std::vector<float> cur_pivot_data_vector(num_centers * cur_chunk_size);
+    std::vector<float> cur_data_vector(num_train * cur_chunk_size);
+    std::vector<uint32_t> closest_center_vector(num_train);
+
+    float *pivot_data = &pivot_data_vector[0];
+    float *cur_pivot_data = &cur_pivot_data_vector[0];
+    float *cur_data = &cur_data_vector[0];
+    uint32_t *closest_center = &closest_center_vector[0];
+
+    for (size_t i = 0; i < num_pq_chunks; i++)
+    {
+        size_t chunk_offset = cur_chunk_size * i;
+
+        for (int32_t j = 0; j < num_train; j++)
+        {
+            std::memcpy(cur_data + j * cur_chunk_size, train_data + j * dim + chunk_offset, cur_chunk_size * sizeof(float));
+        }
+
+        kmeans::kmeanspp_selecting_pivots(cur_data, num_train, cur_chunk_size, cur_pivot_data, num_centers);
+
+        kmeans::run_lloyds(cur_data, num_train, cur_chunk_size, cur_pivot_data, num_centers, KMEANS_ITERS_FOR_PQ, NULL,
+                           closest_center);
+
+        for (uint64_t j = 0; j < num_centers; j++)
+        {
+            std::memcpy(pivot_data + j * dim + chunk_offset, cur_pivot_data + j * cur_chunk_size,
+                        cur_chunk_size * sizeof(float));
+        }
+    }
+
+    return 0;
+}
+
 // given training data in train_data of dimensions num_train * dim, generate
 // PQ pivots using k-means algorithm to partition the co-ordinates into
 // num_pq_chunks (if it divides dimension, else rounded) chunks, and runs
@@ -708,6 +767,76 @@ int generate_opq_pivots(const float *passed_train_data, size_t num_train, uint32
 
     std::string rotmat_path = opq_pivots_path + "_rotation_matrix.bin";
     diskann::save_bin<float>(rotmat_path.c_str(), rotmat_tr.get(), dim, dim);
+
+    return 0;
+}
+
+// generate_pq_data_from_pivots_simplified is a simplified version of generate_pq_data_from_pivots.
+// Input is provided in the in-memory buffers data and pivot_data.
+// Output is stored in the in-memory buffer pq.
+// Simplification is based on the following assumptions:
+//   supporting only float data type
+//   dim % num_pq_chunks == 0, which results in a fixed chunk_size
+//   num_centers == 256 by default
+//   make_zero_mean is false by default.
+// These assumptions allow to make the function much simpler and avoid using
+// array of chunk_offsets and centroids.
+// The compiler pragma for multi-threading support is removed from this implementation
+// for the purpose of integration into systems that strictly control resource allocation.
+int generate_pq_data_from_pivots_simplified(const float *data, const size_t num,
+                                            const float *pivot_data, const size_t pivots_num,
+                                            const size_t dim, const size_t num_pq_chunks,
+                                            std::vector<uint8_t> &pq)
+{
+    if (num_pq_chunks == 0 || num_pq_chunks > dim || dim % num_pq_chunks != 0)
+    {
+        return -1;
+    }
+
+    const size_t num_centers = 256;
+    const size_t chunk_size = dim / num_pq_chunks;
+
+    if (pivots_num != num_centers * dim)
+    {
+        return -1;
+    }
+
+    pq.resize(num * num_pq_chunks);
+
+    std::vector<float> cur_pivot_vector(num_centers * chunk_size);
+    std::vector<float> cur_data_vector(num * chunk_size);
+    std::vector<uint32_t> closest_center_vector(num);
+
+    float *cur_pivot_data = &cur_pivot_vector[0];
+    float *cur_data = &cur_data_vector[0];
+    uint32_t *closest_center = &closest_center_vector[0];
+
+    for (size_t i = 0; i < num_pq_chunks; i++)
+    {
+        const size_t chunk_offset = chunk_size * i;
+
+        for (int j = 0; j < num_centers; j++)
+        {
+            std::memcpy(cur_pivot_data + j * chunk_size, pivot_data + j * dim + chunk_offset,
+                        chunk_size * sizeof(float));
+        }
+
+        for (int j = 0; j < num; j++)
+        {
+            for (size_t k = 0; k < chunk_size; k++)
+            {
+                cur_data[j * chunk_size + k] = data[j * dim + chunk_offset + k];
+            }
+        }
+
+        math_utils::compute_closest_centers(cur_data, num, chunk_size, cur_pivot_data, num_centers, 1, closest_center);
+
+        for (int j = 0; j < num; j++)
+        {
+            assert(closest_center[j] < num_centers);
+            pq[j * num_pq_chunks + i] = closest_center[j];
+        }
+    }
 
     return 0;
 }


### PR DESCRIPTION
- [+] Does this PR have a descriptive title that could go in our release notes?
- [-] Does this PR add any new dependencies?
- [-] Does this PR modify any existing APIs?
   - [-] Is the change to the API backwards compatible?
- [+] Should this result in any changes to our documentation, either updating existing docs or adding new ones?

Added following functions:
   generate_pq_pivots_simplified
   generate_pq_data_from_pivots_simplified

New functions for product quantization that do not rely on retrieving data from files or storing any data in files.
These functions can be used by systems that rely on a different type of data storage.

Tests:
I instrumented existing functions for producing pivot data and generating pq data.
I could confirm that giving identical input (pivot data and input full vectors) a new function generate_pq_data_from_pivots_simplified() produces output identical to the original generate_pq_data_from_pivots() function.
Function generate_pq_pivots_simplified() produces output very similar to the original function generate_pq_pivots() given the same input. The differences can be explained by outputs of non-deterministic core functions for generating pivot data.

