### PR TITLE
[CI] Skip coverage for Dependabot.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,7 +265,7 @@ jobs:
     needs: basics
     name: code coverage
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
By default, Dependabot PRs appear to have [read only permissions](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-on-actions) for their `GITHUB_TOKEN` and no secrets are available. Thus, code-coverage step fails.

Since we expect Depentabot to only update dependencies, we can disable coverage by checking if the `github.actor` is Dependabot.