### PR TITLE
Porting multi-filter OR search support from the DLVS branch

### DIFF
--- a/apps/search_disk_index.cpp
+++ b/apps/search_disk_index.cpp
@@ -308,6 +308,9 @@ int search_disk_index(diskann::Metric &metric, const std::string &index_path_pre
         auto mean_cpuus = diskann::get_mean_stats<float>(stats, query_num,
                                                          [](const diskann::QueryStats &stats) { return stats.cpu_us; });
 
+        auto mean_hops = diskann::get_mean_stats<uint32_t>(
+            stats, query_num, [](const diskann::QueryStats &stats) { return stats.n_hops; });
+
         double recall = 0;
         if (calc_recall_flag)
         {
@@ -321,10 +324,32 @@ int search_disk_index(diskann::Metric &metric, const std::string &index_path_pre
                       << std::setw(16) << mean_cpuus;
         if (calc_recall_flag)
         {
-            diskann::cout << std::setw(16) << recall << std::endl;
+            diskann::cout << std::setw(16) << recall << std::endl ; 
         }
         else
             diskann::cout << std::endl;
+
+        //std::stringstream rslts_string; 
+        //for (auto x = 0; x < query_num; x++)
+        //{
+        //    rslts_string << "-----------------------------------------" << std::endl;
+        //    rslts_string << "Query: " << x << std::endl;
+        //    rslts_string << "GT: {";
+        //    for (auto rx = 0; rx < recall_at; rx++)
+        //    {
+        //        rslts_string << "(" << gt_ids[x* gt_dim + rx] << "," << gt_dists[x * gt_dim + rx] << "), ";
+        //    }
+        //    rslts_string << "}" << std::endl;
+        //    rslts_string << "Results: {";
+        //    for (auto rx = 0; rx < recall_at; rx++)
+        //    {
+        //        rslts_string << "(" << query_result_ids[test_id][x * recall_at + rx] << ","
+        //                   << query_result_dists[test_id][x * recall_at + rx] << "), ";
+        //    }
+        //    rslts_string << "}" << std::endl;
+        //    rslts_string << "-----------------------------------------" << std::endl;
+        //}
+        //diskann::cout << rslts_string.str() << std::endl;
         delete[] stats;
     }
 

--- a/include/neighbor.h
+++ b/include/neighbor.h
@@ -109,6 +109,11 @@ class NeighborPriorityQueue
         return _cur < _size;
     }
 
+    void sort()
+    {
+        std::sort(_data.begin(), _data.begin() + _size);
+    }
+
     size_t size() const
     {
         return _size;

--- a/include/pq_flash_index.h
+++ b/include/pq_flash_index.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #pragma once
+#include <unordered_map>
 #include "common_includes.h"
 
 #include "aligned_file_reader.h"
@@ -34,6 +35,11 @@ template <typename T, typename LabelT = uint32_t> class PQFlashIndex
     // load compressed data, and obtains the handle to the disk-resident index
     DISKANN_DLLEXPORT int load(uint32_t num_threads, const char *index_prefix);
 #endif
+
+    DISKANN_DLLEXPORT void load_labels(const std::string& disk_index_filepath);
+    DISKANN_DLLEXPORT void load_label_medoid_map(
+        const std::string &labels_to_medoids_filepath, std::istream &medoid_stream);
+    DISKANN_DLLEXPORT void load_dummy_map(const std::string& dummy_map_filepath, std::istream &dummy_map_stream);
 
 #ifdef EXEC_ENV_OLS
     DISKANN_DLLEXPORT int load_from_separate_paths(diskann::MemoryMappedFiles &files, uint32_t num_threads,
@@ -77,7 +83,7 @@ template <typename T, typename LabelT = uint32_t> class PQFlashIndex
 
     DISKANN_DLLEXPORT void cached_beam_search(const T *query, const uint64_t k_search, const uint64_t l_search,
                                               uint64_t *res_ids, float *res_dists, const uint64_t beam_width,
-                                              const bool use_filter, const LabelT &filter_label,
+                                              const bool use_filter, const std::vector<LabelT> &filter_labels,
                                               const uint32_t io_limit, const bool use_reorder_data = false,
                                               QueryStats *stats = nullptr);
 
@@ -116,7 +122,9 @@ template <typename T, typename LabelT = uint32_t> class PQFlashIndex
 
   private:
     DISKANN_DLLEXPORT inline bool point_has_label(uint32_t point_id, LabelT label_id);
-    std::unordered_map<std::string, LabelT> load_label_map(std::basic_istream<char> &infile);
+    DISKANN_DLLEXPORT inline bool point_has_any_label(uint32_t point_id, const std::vector<LabelT> &label_ids);
+    void load_label_map(std::basic_istream<char> &map_reader,
+                        std::unordered_map<std::string, LabelT> &string_to_int_map);
     DISKANN_DLLEXPORT void parse_label_file(std::basic_istream<char> &infile, size_t &num_pts_labels);
     DISKANN_DLLEXPORT void get_label_file_metadata(const std::string &fileContent, uint32_t &num_pts,
                                                    uint32_t &num_total_labels);

--- a/include/utils.h
+++ b/include/utils.h
@@ -57,6 +57,7 @@ typedef int FileHandle;
 
 #define PBSTR "||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||"
 #define PBWIDTH 60
+#define MULTIPLE_LABEL_SEPARATOR "|"
 
 inline bool file_exists_impl(const std::string &name, bool dirCheck = false)
 {
@@ -683,6 +684,9 @@ DISKANN_DLLEXPORT double calculate_range_search_recall(unsigned num_queries,
                                                        std::vector<std::vector<uint32_t>> &groundtruth,
                                                        std::vector<std::vector<uint32_t>> &our_results);
 
+DISKANN_DLLEXPORT void split_string(const std::string &string_to_split, const std::string &delimiter,
+                                    std::vector<std::string> &pieces);
+
 template <typename T>
 inline void load_bin(const std::string &bin_file, std::unique_ptr<T[]> &data, size_t &npts, size_t &dim,
                      size_t offset = 0)
@@ -1100,11 +1104,6 @@ inline std::vector<std::string> read_file_to_vector_of_strings(const std::string
             if (line.empty())
             {
                 break;
-            }
-            if (line.find(',') != std::string::npos)
-            {
-                std::cerr << "Every query must have exactly one filter" << std::endl;
-                exit(-1);
             }
             if (!line.empty() && (line.back() == '\r' || line.back() == '\n'))
             {

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -675,20 +675,15 @@ template <typename T, typename LabelT>
 bool PQFlashIndex<T, LabelT>::point_has_any_label(uint32_t point_id, const std::vector<LabelT> &label_ids)
 {
     uint32_t start_vec = _pts_to_label_offsets[point_id];
-    uint32_t num_lbls = _pts_to_labels[start_vec];
+    uint32_t num_lbls = _pts_to_label_counts[start_vec];
     bool ret_val = false;
     for (auto &cur_lbl : label_ids)
     {
-        for (uint32_t i = 0; i < num_lbls; i++)
+        if (point_has_label(point_id, cur_lbl))
         {
-            if (_pts_to_labels[start_vec + 1 + i] == cur_lbl)
-            {
-                ret_val = true;
-                break;
-            }
-        }
-        if (ret_val == true)
+            ret_val = true;
             break;
+        }
     }
     return ret_val;
 }
@@ -1485,6 +1480,8 @@ void PQFlashIndex<T, LabelT>::cached_beam_search(const T *query1, const uint64_t
     const std::vector<LabelT>& label_ids = filter_labels; //avoid renaming. 
     std::vector<LabelT> lbl_vec;
 
+    retset.sort();
+
     while (retset.has_unexpanded_node() && num_ios < max_ios_for_query)
     {
         // clear iteration state
@@ -1619,7 +1616,7 @@ void PQFlashIndex<T, LabelT>::cached_beam_search(const T *query1, const uint64_t
                 }
                 if (full_retset_ids.find(real_id) == full_retset_ids.end())
                 {
-                    full_retset.push_back(Neighbor((unsigned)real_id, cur_expanded_dist));
+                    full_retset.push_back(Neighbor((uint32_t)real_id, cur_expanded_dist));
                     full_retset_ids.insert(real_id);
                 }
             }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -252,6 +252,21 @@ double calculate_range_search_recall(uint32_t num_queries, std::vector<std::vect
     return total_recall / (num_queries);
 }
 
+void split_string(const std::string &string_to_split, const std::string& delimiter, std::vector<std::string> &pieces)
+{
+    size_t start = 0;
+    size_t end;
+    while ((end = string_to_split.find(delimiter, start)) != std::string::npos)
+    {
+        pieces.push_back(string_to_split.substr(start, end - start));
+        start = end + delimiter.length();
+    }
+    if (start != string_to_split.length())
+    {
+        pieces.push_back(string_to_split.substr(start, string_to_split.length() - start));
+    }
+}
+
 #ifdef EXEC_ENV_OLS
 void get_bin_metadata(AlignedFileReader &reader, size_t &npts, size_t &ndim, size_t offset)
 {

--- a/workflows/filtered_ssd_index.md
+++ b/workflows/filtered_ssd_index.md
@@ -54,7 +54,7 @@ Searching a filtered index uses the `apps/search_disk_index.cpp`:
 9. **-K**: search for *K* neighbors and measure *K*-recall@*K*, meaning the intersection between the retrieved top-*K* nearest neighbors and ground truth *K* nearest neighbors.
 10. **--result_path**: Search results will be stored in files with specified prefix, in bin format.
 11. **-L (--search_list)**: A list of search_list sizes to perform search with. Larger parameters will result in slower latencies, but higher accuracies. Must be atleast the value of *K* in arg (9).
-12. **--filter_label**: The filter to be used when searching an index with filters. For each query, a search is performed with this filter.
+12. **--filter_label**: Filters to be used when searching an index with filters. Multiple filters can be specified, separated by '|' and are treated as OR predicates. For each query, a search is performed with these filters.
 
 
 Example with SIFT10K:


### PR DESCRIPTION
This PR allows users to specify multiple filter labels during search. Search will return points that match any one of the filter labels.  