### PR TITLE
Add ability to provide a custom logger class to DiskANN index

### DIFF
--- a/include/logging.h
+++ b/include/logging.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "windows_customizations.h"
+
+namespace diskann
+{
+	namespace logging
+	{
+        enum LogLevel
+        {
+            Debug,
+            Info,
+            Status,
+            Warning,
+            Error,
+            Assert
+        };
+
+        // Interface for a logger that can be used to log messages at various levels.
+        class ILogger
+        {
+        public:
+            virtual ~ILogger() = default;
+
+            // Log a message associated with a specific level, title, file name, function, and line number.
+            virtual void Write(char const *filename, 
+                               char const *function, 
+                               unsigned lineNumber,
+                               LogLevel level, 
+                               char const *title, 
+                               char const *message) = 0;
+
+            // Abort the program.
+            virtual void Abort() = 0;
+        };
+
+        DISKANN_DLLEXPORT void RegisterLogger(ILogger *logger);
+    }
+}

--- a/include/logging.h
+++ b/include/logging.h
@@ -10,7 +10,6 @@ namespace diskann
         {
             Debug,
             Info,
-            Status,
             Warning,
             Error,
             Assert
@@ -29,9 +28,6 @@ namespace diskann
                                LogLevel level, 
                                char const *title, 
                                char const *message) = 0;
-
-            // Abort the program.
-            virtual void Abort() = 0;
         };
 
         DISKANN_DLLEXPORT void RegisterLogger(ILogger *logger);

--- a/nuget/DiskANN-preview.nuspec
+++ b/nuget/DiskANN-preview.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>DiskANN-preview.win-x64</id>
-    <version>0.13.717.2</version>
+    <version>0.13.717.3</version>
     <authors>DiskANN team</authors>
     <owners>DiskANN team</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/nuget/DiskANN-preview.nuspec
+++ b/nuget/DiskANN-preview.nuspec
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>DiskANN-preview.win-x64</id>
+    <version>0.13.717.2</version>
+    <authors>DiskANN team</authors>
+    <owners>DiskANN team</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type="file">LICENSE</license>
+    <licenseUrl>https://aka.ms/deprecateLicenseUrl</licenseUrl>
+    <projectUrl>https://github.com/microsoft/DiskANN</projectUrl>
+    <description>The package includes Windows x64 libraries
+
+The goal of the project is to build scalable, performant and cost-effective approximate nearest neighbor search algorithms. This release has the code from the DiskANN paper published in NeurIPS 2019, and improvements. This code reuses and builds upon some of the code for NSG algorithm.</description>
+    <copyright>Copyright (c) Microsoft Corporation</copyright>
+    <tags>DiskANN ANNS ANN nearest neighbor vector search</tags>
+    <dependencies>
+      <dependency id="intelopenmp.redist.win" version="[2022.0.3.3747]" />
+    </dependencies>
+  </metadata>
+  <files>
+      <file src="x64\Release\diskann.lib" target="lib\native\win-x64\retail" />
+      <file src="x64\Release\diskann.dll" target="lib\native\win-x64\retail" />
+      <file src="x64\Release\diskann.pdb" target="lib\native\win-x64\retail" />
+      <file src="x64\Debug\diskann.lib" target="lib\native\win-x64\debug" />
+      <file src="x64\Debug\diskann.dll" target="lib\native\win-x64\debug" />
+      <file src="x64\Debug\diskann.pdb" target="lib\native\win-x64\debug" />
+      <file src="include\**" target="lib\native\include\diskann" />
+      <file src="LICENSE" target="LICENSE" />
+  </files>
+</package>

--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -16,7 +16,7 @@
 
 #include "distance.h"
 #include "utils.h"
-#include "logger.h"
+#include "logging_internal.h"
 #include "ann_exception.h"
 
 namespace diskann
