### PR TITLE
[multi-vector] Verify `Standard` won't overflow in its constructor.

### DIFF
--- a/diskann-quantization/src/minmax/multi/max_sim.rs
+++ b/diskann-quantization/src/minmax/multi/max_sim.rs
@@ -197,7 +197,7 @@ mod tests {
     where
         Unsigned: Representation<NBITS>,
     {
-        let input_mat = MatRef::new(Standard::<f32>::new(n, dim), input).unwrap();
+        let input_mat = MatRef::new(Standard::<f32>::new(n, dim).unwrap(), input).unwrap();
         let mut output: Mat<MinMaxMeta<NBITS>> =
             Mat::new(MinMaxMeta::new(n, dim), Defaulted).unwrap();
         quantizer

--- a/diskann-quantization/src/minmax/multi/meta.rs
+++ b/diskann-quantization/src/minmax/multi/meta.rs
@@ -529,8 +529,9 @@ mod tests {
                     let input_data = generate_test_data(num_vectors, dim);
 
                     // Multi-vector compression
-                    let input_view = MatRef::new(Standard::new(num_vectors, dim), &input_data)
-                        .expect("input view creation");
+                    let input_view =
+                        MatRef::new(Standard::new(num_vectors, dim).unwrap(), &input_data)
+                            .expect("input view creation");
 
                     let mut multi_mat: Mat<MinMaxMeta<NBITS>> =
                         Mat::new(MinMaxMeta::new(num_vectors, dim), Defaulted)
@@ -584,8 +585,8 @@ mod tests {
             let quantizer = make_quantizer(dim);
             let input_data = generate_test_data(num_vectors, dim);
 
-            let input_view =
-                MatRef::new(Standard::new(num_vectors, dim), &input_data).expect("input view");
+            let input_view = MatRef::new(Standard::new(num_vectors, dim).unwrap(), &input_data)
+                .expect("input view");
 
             let mut mat: Mat<MinMaxMeta<NBITS>> =
                 Mat::new(MinMaxMeta::new(num_vectors, dim), Defaulted).expect("mat creation");
@@ -623,7 +624,8 @@ mod tests {
 
             // Input has 3 vectors
             let input_data = generate_test_data(3, dim);
-            let input_view = MatRef::new(Standard::new(3, dim), &input_data).expect("input view");
+            let input_view =
+                MatRef::new(Standard::new(3, dim).unwrap(), &input_data).expect("input view");
 
             // Output has 2 vectors (mismatch)
             let mut mat: Mat<MinMaxMeta<NBITS>> =
@@ -640,7 +642,8 @@ mod tests {
 
             // Input has dim=8 (mismatch)
             let input_data = generate_test_data(2, 8);
-            let input_view = MatRef::new(Standard::new(2, 8), &input_data).expect("input view");
+            let input_view =
+                MatRef::new(Standard::new(2, 8).unwrap(), &input_data).expect("input view");
 
             // Output correctly has dim=4
             let mut mat: Mat<MinMaxMeta<NBITS>> =
@@ -659,7 +662,8 @@ mod tests {
 
             // Input correctly has dim=4
             let input_data = generate_test_data(2, 4);
-            let input_view = MatRef::new(Standard::new(2, 4), &input_data).expect("input view");
+            let input_view =
+                MatRef::new(Standard::new(2, 4).unwrap(), &input_data).expect("input view");
 
             // Output has intrinsic_dim=8 (mismatch)
             let row_bytes = Data::<NBITS>::canonical_bytes(8);

--- a/diskann-quantization/src/minmax/multi/mod.rs
+++ b/diskann-quantization/src/minmax/multi/mod.rs
@@ -45,7 +45,7 @@
 //!     0.0, 1.0, 0.0, 0.0,  // query vector 1
 //! ];
 //! let query_input = MatRef::new(
-//!     Standard::new(num_query_vectors, dim), &query_data
+//!     Standard::new(num_query_vectors, dim).unwrap(), &query_data
 //! ).unwrap();
 //!
 //! // Full-precision document multi-vector (3 vectors × 4 dimensions)
@@ -55,7 +55,7 @@
 //!     0.0, 0.0, 1.0, 0.0,  // doc vector 2
 //! ];
 //! let doc_input = MatRef::new(
-//!     Standard::new(num_doc_vectors, dim), &doc_data
+//!     Standard::new(num_doc_vectors, dim).unwrap(), &doc_data
 //! ).unwrap();
 //!
 //! // Create owned matrices for quantized output using Mat::new

--- a/diskann-quantization/src/multi_vector/distance/mod.rs
+++ b/diskann-quantization/src/multi_vector/distance/mod.rs
@@ -23,14 +23,14 @@
 //! // Query: 2 vectors of dim 3 (wrapped as QueryMatRef)
 //! let query_data = [1.0f32, 0.0, 0.0, 0.0, 1.0, 0.0];
 //! let query: QueryMatRef<_> = MatRef::new(
-//!     Standard::new(2, 3),
+//!     Standard::new(2, 3).unwrap(),
 //!     &query_data,
 //! ).unwrap().into();
 //!
 //! // Doc: 2 vectors of dim 3
 //! let doc_data = [1.0f32, 0.0, 0.0, 0.0, 0.0, 1.0];
 //! let doc = MatRef::new(
-//!     Standard::new(2, 3),
+//!     Standard::new(2, 3).unwrap(),
 //!     &doc_data,
 //! ).unwrap();
 //!

--- a/diskann-quantization/src/multi_vector/distance/simple.rs
+++ b/diskann-quantization/src/multi_vector/distance/simple.rs
@@ -28,7 +28,7 @@ use crate::multi_vector::{MatRef, MaxSimError, Repr, Standard};
 /// use diskann_quantization::multi_vector::distance::QueryMatRef;
 ///
 /// let data = [1.0f32, 2.0, 3.0, 4.0];
-/// let view = MatRef::new(Standard::new(2, 2), &data).unwrap();
+/// let view = MatRef::new(Standard::new(2, 2).unwrap(), &data).unwrap();
 /// let query: QueryMatRef<_> = view.into();
 /// ```
 #[derive(Debug, Clone, Copy)]
@@ -165,14 +165,14 @@ mod tests {
 
     /// Helper to create a QueryMatRef from raw data
     fn make_query(data: &[f32], nrows: usize, ncols: usize) -> QueryMatRef<'_, Standard<f32>> {
-        MatRef::new(Standard::new(nrows, ncols), data)
+        MatRef::new(Standard::new(nrows, ncols).unwrap(), data)
             .unwrap()
             .into()
     }
 
     /// Helper to create a MatRef from raw data
     fn make_doc(data: &[f32], nrows: usize, ncols: usize) -> MatRef<'_, Standard<f32>> {
-        MatRef::new(Standard::new(nrows, ncols), data).unwrap()
+        MatRef::new(Standard::new(nrows, ncols).unwrap(), data).unwrap()
     }
 
     /// Naive implementation of max-sim for a single query vector against all doc vectors.
@@ -196,7 +196,7 @@ mod tests {
         #[test]
         fn from_mat_ref_and_deref() {
             let data = [1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0];
-            let view = MatRef::new(Standard::new(2, 3), &data).unwrap();
+            let view = MatRef::new(Standard::new(2, 3).unwrap(), &data).unwrap();
             let query: QueryMatRef<_> = view.into();
 
             // Deref access works

--- a/diskann-quantization/src/multi_vector/matrix.rs
+++ b/diskann-quantization/src/multi_vector/matrix.rs
@@ -234,7 +234,7 @@ pub unsafe trait NewOwned<T>: ReprOwned {
 ///
 /// ```rust
 /// use diskann_quantization::multi_vector::{Mat, Standard, Defaulted};
-/// let mat = Mat::new(Standard::<f32>::new(4, 3), Defaulted).unwrap();
+/// let mat = Mat::new(Standard::<f32>::new(4, 3).unwrap(), Defaulted).unwrap();
 /// for i in 0..4 {
 ///     assert!(mat.get_row(i).unwrap().iter().all(|&x| x == 0.0f32));
 /// }
@@ -264,18 +264,31 @@ pub struct Standard<T> {
 
 impl<T: Copy> Standard<T> {
     /// Create a new `Standard` for data of type `T`.
-    pub fn new(nrows: usize, ncols: usize) -> Self {
-        Self {
+    ///
+    /// Successful construction requires:
+    ///
+    /// * The total number of elements determined by `nrows * ncols` does not exceed
+    ///   `usize::MAX`.
+    /// * The total memory footprint defined by `ncols * nrows * size_of::<T>()` does not
+    ///   exceed `isize::MAX`.
+    pub fn new(nrows: usize, ncols: usize) -> Result<Self, Overflow> {
+        Overflow::check::<T>(nrows, ncols)?;
+        Ok(Self {
             nrows,
             ncols,
             _elem: PhantomData,
-        }
+        })
     }
 
-    /// Returns the number of total elements (`rows x cols`) in this matrix, returning `None`
-    /// if this computation overflows.
-    pub fn num_elements(&self) -> Option<usize> {
-        self.nrows.checked_mul(self.ncols())
+    /// Returns the number of total elements (`rows x cols`) in this matrix.
+    pub fn num_elements(&self) -> usize {
+        // Since we've constructed `self` - we know we cannot overflow.
+        self.nrows() * self.ncols()
+    }
+
+    /// Returns `rows`, the number of rows in this matrix.
+    fn nrows(&self) -> usize {
+        self.nrows
     }
 
     /// Returns `ncols`, the number of elements in a row of this matrix.
@@ -288,7 +301,7 @@ impl<T: Copy> Standard<T> {
     /// 1. Computation of the number of elements in `self` does not overflow.
     /// 2. Argument `slice` has the expected number of elements.
     fn check_slice(&self, slice: &[T]) -> Result<(), SliceError> {
-        let len = self.num_elements().ok_or(SliceError::Overflow)?;
+        let len = self.num_elements();
 
         if slice.len() != len {
             Err(SliceError::LengthMismatch {
@@ -301,14 +314,63 @@ impl<T: Copy> Standard<T> {
     }
 }
 
+/// Error for [`Standard::new`].
+#[derive(Debug, Clone, Copy)]
+pub struct Overflow {
+    nrows: usize,
+    ncols: usize,
+    elsize: usize,
+}
+
+impl Overflow {
+    fn check<T>(nrows: usize, ncols: usize) -> Result<(), Self> {
+        let elsize = std::mem::size_of::<T>();
+        // Guard the element count itself so that `num_elements()` can never overflow.
+        let elements = nrows.checked_mul(ncols).ok_or(Self {
+            nrows,
+            ncols,
+            elsize,
+        })?;
+
+        let bytes = elsize.saturating_mul(elements);
+        if bytes <= isize::MAX as usize {
+            Ok(())
+        } else {
+            Err(Self {
+                nrows,
+                ncols,
+                elsize,
+            })
+        }
+    }
+}
+
+impl std::fmt::Display for Overflow {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.elsize == 0 {
+            write!(
+                f,
+                "ZST matrix with dimensions {} x {} has more than `usize::MAX` elements",
+                self.nrows, self.ncols,
+            )
+        } else {
+            write!(
+                f,
+                "a matrix of size {} x {} with element size {} would exceed isize::MAX bytes",
+                self.nrows, self.ncols, self.elsize,
+            )
+        }
+    }
+}
+
+impl std::error::Error for Overflow {}
+
 /// Error types for [`Standard`].
 #[derive(Debug, Clone, Copy, Error)]
 #[non_exhaustive]
 pub enum SliceError {
     #[error("Length mismatch: expected {expected}, found {found}")]
     LengthMismatch { expected: usize, found: usize },
-    #[error("Computing slice length overflowed.")]
-    Overflow,
 }
 
 // SAFETY: The implementation correctly computes row offsets as `i * ncols` and
@@ -325,8 +387,7 @@ unsafe impl<T: Copy> Repr for Standard<T> {
     }
 
     fn layout(&self) -> Result<Layout, LayoutError> {
-        let elements = self.num_elements().ok_or(LayoutError::new())?;
-        Ok(Layout::array::<T>(elements)?)
+        Ok(Layout::array::<T>(self.num_elements())?)
     }
 
     unsafe fn get_row<'a>(self, ptr: NonNull<u8>, i: usize) -> Self::Row<'a> {
@@ -1168,7 +1229,7 @@ mod tests {
 
     #[test]
     fn standard_representation() {
-        let repr = Standard::<f32>::new(4, 3);
+        let repr = Standard::<f32>::new(4, 3).unwrap();
         assert_eq!(repr.nrows(), 4);
         assert_eq!(repr.ncols(), 3);
 
@@ -1180,7 +1241,7 @@ mod tests {
     #[test]
     fn standard_zero_dimensions() {
         for (nrows, ncols) in [(0, 0), (0, 5), (5, 0)] {
-            let repr = Standard::<u8>::new(nrows, ncols);
+            let repr = Standard::<u8>::new(nrows, ncols).unwrap();
             assert_eq!(repr.nrows(), nrows);
             assert_eq!(repr.ncols(), ncols);
             let layout = repr.layout().unwrap();
@@ -1190,7 +1251,7 @@ mod tests {
 
     #[test]
     fn standard_check_slice() {
-        let repr = Standard::<u32>::new(3, 4);
+        let repr = Standard::<u32>::new(3, 4).unwrap();
 
         // Correct length succeeds
         let data = vec![0u32; 12];
@@ -1217,24 +1278,60 @@ mod tests {
         ));
 
         // Overflow case
-        let overflow_repr = Standard::<u8>::new(usize::MAX, 2);
-        assert!(matches!(
-            overflow_repr.check_slice(&[]),
-            Err(SliceError::Overflow)
-        ));
+        let overflow_repr = Standard::<u8>::new(usize::MAX, 2).unwrap_err();
+        assert!(matches!(overflow_repr, Overflow { .. }));
     }
 
     #[test]
-    fn standard_layout_errors() {
-        // Error path 1: num_elements() overflows (nrows * ncols > usize::MAX)
-        let overflow_repr = Standard::<u8>::new(usize::MAX, 2);
-        assert!(overflow_repr.layout().is_err());
+    fn standard_new_rejects_element_count_overflow() {
+        // nrows * ncols overflows usize even though per-element size is small.
+        assert!(Standard::<u8>::new(usize::MAX, 2).is_err());
+        assert!(Standard::<u8>::new(2, usize::MAX).is_err());
+        assert!(Standard::<u8>::new(usize::MAX, usize::MAX).is_err());
+    }
 
-        // Error path 2: Layout::array fails (total byte size overflows)
-        // For a u64, we need elements * 8 > isize::MAX to trigger Layout::array error
-        // Using isize::MAX / 4 elements of u64 (8 bytes each) will overflow
-        let large_repr = Standard::<u64>::new(isize::MAX as usize / 4, 2);
-        assert!(large_repr.layout().is_err());
+    #[test]
+    fn standard_new_rejects_byte_count_exceeding_isize_max() {
+        // Element count fits in usize, but total bytes exceed isize::MAX.
+        let half = (isize::MAX as usize / std::mem::size_of::<u64>()) + 1;
+        assert!(Standard::<u64>::new(half, 1).is_err());
+        assert!(Standard::<u64>::new(1, half).is_err());
+    }
+
+    #[test]
+    fn standard_new_accepts_boundary_below_isize_max() {
+        // Largest allocation that still fits in isize::MAX bytes.
+        let max_elems = isize::MAX as usize / std::mem::size_of::<u64>();
+        let repr = Standard::<u64>::new(max_elems, 1).unwrap();
+        assert_eq!(repr.num_elements(), max_elems);
+    }
+
+    #[test]
+    fn standard_new_zst_rejects_element_count_overflow() {
+        // For ZSTs the byte count is always 0, but element-count overflow
+        // must still be caught so that `num_elements()` never wraps.
+        assert!(Standard::<()>::new(usize::MAX, 2).is_err());
+        assert!(Standard::<()>::new(usize::MAX / 2 + 1, 3).is_err());
+    }
+
+    #[test]
+    fn standard_new_zst_accepts_large_non_overflowing() {
+        // Large-but-valid ZST matrix: element count fits in usize.
+        let repr = Standard::<()>::new(usize::MAX, 1).unwrap();
+        assert_eq!(repr.num_elements(), usize::MAX);
+        assert_eq!(repr.layout().unwrap().size(), 0);
+    }
+
+    #[test]
+    fn standard_new_overflow_error_display() {
+        let err = Standard::<u32>::new(usize::MAX, 2).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("would exceed isize::MAX bytes"), "{msg}");
+
+        let zst_err = Standard::<()>::new(usize::MAX, 2).unwrap_err();
+        let zst_msg = zst_err.to_string();
+        assert!(zst_msg.contains("ZST matrix"), "{zst_msg}");
+        assert!(zst_msg.contains("usize::MAX"), "{zst_msg}");
     }
 
     /////////
@@ -1243,7 +1340,7 @@ mod tests {
 
     #[test]
     fn mat_new_and_basic_accessors() {
-        let mat = Mat::new(Standard::<usize>::new(3, 4), 42usize).unwrap();
+        let mat = Mat::new(Standard::<usize>::new(3, 4).unwrap(), 42usize).unwrap();
         let base: *const u8 = mat.as_ptr().as_ptr();
 
         assert_eq!(mat.num_vectors(), 3);
@@ -1265,7 +1362,7 @@ mod tests {
 
     #[test]
     fn mat_new_with_default() {
-        let mat = Mat::new(Standard::<usize>::new(2, 3), Defaulted).unwrap();
+        let mat = Mat::new(Standard::<usize>::new(2, 3).unwrap(), Defaulted).unwrap();
         let base: *const u8 = mat.as_ptr().as_ptr();
 
         assert_eq!(mat.num_vectors(), 2);
@@ -1287,7 +1384,7 @@ mod tests {
     fn test_mat() {
         for nrows in ROWS {
             for ncols in COLS {
-                let repr = Standard::<usize>::new(*nrows, *ncols);
+                let repr = Standard::<usize>::new(*nrows, *ncols).unwrap();
                 let ctx = &lazy_format!("nrows = {}, ncols = {}", nrows, ncols);
 
                 // Populate the matrix using `&mut Mat`
@@ -1342,14 +1439,13 @@ mod tests {
     fn test_mat_refmut() {
         for nrows in ROWS {
             for ncols in COLS {
-                let repr = Standard::<usize>::new(*nrows, *ncols);
+                let repr = Standard::<usize>::new(*nrows, *ncols).unwrap();
                 let ctx = &lazy_format!("nrows = {}, ncols = {}", nrows, ncols);
 
                 // Populate the matrix using `&mut Mat`
                 {
                     let ctx = &lazy_format!("{ctx} - by matmut");
-                    let mut b: Box<[_]> =
-                        (0..repr.num_elements().unwrap()).map(|_| 0usize).collect();
+                    let mut b: Box<[_]> = (0..repr.num_elements()).map(|_| 0usize).collect();
                     let mut matmut = MatMut::new(repr, &mut b).unwrap();
 
                     fill_mat_mut(matmut.reborrow_mut(), repr);
@@ -1368,8 +1464,7 @@ mod tests {
                 // Populate the matrix using `RowsMut`
                 {
                     let ctx = &lazy_format!("{ctx} - by rows");
-                    let mut b: Box<[_]> =
-                        (0..repr.num_elements().unwrap()).map(|_| 0usize).collect();
+                    let mut b: Box<[_]> = (0..repr.num_elements()).map(|_| 0usize).collect();
                     let mut matmut = MatMut::new(repr, &mut b).unwrap();
 
                     fill_rows_mut(matmut.rows_mut(), repr);
@@ -1399,7 +1494,7 @@ mod tests {
 
         for nrows in rows {
             for ncols in cols {
-                let m = Mat::new(Standard::new(nrows, ncols), 1usize).unwrap();
+                let m = Mat::new(Standard::new(nrows, ncols).unwrap(), 1usize).unwrap();
                 let rows_iter = m.rows();
                 let len = <_ as ExactSizeIterator>::len(&rows_iter);
                 assert_eq!(len, nrows);
@@ -1413,7 +1508,7 @@ mod tests {
 
     #[test]
     fn matref_new_slice_length_error() {
-        let repr = Standard::<u32>::new(3, 4);
+        let repr = Standard::<u32>::new(3, 4).unwrap();
 
         // Correct length succeeds
         let data = vec![0u32; 12];
@@ -1442,7 +1537,7 @@ mod tests {
 
     #[test]
     fn matmut_new_slice_length_error() {
-        let repr = Standard::<u32>::new(3, 4);
+        let repr = Standard::<u32>::new(3, 4).unwrap();
 
         // Correct length succeeds
         let mut data = vec![0u32; 12];

--- a/diskann-quantization/src/multi_vector/mod.rs
+++ b/diskann-quantization/src/multi_vector/mod.rs
@@ -29,7 +29,7 @@
 //! use diskann_vector::{DistanceFunctionMut, PureDistanceFunction};
 //!
 //! // Create an owned matrix (2 vectors, dim 3, initialized to 0.0)
-//! let mut owned = Mat::new(Standard::new(2, 3), 0.0f32).unwrap();
+//! let mut owned = Mat::new(Standard::new(2, 3).unwrap(), 0.0f32).unwrap();
 //! assert_eq!(owned.num_vectors(), 2);
 //!
 //! // Modify via mutable view
@@ -44,10 +44,10 @@
 //!
 //! // Wrap query as QueryMatRef for type-safe asymmetric distance
 //! let query: QueryMatRef<_> = MatRef::new(
-//!     Standard::new(2, 2),
+//!     Standard::new(2, 2).unwrap(),
 //!     &query_data,
 //! ).unwrap().into();
-//! let doc = MatRef::new(Standard::new(2, 2), &doc_data).unwrap();
+//! let doc = MatRef::new(Standard::new(2, 2).unwrap(), &doc_data).unwrap();
 //!
 //! // Chamfer distance (sum of max similarities)
 //! let distance = Chamfer::evaluate(query, doc);
@@ -66,5 +66,6 @@ pub(crate) mod matrix;
 
 pub use distance::{Chamfer, MaxSim, MaxSimError, QueryMatRef};
 pub use matrix::{
-    Defaulted, LayoutError, Mat, MatMut, MatRef, Repr, ReprMut, ReprOwned, SliceError, Standard,
+    Defaulted, LayoutError, Mat, MatMut, MatRef, Overflow, Repr, ReprMut, ReprOwned, SliceError,
+    Standard,
 };

--- a/diskann-quantization/tests/compile-fail/multi/mat_as_view.rs
+++ b/diskann-quantization/tests/compile-fail/multi/mat_as_view.rs
@@ -8,7 +8,7 @@ use diskann_quantization::multi_vector::{Mat, Standard};
 // Test that `as_view` on Mat correctly captures an immutable borrow,
 // preventing mutation of the Mat while the view is in scope.
 fn main() {
-    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3), 0.0f32).unwrap();
+    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3).unwrap(), 0.0f32).unwrap();
     let view = mat.as_view();
     // This should fail: we cannot mutably borrow `mat` while `view` exists
     let _ = mat.as_view_mut();

--- a/diskann-quantization/tests/compile-fail/multi/mat_as_view_mut.rs
+++ b/diskann-quantization/tests/compile-fail/multi/mat_as_view_mut.rs
@@ -8,7 +8,7 @@ use diskann_quantization::multi_vector::{Mat, Standard};
 // Test that `as_view_mut` on Mat correctly captures a mutable lifetime,
 // preventing the Mat from being used while the mutable view is in scope.
 fn main() {
-    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3), 0.0f32).unwrap();
+    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3).unwrap(), 0.0f32).unwrap();
     let view = mat.as_view_mut();
     // This should fail: we cannot use `mat` while `view` is still alive
     let _ = mat.num_vectors();

--- a/diskann-quantization/tests/compile-fail/multi/mat_get_row.rs
+++ b/diskann-quantization/tests/compile-fail/multi/mat_get_row.rs
@@ -8,7 +8,7 @@ use diskann_quantization::multi_vector::{Mat, Standard};
 // Test that `get_row` on Mat correctly captures an immutable borrow,
 // preventing mutation of the Mat while the row is in scope.
 fn main() {
-    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3), 0.0f32).unwrap();
+    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3).unwrap(), 0.0f32).unwrap();
     let row = mat.get_row(0).unwrap();
     // This should fail: we cannot mutably borrow `mat` while `row` exists
     let _ = mat.get_row_mut(1);

--- a/diskann-quantization/tests/compile-fail/multi/mat_get_row_mut.rs
+++ b/diskann-quantization/tests/compile-fail/multi/mat_get_row_mut.rs
@@ -8,7 +8,7 @@ use diskann_quantization::multi_vector::{Mat, Standard};
 // Test that `get_row_mut` on Mat correctly captures a mutable
 // lifetime, preventing the Mat from being used while the row is in scope.
 fn main() {
-    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3), 0.0f32).unwrap();
+    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3).unwrap(), 0.0f32).unwrap();
     let row = mat.get_row_mut(0).unwrap();
     // This should fail: we cannot use `mat` while `row` is still borrowed
     let _ = mat.num_vectors();

--- a/diskann-quantization/tests/compile-fail/multi/mat_reborrow.rs
+++ b/diskann-quantization/tests/compile-fail/multi/mat_reborrow.rs
@@ -9,7 +9,7 @@ use diskann_utils::Reborrow;
 // Test that `reborrow` on Mat correctly captures an immutable borrow,
 // preventing mutation of the Mat while the reborrow is in scope.
 fn main() {
-    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3), 0.0f32).unwrap();
+    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3).unwrap(), 0.0f32).unwrap();
     let view = mat.reborrow();
     // This should fail: we cannot mutably borrow `mat` while `view` exists
     let _ = mat.as_view_mut();

--- a/diskann-quantization/tests/compile-fail/multi/mat_reborrow_mut.rs
+++ b/diskann-quantization/tests/compile-fail/multi/mat_reborrow_mut.rs
@@ -9,7 +9,7 @@ use diskann_utils::ReborrowMut;
 // Test that `reborrow_mut` on Mat correctly captures a mutable borrow,
 // preventing use of the Mat while the reborrow is in scope.
 fn main() {
-    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3), 0.0f32).unwrap();
+    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3).unwrap(), 0.0f32).unwrap();
     let view = mat.reborrow_mut();
     // This should fail: we cannot use `mat` while `view` exists
     let _ = mat.num_vectors();

--- a/diskann-quantization/tests/compile-fail/multi/mat_rows.rs
+++ b/diskann-quantization/tests/compile-fail/multi/mat_rows.rs
@@ -8,7 +8,7 @@ use diskann_quantization::multi_vector::{Mat, Standard};
 // Test that `rows` on Mat correctly captures an immutable borrow,
 // preventing mutation of the Mat while the iterator is in scope.
 fn main() {
-    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3), 0.0f32).unwrap();
+    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3).unwrap(), 0.0f32).unwrap();
     let iter = mat.rows();
     // This should fail: we cannot mutably borrow `mat` while `iter` exists
     let _ = mat.as_view_mut();

--- a/diskann-quantization/tests/compile-fail/multi/mat_rows_mut.rs
+++ b/diskann-quantization/tests/compile-fail/multi/mat_rows_mut.rs
@@ -8,7 +8,7 @@ use diskann_quantization::multi_vector::{Mat, Standard};
 // Test that the `rows_mut` iterator correctly captures a mutable lifetime,
 // preventing the Mat from being used while the iterator is in scope.
 fn main() {
-    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3), 0.0f32).unwrap();
+    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3).unwrap(), 0.0f32).unwrap();
     let iter = mat.rows_mut();
     // This should fail: we cannot use `mat` while the mutable iterator is alive
     let _ = mat.num_vectors();

--- a/diskann-quantization/tests/compile-fail/multi/matmut_as_view_borrows.rs
+++ b/diskann-quantization/tests/compile-fail/multi/matmut_as_view_borrows.rs
@@ -8,7 +8,7 @@ use diskann_quantization::multi_vector::{Mat, MatMut, Standard};
 // Test that `as_view` on MatMut correctly captures an immutable lifetime,
 // preventing mutating the MatMut while the immutable view is in scope.
 fn main() {
-    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3), 0.0f32).unwrap();
+    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3).unwrap(), 0.0f32).unwrap();
     let mut view: MatMut<'_, Standard<f32>> = mat.as_view_mut();
     let immut_view = view.as_view();
     // This should fail: we cannot mutate `view` while `immut_view` exists

--- a/diskann-quantization/tests/compile-fail/multi/matmut_get_row.rs
+++ b/diskann-quantization/tests/compile-fail/multi/matmut_get_row.rs
@@ -8,7 +8,7 @@ use diskann_quantization::multi_vector::{Mat, MatMut, Standard};
 // Test that `get_row` on MatMut correctly captures an immutable borrow,
 // preventing mutation of the MatMut while the row is in scope.
 fn main() {
-    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3), 0.0f32).unwrap();
+    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3).unwrap(), 0.0f32).unwrap();
     let mut view: MatMut<'_, Standard<f32>> = mat.as_view_mut();
     let row = view.get_row(0).unwrap();
     // This should fail: we cannot mutably borrow `view` while `row` exists

--- a/diskann-quantization/tests/compile-fail/multi/matmut_get_row_mut.rs
+++ b/diskann-quantization/tests/compile-fail/multi/matmut_get_row_mut.rs
@@ -8,7 +8,7 @@ use diskann_quantization::multi_vector::{Mat, MatMut, Standard};
 // Test that `get_row_mut` on MatMut correctly captures a mutable lifetime,
 // preventing the MatMut from being used while the row is in scope.
 fn main() {
-    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3), 0.0f32).unwrap();
+    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3).unwrap(), 0.0f32).unwrap();
     let mut view: MatMut<'_, Standard<f32>> = mat.as_view_mut();
     let row = view.get_row_mut(0).unwrap();
     // This should fail: we cannot use `view` while `row` is still borrowed

--- a/diskann-quantization/tests/compile-fail/multi/matmut_reborrow.rs
+++ b/diskann-quantization/tests/compile-fail/multi/matmut_reborrow.rs
@@ -9,7 +9,7 @@ use diskann_utils::Reborrow;
 // Test that `reborrow` on MatMut correctly captures an immutable borrow,
 // preventing mutation of the MatMut while the reborrow is in scope.
 fn main() {
-    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3), 0.0f32).unwrap();
+    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3).unwrap(), 0.0f32).unwrap();
     let mut view: MatMut<'_, Standard<f32>> = mat.as_view_mut();
     let immut_view = view.reborrow();
     // This should fail: we cannot mutably borrow `view` while `immut_view` exists

--- a/diskann-quantization/tests/compile-fail/multi/matmut_reborrow_mut.rs
+++ b/diskann-quantization/tests/compile-fail/multi/matmut_reborrow_mut.rs
@@ -9,7 +9,7 @@ use diskann_utils::ReborrowMut;
 // Test that `reborrow_mut` on MatMut correctly captures a mutable lifetime,
 // preventing the original MatMut from being used while the reborrow is in scope.
 fn main() {
-    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3), 0.0f32).unwrap();
+    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3).unwrap(), 0.0f32).unwrap();
     let mut view: MatMut<'_, Standard<f32>> = mat.as_view_mut();
     let reborrowed = view.reborrow_mut();
     // This should fail: we cannot use `view` while `reborrowed` is still alive

--- a/diskann-quantization/tests/compile-fail/multi/matmut_rows.rs
+++ b/diskann-quantization/tests/compile-fail/multi/matmut_rows.rs
@@ -8,7 +8,7 @@ use diskann_quantization::multi_vector::{Mat, MatMut, Standard};
 // Test that `rows` on MatMut correctly captures an immutable borrow,
 // preventing mutation of the MatMut while the iterator is in scope.
 fn main() {
-    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3), 0.0f32).unwrap();
+    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3).unwrap(), 0.0f32).unwrap();
     let mut view: MatMut<'_, Standard<f32>> = mat.as_view_mut();
     let iter = view.rows();
     // This should fail: we cannot mutably borrow `view` while `iter` exists

--- a/diskann-quantization/tests/compile-fail/multi/matmut_rows_mut.rs
+++ b/diskann-quantization/tests/compile-fail/multi/matmut_rows_mut.rs
@@ -8,7 +8,7 @@ use diskann_quantization::multi_vector::{Mat, MatMut, Standard};
 // Test that the `rows_mut` iterator on MatMut correctly captures a mutable lifetime,
 // preventing the MatMut from being used while the iterator is in scope.
 fn main() {
-    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3), 0.0f32).unwrap();
+    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3).unwrap(), 0.0f32).unwrap();
     let mut view: MatMut<'_, Standard<f32>> = mat.as_view_mut();
     let iter = view.rows_mut();
     // This should fail: we cannot use `view` while the mutable iterator is alive

