### PR TITLE
Remove non-thread-safe code that may lead to crashes when a vector is not found by tag

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -796,7 +796,7 @@ template <typename T, typename TagT, typename LabelT> int Index<T, TagT, LabelT>
     std::shared_lock<std::shared_timed_mutex> lock(_tag_lock);
     if (_tag_to_location.find(tag) == _tag_to_location.end())
     {
-        diskann::cout << "Tag " << tag << " does not exist" << std::endl;
+        // diskann::cout << "Tag " << tag << " does not exist" << std::endl;
         return -1;
     }
 

--- a/src/index.cpp
+++ b/src/index.cpp
@@ -794,13 +794,14 @@ size_t Index<T, TagT, LabelT>::load_graph(std::string filename, size_t expected_
 template <typename T, typename TagT, typename LabelT> int Index<T, TagT, LabelT>::get_vector_by_tag(TagT &tag, T *vec)
 {
     std::shared_lock<std::shared_timed_mutex> lock(_tag_lock);
-    if (_tag_to_location.find(tag) == _tag_to_location.end())
+    const auto tagIt = _tag_to_location.find(tag);
+    if (tagIt == _tag_to_location.end())
     {
         // diskann::cout << "Tag " << tag << " does not exist" << std::endl;
         return -1;
     }
 
-    size_t location = _tag_to_location[tag];
+    const unsigned location = tagIt->second;
     memcpy((void *)vec, (void *)(_data + location * _aligned_dim), (size_t)_dim * sizeof(T));
     return 0;
 }


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
When a vector is not found by tag, disk ANN outputs a message using diskann::cout. It concatenates the message with the tag value, which is not thread safe. in case multiple threads run into this issue, it sometimes leads to a crash.

#### What does this implement/fix? Briefly explain your changes.
This change remove the offending line and replaces it with returning the error code that the caller will handle.
Also changes to return the vector from the find() instead of using a separate operator[]

#### Any other comments?

