### PR TITLE
fix stdint import to build on g++13

### DIFF
--- a/include/ann_exception.h
+++ b/include/ann_exception.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #pragma once
+#include <cstdint>
 #include <string>
 #include <stdexcept>
 #include <system_error>
@@ -19,7 +20,7 @@ class ANNException : public std::runtime_error
   public:
     DISKANN_DLLEXPORT ANNException(const std::string &message, int errorCode);
     DISKANN_DLLEXPORT ANNException(const std::string &message, int errorCode, const std::string &funcSig,
-                                   const std::string &fileName, uint32_t lineNum);
+                                   const std::string &fileName, std::uint32_t lineNum);
 
   private:
     int _errorCode;
@@ -29,6 +30,6 @@ class FileException : public ANNException
 {
   public:
     DISKANN_DLLEXPORT FileException(const std::string &filename, std::system_error &e, const std::string &funcSig,
-                                    const std::string &fileName, uint32_t lineNum);
+                                    const std::string &fileName, std::uint32_t lineNum);
 };
 } // namespace diskann

--- a/include/ann_exception.h
+++ b/include/ann_exception.h
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 #pragma once
-#include <cstdint>
+#include <stdint.h>
 #include <string>
 #include <stdexcept>
 #include <system_error>
@@ -20,7 +20,7 @@ class ANNException : public std::runtime_error
   public:
     DISKANN_DLLEXPORT ANNException(const std::string &message, int errorCode);
     DISKANN_DLLEXPORT ANNException(const std::string &message, int errorCode, const std::string &funcSig,
-                                   const std::string &fileName, std::uint32_t lineNum);
+                                   const std::string &fileName, uint32_t lineNum);
 
   private:
     int _errorCode;
@@ -30,6 +30,6 @@ class FileException : public ANNException
 {
   public:
     DISKANN_DLLEXPORT FileException(const std::string &filename, std::system_error &e, const std::string &funcSig,
-                                    const std::string &fileName, std::uint32_t lineNum);
+                                    const std::string &fileName, uint32_t lineNum);
 };
 } // namespace diskann

--- a/src/ann_exception.cpp
+++ b/src/ann_exception.cpp
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 #include "ann_exception.h"
+#include <cstdint>
 #include <sstream>
 #include <string>
 
@@ -18,7 +19,7 @@ std::string package_string(const std::string &item_name, const std::string &item
 }
 
 ANNException::ANNException(const std::string &message, int errorCode, const std::string &funcSig,
-                           const std::string &fileName, uint32_t lineNum)
+                           const std::string &fileName, std::uint32_t lineNum)
     : ANNException(package_string(std::string("FUNC"), funcSig) + package_string(std::string("FILE"), fileName) +
                        package_string(std::string("LINE"), std::to_string(lineNum)) + "  " + message,
                    errorCode)
@@ -26,7 +27,7 @@ ANNException::ANNException(const std::string &message, int errorCode, const std:
 }
 
 FileException::FileException(const std::string &filename, std::system_error &e, const std::string &funcSig,
-                             const std::string &fileName, uint32_t lineNum)
+                             const std::string &fileName, std::uint32_t lineNum)
     : ANNException(std::string(" While opening file \'") + filename + std::string("\', error code: ") +
                        std::to_string(e.code().value()) + "  " + e.code().message(),
                    e.code().value(), funcSig, fileName, lineNum)

--- a/src/ann_exception.cpp
+++ b/src/ann_exception.cpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 #include "ann_exception.h"
-#include <cstdint>
+#include <stdint.h>
 #include <sstream>
 #include <string>
 
@@ -19,7 +19,7 @@ std::string package_string(const std::string &item_name, const std::string &item
 }
 
 ANNException::ANNException(const std::string &message, int errorCode, const std::string &funcSig,
-                           const std::string &fileName, std::uint32_t lineNum)
+                           const std::string &fileName, uint32_t lineNum)
     : ANNException(package_string(std::string("FUNC"), funcSig) + package_string(std::string("FILE"), fileName) +
                        package_string(std::string("LINE"), std::to_string(lineNum)) + "  " + message,
                    errorCode)
@@ -27,7 +27,7 @@ ANNException::ANNException(const std::string &message, int errorCode, const std:
 }
 
 FileException::FileException(const std::string &filename, std::system_error &e, const std::string &funcSig,
-                             const std::string &fileName, std::uint32_t lineNum)
+                             const std::string &fileName, uint32_t lineNum)
     : ANNException(std::string(" While opening file \'") + filename + std::string("\', error code: ") +
                        std::to_string(e.code().value()) + "  " + e.code().message(),
                    e.code().value(), funcSig, fileName, lineNum)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [yes] Does this PR have a descriptive title that could go in our release notes?
- [no] Does this PR add any new dependencies?
- [no] Does this PR modify any existing APIs?
- [no] Should this result in any changes to our documentation, either updating existing docs or adding new ones?


#### Reference Issues
Fixes #570

#### What does this implement/fix? Briefly explain your changes.
ann_exception.h contained a reference to the type uint32_t, which is imported implicitly by g++9 but not g++13, resulting in build failure.
We patch this by explicitly including stdint.h (and not cstdint to avoid changing the namespace in the signatures, upon which some people might depend)
 

#### Any other comments?

