### PR TITLE
Create in memory data store/graph store with at least max_points as 1

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -136,10 +136,10 @@ Index<T, TagT, LabelT>::Index(Metric m, const size_t dim, const size_t max_point
                 .build(),
             IndexFactory::construct_datastore<T>(
                 DataStoreStrategy::MEMORY,
-                max_points + (dynamic_index && num_frozen_pts == 0 ? (size_t)1 : num_frozen_pts), dim, m),
+                (max_points == 0? (size_t)1 : max_points) + (dynamic_index && num_frozen_pts == 0 ? (size_t)1 : num_frozen_pts), dim, m),
             IndexFactory::construct_graphstore(
                 GraphStoreStrategy::MEMORY,
-                max_points + (dynamic_index && num_frozen_pts == 0 ? (size_t)1 : num_frozen_pts),
+                (max_points == 0? (size_t)1 : max_points) + (dynamic_index && num_frozen_pts == 0 ? (size_t)1 : num_frozen_pts),
                 (size_t)((index_parameters == nullptr ? 0 : index_parameters->max_degree) *
                          defaults::GRAPH_SLACK_FACTOR * 1.05)))
 {

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -118,30 +118,32 @@ Index<T, TagT, LabelT>::Index(Metric m, const size_t dim, const size_t max_point
                               const bool dynamic_index, const bool enable_tags, const bool concurrent_consolidate,
                               const bool pq_dist_build, const size_t num_pq_chunks, const bool use_opq,
                               const bool filtered_index)
-    : Index(IndexConfigBuilder()
-                .with_metric(m)
-                .with_dimension(dim)
-                .with_max_points(max_points)
-                .with_index_write_params(index_parameters)
-                .with_index_search_params(index_search_params)
-                .with_num_frozen_pts(num_frozen_pts)
-                .is_dynamic_index(dynamic_index)
-                .is_enable_tags(enable_tags)
-                .is_concurrent_consolidate(concurrent_consolidate)
-                .is_pq_dist_build(pq_dist_build)
-                .with_num_pq_chunks(num_pq_chunks)
-                .is_use_opq(use_opq)
-                .is_filtered(filtered_index)
-                .with_data_type(diskann_type_to_name<T>())
-                .build(),
-            IndexFactory::construct_datastore<T>(
-                DataStoreStrategy::MEMORY,
-                (max_points == 0? (size_t)1 : max_points) + (dynamic_index && num_frozen_pts == 0 ? (size_t)1 : num_frozen_pts), dim, m),
-            IndexFactory::construct_graphstore(
-                GraphStoreStrategy::MEMORY,
-                (max_points == 0? (size_t)1 : max_points) + (dynamic_index && num_frozen_pts == 0 ? (size_t)1 : num_frozen_pts),
-                (size_t)((index_parameters == nullptr ? 0 : index_parameters->max_degree) *
-                         defaults::GRAPH_SLACK_FACTOR * 1.05)))
+    : Index(
+          IndexConfigBuilder()
+              .with_metric(m)
+              .with_dimension(dim)
+              .with_max_points(max_points)
+              .with_index_write_params(index_parameters)
+              .with_index_search_params(index_search_params)
+              .with_num_frozen_pts(num_frozen_pts)
+              .is_dynamic_index(dynamic_index)
+              .is_enable_tags(enable_tags)
+              .is_concurrent_consolidate(concurrent_consolidate)
+              .is_pq_dist_build(pq_dist_build)
+              .with_num_pq_chunks(num_pq_chunks)
+              .is_use_opq(use_opq)
+              .is_filtered(filtered_index)
+              .with_data_type(diskann_type_to_name<T>())
+              .build(),
+          IndexFactory::construct_datastore<T>(DataStoreStrategy::MEMORY,
+                                               (max_points == 0 ? (size_t)1 : max_points) +
+                                                   (dynamic_index && num_frozen_pts == 0 ? (size_t)1 : num_frozen_pts),
+                                               dim, m),
+          IndexFactory::construct_graphstore(GraphStoreStrategy::MEMORY,
+                                             (max_points == 0 ? (size_t)1 : max_points) +
+                                                 (dynamic_index && num_frozen_pts == 0 ? (size_t)1 : num_frozen_pts),
+                                             (size_t)((index_parameters == nullptr ? 0 : index_parameters->max_degree) *
+                                                      defaults::GRAPH_SLACK_FACTOR * 1.05)))
 {
     if (_pq_dist)
     {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.

This fix the issue where when max_points passed is 0, it should use 1 to align with the logic in the other class constructor it calls into:
https://github.com/microsoft/DiskANN/blob/main/src/index.cpp#L67-L69

Otherwise, the code will assume the underlying in memory block has 1 more than actual capacity and causes memory heap corruption as seen in my debugging:
![ac8915f4-0d7d-47a8-8314-9c81bc093da8](https://github.com/microsoft/DiskANN/assets/106347144/94783158-d912-423e-ad16-5bf21e598057)



#### Any other comments?