@@ -529,37 +529,33 @@ template <> diskann::Distance<float> *get_distance_function(diskann::Metric m)
     {
         if (Avx2SupportedCPU)
         {
-            diskann::cout << "L2: Using AVX2 distance computation DistanceL2Float" << std::endl;
+            Log(logging::Info, "Index", "L2: Using AVX2 distance computation DistanceL2Float");
             return new diskann::DistanceL2Float();
         }
         else if (AvxSupportedCPU)
         {
-            diskann::cout << "L2: AVX2 not supported. Using AVX distance computation" << std::endl;
+            Log(logging::Info, "Index", "L2: AVX2 not supported. Using AVX distance computation");
             return new diskann::AVXDistanceL2Float();
         }
         else
         {
-            diskann::cout << "L2: Older CPU. Using slow distance computation" << std::endl;
+            Log(logging::Info, "Index", "L2: Older CPU. Using slow distance computation");
             return new diskann::SlowDistanceL2Float();
         }
     }
     else if (m == diskann::Metric::COSINE)
     {
-        diskann::cout << "Cosine: Using either AVX or AVX2 implementation" << std::endl;
+        Log(logging::Info, "Index", "Cosine: Using either AVX or AVX2 implementation");
         return new diskann::DistanceCosineFloat();
     }
     else if (m == diskann::Metric::INNER_PRODUCT)
     {
-        diskann::cout << "Inner product: Using AVX2 implementation "
-                         "AVXDistanceInnerProductFloat"
-                      << std::endl;
+        Log(logging::Info, "Index", "Inner product: Using AVX2 implementation AVXDistanceInnerProductFloat");
         return new diskann::AVXDistanceInnerProductFloat();
     }
     else if (m == diskann::Metric::FAST_L2)
     {
-        diskann::cout << "Fast_L2: Using AVX2 implementation with norm "
-                         "memoization DistanceFastL2<float>"
-                      << std::endl;
+        Log(logging::Info, "Index", "Fast_L2: Using AVX2 implementation with norm memoization DistanceFastL2<float>");
         return new diskann::DistanceFastL2<float>();
     }
     else
@@ -568,7 +564,7 @@ template <> diskann::Distance<float> *get_distance_function(diskann::Metric m)
         stream << "Only L2, cosine, and inner product supported for floating "
                   "point vectors as of now."
                << std::endl;
-        diskann::cerr << stream.str() << std::endl;
+        Log(logging::Error, "Index", stream.str().c_str());
         throw diskann::ANNException(stream.str(), -1, __FUNCSIG__, __FILE__, __LINE__);
     }
 }
@@ -579,34 +575,30 @@ template <> diskann::Distance<int8_t> *get_distance_function(diskann::Metric m)
     {
         if (Avx2SupportedCPU)
         {
-            diskann::cout << "Using AVX2 distance computation DistanceL2Int8." << std::endl;
+            Log(logging::Info, "Index", "Using AVX2 distance computation DistanceL2Int8.");
             return new diskann::DistanceL2Int8();
         }
         else if (AvxSupportedCPU)
         {
-            diskann::cout << "AVX2 not supported. Using AVX distance computation" << std::endl;
+            Log(logging::Info, "Index", "AVX2 not supported. Using AVX distance computation");
             return new diskann::AVXDistanceL2Int8();
         }
         else
         {
-            diskann::cout << "Older CPU. Using slow distance computation "
-                             "SlowDistanceL2Int<int8_t>."
-                          << std::endl;
+            Log(logging::Info, "Index", "Older CPU. Using slow distance computation SlowDistanceL2Int<int8_t>.");
             return new diskann::SlowDistanceL2Int<int8_t>();
         }
     }
     else if (m == diskann::Metric::COSINE)
     {
-        diskann::cout << "Using either AVX or AVX2 for Cosine similarity "
-                         "DistanceCosineInt8."
-                      << std::endl;
+        Log(logging::Info, "Index", "Using either AVX or AVX2 for Cosine similarity DistanceCosineInt8.");
         return new diskann::DistanceCosineInt8();
     }
     else
     {
         std::stringstream stream;
         stream << "Only L2 and cosine supported for signed byte vectors." << std::endl;
-        diskann::cerr << stream.str() << std::endl;
+        Log(logging::Error, "Index", stream.str().c_str());
         throw diskann::ANNException(stream.str(), -1, __FUNCSIG__, __FILE__, __LINE__);
     }
 }
