### PR TITLE
Generate metadata file at same directory of output files

### DIFF
--- a/scripts/IndexParser/parse_disk_index.py
+++ b/scripts/IndexParser/parse_disk_index.py
@@ -47,7 +47,8 @@ def parse_index_with_PQ_vectors(index_path_prefix, data_type_code, data_type_siz
             max_node_len = struct.unpack('Q', index_file.read(8))[0]
             nnodes_per_sector = struct.unpack('Q', index_file.read(8))[0]
 
-            metadata_file = pathlib.Path.stem(out_graph_csv) + "_metadata.tsv"
+            output_path = pathlib.Path(out_graph_csv)
+            metadata_file = output_path.parent / (output_path.stem + "_metadata.tsv")
             with open(metadata_file, "w") as metadata_out:
                 str_metadata = "Num nodes: " + str(num_nodes) + "\n" + "Num dims: " + str(num_dims) + "\n" + "Medoid id: " + str(medoid_id) + "\n" + "Max node len: " + str(max_node_len) + "\n" + "Nodes per sector: " + str(nnodes_per_sector) + "\n"
                 metadata_out.write(str_metadata)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
<img width="933" alt="image" src="https://github.com/user-attachments/assets/09612a1a-9f75-4df2-83cb-dab5e7d7b2f2" />
fix: 
1. The pathlib does not work well in parse_disk_index.py
2. This script does not generate the _metadata.tsv to same output folder when specify multi-level directories.

#### Any other comments?

