### PR TITLE
Extending simplified PQ functions

### DIFF
--- a/include/pq.h
+++ b/include/pq.h
@@ -67,18 +67,22 @@ DISKANN_DLLEXPORT int generate_opq_pivots(const float *train_data, size_t num_tr
                                           unsigned num_pq_chunks, std::string opq_pivots_path,
                                           bool make_zero_mean = false);
 
-DISKANN_DLLEXPORT int generate_pq_pivots_simplified(const float *train_data, size_t num_train, size_t dim,
-                                                    size_t num_pq_chunks, std::vector<float> &pivot_data_vector);
+DISKANN_DLLEXPORT int generate_pq_pivots_simplified(float *train_data, size_t num_train, size_t dim,
+                                                    size_t num_pq_chunks, std::vector<float> &pivot_data_vector,
+                                                    std::vector<float> &centroids, const bool make_zero_mean = true,
+                                                    const uint32_t kmeans_iters_for_pq = 15);
 
 template <typename T>
 int generate_pq_data_from_pivots(const std::string &data_file, unsigned num_centers, unsigned num_pq_chunks,
                                  const std::string &pq_pivots_path, const std::string &pq_compressed_vectors_path,
                                  bool use_opq = false);
 
-DISKANN_DLLEXPORT int generate_pq_data_from_pivots_simplified(const float *data, const size_t num,
+using PQ_DATA_TYPE = uint8_t;
+DISKANN_DLLEXPORT int generate_pq_data_from_pivots_simplified(float *data, const size_t num,
                                                               const float *pivot_data, const size_t pivots_num,
                                                               const size_t dim, const size_t num_pq_chunks,
-                                                              std::vector<uint8_t> &pq);
+                                                              const std::vector<float> &centroids,
+                                                              std::vector<PQ_DATA_TYPE> &pq);
 
 template <typename T>
 void generate_disk_quantized_data(const std::string &data_file_to_use, const std::string &disk_pq_pivots_path,


### PR DESCRIPTION
- [x] Does this PR have a descriptive title that could go in our release notes?
- [-] Does this PR add any new dependencies?
- [ x] Does this PR modify any existing APIs?
   - [x] Is the change to the API backwards compatible?
- [-] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
Extending functions for in-memory PQ calculations:
  - added support for generating and using centroids.
  - removed constrain dim % num_pq_chunks == 0.

For testing I modified (but not added to the PR) generate_pq utility. Code for testing loads pivot and centroids data produced by original functions and uses these data to calculate PQ with a new function. Then it compares results with PQ data produced by the original function.

```
    . . .
    diskann::generate_pq_data_from_pivots<float>(data_path, (uint32_t)num_pq_centers, (uint32_t)num_pq_chunks,
                                             pq_pivots_path, pq_compressed_vectors_path, opq);

    const size_t num_centers = 256;
    std::vector<float> pivot_data;
    std::vector<float> centroids;
    std::vector<float> data;
    std::vector<uint8_t> pq;
    std::vector<uint8_t> control_pq;
    int ret;

    ret = generate_pq_pivots_simplified(train_data, train_size, train_dim, num_pq_chunks,
                                       pivot_data, centroids);
    assert(ret == 0);
    assert(pivot_data.size() == num_centers * train_dim);
    assert(centroids.size() == train_dim);

    load_pivots(pq_pivots_path, pivot_data, centroids);
    load_data(data_path, data);
    load_data(pq_compressed_vectors_path, control_pq);

    ret = generate_pq_data_from_pivots_simplified(&data[0], data.size() / train_dim,
                                                 &pivot_data[0], pivot_data.size(),
                                                 train_dim, num_pq_chunks,
                                                 centroids,
                                                 pq);
    assert(ret == 0);
    assert(pq.size() == control_pq.size());
    for (size_t i = 0; i < pq.size(); i++)
    {
        assert(pq[i] == control_pq[i]);
    }

```