@@ -616,26 +608,24 @@ template <> diskann::Distance<uint8_t> *get_distance_function(diskann::Metric m)
     if (m == diskann::Metric::L2)
     {
 #ifdef _WINDOWS
-        diskann::cout << "WARNING: AVX/AVX2 distance function not defined for Uint8. Using "
-                         "slow version. "
-                         "Contact gopalsr@microsoft.com if you need AVX/AVX2 support."
-                      << std::endl;
+        Log(logging::Warning, 
+            "Index", 
+            "WARNING: AVX/AVX2 distance function not defined for Uint8. Using slow version. Contact gopalsr@microsoft.com if you need AVX/AVX2 support.");
 #endif
         return new diskann::DistanceL2UInt8();
     }
     else if (m == diskann::Metric::COSINE)
     {
-        diskann::cout << "AVX/AVX2 distance function not defined for Uint8. Using "
-                         "slow version SlowDistanceCosineUint8() "
-                         "Contact gopalsr@microsoft.com if you need AVX/AVX2 support."
-                      << std::endl;
+        Log(logging::Warning, 
+            "Index", 
+            "AVX/AVX2 distance function not defined for Uint8. Using slow version SlowDistanceCosineUint8(). Contact gopalsr@microsoft.com if you need AVX/AVX2 support.");
         return new diskann::SlowDistanceCosineUInt8();
     }
     else
     {
         std::stringstream stream;
         stream << "Only L2 and cosine supported for unsigned byte vectors." << std::endl;
-        diskann::cerr << stream.str() << std::endl;
+        Log(logging::Error, "Index", stream.str().c_str());
         throw diskann::ANNException(stream.str(), -1, __FUNCSIG__, __FILE__, __LINE__);
     }
 }

--- a/src/dll/CMakeLists.txt
+++ b/src/dll/CMakeLists.txt
@@ -1,7 +1,7 @@
 #Copyright(c) Microsoft Corporation.All rights reserved.
 #Licensed under the MIT                        license.
 
-add_library(${PROJECT_NAME} SHARED dllmain.cpp ../partition.cpp ../pq.cpp ../pq_flash_index.cpp ../logger.cpp ../utils.cpp 
+add_library(${PROJECT_NAME} SHARED dllmain.cpp ../partition.cpp ../pq.cpp ../pq_flash_index.cpp ../logger.cpp ../logging_internal.cpp ../utils.cpp 
     ../windows_aligned_file_reader.cpp ../distance.cpp ../memory_mapper.cpp ../index.cpp ../math_utils.cpp ../disk_utils.cpp
     ../ann_exception.cpp ../natural_number_set.cpp ../natural_number_map.cpp ../scratch.cpp)
 

--- a/src/logging_internal.cpp
+++ b/src/logging_internal.cpp
@@ -47,11 +47,6 @@ namespace diskann
                    << std::endl;
         }
 
-        void ConsoleLogger::Abort()
-        {
-            // No-op.
-        }
-
         // By default console logger is used.
         static ConsoleLogger consoleLogger;
         static ILogger *g_logger = &consoleLogger;

