### PR TITLE
Fix missing ann_exception.h in index_build_params.h

### DIFF
--- a/include/index_build_params.h
+++ b/include/index_build_params.h
@@ -2,6 +2,7 @@
 
 #include "common_includes.h"
 #include "parameters.h"
+#include "ann_exception.h"
 
 namespace diskann
 {


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [X] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
In include/index_build_params.h, the reference to ANNException class relies on the header file include/ann_exception.h. The current build didn't fail maybe because other files include that ann_exception.h header but that was dangerous: it's not guaranteed that the ann_exception.h will always be included by other files in future builds. I suggest we explicitly include the ann_exception.h header whenever we need it.

#### Any other comments?

