### PR TITLE
Fix the wrong behavior when saving tags without calling any lazy_delete.

### DIFF
--- a/include/index.h
+++ b/include/index.h
@@ -307,7 +307,7 @@ template <typename T, typename TagT = uint32_t, typename LabelT = uint32_t> clas
     // Renumber nodes, update tag and location maps and compact the
     // graph, mode = _consolidated_order in case of lazy deletion and
     // _compacted_order in case of eager deletion
-    DISKANN_DLLEXPORT void compact_data();
+    DISKANN_DLLEXPORT void compact_data(bool forced = false);
     DISKANN_DLLEXPORT void compact_frozen_point();
 
     // Remove deleted nodes from adjacency list of node loc

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -2763,7 +2763,6 @@ template <typename T, typename TagT, typename LabelT> void Index<T, TagT, LabelT
     if (_data_compacted)
     {
         diskann::cerr << "Warning! Calling compact_data() when _data_compacted is true!" << std::endl;
-        return;
     }
 
     if (_delete_set->size() > 0)

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -286,7 +286,7 @@ void Index<T, TagT, LabelT>::save(const char *filename, bool compact_before_save
 
     if (compact_before_save)
     {
-        compact_data();
+        compact_data(true);
         compact_frozen_point();
     }
     else
@@ -2755,7 +2755,7 @@ template <typename T, typename TagT, typename LabelT> void Index<T, TagT, LabelT
 }
 
 // Should be called after acquiring _update_lock
-template <typename T, typename TagT, typename LabelT> void Index<T, TagT, LabelT>::compact_data()
+template <typename T, typename TagT, typename LabelT> void Index<T, TagT, LabelT>::compact_data(bool forced)
 {
     if (!_dynamic_index)
         throw ANNException("Can not compact a non-dynamic index", -1, __FUNCSIG__, __FILE__, __LINE__);
@@ -2763,6 +2763,11 @@ template <typename T, typename TagT, typename LabelT> void Index<T, TagT, LabelT
     if (_data_compacted)
     {
         diskann::cerr << "Warning! Calling compact_data() when _data_compacted is true!" << std::endl;
+
+        if (!forced)
+        {
+            return;
+        }
     }
 
     if (_delete_set->size() > 0)


### PR DESCRIPTION
When there is no lazy_deletes called, _data_compacted will remain true, which will make compact_data no-op. However, save tags has the assumption that compact_data is called so that tags are in the right position.