### PR TITLE
Add initial QEMU tests for `diskann-wide`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,11 +114,12 @@ jobs:
           key: ${{ matrix.crate }}
 
       - name: Clippy ${{ matrix.crate }} (no default features)
-        run: cargo clippy --locked --package ${{ matrix.crate }} \
-          --no-default-features \
-          --profile ci \
-          --no-deps \
-          --config "$RUST_CONFIG"
+        run: |
+          cargo clippy --locked --package ${{ matrix.crate }} \
+            --no-default-features \
+            --profile ci \
+            --no-deps \
+            --config "$RUST_CONFIG"
 
   # TODO: Re-enable docs check later
   # docs:


### PR DESCRIPTION
This adds [QEMU](https://www.qemu.org/) tests to CI to provide coverage of our architecture detection mechanisms.

QEMU is an emulator that, amongst other things, allows to run binaries as if we were running on an older CPU. This can help catch improper compilation when we target older CPUs. Unfortunately, user-space emulation of AVX-512 doesn't go the other way, so we can't quite use this to test our AVX-512 code on non-AVX-512 hosts.

Additionally, this closes #694 by changing the application of `-Dwarnings` from overriding `RUSTFLAGS` to instead passing it via the `--config` flag. The former effectively disables our `.cargo/config.toml`, which in-turn disabled the `x86-64-v3` CPU target.

An example of a failing run can be seen [here](https://github.com/microsoft/DiskANN/actions/runs/21684708571/job/62528565039), where the CI test fails due to an illegal instruction found by QEMU.