### PR TITLE
Fix the code hang while caching nodes if search is run with a single thread

### DIFF
--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -48,6 +48,7 @@ jobs:
           name: dependencies
           path: |
             dependencies_documentation.txt
+            overwrite: true
       - name: Archive documentation artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-python-pdoc.yml
+++ b/.github/workflows/build-python-pdoc.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           name: dependencies
           path: |
-            dependencies_documentation.txt
+            ${{ github.run_id }}-dependencies_documentation.txt
             overwrite: true
       - name: Archive documentation artifacts
         uses: actions/upload-artifact@v4

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -365,7 +365,6 @@ void PQFlashIndex<T, LabelT>::cache_bfs_levels(uint64_t num_nodes_to_cache, std:
     }
     diskann::cout << "Caching " << num_nodes_to_cache << "..." << std::endl;
 
-
     std::unique_ptr<tsl::robin_set<uint32_t>> cur_level, prev_level;
     cur_level = std::make_unique<tsl::robin_set<uint32_t>>();
     prev_level = std::make_unique<tsl::robin_set<uint32_t>>();

--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -365,10 +365,6 @@ void PQFlashIndex<T, LabelT>::cache_bfs_levels(uint64_t num_nodes_to_cache, std:
     }
     diskann::cout << "Caching " << num_nodes_to_cache << "..." << std::endl;
 
-    // borrow thread data
-    ScratchStoreManager<SSDThreadData<T>> manager(this->_thread_data);
-    auto this_thread_data = manager.scratch_space();
-    IOContext &ctx = this_thread_data->ctx;
 
     std::unique_ptr<tsl::robin_set<uint32_t>> cur_level, prev_level;
     cur_level = std::make_unique<tsl::robin_set<uint32_t>>();


### PR DESCRIPTION
Removed another instance of ScratchStoreManager from a top-level function