### PR TITLE
[CI] Add minimal ARM checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,7 @@ jobs:
         runner:
           - ubuntu-latest
           - ubuntu-24.04-arm
+      fail-fast: false
     name: clippy (${{ matrix.runner }})
     runs-on: ${{ matrix.runner }}
     steps:


### PR DESCRIPTION
Add minimal CI support for Arm by at least running `clippy`.