### PR TITLE
[diskann-wide] Optimize `load_simd_first` for 8-bit and 16-bit element types.

### DIFF
--- a/diskann-wide/src/arch/x86_64/algorithms.rs
+++ b/diskann-wide/src/arch/x86_64/algorithms.rs
@@ -83,7 +83,7 @@ pub(crate) unsafe fn __load_first_of_16_bytes(arch: V3, ptr: *const u8, first: u
         };
     }
 
-    // For first > 8, use two overlapping 8-byte loads combined with `pshufb`.
+    // For `first > 8`, use the optimized two-load method.
     if first > 8 {
         // SAFETY: `first` is in `(8, 16)` and `[ptr, ptr + first)` is valid.
         return unsafe {
@@ -91,7 +91,7 @@ pub(crate) unsafe fn __load_first_of_16_bytes(arch: V3, ptr: *const u8, first: u
         };
     }
 
-    // For first <= 8, everything fits in general purpose registers.
+    // For `first <= 8`, everything fits in general purpose registers.
     //
     // Use two overlapping reads whose results are combined with a single shift + OR.
     //
@@ -137,14 +137,13 @@ pub(crate) unsafe fn __load_first_u16_of_16_bytes(
     let byte_ptr = ptr as *const u8;
     let bytes = first * 2;
 
-    // For bytes > 8 (i.e., first >= 5), use two overlapping 8-byte loads
-    // combined with `pshufb`.
+    // For `bytes > 8` (i.e., `first > 4`), use the optimized two-load method.
     if bytes > 8 {
         // SAFETY: `bytes` is in `(8, 16)` and `[byte_ptr, byte_ptr + bytes)` is valid.
         return unsafe { __load_8_to_16_bytes(arch, byte_ptr, bytes) };
     }
 
-    // For bytes <= 8, everything fits in general purpose registers.
+    // For `bytes <= 8`, everything fits in general purpose registers.
     //
     // SAFETY: All reads are within `[ptr, ptr + first)`, which the caller
     // asserts is valid.


### PR DESCRIPTION
Optimize `SIMDVector::load_simd_first` for `u8`, `i8` and `u16` data type on the `x86_64::V3` architecture.

These types use the `__load_first*` algorithms since AVX2 does not have masked loads for 8/16-bit types. The current implementation uses a cascaded load-chain to ensure the safety contract is upheld. This results in a lot of fiddly conditional logic. 

This new implementation uses at most 2 data loads (plus sometimes one more load from a const variable for the shuffle-mask) to avoid the data dependent chain and avoids using the `u128` type directly, which saves a bunch of LLVM register shenanigans.

These functions are called in the epilogue handling of many distance function implementations.

Performance results are below. This is a pretty clear win for the 8-bit case. It appears to be kind of a wash for the 16-bit case though.

| uint8 x uint8 -- squared_l2 | | | |
|-----|-----------------|----------------|-------|
| **Dim** | **Before Min (ns)** | **After Min (ns)** | **Delta Min** |
| 100 | 6.528 | 6.044 | -7.4% |
| 101 | 7.660 | 6.052 | **-21.0%** |
| 102 | 7.728 | 6.068 | **-21.5%** |
| 103 | 9.000 | 6.084 | **-32.4%** |
| 104 | 5.812 | 5.668 | -2.5% |
| 105 | 6.724 | 6.024 | **-10.4%** |
| 128 | 6.224 | 6.260 | +0.6% |
| 160 | 7.544 | 7.532 | -0.2% |

| float16 x float16 -- squared_l2 | | | |
|-----|-----------------|----------------|-------|
| **Dim** | **Before Min (ns)** | **After Min (ns)** | **Delta Min** |
| 100 | 7.816 | 7.548 | -3.4% |
| 101 | 8.084 | 8.036 | -0.6% |
| 102 | 7.916 | 8.032 | +1.5% |
| 103 | 8.092 | 8.020 | -0.9% |
| 104 | 7.128 | 7.316 | +2.6% |
| 105 | 8.860 | 8.100 | -8.6% |
| 128 | 8.684 | 8.632 | -0.6% |
| 160 | 10.696 | 10.464 | -2.2% |

| float16 x float16 -- inner_product | | | |
|-----|-----------------|----------------|-------|
| **Dim** | **Before Min (ns)** | **After Min (ns)** | **Delta Min** |
| 100 | 6.756 | 6.480 | -4.1% |
| 101 | 6.988 | 7.004 | +0.2% |
| 102 | 6.804 | 6.968 | +2.4% |
| 103 | 6.988 | 7.004 | +0.2% |
| 104 | 6.140 | 6.112 | -0.5% |
| 105 | 7.492 | 6.932 | -7.5% |
| 128 | 7.556 | 7.564 | +0.1% |
| 160 | 9.408 | 9.348 | -0.6% |