### PR TITLE
Ensure dist_scratch has enough space for writing out distances

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -962,6 +962,7 @@ std::pair<uint32_t, uint32_t> Index<T, TagT, LabelT>::iterate_to_fixed_point(
             }
         }
 
+        dist_scratch.resize(id_scratch.size());
         assert(dist_scratch.capacity() >= id_scratch.size());
         compute_dists(id_scratch, dist_scratch);
         cmps += (uint32_t)id_scratch.size();


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
None

#### What does this implement/fix? Briefly explain your changes.
This PR resizes the `dist_scratch` vector to have the same size as the `id_scratch` vector which is a needed pre-allocation for the writing of distances during index building time

#### Any other comments?
None

