### PR TITLE
Avoid unlock twice when io_setup failed

### DIFF
--- a/src/linux_aligned_file_reader.cpp
+++ b/src/linux_aligned_file_reader.cpp
@@ -160,8 +160,8 @@ void LinuxAlignedFileReader::register_thread()
     {
         diskann::cout << "allocating ctx: " << ctx << " to thread-id:" << my_id << std::endl;
         ctx_map[my_id] = ctx;
+        lk.unlock();
     }
-    lk.unlock();
 }
 
 void LinuxAlignedFileReader::deregister_thread()

--- a/src/linux_aligned_file_reader.cpp
+++ b/src/linux_aligned_file_reader.cpp
@@ -146,7 +146,6 @@ void LinuxAlignedFileReader::register_thread()
     int ret = io_setup(MAX_EVENTS, &ctx);
     if (ret != 0)
     {
-        lk.unlock();
         if (ret == -EAGAIN)
         {
             std::cerr << "io_setup() failed with EAGAIN: Consider increasing /proc/sys/fs/aio-max-nr" << std::endl;
@@ -160,7 +159,6 @@ void LinuxAlignedFileReader::register_thread()
     {
         diskann::cout << "allocating ctx: " << ctx << " to thread-id:" << my_id << std::endl;
         ctx_map[my_id] = ctx;
-        lk.unlock();
     }
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.

Fix `unlock` twice when io_setup failed.


#### Any other comments?

