### PR TITLE
Users/suryangupta/benchmark disk reads

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -31,6 +31,9 @@ target_link_libraries(test_insert_deletes_consolidate ${PROJECT_NAME} ${DISKANN_
 add_executable(benchmark_reads benchmark_reads.cpp)
 target_link_libraries(benchmark_reads ${PROJECT_NAME} ${DISKANN_TOOLS_TCMALLOC_LINK_OPTIONS} Boost::program_options)
 
+add_executable(benchmark_reads_single_threaded benchmark_reads_single_threaded.cpp)
+target_link_libraries(benchmark_reads_single_threaded ${PROJECT_NAME} ${DISKANN_TOOLS_TCMALLOC_LINK_OPTIONS} Boost::program_options)
+
 if (NOT MSVC)
     install(TARGETS build_memory_index
             build_stitched_index

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -28,6 +28,9 @@ target_link_libraries(test_streaming_scenario ${PROJECT_NAME} ${DISKANN_TOOLS_TC
 add_executable(test_insert_deletes_consolidate test_insert_deletes_consolidate.cpp)
 target_link_libraries(test_insert_deletes_consolidate ${PROJECT_NAME} ${DISKANN_TOOLS_TCMALLOC_LINK_OPTIONS} Boost::program_options)
 
+add_executable(benchmark_reads benchmark_reads.cpp)
+target_link_libraries(benchmark_reads ${PROJECT_NAME} ${DISKANN_TOOLS_TCMALLOC_LINK_OPTIONS} Boost::program_options)
+
 if (NOT MSVC)
     install(TARGETS build_memory_index
             build_stitched_index
@@ -37,6 +40,7 @@ if (NOT MSVC)
             range_search_disk_index
             test_streaming_scenario
             test_insert_deletes_consolidate
+            benchmark_reads
             RUNTIME
     )
 endif()

--- a/apps/benchmark_reads.cpp
+++ b/apps/benchmark_reads.cpp
@@ -1,0 +1,53 @@
+#include <iostream>
+#include <cstdlib>
+#include "windows_aligned_file_reader.h"
+#include "aligned_file_reader.h"
+#include "utils.h"
+
+using namespace std;
+using namespace diskann;
+
+#define IS_ALIGNED(X, Y) ((uint64_t)(X) % (uint64_t)(Y) == 0)
+
+#define SECTOR_LEN 4096
+
+void do_reads()
+{
+    string file_name = "C:\\DiskANN\\Data\\turning_100k\\index_disk.index";
+    auto reader = new WindowsAlignedFileReader();
+    reader->open(file_name.c_str());
+    auto ctx = reader->get_ctx();
+
+    std::vector<AlignedRead> read_reqs;
+    int num_sectors = 100;
+
+    char *buf = nullptr;
+    alloc_aligned((void **)&buf, num_sectors * SECTOR_LEN, SECTOR_LEN);
+
+    // create read requests
+    for (size_t i = 0; i < num_sectors; ++i)
+    {
+        AlignedRead read;
+        read.len = SECTOR_LEN;
+        read.buf = buf + i * SECTOR_LEN;
+        auto sector_id = (rand() % 10000);
+        read.offset = sector_id * SECTOR_LEN;
+        if (read.offset)
+            read_reqs.push_back(read);
+    }
+
+    auto s = std::chrono::high_resolution_clock::now();
+    for (int i = 0; i < 10000; i++)
+    {
+        reader->read(read_reqs, ctx, false);
+    }
+    auto e = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double> diff = e - s;
+    cout << "Time taken to read: " << diff.count() << endl;
+}
+
+int main()
+{
+    cout << "Hello World" << endl;
+    do_reads();
+}

--- a/apps/benchmark_reads.cpp
+++ b/apps/benchmark_reads.cpp
@@ -38,13 +38,14 @@ void do_multiple_reads_with_threads(int thread_count)
     string file_name = "F:\\indices\\turing_10m\\disk_index_disk.index";
     auto reader = new WindowsAlignedFileReader();
     reader->open(file_name.c_str());
-    int batches_of = 100;
+    int total_reads = 1000000;
+    int batches_of = 5;
 
     vector<char *> buffers(thread_count);
 
-    omp_set_num_threads(thread_count);
+    // omp_set_num_threads(thread_count);
 
-#pragma omp parallel for num_threads((int)thread_count)
+// #pragma omp parallel for num_threads((int)thread_count)
     for (int i = 0; i < thread_count; i++)
     {
         char *buf = nullptr;
@@ -53,9 +54,9 @@ void do_multiple_reads_with_threads(int thread_count)
         reader->register_thread();
     }
 
-    int no_of_reads = 10000;
+    int no_of_reads = total_reads / batches_of;
     Timer timer;
-#pragma omp parallel for schedule(dynamic, 1)
+// #pragma omp parallel for schedule(dynamic, 1)
     for (int i = 0; i < no_of_reads; i++)
     {
         char *buf = buffers[omp_get_thread_num()];

--- a/apps/benchmark_reads_single_threaded.cpp
+++ b/apps/benchmark_reads_single_threaded.cpp
@@ -66,7 +66,7 @@ int main(int argc, char *argv[])
             // cout << "Got cmd argument" << endl;
         }
     }
-    cout << "Using batches of " << val << endl;
+    // cout << "Using batches of " << val << endl;
 
     // cout << "Hello World" << endl;
     do_reads_in_batches_of(val);

--- a/src/windows_aligned_file_reader.cpp
+++ b/src/windows_aligned_file_reader.cpp
@@ -18,7 +18,7 @@ void WindowsAlignedFileReader::open(const std::string &fname)
     m_filename = fname;
 #endif
 
-    this->register_thread();
+    // this->register_thread();
 }
 
 void WindowsAlignedFileReader::close()


### PR DESCRIPTION
This PR contains two binaries to benchmark disk reads:
- `benchmark_reads_single_threaded.cpp` - Does 1M 4KB reads in user specified batches.
- `benchmark_reads.cpp` - Does 1M 4KB reads in batches specified in the code using user specified rayon threads. 