### PR TITLE
Fix dead code in IndexConfigBuilder::build() logic, and other issues

### DIFF
--- a/include/index_config.h
+++ b/include/index_config.h
@@ -1,7 +1,13 @@
 #pragma once
 
+#include <memory>
+#include <string>
+
 #include "common_includes.h"
 #include "parameters.h"
+#include "distance.h"
+#include "ann_exception.h"
+#include "logger.h"
 
 namespace diskann
 {
@@ -198,13 +204,8 @@ class IndexConfigBuilder
 
     IndexConfig build()
     {
-        if (_data_type == "" || _data_type.empty())
+        if (_data_type.empty())
             throw ANNException("Error: data_type can not be empty", -1);
-
-        if (_dynamic_index && _num_frozen_pts == 0)
-        {
-            _num_frozen_pts = 1;
-        }
 
         if (_dynamic_index)
         {


### PR DESCRIPTION


<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [X] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
   - [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?
 
#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
This PR fixes a logical error in IndexConfigBuilder::build() where a safety check logic was duplicated, causing the logging code to become unreachable dead code. A couple of minor things: missing some header includes; string check is redundant.

Previously, there were two identical if (_dynamic_index && _num_frozen_pts == 0) checks.

The first check silently set _num_frozen_pts = 1.

The second check (which contained the warning log) would effectively become if (true && 1 == 0), which always evaluates to false.

As a result, the warning message "_num_frozen_pts passed as 0 ..." would never be printed.

The fix: I removed the first redundant check. Now the code correctly logs the warning before overriding the value to 1.

I also fixed a few other minor things like missing header includes and string checks.

#### Any other comments?

