### PR TITLE
560 bug remove unused line

### DIFF
--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -705,10 +705,9 @@ void PQFlashIndex<T, LabelT>::parse_label_file(std::basic_istream<char> &infile,
     uint32_t num_pts_in_label_file;
     uint32_t num_total_labels;
     get_label_file_metadata(buffer, num_pts_in_label_file, num_total_labels);
-    _num_total_labels = num_total_labels;
 
     _pts_to_label_offsets = new uint32_t[num_pts_in_label_file];
-    _pts_to_label_counts = new uint32_t[num_total_labels];
+    _pts_to_label_counts = new uint32_t[num_pts_in_label_file];
     _pts_to_labels = new LabelT[num_total_labels];
     uint32_t labels_seen_so_far = 0;
 

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -675,7 +675,6 @@ template <typename T, typename LabelT>
 bool PQFlashIndex<T, LabelT>::point_has_any_label(uint32_t point_id, const std::vector<LabelT> &label_ids)
 {
     uint32_t start_vec = _pts_to_label_offsets[point_id];
-    uint32_t num_lbls = _pts_to_label_counts[start_vec];
     bool ret_val = false;
     for (auto &cur_lbl : label_ids)
     {
@@ -706,9 +705,10 @@ void PQFlashIndex<T, LabelT>::parse_label_file(std::basic_istream<char> &infile,
     uint32_t num_pts_in_label_file;
     uint32_t num_total_labels;
     get_label_file_metadata(buffer, num_pts_in_label_file, num_total_labels);
+    _num_total_labels = num_total_labels;
 
     _pts_to_label_offsets = new uint32_t[num_pts_in_label_file];
-    _pts_to_label_counts = new uint32_t[num_pts_in_label_file];
+    _pts_to_label_counts = new uint32_t[num_total_labels];
     _pts_to_labels = new LabelT[num_total_labels];
     uint32_t labels_seen_so_far = 0;
 

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -674,7 +674,6 @@ inline bool PQFlashIndex<T, LabelT>::point_has_label(uint32_t point_id, LabelT l
 template <typename T, typename LabelT>
 bool PQFlashIndex<T, LabelT>::point_has_any_label(uint32_t point_id, const std::vector<LabelT> &label_ids)
 {
-    uint32_t start_vec = _pts_to_label_offsets[point_id];
     bool ret_val = false;
     for (auto &cur_lbl : label_ids)
     {


### PR DESCRIPTION
#### Reference Issues/PRs
#560 

#### What does this implement/fix? Briefly explain your changes.
Unused lines causes crash (access violation) when multi filter file is loaded.

