### PR TITLE
Update push-test.yml

### DIFF
--- a/.github/workflows/disk-pq.yml
+++ b/.github/workflows/disk-pq.yml
@@ -111,7 +111,7 @@ jobs:
       - name: upload data and bin
         uses: actions/upload-artifact@v4
         with:
-          name: disk-pq
+          name: disk-pq-${{matrix.os}}
           path: |
             ./dist/**
             ./data/**

--- a/.github/workflows/dynamic-labels.yml
+++ b/.github/workflows/dynamic-labels.yml
@@ -96,7 +96,7 @@ jobs:
       - name: upload data and bin
         uses: actions/upload-artifact@v4
         with:
-          name: dynamic
+          name: dynamic-${{matrix.os}}
           path: |
             ./dist/**
             ./data/**

--- a/.github/workflows/dynamic-labels.yml
+++ b/.github/workflows/dynamic-labels.yml
@@ -96,7 +96,7 @@ jobs:
       - name: upload data and bin
         uses: actions/upload-artifact@v4
         with:
-          name: dynamic-${{matrix.os}}
+          name: dynamic-labels-${{matrix.os}}
           path: |
             ./dist/**
             ./data/**

--- a/.github/workflows/dynamic.yml
+++ b/.github/workflows/dynamic.yml
@@ -69,7 +69,7 @@ jobs:
       - name: upload data and bin
         uses: actions/upload-artifact@v4
         with:
-          name: dynamic
+          name: dynamic-${{matrix.os}}
           path: |
             ./dist/**
             ./data/**

--- a/.github/workflows/in-mem-no-pq.yml
+++ b/.github/workflows/in-mem-no-pq.yml
@@ -75,7 +75,7 @@ jobs:
       - name: upload data and bin
         uses: actions/upload-artifact@v4
         with:
-          name: in-memory-no-pq
+          name: in-memory-no-pq-${{matrix.os}}
           path: |
             ./dist/**
             ./data/**

--- a/.github/workflows/in-mem-pq.yml
+++ b/.github/workflows/in-mem-pq.yml
@@ -50,7 +50,7 @@ jobs:
       - name: upload data and bin
         uses: actions/upload-artifact@v4
         with:
-          name: in-memory-pq
+          name: in-memory-pq-${{matrix.os}}
           path: |
             ./dist/**
             ./data/**

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -113,7 +113,7 @@ jobs:
       - name: upload data and bin
         uses: actions/upload-artifact@v4
         with:
-          name: labels
+          name: labels-${{matrix.os}}
           path: |
             ./dist/**
             ./data/**

--- a/.github/workflows/multi-sector-disk-pq.yml
+++ b/.github/workflows/multi-sector-disk-pq.yml
@@ -54,7 +54,7 @@ jobs:
       - name: upload data and bin
         uses: actions/upload-artifact@v4
         with:
-          name: multi-sector-disk-pq
+          name: multi-sector-disk-pq-${{matrix.os}}
           path: |
             ./dist/**
             ./data/**

--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -21,6 +21,6 @@ jobs:
       - name: Upload Metrics Logs
         uses: actions/upload-artifact@v4
         with:
-          name: metrics
+          name: metrics-${{matrix.os}}
           path: |
             ./metrics/**

--- a/.github/workflows/push-test.yml
+++ b/.github/workflows/push-test.yml
@@ -35,19 +35,16 @@ jobs:
         with:
           fetch-depth: 1
           submodules: true
-      - name: Build dispannpy dependency tree
+      - name: Build diskannpy dependency tree
         run: |
           pip install diskannpy pipdeptree
           echo "dependencies" > dependencies_${{ matrix.os }}.txt
           pipdeptree >> dependencies_${{ matrix.os }}.txt
-      - name: Archive dispannpy dependencies artifact
+      - name: Archive diskannpy dependencies artifact
         uses: actions/upload-artifact@v4
         with:
-          name: dependencies
+          name: dependencies_${{ matrix.os }}
           path: |
             dependencies_${{ matrix.os }}.txt
       - name: DiskANN Build CLI Applications
         uses: ./.github/actions/build
-#  python:
-#    name: DiskANN Build Python Wheel
-#    uses: ./.github/workflows/build-python.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ test-command = "python -m unittest discover {project}/python/tests"
 
 [tool.cibuildwheel.linux]
 before-build = [
+    "rpm --import https://repo.almalinux.org/almalinux/RPM-GPG-KEY-AlmaLinux",
     "dnf makecache --refresh",
     "dnf upgrade -y almalinux-release",
     "dnf install -y epel-release",


### PR DESCRIPTION
When the upload-artifact action was updated to v4, the behavior of it changes such that you cannot create a unified "artifact" by having it add files to an existing artifact name. Instead, they all require a unique artifact name to be uploaded.

This should fix the current workflow build errors.
