### PR TITLE
Fix PQScratch memory leak

### DIFF
--- a/include/pq_scratch.h
+++ b/include/pq_scratch.h
@@ -17,6 +17,7 @@ template <typename T> class PQScratch
 
     PQScratch(size_t graph_degree, size_t aligned_dim);
     void initialize(size_t dim, const T *query, const float norm = 1.0f);
+    virtual ~PQScratch();
 };
 
 } // namespace diskann

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -93,7 +93,7 @@ template <typename T, typename LabelT> PQFlashIndex<T, LabelT>::~PQFlashIndex()
     {
         delete[] _pts_to_labels;
     }
-    if (_medoids != nullptr) 
+    if (_medoids != nullptr)
     {
         delete[] _medoids;
     }

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -93,6 +93,10 @@ template <typename T, typename LabelT> PQFlashIndex<T, LabelT>::~PQFlashIndex()
     {
         delete[] _pts_to_labels;
     }
+    if (_medoids != nullptr) 
+    {
+        delete[] _medoids;
+    }
 }
 
 template <typename T, typename LabelT> inline uint64_t PQFlashIndex<T, LabelT>::get_node_sector(uint64_t node_id)

--- a/src/scratch.cpp
+++ b/src/scratch.cpp
@@ -117,7 +117,7 @@ template <typename T> SSDQueryScratch<T>::~SSDQueryScratch()
     diskann::aligned_free((void *)sector_scratch);
     diskann::aligned_free((void *)this->_aligned_query_T);
 
-    delete[] this->_pq_scratch;
+    delete this->_pq_scratch;
 }
 
 template <typename T>

--- a/src/scratch.cpp
+++ b/src/scratch.cpp
@@ -143,6 +143,15 @@ template <typename T> PQScratch<T>::PQScratch(size_t graph_degree, size_t aligne
     memset(rotated_query, 0, aligned_dim * sizeof(float));
 }
 
+template <typename T> PQScratch<T>::~PQScratch()
+{
+    diskann::aligned_free((void *)aligned_pq_coord_scratch);
+    diskann::aligned_free((void *)aligned_pqtable_dist_scratch);
+    diskann::aligned_free((void *)aligned_dist_scratch);
+    diskann::aligned_free((void *)aligned_query_float);
+    diskann::aligned_free((void *)rotated_query);
+}
+
 template <typename T> void PQScratch<T>::initialize(size_t dim, const T *query, const float norm)
 {
     for (size_t d = 0; d < dim; ++d)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.

i use tcmalloc check the diskann  memory which shows 2 memory leaks.
1. in `PQScratch` as following code shows:
https://github.com/microsoft/DiskANN/blob/a25ee6f211545c63f524b91b15abd195283cff93/src/scratch.cpp#L133-L144

it allocate aligned memory without release.

2. in `PQFlashIndex` as following code shows
https://github.com/microsoft/DiskANN/blob/a25ee6f211545c63f524b91b15abd195283cff93/src/pq_flash_index.cpp#L1174-L1177

it allocate memory without release

so i think we can make fix the memory leaks

#### Any other comments?

