### PR TITLE
Adding GraphParams to be able to save graph parameters of index to SavedParams

### DIFF
--- a/diskann-providers/src/model/graph/provider/async_/bf_tree/mod.rs
+++ b/diskann-providers/src/model/graph/provider/async_/bf_tree/mod.rs
@@ -10,8 +10,8 @@ mod vector_provider;
 
 // Accessors
 pub use provider::{
-    BfTreePaths, BfTreeProvider, BfTreeProviderParameters, CreateQuantProvider, FullAccessor,
-    GraphParams, Hidden, Index, QuantAccessor, QuantIndex, StartPoint, VectorDtype,
+    AsVectorDtype, BfTreePaths, BfTreeProvider, BfTreeProviderParameters, CreateQuantProvider,
+    FullAccessor, GraphParams, Hidden, Index, QuantAccessor, QuantIndex, StartPoint, VectorDtype,
 };
 
 pub use bf_tree::Config;

--- a/diskann-providers/src/model/graph/provider/async_/bf_tree/provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/bf_tree/provider.rs
@@ -1838,19 +1838,26 @@ pub enum VectorDtype {
     I8,
 }
 
-impl VectorDtype {
-    /// Derive the `VectorDtype` from a concrete [`VectorRepr`] type parameter.
-    #[allow(clippy::panic)]
-    pub fn from_type<T: VectorRepr>() -> Self {
-        let name = std::any::type_name::<T>();
-        match name {
-            "f32" => Self::F32,
-            "half::f16" | "f16" => Self::F16,
-            "i8" => Self::I8,
-            "u8" => Self::U8,
-            _ => panic!("unsupported VectorRepr type: {}", name),
-        }
-    }
+/// A trait for mapping concrete vector element types to their [`VectorDtype`]
+/// discriminant at compile time.
+pub trait AsVectorDtype {
+    const DATA_TYPE: VectorDtype;
+}
+
+impl AsVectorDtype for f32 {
+    const DATA_TYPE: VectorDtype = VectorDtype::F32;
+}
+
+impl AsVectorDtype for half::f16 {
+    const DATA_TYPE: VectorDtype = VectorDtype::F16;
+}
+
+impl AsVectorDtype for i8 {
+    const DATA_TYPE: VectorDtype = VectorDtype::I8;
+}
+
+impl AsVectorDtype for u8 {
+    const DATA_TYPE: VectorDtype = VectorDtype::U8;
 }
 
 /// Graph configuration parameters persisted alongside the index.


### PR DESCRIPTION
This PR addresses the following issue:

We want to save alpha, l_build, backedge_ratio and vector_dtype somewhere and the best place to do it (in my opinion) is SavedParams.
For that we need to save GraphParams in BfTreeProviderParameters and in BfTreeProvider. This is what this PR does.