### PR TITLE
Fixing the hang when search is run on single thread

### DIFF
--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -137,6 +137,7 @@ void PQFlashIndex<T, LabelT>::setup_thread_data(uint64_t nthreads, uint64_t visi
             this->_thread_data.push(data);
         }
     }
+    this->_thread_data.push_notify_all();
     _load_flag = true;
 }
 


### PR DESCRIPTION
#### What does this implement/fix? Briefly explain your changes.
The PR fixes the code freeze that occurs when search is run on a single thread. 

#### Any other comments?

