### PR TITLE
add wait() method to AlignedFileReader

### DIFF
--- a/include/aligned_file_reader.h
+++ b/include/aligned_file_reader.h
@@ -117,4 +117,9 @@ class AlignedFileReader
     // process batch of aligned requests in parallel
     // NOTE :: blocking call
     virtual void read(std::vector<AlignedRead> &read_reqs, IOContext &ctx, bool async = false) = 0;
+
+#ifdef USE_BING_INFRA
+    // wait for completion of one request in a batch of requests
+    virtual void wait(IOContext &ctx, int &completedIndex) = 0;
+#endif
 };


### PR DESCRIPTION
Add wait() method for asynchronous IOs where there is no callback support in the underlying implementation.
Caller can issue a number of IOs asynchronously and then block and wait for all the IO results to come back.