--- a/diskann-quantization/tests/compile-fail/multi/matref_get_row.rs
+++ b/diskann-quantization/tests/compile-fail/multi/matref_get_row.rs
@@ -8,7 +8,7 @@ use diskann_quantization::multi_vector::{Mat, MatRef, Standard};
 // Test that `get_row` on MatRef returns a row with the correct lifetime,
 // and that an immutable borrow is held while the row is in scope.
 fn main() {
-    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3), 0.0f32).unwrap();
+    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3).unwrap(), 0.0f32).unwrap();
     let view: MatRef<'_, Standard<f32>> = mat.as_view();
     let row = view.get_row(0).unwrap();
     // This should fail: we cannot mutably borrow `mat` while `row` exists

--- a/diskann-quantization/tests/compile-fail/multi/matref_rows.rs
+++ b/diskann-quantization/tests/compile-fail/multi/matref_rows.rs
@@ -8,7 +8,7 @@ use diskann_quantization::multi_vector::{Mat, MatRef, Standard};
 // Test that `rows` on MatRef returns an iterator with the correct lifetime,
 // preventing mutation of the underlying Mat while iterating.
 fn main() {
-    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3), 0.0f32).unwrap();
+    let mut mat: Mat<Standard<f32>> = Mat::new(Standard::new(4, 3).unwrap(), 0.0f32).unwrap();
     let view: MatRef<'_, Standard<f32>> = mat.as_view();
     let iter = view.rows();
     // This should fail: we cannot mutably borrow `mat` while `iter` exists


### PR DESCRIPTION
Move the check that:

1. `nrows * ncols` will not overflow
2. `nrows * ncols * std::mem::size_of::<T>()` will not exceed `isize::MAX`

into the constructor `Standard::new()`. This allows the calculation of the number of elements and allocation sizes to be performed with safely with reckless abandon in implementation code as we no longer need to worry about overflow. The constructor `Standard::new()` can now return an error, which is slightly less ergonomic, but I think the improved safety in the implementation is worth it.