### PR TITLE
Bump version to 0.46.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "diskann"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-core"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "diskann",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-runner"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-simd"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "diskann-benchmark-runner",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-disk"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-label-filter"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-linalg"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "approx",
  "cfg-if",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-platform"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "io-uring",
  "libc",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-providers"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-quantization"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-tools"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-utils"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "cfg-if",
  "diskann-vector",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-vector"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "approx",
  "cfg-if",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-wide"
-version = "0.45.0"
+version = "0.46.0"
 dependencies = [
  "cfg-if",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.45.0"      # Obeying semver
+version = "0.46.0"      # Obeying semver
 description = "DiskANN is a fast approximate nearest neighbor search library for high dimensional data"
 authors = ["Microsoft"]
 documentation = "https://github.com/microsoft/DiskANN"
@@ -46,22 +46,22 @@ undocumented_unsafe_blocks = "warn"
 
 [workspace.dependencies]
 # Base And Numerics
-diskann-wide = { path = "diskann-wide", version = "0.45.0" }
-diskann-vector = { path = "diskann-vector", version = "0.45.0" }
-diskann-linalg = { path = "diskann-linalg", version = "0.45.0" }
-diskann-utils = { path = "diskann-utils", default-features = false, version = "0.45.0" }
-diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.45.0" }
-diskann-platform = { path = "diskann-platform", version = "0.45.0" }
+diskann-wide = { path = "diskann-wide", version = "0.46.0" }
+diskann-vector = { path = "diskann-vector", version = "0.46.0" }
+diskann-linalg = { path = "diskann-linalg", version = "0.46.0" }
+diskann-utils = { path = "diskann-utils", default-features = false, version = "0.46.0" }
+diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.46.0" }
+diskann-platform = { path = "diskann-platform", version = "0.46.0" }
 # Algorithm
-diskann = { path = "diskann", version = "0.45.0" }
+diskann = { path = "diskann", version = "0.46.0" }
 # Providers
-diskann-providers = { path = "diskann-providers", default-features = false, version = "0.45.0" }
-diskann-disk = { path = "diskann-disk", version = "0.45.0" }
-diskann-label-filter = { path = "diskann-label-filter", version = "0.45.0" }
+diskann-providers = { path = "diskann-providers", default-features = false, version = "0.46.0" }
+diskann-disk = { path = "diskann-disk", version = "0.46.0" }
+diskann-label-filter = { path = "diskann-label-filter", version = "0.46.0" }
 # Infra
-diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.45.0" }
-diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.45.0" }
-diskann-tools = { path = "diskann-tools", version = "0.45.0" }
+diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.46.0" }
+diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.46.0" }
+diskann-tools = { path = "diskann-tools", version = "0.46.0" }
 
 # External dependencies (shared versions)
 anyhow = "1.0.98"


### PR DESCRIPTION
## What's Changed

### API Breaking Changes
* Remove the `experimental_avx512` feature. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/732
* Use VirtualStorageProvider::new_overlay(test_data_root()) in tests by @Copilot in https://github.com/microsoft/DiskANN/pull/726
* save and load max_record_size and leaf_page_size for bftrees by @backurs in https://github.com/microsoft/DiskANN/pull/724
* [multi-vector] Verify `Standard` won't overflow in its constructor. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/757
* VirtualStorageProvider: Make new() private, add new_physical by @Copilot in https://github.com/microsoft/DiskANN/pull/764
* [minmax] Refactor full query by @arkrishn94 in https://github.com/microsoft/DiskANN/pull/770
* Bump diskann-quantization to edition 2024. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/772

### Additions
* [multi-vector] Enable cloning of `Mat` and friends. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/759
* adding bftreepaths in mod.rs by @backurs in https://github.com/microsoft/DiskANN/pull/775
* [quantization] Add `as_raw_ptr`. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/774

### Bug Fixes
* Fix `diskann` compilation without default-features and add CI tests. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/722

### Docs and Comments
* Updating the benchmark README to use diskann-benchmark by @bryantower in https://github.com/microsoft/DiskANN/pull/709
* Fix doc comment: Windows line endings are \r\n not \n\r by @Copilot in https://github.com/microsoft/DiskANN/pull/717
* Fix spelling errors in streaming API documentation by @Copilot in https://github.com/microsoft/DiskANN/pull/715
* Add performance diagnostic to `diskann-benchmark` by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/744
* Add agents.md onboarding guide for coding agents by @Copilot in https://github.com/microsoft/DiskANN/pull/765
* [doc] Fix lots of little typos in `diskann-wide` by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/771

### Performance
* [diskann-wide] Optimize `load_simd_first` for 8-bit and 16-bit element types. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/747

### Dependencies
* Bump bytes from 1.11.0 to 1.11.1 by @dependabot[bot] in https://github.com/microsoft/DiskANN/pull/723
* [diskann] Add note on the selection of `PruneKind` in `graph::config::Builder`. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/734
* [diskann-providers] Remove the LRU dependency and make `vfs` and `serde_json` optional. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/733

### Infrastructure
* Add initial QEMU tests for `diskann-wide`. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/719
* [CI] Skip coverage for Dependabot. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/725
* Add miri test coverage to CI workflow by @Copilot in https://github.com/microsoft/DiskANN/pull/729
* [CI] Add minimal ARM checks by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/745
* Enable CodeQL security analysis by @Copilot in https://github.com/microsoft/DiskANN/pull/754

## New Contributors
* @backurs made their first contribution in https://github.com/microsoft/DiskANN/pull/724
* @arkrishn94 made their first contribution in https://github.com/microsoft/DiskANN/pull/770

**Full Changelog**: https://github.com/microsoft/DiskANN/compare/0.45.0...0.46.0