### PR TITLE
Remove restriction of caching only 10 % nodes in disk search

### DIFF
--- a/src/pq_flash_index.cpp
+++ b/src/pq_flash_index.cpp
@@ -355,13 +355,12 @@ void PQFlashIndex<T, LabelT>::cache_bfs_levels(uint64_t num_nodes_to_cache, std:
 
     tsl::robin_set<uint32_t> node_set;
 
-    // Do not cache more than 10% of the nodes in the index
-    uint64_t tenp_nodes = (uint64_t)(std::round(this->_num_points * 0.1));
-    if (num_nodes_to_cache > tenp_nodes)
+    // If num_nodes_to_cache is more than total_nodes then reduce num_nodes_to_cache to total_nodes.
+    if (num_nodes_to_cache > this->_num_points)
     {
-        diskann::cout << "Reducing nodes to cache from: " << num_nodes_to_cache << " to: " << tenp_nodes
-                      << "(10 percent of total nodes:" << this->_num_points << ")" << std::endl;
-        num_nodes_to_cache = tenp_nodes == 0 ? 1 : tenp_nodes;
+        diskann::cout << "Reducing nodes to cache from: " << num_nodes_to_cache
+                      << " to total nodes:" << this->_num_points << std::endl;
+        num_nodes_to_cache = this->_num_points;
     }
     diskann::cout << "Caching " << num_nodes_to_cache << "..." << std::endl;
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [X] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
Remove restriction of caching only 10 % nodes in disk search, instead update the logic to reduce the num_nodes_to_cache to total_nodes when it is more than total_nodes.

#### Any other comments?
This will make this feature more aligned with Rust implementation.

