### PR TITLE
Distance computation: Fix SSE instructions

### DIFF
--- a/src/distance.cpp
+++ b/src/distance.cpp
@@ -346,10 +346,10 @@ template <typename T> float DistanceInnerProduct<T>::inner_product(const T *a, c
 #else
 #ifdef __SSE2__
 #define SSE_DOT(addr1, addr2, dest, tmp1, tmp2)                                                                        \
-    tmp1 = _mm128_loadu_ps(addr1);                                                                                     \
-    tmp2 = _mm128_loadu_ps(addr2);                                                                                     \
-    tmp1 = _mm128_mul_ps(tmp1, tmp2);                                                                                  \
-    dest = _mm128_add_ps(dest, tmp1);
+    tmp1 = _mm_loadu_ps(addr1);                                                                                     \
+    tmp2 = _mm_loadu_ps(addr2);                                                                                     \
+    tmp1 = _mm_mul_ps(tmp1, tmp2);                                                                                  \
+    dest = _mm_add_ps(dest, tmp1);
     __m128 sum;
     __m128 l0, l1, l2, l3;
     __m128 r0, r1, r2, r3;
@@ -458,9 +458,9 @@ template <typename T> float DistanceFastL2<T>::norm(const T *a, uint32_t size) c
 #else
 #ifdef __SSE2__
 #define SSE_L2NORM(addr, dest, tmp)                                                                                    \
-    tmp = _mm128_loadu_ps(addr);                                                                                       \
-    tmp = _mm128_mul_ps(tmp, tmp);                                                                                     \
-    dest = _mm128_add_ps(dest, tmp);
+    tmp = _mm_loadu_ps(addr);                                                                                       \
+    tmp = _mm_mul_ps(tmp, tmp);                                                                                     \
+    dest = _mm_add_ps(dest, tmp);
 
     __m128 sum;
     __m128 l0, l1, l2, l3;


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.

Currently, invalid SSE instructions like _mm128_loadu_ps are used. This causes DiskANN compilation to fail on machines that only support SSE and not AVX. Instead, it should be _mm_loadu_ps.

Change the instructions to the correct ones.