### PR TITLE
export max_degree

### DIFF
--- a/include/pq_flash_index.h
+++ b/include/pq_flash_index.h
@@ -107,6 +107,7 @@ template <typename T, typename LabelT = uint32_t> class PQFlashIndex
 
     DISKANN_DLLEXPORT std::vector<std::uint8_t> get_pq_vector(std::uint64_t vid);
     DISKANN_DLLEXPORT uint64_t get_num_points();
+    DISKANN_DLLEXPORT uint64_t get_max_degree();
 
   protected:
     DISKANN_DLLEXPORT void use_medoids_data_as_centroids();

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -1792,6 +1792,11 @@ template <typename T, typename LabelT> std::uint64_t PQFlashIndex<T, LabelT>::ge
     return _num_points;
 }
 
+template <typename T, typename LabelT> std::uint64_t PQFlashIndex<T, LabelT>::get_max_degree()
+{
+    return _max_degree;
+}
+
 // instantiations
 template class PQFlashIndex<uint8_t>;
 template class PQFlashIndex<int8_t>;


### PR DESCRIPTION
after load PQFlashIndex, some one may want to know the graph's max_degree to caculate `num_nodes_to_cache` with limited cache budget.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.

#### Any other comments?