--- a/src/logging_internal.cpp
+++ b/src/logging_internal.cpp
@@ -1,0 +1,83 @@
+#include "logging.h"
+
+#include <cstdarg>
+#include <sstream>
+
+// This is not getting exposed through the DLL.
+#include "logging_internal.h"
+#include "logger.h"
+
+namespace diskann
+{
+	namespace logging
+	{
+        namespace
+        {
+            // Formatting functions for log messages.
+		    constexpr unsigned c_messageBufferSizeOnStack = 4096;
+
+            // A marker to be placed at the end of the truncated log lines.
+            const char c_truncatedMessage[] = "[TEXT TRUNCATED]";
+
+            template <size_t SIZE>
+            void FormatMessage(char (&buffer)[SIZE], char const *format, va_list args)
+            {
+                static_assert(SIZE > _countof(c_truncatedMessage), "The message buffer is too short for truncation marker");
+
+                const int result = vsnprintf_s(buffer, _TRUNCATE, format, args);
+
+                // If truncation occurred, place the truncation marker at the end of the
+                // buffer. Note that _countof also counts the terminating '\0'.
+                if (result == -1)
+                {
+                    const unsigned position = SIZE - _countof(c_truncatedMessage);
+                    memcpy(&buffer[position], &c_truncatedMessage[0], _countof(c_truncatedMessage));
+                }
+            }
+        }
+
+        //
+        // ConsoleLogger implementation.
+        //
+        void ConsoleLogger::Write(char const *filename, char const *function, unsigned lineNumber, LogLevel level,
+                               char const *title, char const *message)
+        {
+            auto& output = level == LogLevel::Error || level == LogLevel::Assert ? diskann::cerr : diskann::cout;
+            output << "[" << filename << ": " << function << ": " << lineNumber << "] " << title << ": " << message
+                   << std::endl;
+        }
+
+        void ConsoleLogger::Abort()
+        {
+            // No-op.
+        }
+
+        // By default console logger is used.
+        static ConsoleLogger consoleLogger;
+        static ILogger *g_logger = &consoleLogger;
+
+        // Function to register a custom logger.
+        void RegisterLogger(ILogger *logger)
+        {
+            g_logger = (logger != nullptr) ? logger : &consoleLogger;
+        }
+
+        // Logging implementation.
+        void LogImpl(char const *filename, 
+                     char const *function, 
+                     unsigned lineNumber, 
+                     LogLevel level, 
+                     char const *title,
+                     char const *format, ...)
+        {
+            char message[c_messageBufferSizeOnStack];
+
+            va_list arguments;
+            va_start(arguments, format);
+            FormatMessage(message, format, arguments);
+            va_end(arguments);
+
+            g_logger->Write(filename, function, lineNumber, level, title, message);
+        }
+    }
+}

--- a/src/logging_internal.h
+++ b/src/logging_internal.h
@@ -33,8 +33,6 @@ namespace diskann
                                LogLevel level,
                                char const* title, 
                                char const* message) override;
-
-            virtual void Abort() override;
         };
     }
 }

--- a/src/logging_internal.h
+++ b/src/logging_internal.h
@@ -1,0 +1,40 @@
+#include "logging.h"
+
+namespace diskann
+{
+    namespace logging
+    {
+        // Macro that logs a message. The macro gathers the source file name and the
+        // line number. The caller may specify optional arguments that will be passed to
+        // sprintf() to create the rest of the log message.
+        #define Log(level, title, format, ...)                                                                                \
+            logging::LogImpl(__FILE__, __FUNCTION__, __LINE__, level, title, format, __VA_ARGS__)
+
+        // Generates a log message for a specified title, source file, function,
+        // and line number.
+        // The format arument and those that follow are passed to sprintf() to
+        // create the log message.
+        // This method is thread safe.
+        void LogImpl(char const* filename, 
+                     char const* function, 
+                     unsigned lineNumber, 
+                     LogLevel level, 
+                     char const* title,
+                     char const* format, ...);
+
+        // Implementation of a logger that outputs to diskann::cout and diskann::cerr.
+        class ConsoleLogger : public ILogger
+        {
+        public:
+            // ILogger interface implementation.
+            virtual void Write(char const* filename, 
+                               char const* function, 
+                               unsigned lineNumber, 
+                               LogLevel level,
+                               char const* title, 
+                               char const* message) override;
+
+            virtual void Abort() override;
+        };
+    }
+}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
DiskANN code output various statements to cout and cerr streams. In some cases this code runs as part of the service that cannot use these streams, such as when run as an Autopilot service. This output is crucial for monitoring, debugging.

The change adds an interface for the logging component and allows to specify a custom implementation of the logger. By default logging is done to a console implementation (similar to the existing cout and cerr).

#### Any other comments?
Mostly converted cout and cerr statements from index.cpp, but not everything. Only the most important parts were converted.

