### PR TITLE
Enabling flag support in codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,6 +20,24 @@ coverage:
         threshold: 0%
         informational: false
 
+flag_management:
+  default_rules: # the rules that will be followed for any flag added, generally
+    carryforward: true
+    statuses:
+      - type: project
+        target: auto
+        threshold: 1%
+      - type: patch
+        target: 90%
+  individual_flags: # exceptions to the default rules above, stated flag by flag
+    - name: miri
+      carryforward: true
+      statuses:
+        - type: project
+          target: 0%
+        - type: patch
+          target: 0%
+
 comment:
   layout: "reach,diff,flags,tree"
   behavior: default


### PR DESCRIPTION
It seems like flags we pass during upload of code coverage data, are not properly handled by codecov:
```
      - name: Upload coverage to Codecov
        uses: codecov/codecov-action@v4
        with:
          files: lcov.info
          fail_ci_if_error: true
          flags: unittests
        env:
          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

      - name: Upload miri coverage to Codecov
        uses: codecov/codecov-action@v4
        with:
          files: lcov_miri.info
          fail_ci_if_error: true
          flags: miri
```

This PR attempts to follow https://docs.codecov.com/docs/flags and enable flag support in .codecov.yml