### PR TITLE
[diskann] Add note on the selection of `PruneKind` in `graph::config::Builder`.

### DIFF
--- a/diskann/src/graph/config/mod.rs
+++ b/diskann/src/graph/config/mod.rs
@@ -563,7 +563,7 @@ impl Builder {
     /// prefer to use [`diskann_vector::distance::Metric`]'s conversion function like the
     /// example below:
     /// ```rust
-    /// use diskann::graph::{Config, config};
+    /// use diskann::graph::config;
     /// use diskann_vector::distance::Metric;
     ///
     /// let _ = config::Builder::new(


### PR DESCRIPTION
Add a note to `diskann::graph::config::Builder::new()` highlighting the conversion from `diskann_vector::distance::Metric` to `diskann::graph::config::PruneKind`.

Incorrectly selecting `PruneKind` can have a profoundly negative impact on recall.