### PR TITLE
Fix: Add missing cstdint include for uint32_t definition

### DIFF
--- a/include/ann_exception.h
+++ b/include/ann_exception.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <stdexcept>
 #include <system_error>
+#include <cstdint>
 #include "windows_customizations.h"
 
 #ifndef _WINDOWS


### PR DESCRIPTION
## Summary
Fixed compilation error where `uint32_t` identifier was undefined by adding the required `<cstdint>` header include.

## Problem
The code was using `uint32_t` in function parameters (lines 23 and 32) but the necessary header wasn't included, causing compilation failures with error "identifier 'uint32_t' is undefined".

## Solution
Added `#include <cstdint>` to include the standard fixed-width integer type definitions.

## Files Changed
- `include/ann_exception.h`: Added cstdint include

## Testing
- [x] Code compiles successfully
- [x] No breaking changes to existing API
- [x] Header-only change, no runtime impact

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Additional Notes
This ensures proper C++11 standard compliance and portability across different compilers and platforms.
