### PR TITLE
Expand BetaFilter for External SearchStrategy Implementations

### DIFF
--- a/diskann-providers/src/model/graph/provider/layers/betafilter.rs
+++ b/diskann-providers/src/model/graph/provider/layers/betafilter.rs
@@ -112,12 +112,13 @@ where
 ///
 /// The [`BetaComputer`] then uses this ID to consult the filter predicate and adjust the
 /// distance accordingly.
-impl<Provider, Strategy, T, I> SearchStrategy<Provider, T> for BetaFilter<Strategy, I>
+impl<Provider, Strategy, T, I, O> SearchStrategy<Provider, T, O> for BetaFilter<Strategy, I>
 where
     T: ?Sized,
     I: VectorId,
+    O: Send,
     Provider: DataProvider<InternalId = I>,
-    Strategy: SearchStrategy<Provider, T>,
+    Strategy: SearchStrategy<Provider, T, O>,
 {
     /// An accessor that returns the ID in addition to the element yielded by the inner
     /// accessor.

--- a/diskann-providers/src/model/graph/provider/layers/mod.rs
+++ b/diskann-providers/src/model/graph/provider/layers/mod.rs
@@ -11,4 +11,4 @@
 //! * [`BetaFilter`]
 
 mod betafilter;
-pub use betafilter::{BetaAccessor, BetaComputer, BetaFilter, Unwrap as BetaFilterUnwrap};
+pub use betafilter::BetaFilter;


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ y] Does this PR have a descriptive title that could go in our release notes?
- [n ] Does this PR add any new dependencies?
- [y ] Does this PR modify any existing APIs?
- [ y] Is the change to the API backwards compatible?
- [n ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
The extra O generic is needed because the original 2-parameter form     
  SearchStrategy<Provider, T> defaults O to Provider::InternalId, which is   u32. That means BetaFilter could only produce search results as u32      (internal IDs).                                                         
                                                                          
  In diskann-garnet, the unfiltered path uses FullPrecision, which        
  implements SearchStrategy<Provider, T, O> for any O — so it can output
  GarnetId directly into SearchResults<GarnetId>. But BetaFilter was      
  locked to O = u32, forcing diskann-garnet to use the
  FilteredSearchResults adapter to convert u32 → GarnetId after the       
  search.

  By adding O to BetaFilter's impl:

  impl<Provider, Strategy, T, I, O> SearchStrategy<Provider, T, O> for    
  BetaFilter<Strategy, I>
  where
      O: Send,
      Strategy: SearchStrategy<Provider, T, O>,

  BetaFilter becomes transparent to the output type — it delegates O to   
  whatever the inner strategy uses. If the inner strategy (FullPrecision) 
  can output GarnetId, then BetaFilter wrapping it can too. This
  eliminates the need for FilteredSearchResults entirely.

  The O: Send bound is required because SearchStrategy needs O: Send for  
  the search output buffer to work across async boundaries.


#### Any other comments?

Removed previous solution to reimport the beta's internal:
Why these types need to be public:

  - BetaFilter's blanket impl (SearchStrategy<Provider, T>) hard-codes the output to the provider's internal ID     
  (u32). Consumers with a different external ID type (like GarnetId) can't use BetaFilter directly with their output
   buffer — they're forced to write an adapter (FilteredSearchResults) that accepts u32 and manually converts.      
  - If BetaAccessor/BetaComputer/Unwrap are re-exported, consumers can write:
  impl<T: VectorRepr> SearchStrategy<GarnetProvider<T>, [T], GarnetId>
      for BetaFilter<FullPrecision, u32>
  - naming the associated types directly, and the conversion     
  happens in the post-processor — no wrapper needed.

