### PR TITLE
(Do not review) Refactor post-processing logic from the core search and implement rag_search using that pattern

### DIFF
--- a/diskann-benchmark-core/src/search/graph/mod.rs
+++ b/diskann-benchmark-core/src/search/graph/mod.rs
@@ -5,12 +5,14 @@
 
 pub mod knn;
 pub mod multihop;
+pub mod rag;
 pub mod range;
 
 pub mod strategy;
 
 pub use knn::KNN;
 pub use multihop::MultiHop;
+pub use rag::RAG;
 pub use range::Range;
 
 pub use strategy::Strategy;

--- a/diskann-benchmark-core/src/search/graph/rag.rs
+++ b/diskann-benchmark-core/src/search/graph/rag.rs
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+//! A built-in helper for benchmarking RAG (Retrieval-Augmented Generation) search.
+//!
+//! This mirrors [`super::KNN`] but uses [`graph::search::RagSearch`] as the search
+//! parameters, applying diversity-maximizing reranking in post-processing.
+
+use std::sync::Arc;
+
+use diskann::{
+    ANNResult,
+    graph::{self, glue},
+    provider,
+};
+use diskann_benchmark_runner::utils::{MicroSeconds, percentiles};
+use diskann_utils::{future::AsyncFriendly, views::Matrix};
+
+use crate::{
+    search::{self, Search, graph::Strategy},
+    utils,
+};
+
+/// A built-in helper for benchmarking the RAG search method
+/// [`graph::DiskANNIndex::search`] with [`graph::search::RagSearch`].
+///
+/// This is identical to [`super::KNN`] in structure but uses [`graph::search::RagSearch`]
+/// as the search parameters, which applies diversity-maximizing reranking via greedy
+/// orthogonalization in post-processing.
+///
+/// The provided implementation of [`Search`] accepts [`graph::search::RagSearch`]
+/// and returns [`super::knn::Metrics`] as additional output.
+#[derive(Debug)]
+pub struct RAG<DP, T, S>
+where
+    DP: provider::DataProvider,
+{
+    index: Arc<graph::DiskANNIndex<DP>>,
+    queries: Arc<Matrix<T>>,
+    strategy: Strategy<S>,
+}
+
+impl<DP, T, S> RAG<DP, T, S>
+where
+    DP: provider::DataProvider,
+{
+    /// Construct a new [`RAG`] searcher.
+    ///
+    /// If `strategy` is one of the container variants of [`Strategy`], its length
+    /// must match the number of rows in `queries`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the number of elements in `strategy` is not compatible with
+    /// the number of rows in `queries`.
+    pub fn new(
+        index: Arc<graph::DiskANNIndex<DP>>,
+        queries: Arc<Matrix<T>>,
+        strategy: Strategy<S>,
+    ) -> anyhow::Result<Arc<Self>> {
+        strategy.length_compatible(queries.nrows())?;
+
+        Ok(Arc::new(Self {
+            index,
+            queries,
+            strategy,
+        }))
+    }
+}
+
+impl<DP, T, S> Search for RAG<DP, T, S>
+where
+    DP: provider::DataProvider<Context: Default, ExternalId: search::Id>,
+    S: glue::SearchStrategy<DP, [T], DP::ExternalId>
+        + glue::PostProcess<graph::search::RagSearchParams, DP, [T], DP::ExternalId>
+        + Clone
+        + AsyncFriendly,
+    T: AsyncFriendly + Clone,
+{
+    type Id = DP::ExternalId;
+    type Parameters = graph::search::RagSearch;
+    type Output = super::knn::Metrics;
+
+    fn num_queries(&self) -> usize {
+        self.queries.nrows()
+    }
+
+    fn id_count(&self, parameters: &Self::Parameters) -> search::IdCount {
+        search::IdCount::Fixed(parameters.k_value())
+    }
+
+    async fn search<O>(
+        &self,
+        parameters: &Self::Parameters,
+        buffer: &mut O,
+        index: usize,
+    ) -> ANNResult<Self::Output>
+    where
+        O: graph::SearchOutputBuffer<DP::ExternalId> + Send,
+    {
+        let context = DP::Context::default();
+        let rag_search = parameters.clone();
+        let stats = self
+            .index
+            .search(
+                rag_search,
+                self.strategy.get(index)?,
+                &context,
+                self.queries.row(index),
+                buffer,
+            )
+            .await?;
+
+        Ok(super::knn::Metrics {
+            comparisons: stats.cmps,
+            hops: stats.hops,
+        })
+    }
+}
+
+/// An [`search::Aggregate`]d summary of multiple [`RAG`] search runs.
+///
+/// This reuses [`super::knn::Summary`] since the output format is identical —
+/// the only difference is the search parameters type.
+pub struct Aggregator<'a, I> {
+    groundtruth: &'a dyn crate::recall::Rows<I>,
+    recall_k: usize,
+    recall_n: usize,
+}
+
+impl<'a, I> Aggregator<'a, I> {
+    /// Construct a new [`Aggregator`] using `groundtruth` for recall computation.
+    pub fn new(
+        groundtruth: &'a dyn crate::recall::Rows<I>,
+        recall_k: usize,
+        recall_n: usize,
+    ) -> Self {
+        Self {
+            groundtruth,
+            recall_k,
+            recall_n,
+        }
+    }
+}
+
+impl<I> search::Aggregate<graph::search::RagSearch, I, super::knn::Metrics> for Aggregator<'_, I>
+where
+    I: crate::recall::RecallCompatible,
+{
+    type Output = super::knn::Summary;
+
+    fn aggregate(
+        &mut self,
+        run: search::Run<graph::search::RagSearch>,
+        mut results: Vec<search::SearchResults<I, super::knn::Metrics>>,
+    ) -> anyhow::Result<super::knn::Summary> {
+        // Compute the recall using just the first result.
+        let recall = match results.first() {
+            Some(first) => crate::recall::knn(
+                self.groundtruth,
+                None,
+                first.ids().as_rows(),
+                self.recall_k,
+                self.recall_n,
+                true,
+            )?,
+            None => anyhow::bail!("Results must be non-empty"),
+        };
+
+        let mut mean_latencies = Vec::with_capacity(results.len());
+        let mut p90_latencies = Vec::with_capacity(results.len());
+        let mut p99_latencies = Vec::with_capacity(results.len());
+
+        results.iter_mut().for_each(|r| {
+            match percentiles::compute_percentiles(r.latencies_mut()) {
+                Ok(values) => {
+                    let percentiles::Percentiles { mean, p90, p99, .. } = values;
+                    mean_latencies.push(mean);
+                    p90_latencies.push(p90);
+                    p99_latencies.push(p99);
+                }
+                Err(_) => {
+                    let zero = MicroSeconds::new(0);
+                    mean_latencies.push(0.0);
+                    p90_latencies.push(zero);
+                    p99_latencies.push(zero);
+                }
+            }
+        });
+
+        // Extract the inner Knn parameters so we can produce a knn::Summary.
+        let knn_params = *run.parameters().knn();
+
+        Ok(super::knn::Summary {
+            setup: run.setup().clone(),
+            parameters: knn_params,
+            end_to_end_latencies: results.iter().map(|r| r.end_to_end_latency()).collect(),
+            recall,
+            mean_latencies,
+            p90_latencies,
+            p99_latencies,
+            mean_cmps: utils::average_all(
+                results
+                    .iter()
+                    .flat_map(|r| r.output().iter().map(|o| o.comparisons)),
+            ),
+            mean_hops: utils::average_all(
+                results
+                    .iter()
+                    .flat_map(|r| r.output().iter().map(|o| o.hops)),
+            ),
+        })
+    }
+}

--- a/diskann-benchmark/example/mimir-search-rag.json
+++ b/diskann-benchmark/example/mimir-search-rag.json
@@ -1,0 +1,31 @@
+{
+  "search_directories": [
+    "C:/data/mimir"
+  ],
+  "jobs": [
+    {
+      "type": "disk-index",
+      "content": {
+        "source": {
+          "disk-index-source": "Load",
+          "data_type": "float16",
+          "load_path": "C:/data/mimir/mimir_new"
+        },
+        "search_phase": {
+          "queries": "mimir_query.bin",
+          "groundtruth": "mimir_gt_1000.bin",
+          "search_list": [2000],
+          "beam_width": 4,
+          "recall_at": 1000,
+          "num_threads": 1,
+          "is_flat_search": false,
+          "distance": "squared_l2",
+          "vector_filters_file": null,
+          "is_rag_search": true,
+          "rag_eta": 0.01,
+          "rag_power": 2.0
+        }
+      }
+    }
+  ]
+}

--- a/diskann-benchmark/example/mimir-search-standard-knn.json
+++ b/diskann-benchmark/example/mimir-search-standard-knn.json
@@ -1,0 +1,31 @@
+{
+  "search_directories": [
+    "C:/data/mimir"
+  ],
+  "jobs": [
+    {
+      "type": "disk-index",
+      "content": {
+        "source": {
+          "disk-index-source": "Load",
+          "data_type": "float16",
+          "load_path": "C:/data/mimir/mimir_new"
+        },
+        "search_phase": {
+          "queries": "mimir_query.bin",
+          "groundtruth": "mimir_gt_1000.bin",
+          "search_list": [2000],
+          "beam_width": 4,
+          "recall_at": 1000,
+          "num_threads": 1,
+          "is_flat_search": false,
+          "distance": "squared_l2",
+          "vector_filters_file": null,
+          "is_rag_search": false,
+          "rag_eta": null,
+          "rag_power": null
+        }
+      }
+    }
+  ]
+}

--- a/diskann-benchmark/example/rag-search.json
+++ b/diskann-benchmark/example/rag-search.json
@@ -1,0 +1,59 @@
+{
+  "search_directories": [
+    "test_data/disk_index_search"
+  ],
+  "jobs": [
+    {
+      "type": "async-index-build",
+      "content": {
+        "source": {
+          "index-source": "Load",
+          "data_type": "float32",
+          "distance": "squared_l2",
+          "load_path": "disk_index_siftsmall_learn_256pts_saved_index"
+        },
+        "search_phase": {
+          "search-type": "topk",
+          "queries": "disk_index_sample_query_10pts.fbin",
+          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "reps": 3,
+          "num_threads": [1],
+          "runs": [
+            {
+              "search_n": 10,
+              "search_l": [10, 20, 50, 100],
+              "recall_k": 10
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "async-index-build",
+      "content": {
+        "source": {
+          "index-source": "Load",
+          "data_type": "float32",
+          "distance": "squared_l2",
+          "load_path": "disk_index_siftsmall_learn_256pts_saved_index"
+        },
+        "search_phase": {
+          "search-type": "topk-rag",
+          "queries": "disk_index_sample_query_10pts.fbin",
+          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "reps": 3,
+          "num_threads": [1],
+          "runs": [
+            {
+              "search_n": 10,
+              "search_l": [10, 20, 50, 100],
+              "recall_k": 10
+            }
+          ],
+          "rag_eta": 0.01,
+          "rag_power": 2.0
+        }
+      }
+    }
+  ]
+}

--- a/diskann-benchmark/src/backend/disk_index/search.rs
+++ b/diskann-benchmark/src/backend/disk_index/search.rs
@@ -44,6 +44,7 @@ pub(super) struct DiskSearchStats {
     pub(crate) is_flat_search: bool,
     pub(crate) distance: SimilarityMeasure,
     pub(crate) uses_vector_filters: bool,
+    pub(crate) is_rag_search: bool,
     pub(super) num_nodes_to_cache: Option<usize>,
     pub(super) search_results_per_l: Vec<DiskSearchResult>,
     span_metrics: serde_json::Value,
@@ -261,6 +262,10 @@ where
             .zip(statistics_vec.par_iter_mut())
             .zip(result_counts.par_iter_mut());
 
+        let is_rag = search_params.is_rag_search.unwrap_or(false);
+        let rag_eta = search_params.rag_eta.unwrap_or(0.01);
+        let rag_power = search_params.rag_power.unwrap_or(2.0);
+
         zipped.for_each_in_pool(&pool, |(((((q, vf), id_chunk), dist_chunk), stats), rc)| {
             let vector_filter = if search_params.vector_filters_file.is_none() {
                 None
@@ -269,14 +274,28 @@ where
                     as Box<dyn Fn(&u32) -> bool + Send + Sync>)
             };
 
-            match searcher.search(
-                q,
-                search_params.recall_at,
-                l,
-                Some(search_params.beam_width),
-                vector_filter,
-                search_params.is_flat_search,
-            ) {
+            let search_result = if is_rag {
+                searcher.search_rag(
+                    q,
+                    search_params.recall_at,
+                    l,
+                    Some(search_params.beam_width),
+                    vector_filter,
+                    rag_eta,
+                    rag_power,
+                )
+            } else {
+                searcher.search(
+                    q,
+                    search_params.recall_at,
+                    l,
+                    Some(search_params.beam_width),
+                    vector_filter,
+                    search_params.is_flat_search,
+                )
+            };
+
+            match search_result {
                 Ok(search_result) => {
                     *stats = search_result.stats.query_statistics;
                     *rc = search_result.results.len() as u32;
@@ -343,6 +362,7 @@ where
         is_flat_search: search_params.is_flat_search,
         distance: search_params.distance,
         uses_vector_filters: search_params.vector_filters_file.is_some(),
+        is_rag_search: search_params.is_rag_search.unwrap_or(false),
         num_nodes_to_cache: search_params.num_nodes_to_cache,
         search_results_per_l,
         span_metrics,
@@ -427,6 +447,7 @@ impl fmt::Display for DiskSearchStats {
         writeln!(f, "Flat search,      : {}", self.is_flat_search)?;
         writeln!(f, "Distance,         : {}", self.distance)?;
         writeln!(f, "Vector filters,   : {}", self.uses_vector_filters)?;
+        writeln!(f, "RAG search,       : {}", self.is_rag_search)?;
         writeln!(
             f,
             "Nodes to cache,   : {}",

--- a/diskann-benchmark/src/backend/index/benchmarks.rs
+++ b/diskann-benchmark/src/backend/index/benchmarks.rs
@@ -43,7 +43,9 @@ use crate::{
         result::{AggregatedSearchResults, BuildResult},
         streaming::{self, managed, stats::StreamStats, FullPrecisionStream, Managed},
     },
-    inputs::async_::{DynamicIndexRun, IndexBuild, IndexOperation, IndexSource, SearchPhase},
+    inputs::async_::{
+        DynamicIndexRun, IndexBuild, IndexOperation, IndexSource, RagSearchPhase, SearchPhase,
+    },
     utils::{
         self,
         datafiles::{self},
@@ -490,6 +492,103 @@ where
             result.append(AggregatedSearchResults::Topk(search_results));
             Ok(result)
         }
+        SearchPhase::TopkRag(search_phase) => {
+            // RAG search is handled by the RunRagSearch trait dispatch.
+            // This arm is unreachable for types that support RAG (f32 with FullPrecision)
+            // and serves as a fallback for types that don't.
+            let _ = (
+                search_phase,
+                search_strategy,
+                index,
+                build_stats,
+                checkpoint,
+            );
+            anyhow::bail!(
+                "RAG search is not supported in this context. \
+                 Use run_search_outer_with_rag or the RunRagSearch trait for f32 full-precision indexes."
+            )
+        }
+    }
+}
+
+/// Trait for dispatching RAG search by element type.
+///
+/// RAG post-processing requires full-precision f32 vectors, so only
+/// `f32` provides a real implementation. Other types bail at runtime.
+trait RunRagSearch:
+    SampleableForStart + std::fmt::Debug + Copy + AsyncFriendly + bytemuck::Pod + VectorRepr
+{
+    fn run_rag(
+        search_phase: &RagSearchPhase,
+        index: diskann_async::MemoryIndex<Self>,
+        build_stats: Option<BuildStats>,
+        checkpoint: Checkpoint<'_>,
+    ) -> anyhow::Result<BuildResult>;
+}
+
+impl RunRagSearch for f16 {
+    fn run_rag(
+        _search_phase: &RagSearchPhase,
+        _index: diskann_async::MemoryIndex<Self>,
+        _build_stats: Option<BuildStats>,
+        _checkpoint: Checkpoint<'_>,
+    ) -> anyhow::Result<BuildResult> {
+        anyhow::bail!("RAG search requires float32 data type")
+    }
+}
+
+impl RunRagSearch for u8 {
+    fn run_rag(
+        _search_phase: &RagSearchPhase,
+        _index: diskann_async::MemoryIndex<Self>,
+        _build_stats: Option<BuildStats>,
+        _checkpoint: Checkpoint<'_>,
+    ) -> anyhow::Result<BuildResult> {
+        anyhow::bail!("RAG search requires float32 data type")
+    }
+}
+
+impl RunRagSearch for i8 {
+    fn run_rag(
+        _search_phase: &RagSearchPhase,
+        _index: diskann_async::MemoryIndex<Self>,
+        _build_stats: Option<BuildStats>,
+        _checkpoint: Checkpoint<'_>,
+    ) -> anyhow::Result<BuildResult> {
+        anyhow::bail!("RAG search requires float32 data type")
+    }
+}
+
+impl RunRagSearch for f32 {
+    fn run_rag(
+        search_phase: &RagSearchPhase,
+        index: diskann_async::MemoryIndex<Self>,
+        build_stats: Option<BuildStats>,
+        checkpoint: Checkpoint<'_>,
+    ) -> anyhow::Result<BuildResult> {
+        let mut result = BuildResult::new_topk(build_stats);
+
+        // Save construction stats before running queries.
+        checkpoint.checkpoint(&result)?;
+
+        let queries: Arc<Matrix<f32>> = Arc::new(datafiles::load_dataset(datafiles::BinFile(
+            &search_phase.queries,
+        ))?);
+
+        let groundtruth =
+            datafiles::load_groundtruth(datafiles::BinFile(&search_phase.groundtruth))?;
+
+        let rag = benchmark_core::search::graph::RAG::new(
+            index,
+            queries,
+            benchmark_core::search::graph::Strategy::broadcast(common::FullPrecision),
+        )?;
+
+        let steps = search::rag::RagSearchSteps::new(search_phase);
+
+        let search_results = search::rag::run(&rag, &groundtruth, steps)?;
+        result.append(AggregatedSearchResults::Topk(search_results));
+        Ok(result)
     }
 }
 
@@ -544,13 +643,17 @@ macro_rules! impl_build {
                     }
                 };
 
-                let result = run_search_outer(
-                    &self.input.search_phase,
-                    common::FullPrecision,
-                    index,
-                    build_stats,
-                    checkpoint,
-                )?;
+                let result = if let SearchPhase::TopkRag(rag_phase) = &self.input.search_phase {
+                    <$T as RunRagSearch>::run_rag(rag_phase, index, build_stats, checkpoint)?
+                } else {
+                    run_search_outer(
+                        &self.input.search_phase,
+                        common::FullPrecision,
+                        index,
+                        build_stats,
+                        checkpoint,
+                    )?
+                };
 
                 writeln!(output, "\n\n{}", result)?;
                 Ok(result)

--- a/diskann-benchmark/src/backend/index/search/mod.rs
+++ b/diskann-benchmark/src/backend/index/search/mod.rs
@@ -4,4 +4,5 @@
  */
 
 pub(crate) mod knn;
+pub(crate) mod rag;
 pub(crate) mod range;

--- a/diskann-benchmark/src/backend/index/search/rag.rs
+++ b/diskann-benchmark/src/backend/index/search/rag.rs
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+use std::{num::NonZeroUsize, sync::Arc};
+
+use diskann_benchmark_core::{self as benchmark_core, search as core_search};
+
+use crate::{
+    backend::index::result::SearchResults,
+    inputs::async_::{GraphSearch, RagSearchPhase},
+};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct RagSearchSteps<'a> {
+    pub reps: NonZeroUsize,
+    pub num_tasks: &'a [NonZeroUsize],
+    pub runs: &'a [GraphSearch],
+    pub rag_eta: f64,
+    pub rag_power: f64,
+}
+
+impl<'a> RagSearchSteps<'a> {
+    pub(crate) fn new(phase: &'a RagSearchPhase) -> Self {
+        Self {
+            reps: phase.reps,
+            num_tasks: &phase.num_threads,
+            runs: &phase.runs,
+            rag_eta: phase.rag_eta,
+            rag_power: phase.rag_power,
+        }
+    }
+}
+
+pub(crate) fn run<I>(
+    runner: &dyn Rag<I>,
+    groundtruth: &dyn benchmark_core::recall::Rows<I>,
+    steps: RagSearchSteps<'_>,
+) -> anyhow::Result<Vec<SearchResults>> {
+    let mut all = Vec::new();
+
+    for threads in steps.num_tasks.iter() {
+        for graph_run in steps.runs.iter() {
+            let setup = core_search::Setup {
+                threads: *threads,
+                tasks: *threads,
+                reps: steps.reps,
+            };
+
+            let parameters: Vec<_> = graph_run
+                .search_l
+                .iter()
+                .map(|search_l| {
+                    let knn = diskann::graph::search::Knn::new(graph_run.search_n, *search_l, None)
+                        .unwrap();
+                    let rag_search =
+                        diskann::graph::search::RagSearch::new(knn, steps.rag_eta, steps.rag_power);
+
+                    core_search::Run::new(rag_search, setup.clone())
+                })
+                .collect();
+
+            all.extend(runner.search_all(
+                parameters,
+                groundtruth,
+                graph_run.recall_k,
+                graph_run.search_n,
+            )?);
+        }
+    }
+
+    Ok(all)
+}
+
+type Run = core_search::Run<diskann::graph::search::RagSearch>;
+
+pub(crate) trait Rag<I> {
+    fn search_all(
+        &self,
+        parameters: Vec<Run>,
+        groundtruth: &dyn benchmark_core::recall::Rows<I>,
+        recall_k: usize,
+        recall_n: usize,
+    ) -> anyhow::Result<Vec<SearchResults>>;
+}
+
+///////////
+// Impls //
+///////////
+
+impl<DP, T, S> Rag<DP::InternalId> for Arc<core_search::graph::RAG<DP, T, S>>
+where
+    DP: diskann::provider::DataProvider,
+    core_search::graph::RAG<DP, T, S>: core_search::Search<
+        Id = DP::InternalId,
+        Parameters = diskann::graph::search::RagSearch,
+        Output = core_search::graph::knn::Metrics,
+    >,
+{
+    fn search_all(
+        &self,
+        parameters: Vec<core_search::Run<diskann::graph::search::RagSearch>>,
+        groundtruth: &dyn benchmark_core::recall::Rows<DP::InternalId>,
+        recall_k: usize,
+        recall_n: usize,
+    ) -> anyhow::Result<Vec<SearchResults>> {
+        let results = core_search::search_all(
+            self.clone(),
+            parameters.into_iter(),
+            core_search::graph::rag::Aggregator::new(groundtruth, recall_k, recall_n),
+        )?;
+
+        Ok(results.into_iter().map(SearchResults::new).collect())
+    }
+}

--- a/diskann-benchmark/src/backend/index/spherical.rs
+++ b/diskann-benchmark/src/backend/index/spherical.rs
@@ -495,6 +495,11 @@ mod imp {
                             writeln!(output, "\n\n{}", result)?;
                             Ok(result)
                         }
+                        SearchPhase::TopkRag(_) => {
+                            anyhow::bail!(
+                                "RAG search is not supported for spherical quantization indexes"
+                            )
+                        }
                     }
                 }
             }

--- a/diskann-benchmark/src/inputs/async_.rs
+++ b/diskann-benchmark/src/inputs/async_.rs
@@ -170,6 +170,33 @@ impl Example for TopkSearchPhase {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct RagSearchPhase {
+    pub(crate) queries: InputFile,
+    pub(crate) groundtruth: InputFile,
+    pub(crate) reps: NonZeroUsize,
+    // Enable sweeping threads
+    pub(crate) num_threads: Vec<NonZeroUsize>,
+    pub(crate) runs: Vec<GraphSearch>,
+    pub(crate) rag_eta: f64,
+    pub(crate) rag_power: f64,
+}
+
+impl CheckDeserialization for RagSearchPhase {
+    fn check_deserialization(&mut self, checker: &mut Checker) -> Result<(), anyhow::Error> {
+        // Check the validity of the input files.
+        self.queries.check_deserialization(checker)?;
+
+        self.groundtruth.check_deserialization(checker)?;
+        for (i, run) in self.runs.iter_mut().enumerate() {
+            run.check_deserialization(checker)
+                .with_context(|| format!("search run {}", i))?;
+        }
+
+        Ok(())
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct RangeSearchPhase {
     pub(crate) queries: InputFile,
@@ -333,6 +360,7 @@ pub(crate) enum SearchPhase {
     Range(RangeSearchPhase),
     TopkBetaFilter(BetaSearchPhase),
     TopkMultihopFilter(MultiHopSearchPhase),
+    TopkRag(RagSearchPhase),
 }
 
 impl CheckDeserialization for SearchPhase {
@@ -342,6 +370,7 @@ impl CheckDeserialization for SearchPhase {
             SearchPhase::Range(phase) => phase.check_deserialization(checker),
             SearchPhase::TopkBetaFilter(phase) => phase.check_deserialization(checker),
             SearchPhase::TopkMultihopFilter(phase) => phase.check_deserialization(checker),
+            SearchPhase::TopkRag(phase) => phase.check_deserialization(checker),
         }
     }
 }

--- a/diskann-benchmark/src/inputs/disk.rs
+++ b/diskann-benchmark/src/inputs/disk.rs
@@ -85,6 +85,15 @@ pub(crate) struct DiskSearchPhase {
     pub(crate) vector_filters_file: Option<InputFile>,
     pub(crate) num_nodes_to_cache: Option<usize>,
     pub(crate) search_io_limit: Option<usize>,
+    /// When true, apply RAG (diversity-maximizing) post-processing to search results.
+    #[serde(default)]
+    pub(crate) is_rag_search: Option<bool>,
+    /// Ridge regularization parameter for RAG post-processing.
+    #[serde(default)]
+    pub(crate) rag_eta: Option<f64>,
+    /// Power to raise similarity scores to before scaling vectors in RAG.
+    #[serde(default)]
+    pub(crate) rag_power: Option<f64>,
 }
 
 /////////
@@ -272,6 +281,9 @@ impl Example for DiskIndexOperation {
             vector_filters_file: None,
             num_nodes_to_cache: None,
             search_io_limit: None,
+            is_rag_search: None,
+            rag_eta: None,
+            rag_power: None,
         };
 
         Self {
@@ -396,6 +408,11 @@ impl DiskSearchPhase {
         match &self.search_io_limit {
             Some(lim) => write_field!(f, "Search IO Limit", format!("{lim}"))?,
             None => write_field!(f, "Search IO Limit", "none (defaults to `usize::MAX`)")?,
+        }
+        write_field!(f, "RAG Search", self.is_rag_search.unwrap_or(false))?;
+        if self.is_rag_search.unwrap_or(false) {
+            write_field!(f, "RAG Eta", self.rag_eta.unwrap_or(0.0))?;
+            write_field!(f, "RAG Power", self.rag_power.unwrap_or(1.0))?;
         }
         Ok(())
     }

--- a/diskann-disk/src/search/provider/disk_provider.rs
+++ b/diskann-disk/src/search/provider/disk_provider.rs
@@ -372,6 +372,115 @@ where
     }
 }
 
+/// RAG post-processing for disk search.
+///
+/// This implementation filters candidates, loads their full-precision vectors,
+/// converts to f32, and runs diversity-maximizing reranking via
+/// [`graph::search::rag_post_process::rag_post_process`].
+impl<'this, Data, ProviderFactory>
+    glue::PostProcess<
+        graph::search::RagSearchParams,
+        DiskProvider<Data>,
+        [Data::VectorDataType],
+        (u32, Data::AssociatedDataType),
+    > for DiskSearchStrategy<'this, Data, ProviderFactory>
+where
+    Data: GraphDataType<VectorIdType = u32>,
+    ProviderFactory: VertexProviderFactory<Data>,
+{
+    async fn post_process_with<'a, I, B>(
+        &self,
+        processor: &graph::search::RagSearchParams,
+        accessor: &mut Self::SearchAccessor<'a>,
+        query: &[Data::VectorDataType],
+        _computer: &Self::QueryComputer,
+        candidates: I,
+        output: &mut B,
+    ) -> ANNResult<usize>
+    where
+        I: Iterator<Item = Neighbor<u32>> + Send,
+        B: SearchOutputBuffer<(u32, Data::AssociatedDataType)> + Send + ?Sized,
+    {
+        let provider = accessor.provider;
+
+        // Step 1: Filter candidates and compute full-precision distances (like RerankAndFilter).
+        let mut uncached_ids = Vec::new();
+        let mut candidate_entries: Vec<(u32, f32, Data::AssociatedDataType)> = Vec::new();
+
+        for n in candidates
+            .map(|n| n.id)
+            .filter(|id| (self.vector_filter)(id))
+        {
+            if let Some(entry) = accessor.scratch.distance_cache.get(&n) {
+                candidate_entries.push((n, entry.0, entry.1));
+            } else {
+                uncached_ids.push(n);
+            }
+        }
+
+        if !uncached_ids.is_empty() {
+            ensure_vertex_loaded(&mut accessor.scratch.vertex_provider, &uncached_ids)?;
+            for n in &uncached_ids {
+                let v = accessor.scratch.vertex_provider.get_vector(n)?;
+                let d = provider.distance_comparer.evaluate_similarity(query, v);
+                let a = accessor.scratch.vertex_provider.get_associated_data(n)?;
+                candidate_entries.push((*n, d, *a));
+            }
+        }
+
+        if candidate_entries.is_empty() {
+            return Ok(0);
+        }
+
+        // Step 2: Load all candidate vertices so we can read their vectors for RAG.
+        let all_ids: Vec<u32> = candidate_entries.iter().map(|(id, _, _)| *id).collect();
+        ensure_vertex_loaded(&mut accessor.scratch.vertex_provider, &all_ids)?;
+
+        // Step 3: Convert query to f32.
+        let query_f32 = Data::VectorDataType::as_f32(query)
+            .map_err(|e| ANNError::log_index_error(format!("f32 conversion failed: {e}")))?;
+
+        // Step 4: Build RAG candidates with f32 vectors, using index as Id.
+        let mut rag_data: Vec<(usize, f32, Vec<f32>)> = Vec::with_capacity(candidate_entries.len());
+        for (idx, (id, dist, _)) in candidate_entries.iter().enumerate() {
+            let raw_vec = accessor.scratch.vertex_provider.get_vector(id)?;
+            let vec_f32 = Data::VectorDataType::as_f32(raw_vec)
+                .map_err(|e| ANNError::log_index_error(format!("f32 conversion failed: {e}")))?;
+            rag_data.push((idx, *dist, vec_f32.to_vec()));
+        }
+
+        // Step 5: Run RAG post-processing.
+        let k = output
+            .size_hint()
+            .unwrap_or(candidate_entries.len())
+            .min(candidate_entries.len());
+
+        let borrowed: Vec<(usize, f32, &[f32])> = rag_data
+            .iter()
+            .map(|(idx, dist, v)| (*idx, *dist, v.as_slice()))
+            .collect();
+
+        let reranked = graph::search::rag_post_process::rag_post_process(
+            borrowed,
+            &query_f32,
+            k,
+            processor.rag_eta,
+            processor.rag_power,
+        );
+
+        // Step 6: Map back to output format and write.
+        let result: Vec<((u32, Data::AssociatedDataType), f32)> = reranked
+            .into_iter()
+            .map(|(idx, dist)| {
+                let (id, _, assoc) = &candidate_entries[idx];
+                ((*id, *assoc), dist)
+            })
+            .collect();
+
+        Ok(output.extend(result))
+    }
+}
+
 /// The query computer for the disk provider. This is used to compute the distance between the query vector and the PQ coordinates.
 pub struct DiskQueryComputer {
     num_pq_chunks: usize,
@@ -943,6 +1052,89 @@ where
         let mut search_result = SearchResult {
             results: Vec::with_capacity(return_list_size as usize),
             stats,
+        };
+
+        for ((vertex_id, distance), associated_data) in indices
+            .into_iter()
+            .zip(distances.into_iter())
+            .zip(associated_data.into_iter())
+        {
+            search_result.results.push(SearchResultItem {
+                vertex_id,
+                distance,
+                data: associated_data,
+            });
+        }
+
+        Ok(search_result)
+    }
+
+    /// Perform a RAG (diversity-maximizing) search on the disk index.
+    ///
+    /// This uses the same graph traversal as [`Self::search`] but applies RAG
+    /// post-processing instead of the default reranking, using
+    /// [`graph::search::RagSearch`] with the strategy's
+    /// [`PostProcess<RagSearchParams>`](glue::PostProcess) implementation.
+    #[allow(clippy::too_many_arguments)]
+    pub fn search_rag(
+        &self,
+        query: &[Data::VectorDataType],
+        return_list_size: u32,
+        search_list_size: u32,
+        beam_width: Option<usize>,
+        vector_filter: Option<VectorFilter<Data>>,
+        rag_eta: f64,
+        rag_power: f64,
+    ) -> ANNResult<SearchResult<Data::AssociatedDataType>> {
+        let mut query_stats = QueryStatistics::default();
+        let mut indices = vec![0u32; return_list_size as usize];
+        let mut distances = vec![0f32; return_list_size as usize];
+        let mut associated_data =
+            vec![Data::AssociatedDataType::default(); return_list_size as usize];
+
+        let mut result_output_buffer = search_output_buffer::IdDistanceAssociatedData::new(
+            &mut indices[..return_list_size as usize],
+            &mut distances[..return_list_size as usize],
+            &mut associated_data[..return_list_size as usize],
+        );
+
+        let filter = vector_filter.unwrap_or(default_vector_filter::<Data>());
+        let strategy = self.search_strategy(query, &filter);
+        let timer = Instant::now();
+        let k = return_list_size as usize;
+        let l = search_list_size as usize;
+
+        let rag_search =
+            graph::search::RagSearch::new(Knn::new(k, l, beam_width)?, rag_eta, rag_power);
+        let stats = self.runtime.block_on(self.index.search(
+            rag_search,
+            &strategy,
+            &DefaultContext,
+            strategy.query,
+            &mut result_output_buffer,
+        ))?;
+
+        query_stats.total_comparisons = stats.cmps;
+        query_stats.search_hops = stats.hops;
+        query_stats.total_execution_time_us = timer.elapsed().as_micros();
+        query_stats.io_time_us = IOTracker::time(&strategy.io_tracker.io_time_us) as u128;
+        query_stats.total_io_operations = strategy.io_tracker.io_count() as u32;
+        query_stats.total_vertices_loaded = strategy.io_tracker.io_count() as u32;
+        query_stats.query_pq_preprocess_time_us =
+            IOTracker::time(&strategy.io_tracker.preprocess_time_us) as u128;
+        query_stats.cpu_time_us = query_stats.total_execution_time_us
+            - query_stats.io_time_us
+            - query_stats.query_pq_preprocess_time_us;
+
+        let stat_result = SearchResultStats {
+            cmps: query_stats.total_comparisons,
+            result_count: stats.result_count,
+            query_statistics: query_stats,
+        };
+
+        let mut search_result = SearchResult {
+            results: Vec::with_capacity(return_list_size as usize),
+            stats: stat_result,
         };
 
         for ((vertex_id, distance), associated_data) in indices

--- a/diskann/src/graph/glue.rs
+++ b/diskann/src/graph/glue.rs
@@ -404,7 +404,7 @@ where
     T: ?Sized + Sync,
     O: Send,
 {
-    fn post_process_with<'a, I, B>(
+    async fn post_process_with<'a, I, B>(
         &self,
         _processor: &DefaultPostProcess,
         accessor: &mut Self::SearchAccessor<'a>,
@@ -412,18 +412,16 @@ where
         computer: &Self::QueryComputer,
         candidates: I,
         output: &mut B,
-    ) -> impl std::future::Future<Output = ANNResult<usize>> + Send
+    ) -> ANNResult<usize>
     where
         I: Iterator<Item = Neighbor<Provider::InternalId>> + Send,
         B: SearchOutputBuffer<O> + Send + ?Sized,
     {
-        async move {
-            self.post_processor()
-                .post_process(accessor, query, computer, candidates, output)
-                .send()
-                .await
-                .into_ann_result()
-        }
+        self.post_processor()
+            .post_process(accessor, query, computer, candidates, output)
+            .send()
+            .await
+            .into_ann_result()
     }
 }
 

--- a/diskann/src/graph/glue.rs
+++ b/diskann/src/graph/glue.rs
@@ -346,8 +346,8 @@ where
 /// duplicating the core search algorithm. The `Processor` type parameter selects which
 /// post-processing behavior to use.
 ///
-/// For example, a standard k-NN search can be combined with diversity-aware
-/// post-processing by implementing `PostProcess<PostProcessOnlyDiverseSearch>` for a
+/// For example, a standard k-NN search can be combined with RAG-aware
+/// post-processing by implementing `PostProcess<RagSearchParams>` for a
 /// strategy, without rewriting the search loop.
 ///
 /// A blanket implementation exists for [`DefaultPostProcess`], which delegates to the
@@ -424,58 +424,6 @@ where
                 .await
                 .into_ann_result()
         }
-    }
-}
-
-/// Post-processor that applies diversity filtering to search results.
-///
-/// Unlike the full [`super::search::Diverse`] search which uses a
-/// [`crate::neighbor::DiverseNeighborQueue`] during the search loop itself,
-/// `PostProcessOnlyDiverseSearch` applies diversity filtering purely in post-processing.
-/// This means it can be composed with **any** search algorithm (e.g.,
-/// [`super::search::Knn`] via [`super::search::KnnWith`]) without duplicating search logic.
-///
-/// # Usage
-///
-/// Strategy implementations should implement
-/// `PostProcess<PostProcessOnlyDiverseSearch, Provider, T, O>` to bridge their accessor
-/// to the diversity filtering logic.
-///
-/// ```ignore
-/// use diskann::graph::search::{Knn, KnnWith};
-/// use diskann::graph::glue::PostProcessOnlyDiverseSearch;
-///
-/// let diverse_pp = PostProcessOnlyDiverseSearch::new(/* params */);
-/// let search = KnnWith::new(Knn::new(10, 100, None)?, diverse_pp);
-/// let stats = index.search(search, &strategy, &context, &query, &mut output).await?;
-/// ```
-#[derive(Debug, Clone)]
-pub struct PostProcessOnlyDiverseSearch {
-    // TODO: Add diversity parameters here, e.g.:
-    // pub diverse_attribute_id: usize,
-    // pub diverse_results_k: usize,
-    // pub attribute_provider: Arc<dyn AttributeValueProvider<Id = ...>>,
-}
-
-impl PostProcessOnlyDiverseSearch {
-    /// Apply diversity filtering to the candidate results.
-    ///
-    /// This method contains the core diversity logic that is independent of any
-    /// particular strategy or accessor type.
-    pub fn post_process<I, Id>(
-        &self,
-        candidates: I,
-        // TODO: Add additional parameters as needed, e.g.:
-        // diverse_attribute_id: usize,
-        // diverse_results_k: usize,
-    ) -> impl Iterator<Item = Neighbor<Id>>
-    where
-        I: Iterator<Item = Neighbor<Id>>,
-        Id: Default + Eq,
-    {
-        // TODO: Implement diversity filtering logic.
-        // For now, pass through all candidates unchanged.
-        candidates
     }
 }
 

--- a/diskann/src/graph/glue.rs
+++ b/diskann/src/graph/glue.rs
@@ -83,7 +83,7 @@ use diskann_vector::{DistanceFunction, PreprocessedDistanceFunction};
 
 use crate::{
     ANNError, ANNResult,
-    error::{ErrorExt, RankedError, StandardError, ToRanked, TransientError},
+    error::{ErrorExt, IntoANNResult, RankedError, StandardError, ToRanked, TransientError},
     graph::{AdjacencyList, SearchOutputBuffer},
     neighbor::Neighbor,
     provider::{
@@ -338,6 +338,145 @@ where
     /// Construct the [`SearchPostProcess`] struct to post-process the results of search and
     /// store them into the output container.
     fn post_processor(&self) -> Self::PostProcessor;
+}
+
+/// A composable post-processing override for search strategies.
+///
+/// This trait allows search results to be post-processed in different ways without
+/// duplicating the core search algorithm. The `Processor` type parameter selects which
+/// post-processing behavior to use.
+///
+/// For example, a standard k-NN search can be combined with diversity-aware
+/// post-processing by implementing `PostProcess<PostProcessOnlyDiverseSearch>` for a
+/// strategy, without rewriting the search loop.
+///
+/// A blanket implementation exists for [`DefaultPostProcess`], which delegates to the
+/// strategy's [`SearchPostProcess`]or via [`SearchStrategy::post_processor()`]. This means
+/// every [`SearchStrategy`] automatically supports `PostProcess<DefaultPostProcess>`
+/// with no additional code.
+///
+/// # Usage
+///
+/// Search types like [`super::search::KnnWith`] accept a `Processor` type parameter and
+/// require `S: PostProcess<Processor, Provider, T, O>` in their `Search` impl. This
+/// enables composing any search algorithm with any post-processing strategy.
+pub trait PostProcess<Processor, Provider, T, O = <Provider as DataProvider>::InternalId>:
+    SearchStrategy<Provider, T, O>
+where
+    Provider: DataProvider,
+    T: ?Sized,
+    O: Send,
+{
+    /// Post-process search results using the given `processor`.
+    ///
+    /// This method bridges between the strategy's accessor/computer and the processor's
+    /// logic. Implementations should extract any data the processor needs from the
+    /// accessor and delegate to the processor.
+    fn post_process_with<'a, I, B>(
+        &self,
+        processor: &Processor,
+        accessor: &mut Self::SearchAccessor<'a>,
+        query: &T,
+        computer: &Self::QueryComputer,
+        candidates: I,
+        output: &mut B,
+    ) -> impl std::future::Future<Output = ANNResult<usize>> + Send
+    where
+        I: Iterator<Item = Neighbor<Provider::InternalId>> + Send,
+        B: SearchOutputBuffer<O> + Send + ?Sized;
+}
+
+/// Marker for default post-processing behavior.
+///
+/// When used with [`PostProcess`], delegates to the strategy's existing
+/// [`SearchPostProcess`]or via [`SearchStrategy::post_processor()`].
+///
+/// A blanket implementation is provided so that every [`SearchStrategy`] automatically
+/// implements `PostProcess<DefaultPostProcess>`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DefaultPostProcess;
+
+/// Blanket implementation: every [`SearchStrategy`] supports default post-processing.
+impl<S, Provider, T, O> PostProcess<DefaultPostProcess, Provider, T, O> for S
+where
+    S: SearchStrategy<Provider, T, O>,
+    Provider: DataProvider,
+    T: ?Sized + Sync,
+    O: Send,
+{
+    fn post_process_with<'a, I, B>(
+        &self,
+        _processor: &DefaultPostProcess,
+        accessor: &mut Self::SearchAccessor<'a>,
+        query: &T,
+        computer: &Self::QueryComputer,
+        candidates: I,
+        output: &mut B,
+    ) -> impl std::future::Future<Output = ANNResult<usize>> + Send
+    where
+        I: Iterator<Item = Neighbor<Provider::InternalId>> + Send,
+        B: SearchOutputBuffer<O> + Send + ?Sized,
+    {
+        async move {
+            self.post_processor()
+                .post_process(accessor, query, computer, candidates, output)
+                .send()
+                .await
+                .into_ann_result()
+        }
+    }
+}
+
+/// Post-processor that applies diversity filtering to search results.
+///
+/// Unlike the full [`super::search::Diverse`] search which uses a
+/// [`crate::neighbor::DiverseNeighborQueue`] during the search loop itself,
+/// `PostProcessOnlyDiverseSearch` applies diversity filtering purely in post-processing.
+/// This means it can be composed with **any** search algorithm (e.g.,
+/// [`super::search::Knn`] via [`super::search::KnnWith`]) without duplicating search logic.
+///
+/// # Usage
+///
+/// Strategy implementations should implement
+/// `PostProcess<PostProcessOnlyDiverseSearch, Provider, T, O>` to bridge their accessor
+/// to the diversity filtering logic.
+///
+/// ```ignore
+/// use diskann::graph::search::{Knn, KnnWith};
+/// use diskann::graph::glue::PostProcessOnlyDiverseSearch;
+///
+/// let diverse_pp = PostProcessOnlyDiverseSearch::new(/* params */);
+/// let search = KnnWith::new(Knn::new(10, 100, None)?, diverse_pp);
+/// let stats = index.search(search, &strategy, &context, &query, &mut output).await?;
+/// ```
+#[derive(Debug, Clone)]
+pub struct PostProcessOnlyDiverseSearch {
+    // TODO: Add diversity parameters here, e.g.:
+    // pub diverse_attribute_id: usize,
+    // pub diverse_results_k: usize,
+    // pub attribute_provider: Arc<dyn AttributeValueProvider<Id = ...>>,
+}
+
+impl PostProcessOnlyDiverseSearch {
+    /// Apply diversity filtering to the candidate results.
+    ///
+    /// This method contains the core diversity logic that is independent of any
+    /// particular strategy or accessor type.
+    pub fn post_process<I, Id>(
+        &self,
+        candidates: I,
+        // TODO: Add additional parameters as needed, e.g.:
+        // diverse_attribute_id: usize,
+        // diverse_results_k: usize,
+    ) -> impl Iterator<Item = Neighbor<Id>>
+    where
+        I: Iterator<Item = Neighbor<Id>>,
+        Id: Default + Eq,
+    {
+        // TODO: Implement diversity filtering logic.
+        // For now, pass through all candidates unchanged.
+        candidates
+    }
 }
 
 /// Perform post-processing on the results of search, storing the results in an output buffer.

--- a/diskann/src/graph/index.rs
+++ b/diskann/src/graph/index.rs
@@ -27,7 +27,7 @@ use super::{
     AdjacencyList, Config, ConsolidateKind, InplaceDeleteMethod,
     glue::{
         self, AsElement, ExpandBeam, FillSet, IdIterator, InplaceDeleteStrategy, InsertStrategy,
-        PruneStrategy, SearchExt, SearchPostProcess, SearchStrategy, aliases,
+        PostProcess, PruneStrategy, SearchExt, SearchStrategy, aliases,
     },
     internal::{BackedgeBuffer, SortedNeighbors, prune},
     search::{
@@ -1297,17 +1297,15 @@ where
             // placed into the output.
             let proxy = v.async_lower();
             let num_results = search_strategy
-                .post_processor()
-                .post_process(
+                .post_process_with(
+                    &glue::DefaultPostProcess,
                     &mut search_accessor,
                     &*proxy,
                     &computer,
                     scratch.best.iter(),
                     &mut neighbor::BackInserter::new(output.as_mut_slice()),
                 )
-                .send()
-                .await
-                .into_ann_result()?;
+                .await?;
 
             let mut undeleted_ids: Vec<_> = output
                 .iter()
@@ -2198,7 +2196,7 @@ where
     ) -> ANNResult<SearchStats>
     where
         T: ?Sized,
-        S: SearchStrategy<DP, T, O, SearchAccessor<'a>: IdIterator<I>>,
+        S: glue::PostProcess<glue::DefaultPostProcess, DP, T, O, SearchAccessor<'a>: IdIterator<I>>,
         I: Iterator<Item = <DP as DataProvider>::InternalId>,
         O: Send,
         OB: search_output_buffer::SearchOutputBuffer<O> + Send,
@@ -2233,17 +2231,15 @@ where
         }
 
         let result_count = strategy
-            .post_processor()
-            .post_process(
+            .post_process_with(
+                &glue::DefaultPostProcess,
                 &mut accessor,
                 query,
                 &computer,
                 scratch.best.iter().take(search_params.l_value().get()),
                 output,
             )
-            .send()
-            .await
-            .into_ann_result()?;
+            .await?;
 
         Ok(SearchStats {
             cmps: scratch.cmps,

--- a/diskann/src/graph/search/diverse_search.rs
+++ b/diskann/src/graph/search/diverse_search.rs
@@ -14,7 +14,7 @@ use crate::{
     error::IntoANNResult,
     graph::{
         DiverseSearchParams,
-        glue::{SearchExt, SearchPostProcess, SearchStrategy},
+        glue::{DefaultPostProcess, PostProcess, SearchExt, SearchPostProcess, SearchStrategy},
         index::{DiskANNIndex, SearchStats},
         search_output_buffer::SearchOutputBuffer,
     },
@@ -96,7 +96,7 @@ impl<DP, S, T, O, OB, P> Search<DP, S, T, O, OB> for Diverse<P>
 where
     DP: DataProvider,
     T: Sync + ?Sized,
-    S: SearchStrategy<DP, T, O>,
+    S: PostProcess<DefaultPostProcess, DP, T, O>,
     O: Send,
     OB: SearchOutputBuffer<O> + Send,
     P: AttributeValueProvider<Id = DP::InternalId>,
@@ -136,17 +136,15 @@ where
             diverse_scratch.best.post_process();
 
             let result_count = strategy
-                .post_processor()
-                .post_process(
+                .post_process_with(
+                    &DefaultPostProcess,
                     &mut accessor,
                     query,
                     &computer,
                     diverse_scratch.best.iter().take(self.inner.l_value().get()),
                     output,
                 )
-                .send()
-                .await
-                .into_ann_result()?;
+                .await?;
 
             Ok(stats.finish(result_count as u32))
         }

--- a/diskann/src/graph/search/knn_search.rs
+++ b/diskann/src/graph/search/knn_search.rs
@@ -330,17 +330,16 @@ where
 /// the post-processing logic.
 ///
 /// This eliminates the need to duplicate the core search loop for each post-processing
-/// variant. For example, pairing `KnnWith<PostProcessOnlyDiverseSearch>` gives
-/// diversity-aware results without rewriting the search algorithm.
+/// variant. For example, pairing `KnnWith<RagSearchParams>` gives
+/// RAG-reranked results without rewriting the search algorithm.
 ///
 /// # Example
 ///
 /// ```ignore
-/// use diskann::graph::search::{Knn, KnnWith};
-/// use diskann::graph::glue::PostProcessOnlyDiverseSearch;
+/// use diskann::graph::search::{Knn, KnnWith, RagSearchParams};
 ///
-/// let diverse_pp = PostProcessOnlyDiverseSearch { /* ... */ };
-/// let search = KnnWith::new(Knn::new(10, 100, None)?, diverse_pp);
+/// let rag_pp = RagSearchParams::new(0.01, 2.0);
+/// let search = KnnWith::new(Knn::new(10, 100, None)?, rag_pp);
 /// let stats = index.search(search, &strategy, &context, &query, &mut output).await?;
 /// ```
 #[derive(Debug, Clone)]

--- a/diskann/src/graph/search/knn_search.rs
+++ b/diskann/src/graph/search/knn_search.rs
@@ -7,7 +7,7 @@
 
 use std::{fmt::Debug, num::NonZeroUsize};
 
-use diskann_utils::future::{AssertSend, SendFuture};
+use diskann_utils::future::SendFuture;
 use thiserror::Error;
 
 use super::Search;
@@ -15,9 +15,9 @@ use crate::{
     ANNError, ANNErrorKind, ANNResult,
     error::IntoANNResult,
     graph::{
-        glue::{SearchExt, SearchPostProcess, SearchStrategy},
+        glue::{DefaultPostProcess, PostProcess, SearchExt},
         index::{DiskANNIndex, SearchStats},
-        search::record::NoopSearchRecord,
+        search::record::{NoopSearchRecord, SearchRecord},
         search_output_buffer::SearchOutputBuffer,
     },
     provider::{BuildQueryComputer, DataProvider},
@@ -141,13 +141,74 @@ impl Knn {
     pub fn beam_width(&self) -> NonZeroUsize {
         self.beam_width
     }
+
+    /// Core search implementation shared by [`Knn`], [`RecordedKnn`], and [`KnnWith`].
+    ///
+    /// All k-NN search variants follow the same algorithm: create an accessor, build a
+    /// query computer, run `search_internal`, then post-process. The only axes of
+    /// variation are:
+    ///
+    /// * `recorder` — controls whether the traversal path is recorded.
+    /// * `post_processor` — selects which post-processing pipeline to apply.
+    async fn search_core<DP, S, T, O, OB, SR, PP>(
+        &self,
+        index: &DiskANNIndex<DP>,
+        strategy: &S,
+        context: &DP::Context,
+        query: &T,
+        output: &mut OB,
+        recorder: &mut SR,
+        post_processor: &PP,
+    ) -> ANNResult<SearchStats>
+    where
+        DP: DataProvider,
+        T: Sync + ?Sized,
+        S: PostProcess<PP, DP, T, O>,
+        O: Send,
+        OB: SearchOutputBuffer<O> + Send + ?Sized,
+        SR: SearchRecord<DP::InternalId> + ?Sized,
+        PP: Send + Sync,
+    {
+        let mut accessor = strategy
+            .search_accessor(&index.data_provider, context)
+            .into_ann_result()?;
+
+        let computer = accessor.build_query_computer(query).into_ann_result()?;
+        let start_ids = accessor.starting_points().await?;
+
+        let mut scratch = index.search_scratch(self.l_value.get(), start_ids.len());
+
+        let stats = index
+            .search_internal(
+                Some(self.beam_width.get()),
+                &start_ids,
+                &mut accessor,
+                &computer,
+                &mut scratch,
+                recorder,
+            )
+            .await?;
+
+        let result_count = strategy
+            .post_process_with(
+                post_processor,
+                &mut accessor,
+                query,
+                &computer,
+                scratch.best.iter().take(self.l_value.get().into_usize()),
+                output,
+            )
+            .await?;
+
+        Ok(stats.finish(result_count as u32))
+    }
 }
 
 impl<DP, S, T, O, OB> Search<DP, S, T, O, OB> for Knn
 where
     DP: DataProvider,
     T: Sync + ?Sized,
-    S: SearchStrategy<DP, T, O>,
+    S: PostProcess<DefaultPostProcess, DP, T, O>,
     O: Send,
     OB: SearchOutputBuffer<O> + Send + ?Sized,
 {
@@ -186,40 +247,17 @@ where
         output: &mut OB,
     ) -> impl SendFuture<ANNResult<Self::Output>> {
         async move {
-            let mut accessor = strategy
-                .search_accessor(&index.data_provider, context)
-                .into_ann_result()?;
-
-            let computer = accessor.build_query_computer(query).into_ann_result()?;
-            let start_ids = accessor.starting_points().await?;
-
-            let mut scratch = index.search_scratch(self.l_value.get(), start_ids.len());
-
-            let stats = index
-                .search_internal(
-                    Some(self.beam_width.get()),
-                    &start_ids,
-                    &mut accessor,
-                    &computer,
-                    &mut scratch,
-                    &mut NoopSearchRecord::new(),
-                )
-                .await?;
-
-            let result_count = strategy
-                .post_processor()
-                .post_process(
-                    &mut accessor,
-                    query,
-                    &computer,
-                    scratch.best.iter().take(self.l_value.get().into_usize()),
-                    output,
-                )
-                .send()
-                .await
-                .into_ann_result()?;
-
-            Ok(stats.finish(result_count as u32))
+            let mut recorder = NoopSearchRecord::new();
+            self.search_core(
+                index,
+                strategy,
+                context,
+                query,
+                output,
+                &mut recorder,
+                &DefaultPostProcess,
+            )
+            .await
         }
     }
 }
@@ -250,10 +288,10 @@ impl<'r, DP, S, T, O, OB, SR> Search<DP, S, T, O, OB> for RecordedKnn<'r, SR>
 where
     DP: DataProvider,
     T: Sync + ?Sized,
-    S: SearchStrategy<DP, T, O>,
+    S: PostProcess<DefaultPostProcess, DP, T, O>,
     O: Send,
     OB: SearchOutputBuffer<O> + Send + ?Sized,
-    SR: super::record::SearchRecord<DP::InternalId> + ?Sized,
+    SR: SearchRecord<DP::InternalId> + ?Sized,
 {
     type Output = SearchStats;
 
@@ -266,43 +304,107 @@ where
         output: &mut OB,
     ) -> impl SendFuture<ANNResult<Self::Output>> {
         async move {
-            let mut accessor = strategy
-                .search_accessor(&index.data_provider, context)
-                .into_ann_result()?;
-
-            let computer = accessor.build_query_computer(query).into_ann_result()?;
-            let start_ids = accessor.starting_points().await?;
-
-            let mut scratch = index.search_scratch(self.inner.l_value.get(), start_ids.len());
-
-            let stats = index
-                .search_internal(
-                    Some(self.inner.beam_width.get()),
-                    &start_ids,
-                    &mut accessor,
-                    &computer,
-                    &mut scratch,
-                    self.recorder,
-                )
-                .await?;
-
-            let result_count = strategy
-                .post_processor()
-                .post_process(
-                    &mut accessor,
+            self.inner
+                .search_core(
+                    index,
+                    strategy,
+                    context,
                     query,
-                    &computer,
-                    scratch
-                        .best
-                        .iter()
-                        .take(self.inner.l_value.get().into_usize()),
                     output,
+                    self.recorder,
+                    &DefaultPostProcess,
                 )
-                .send()
                 .await
-                .into_ann_result()?;
+        }
+    }
+}
 
-            Ok(stats.finish(result_count as u32))
+///////////////////////
+// KnnWith (generic) //
+///////////////////////
+
+/// K-NN search with a custom post-processor.
+///
+/// This type composes a standard [`Knn`] search with an arbitrary post-processing
+/// strategy `PP`. The strategy `S` must implement `PostProcess<PP, ...>` to provide
+/// the post-processing logic.
+///
+/// This eliminates the need to duplicate the core search loop for each post-processing
+/// variant. For example, pairing `KnnWith<PostProcessOnlyDiverseSearch>` gives
+/// diversity-aware results without rewriting the search algorithm.
+///
+/// # Example
+///
+/// ```ignore
+/// use diskann::graph::search::{Knn, KnnWith};
+/// use diskann::graph::glue::PostProcessOnlyDiverseSearch;
+///
+/// let diverse_pp = PostProcessOnlyDiverseSearch { /* ... */ };
+/// let search = KnnWith::new(Knn::new(10, 100, None)?, diverse_pp);
+/// let stats = index.search(search, &strategy, &context, &query, &mut output).await?;
+/// ```
+#[derive(Debug, Clone)]
+pub struct KnnWith<PP> {
+    /// Base k-NN search parameters.
+    inner: Knn,
+    /// The post-processor to apply after the core search.
+    post_processor: PP,
+}
+
+impl<PP> KnnWith<PP> {
+    /// Create a new k-NN search with custom post-processing.
+    pub fn new(inner: Knn, post_processor: PP) -> Self {
+        Self {
+            inner,
+            post_processor,
+        }
+    }
+
+    /// Returns a reference to the inner k-NN parameters.
+    #[inline]
+    pub fn inner(&self) -> &Knn {
+        &self.inner
+    }
+
+    /// Returns a reference to the post-processor.
+    #[inline]
+    pub fn post_processor(&self) -> &PP {
+        &self.post_processor
+    }
+}
+
+impl<DP, S, T, O, OB, PP> Search<DP, S, T, O, OB> for KnnWith<PP>
+where
+    DP: DataProvider,
+    T: Sync + ?Sized,
+    S: PostProcess<PP, DP, T, O>,
+    O: Send,
+    OB: SearchOutputBuffer<O> + Send + ?Sized,
+    PP: Send + Sync,
+{
+    type Output = SearchStats;
+
+    fn search(
+        self,
+        index: &DiskANNIndex<DP>,
+        strategy: &S,
+        context: &DP::Context,
+        query: &T,
+        output: &mut OB,
+    ) -> impl SendFuture<ANNResult<Self::Output>> {
+        async move {
+            let mut recorder = NoopSearchRecord::new();
+            self.inner
+                .search_core(
+                    index,
+                    strategy,
+                    context,
+                    query,
+                    output,
+                    &mut recorder,
+                    &self.post_processor,
+                )
+                .await
         }
     }
 }

--- a/diskann/src/graph/search/knn_search.rs
+++ b/diskann/src/graph/search/knn_search.rs
@@ -150,6 +150,7 @@ impl Knn {
     ///
     /// * `recorder` — controls whether the traversal path is recorded.
     /// * `post_processor` — selects which post-processing pipeline to apply.
+    #[allow(clippy::too_many_arguments)]
     async fn search_core<DP, S, T, O, OB, SR, PP>(
         &self,
         index: &DiskANNIndex<DP>,

--- a/diskann/src/graph/search/mod.rs
+++ b/diskann/src/graph/search/mod.rs
@@ -30,6 +30,8 @@ use crate::{ANNResult, graph::index::DiskANNIndex, provider::DataProvider};
 
 mod knn_search;
 mod multihop_search;
+pub mod rag_post_process;
+mod rag_search;
 mod range_search;
 
 pub mod record;
@@ -90,6 +92,7 @@ where
 // Re-export search parameter types.
 pub use knn_search::{Knn, KnnSearchError, KnnWith, RecordedKnn};
 pub use multihop_search::MultihopSearch;
+pub use rag_search::{RagSearch, RagSearchParams};
 pub use range_search::{Range, RangeSearchError, RangeSearchOutput};
 
 // Feature-gated diverse search.

--- a/diskann/src/graph/search/mod.rs
+++ b/diskann/src/graph/search/mod.rs
@@ -88,7 +88,7 @@ where
 }
 
 // Re-export search parameter types.
-pub use knn_search::{Knn, KnnSearchError, RecordedKnn};
+pub use knn_search::{Knn, KnnSearchError, KnnWith, RecordedKnn};
 pub use multihop_search::MultihopSearch;
 pub use range_search::{Range, RangeSearchError, RangeSearchOutput};
 

--- a/diskann/src/graph/search/multihop_search.rs
+++ b/diskann/src/graph/search/multihop_search.rs
@@ -6,7 +6,7 @@
 //! Label-filtered search using multi-hop expansion.
 
 use diskann_utils::Reborrow;
-use diskann_utils::future::{AssertSend, SendFuture};
+use diskann_utils::future::SendFuture;
 use diskann_vector::PreprocessedDistanceFunction;
 use hashbrown::HashSet;
 
@@ -16,8 +16,8 @@ use crate::{
     error::{ErrorExt, IntoANNResult},
     graph::{
         glue::{
-            self, ExpandBeam, HybridPredicate, Predicate, PredicateMut, SearchExt,
-            SearchPostProcess, SearchStrategy,
+            self, DefaultPostProcess, ExpandBeam, HybridPredicate, PostProcess, Predicate,
+            PredicateMut, SearchExt,
         },
         index::{
             DiskANNIndex, InternalSearchStats, QueryLabelProvider, QueryVisitDecision, SearchStats,
@@ -57,7 +57,7 @@ impl<'q, DP, S, T, O, OB> Search<DP, S, T, O, OB> for MultihopSearch<'q, DP::Int
 where
     DP: DataProvider,
     T: Sync + ?Sized,
-    S: SearchStrategy<DP, T, O>,
+    S: PostProcess<DefaultPostProcess, DP, T, O>,
     O: Send,
     OB: SearchOutputBuffer<O> + Send,
 {
@@ -93,17 +93,15 @@ where
             .await?;
 
             let result_count = strategy
-                .post_processor()
-                .post_process(
+                .post_process_with(
+                    &DefaultPostProcess,
                     &mut accessor,
                     query,
                     &computer,
                     scratch.best.iter().take(self.inner.l_value().get()),
                     output,
                 )
-                .send()
-                .await
-                .into_ann_result()?;
+                .await?;
 
             Ok(stats.finish(result_count as u32))
         }

--- a/diskann/src/graph/search/rag_post_process.rs
+++ b/diskann/src/graph/search/rag_post_process.rs
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+//! RAG (Retrieval-Augmented Generation) search post-processing.
+//!
+//! This module provides post-processing functionality for RAG search,
+//! which reranks search results to maximize diversity using the greedy orthogonalization algorithm.
+//!
+//! ## Algorithm: Greedy Orthogonalization on Scaled Vectors
+//!
+//! Given l candidate vectors v_1, ..., v_l and a query q, select k vectors that maximize
+//! the determinant of the Gram matrix of scaled vectors.
+//!
+//! Each vector v_i is scaled by: `scale_i = (v_i . q)^power`
+//!
+//! The algorithm works as follows:
+//! 1. Initialize residuals R_i = scale_i * v_i for all candidates
+//! 2. For t = 1 to k:
+//!    - Pick i* = argmax_i ||R_i||^2
+//!    - Add i* to selected set S
+//!    - Orthogonalize remaining vectors: R_j = R_j - (R_j . R_i* / ||R_i*||^2) * R_i*
+//!
+//! This is equivalent to pivoted QR decomposition and provides a (1/k!)-approximation
+//! to the optimal volume selection. Complexity: O(n * k * d).
+
+use diskann_vector::{MathematicalValue, PureDistanceFunction, distance::InnerProduct};
+
+/// Post-process search results using RAG-optimized reranking.
+///
+/// If RAG search is enabled, uses greedy orthogonalization for diversity.
+/// Otherwise, returns results sorted by distance.
+///
+/// # Arguments
+///
+/// * `candidates` - Vector of (id, distance, vector) tuples.
+/// * `query` - The query vector as f32 slice.
+/// * `k` - Number of results to return.
+/// * `rag_eta` - Ridge regularization parameter. Use 0.0 for pure greedy orthogonalization.
+/// * `rag_power` - Power to raise similarity scores to before scaling vectors.
+///
+/// # Returns
+///
+/// Returns a vector of (id, distance) tuples, reranked for diversity.
+pub fn rag_post_process(
+    candidates: Vec<(u32, f32, &[f32])>,
+    query: &[f32],
+    k: usize,
+    rag_eta: f64,
+    rag_power: f64,
+) -> Vec<(u32, f32)> {
+    if candidates.is_empty() {
+        return Vec::new();
+    }
+
+    let k = k.min(candidates.len());
+
+    // Convert candidates vectors to owned f32 for in-place orthogonalization
+    let candidates_f32: Vec<(u32, f32, Vec<f32>)> = candidates
+        .into_iter()
+        .map(|(id, dist, v)| (id, dist, v.to_vec()))
+        .collect();
+
+    let results = if rag_eta > 0.0 {
+        // Use eta-based algorithm
+        post_process_with_eta_f32(candidates_f32, query, k, rag_eta, rag_power)
+    } else {
+        // Use greedy orthogonalization (eta = 0)
+        post_process_greedy_orthogonalization_f32(candidates_f32, query, k, rag_power)
+    };
+
+    debug_assert_eq!(
+        results.len(),
+        k,
+        "RAG post-process should return exactly k={} results, got {}",
+        k,
+        results.len()
+    );
+
+    results
+}
+
+/// Ridge-aware greedy log-det algorithm for eta > 0 (f32 version).
+///
+/// Maximizes: log det(eta*I + sum_i v_i v_i^T) where vectors are scaled by similarity^power.
+///
+/// This algorithm is equivalent to greedy orthogonalization but with a ridge regularization.
+/// The key insight is that we can reduce this to a modified QR-like iteration:
+///
+/// **Initialization:**
+/// - r_i <- v_i / sqrt(eta) (scale vectors)
+/// - s_i <- ||r_i||^2 (precompute squared norms)
+///
+/// **For t = 1 to k:**
+/// 1. Select: j = argmax_i s_i
+/// 2. Normalize: q = r_j / sqrt(1 + s_j)  (the 1 + s_j is the ridge effect)
+/// 3. Update: For all i != j:
+///    - alpha = q^T r_i
+///    - r_i <- r_i - alpha*q
+///    - s_i <- s_i - alpha^2 (incremental norm update)
+///
+/// Complexity: O(n * k * d) - same as greedy orthogonalization!
+fn post_process_with_eta_f32(
+    candidates: Vec<(u32, f32, Vec<f32>)>,
+    query: &[f32],
+    k: usize,
+    rag_eta: f64,
+    rag_power: f64,
+) -> Vec<(u32, f32)> {
+    let eta = rag_eta as f32;
+    let power = rag_power;
+
+    if candidates.is_empty() || query.is_empty() {
+        return Vec::new();
+    }
+
+    let n = candidates.len();
+    let k = k.min(n);
+
+    if k == 0 {
+        return Vec::new();
+    }
+
+    let d = candidates[0].2.len();
+    if d == 0 {
+        return Vec::new();
+    }
+
+    let inv_sqrt_eta = 1.0 / eta.sqrt();
+
+    // Initialization: r_i = (scale_i * v_i) / sqrt(eta), s_i = ||r_i||^2
+    // where scale_i = max(0, v_i . q)^power
+    let mut residuals: Vec<Vec<f32>> = Vec::with_capacity(n);
+    let mut norms_sq: Vec<f32> = Vec::with_capacity(n);
+
+    for (_, _, v) in &candidates {
+        let similarity = dot_product(v, query);
+        let scale = similarity.max(0.0).powf(power as f32) * inv_sqrt_eta;
+        let r: Vec<f32> = v.iter().map(|&x| x * scale).collect();
+        let s = dot_product(&r, &r);
+        residuals.push(r);
+        norms_sq.push(s);
+    }
+
+    let mut available: Vec<bool> = vec![true; n];
+    let mut selected: Vec<usize> = Vec::with_capacity(k);
+
+    for _ in 0..k {
+        let best_idx = available
+            .iter()
+            .enumerate()
+            .filter(|&(_, &avail)| avail)
+            .max_by(|(i, _), (j, _)| {
+                norms_sq[*i]
+                    .partial_cmp(&norms_sq[*j])
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            })
+            .map(|(i, _)| i);
+
+        let Some(j) = best_idx else {
+            break;
+        };
+
+        // Add to selected set
+        selected.push(j);
+        available[j] = false;
+
+        // Early exit if this is the last selection
+        if selected.len() == k {
+            break;
+        }
+
+        // Normalize: q = r_j / sqrt(1 + s_j)
+        // The (1 + s_j) term is the ridge effect
+        let norm_factor = 1.0 / (1.0 + norms_sq[j]).sqrt();
+        let q: Vec<f32> = residuals[j].iter().map(|&x| x * norm_factor).collect();
+
+        // Update: For all i != j
+        for i in 0..n {
+            if !available[i] {
+                continue;
+            }
+
+            // alpha = q^T r_i
+            let alpha = dot_product(&q, &residuals[i]);
+
+            // r_i <- r_i - alpha*q (SIMD-friendly loop)
+            for (r_val, &q_val) in residuals[i].iter_mut().zip(q.iter()) {
+                *r_val -= alpha * q_val;
+            }
+
+            // s_i <- s_i - alpha^2 (incremental norm update)
+            norms_sq[i] = (norms_sq[i] - alpha * alpha).max(0.0);
+        }
+    }
+
+    selected
+        .iter()
+        .map(|&idx| {
+            let (id, dist, _) = candidates[idx];
+            (id, dist)
+        })
+        .collect()
+}
+
+/// Multiply a matrix by a vector: result = M * v
+#[allow(dead_code)]
+#[inline]
+fn matrix_vec_mult(m: &[Vec<f32>], v: &[f32]) -> Vec<f32> {
+    m.iter().map(|row| dot_product(row, v)).collect()
+}
+
+/// Greedy orthogonalization algorithm for eta = 0 (f32 version).
+///
+/// Each vector is scaled by `max(0, dot_product_with_query)^power` before applying
+/// the greedy max-determinant selection algorithm.
+///
+/// Optimized with:
+/// - Cached squared norms (avoid recomputing each iteration)
+/// - Parallel orthogonalization updates using rayon
+fn post_process_greedy_orthogonalization_f32(
+    candidates: Vec<(u32, f32, Vec<f32>)>,
+    query: &[f32],
+    k: usize,
+    rag_power: f64,
+) -> Vec<(u32, f32)> {
+    let power = rag_power;
+
+    if candidates.is_empty() || query.is_empty() {
+        return Vec::new();
+    }
+
+    let n = candidates.len();
+    let k = k.min(n);
+
+    if k == 0 {
+        return Vec::new();
+    }
+
+    // Compute scaled vectors and cache norms
+    let mut residuals: Vec<Vec<f32>> = Vec::with_capacity(n);
+    let mut norms_sq: Vec<f32> = Vec::with_capacity(n);
+
+    for (_, _, v) in &candidates {
+        let similarity = dot_product(v, query);
+        let scale = similarity.max(0.0).powf(power as f32);
+        let r: Vec<f32> = v.iter().map(|&x| x * scale).collect();
+        let s = dot_product(&r, &r);
+        residuals.push(r);
+        norms_sq.push(s);
+    }
+
+    let mut available: Vec<bool> = vec![true; n];
+    let mut selected: Vec<usize> = Vec::with_capacity(k);
+
+    for _ in 0..k {
+        // Find the vector with maximum residual norm squared (using cached norms)
+        let best = available
+            .iter()
+            .enumerate()
+            .filter(|&(_, &avail)| avail)
+            .max_by(|(i, _), (j, _)| {
+                norms_sq[*i]
+                    .partial_cmp(&norms_sq[*j])
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
+
+        let Some((i_star, _)) = best else {
+            break;
+        };
+
+        let best_norm_sq = norms_sq[i_star];
+
+        // Add to selected set
+        selected.push(i_star);
+        available[i_star] = false;
+
+        // Early exit if this is the last selection
+        if selected.len() == k {
+            break;
+        }
+
+        // Skip orthogonalization if norm is zero
+        if best_norm_sq <= 0.0 {
+            continue;
+        }
+
+        // Orthogonalize remaining residuals: R_j = R_j - (R_j . R_i* / ||R_i*||^2) * R_i*
+        // Clone r_star to avoid borrow issues
+        let r_star = residuals[i_star].clone();
+        let inv_norm_sq_star = 1.0 / best_norm_sq;
+
+        for j in 0..n {
+            if !available[j] {
+                continue;
+            }
+
+            let proj_coeff = dot_product(&residuals[j], &r_star) * inv_norm_sq_star;
+
+            // r_j <- r_j - proj_coeff * r_star (SIMD-friendly loop)
+            for (r_val, &rs_val) in residuals[j].iter_mut().zip(r_star.iter()) {
+                *r_val -= proj_coeff * rs_val;
+            }
+
+            // Update norm incrementally: ||r||^2 - proj^2 * ||rs||^2
+            norms_sq[j] = (norms_sq[j] - proj_coeff * proj_coeff * best_norm_sq).max(0.0);
+        }
+    }
+
+    selected
+        .iter()
+        .map(|&idx| {
+            let (id, dist, _) = candidates[idx];
+            (id, dist)
+        })
+        .collect()
+}
+
+/// Compute dot product of two vectors using SIMD-optimized implementation.
+#[inline]
+fn dot_product(a: &[f32], b: &[f32]) -> f32 {
+    <InnerProduct as PureDistanceFunction<&[f32], &[f32], MathematicalValue<f32>>>::evaluate(a, b)
+        .into_inner()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rag_post_process_with_eta() {
+        let v1 = vec![1.0f32, 0.0, 0.0];
+        let v2 = vec![0.0f32, 1.0, 0.0];
+        let v3 = vec![0.0f32, 0.0, 1.0];
+        let candidates = vec![
+            (1u32, 0.5f32, v1.as_slice()),
+            (2u32, 0.3f32, v2.as_slice()),
+            (3u32, 0.7f32, v3.as_slice()),
+        ];
+        let query = vec![1.0, 1.0, 1.0];
+
+        let result = rag_post_process(candidates, &query, 3, 0.01, 2.0);
+
+        // With eta > 0 and orthogonal vectors, all three should be selected
+        // (order determined by scaled residual norms, not distance).
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn test_rag_post_process_enabled_greedy() {
+        let v1 = vec![1.0f32, 0.0, 0.0];
+        let v2 = vec![0.99f32, 0.1, 0.0]; // Similar to 1
+        let v3 = vec![0.0f32, 1.0, 0.0]; // Orthogonal
+        let candidates = vec![
+            (1u32, 0.5f32, v1.as_slice()),
+            (2u32, 0.3f32, v2.as_slice()),
+            (3u32, 0.4f32, v3.as_slice()),
+        ];
+        let query = vec![1.0, 1.0, 0.0];
+
+        let result = rag_post_process(candidates, &query, 2, 0.0, 1.0);
+
+        // With greedy orthogonalization, should prefer diverse vectors
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_rag_post_process_empty() {
+        let candidates: Vec<(u32, f32, &[f32])> = vec![];
+        let query = vec![1.0, 1.0, 1.0];
+
+        let result = rag_post_process(candidates, &query, 3, 0.01, 2.0);
+        assert!(result.is_empty());
+    }
+}

--- a/diskann/src/graph/search/rag_post_process.rs
+++ b/diskann/src/graph/search/rag_post_process.rs
@@ -43,13 +43,13 @@ use diskann_vector::{MathematicalValue, PureDistanceFunction, distance::InnerPro
 /// # Returns
 ///
 /// Returns a vector of (id, distance) tuples, reranked for diversity.
-pub fn rag_post_process(
-    candidates: Vec<(u32, f32, &[f32])>,
+pub fn rag_post_process<Id: Copy>(
+    candidates: Vec<(Id, f32, &[f32])>,
     query: &[f32],
     k: usize,
     rag_eta: f64,
     rag_power: f64,
-) -> Vec<(u32, f32)> {
+) -> Vec<(Id, f32)> {
     if candidates.is_empty() {
         return Vec::new();
     }
@@ -57,7 +57,7 @@ pub fn rag_post_process(
     let k = k.min(candidates.len());
 
     // Convert candidates vectors to owned f32 for in-place orthogonalization
-    let candidates_f32: Vec<(u32, f32, Vec<f32>)> = candidates
+    let candidates_f32: Vec<(Id, f32, Vec<f32>)> = candidates
         .into_iter()
         .map(|(id, dist, v)| (id, dist, v.to_vec()))
         .collect();
@@ -101,13 +101,13 @@ pub fn rag_post_process(
 ///    - s_i <- s_i - alpha^2 (incremental norm update)
 ///
 /// Complexity: O(n * k * d) - same as greedy orthogonalization!
-fn post_process_with_eta_f32(
-    candidates: Vec<(u32, f32, Vec<f32>)>,
+fn post_process_with_eta_f32<Id: Copy>(
+    candidates: Vec<(Id, f32, Vec<f32>)>,
     query: &[f32],
     k: usize,
     rag_eta: f64,
     rag_power: f64,
-) -> Vec<(u32, f32)> {
+) -> Vec<(Id, f32)> {
     let eta = rag_eta as f32;
     let power = rag_power;
 
@@ -219,12 +219,12 @@ fn matrix_vec_mult(m: &[Vec<f32>], v: &[f32]) -> Vec<f32> {
 /// Optimized with:
 /// - Cached squared norms (avoid recomputing each iteration)
 /// - Parallel orthogonalization updates using rayon
-fn post_process_greedy_orthogonalization_f32(
-    candidates: Vec<(u32, f32, Vec<f32>)>,
+fn post_process_greedy_orthogonalization_f32<Id: Copy>(
+    candidates: Vec<(Id, f32, Vec<f32>)>,
     query: &[f32],
     k: usize,
     rag_power: f64,
-) -> Vec<(u32, f32)> {
+) -> Vec<(Id, f32)> {
     let power = rag_power;
 
     if candidates.is_empty() || query.is_empty() {

--- a/diskann/src/graph/search/rag_search.rs
+++ b/diskann/src/graph/search/rag_search.rs
@@ -32,17 +32,19 @@
 
 use std::num::NonZeroUsize;
 
-use diskann_utils::future::SendFuture;
+use diskann_utils::{Reborrow, future::SendFuture};
 
 use super::{Knn, KnnWith, Search};
 use crate::{
     ANNResult,
+    error::ErrorExt,
     graph::{
-        glue::PostProcess,
+        glue::{PostProcess, SearchStrategy},
         index::{DiskANNIndex, SearchStats},
         search_output_buffer::SearchOutputBuffer,
     },
-    provider::DataProvider,
+    neighbor::Neighbor,
+    provider::{Accessor, DataProvider},
 };
 
 /// Parameters for RAG post-processing.
@@ -85,6 +87,84 @@ impl RagSearchParams {
     /// Create new RAG search parameters.
     pub fn new(rag_eta: f64, rag_power: f64) -> Self {
         Self { rag_eta, rag_power }
+    }
+}
+
+/// Blanket implementation: any [`SearchStrategy`] whose accessor yields elements
+/// reborrowing to `AsRef<[f32]>` supports RAG post-processing for `[f32]` queries.
+///
+/// This impl fetches candidate vectors from the accessor, runs the RAG reranking
+/// algorithm ([`super::rag_post_process::rag_post_process`]), and writes the diversified
+/// results to the output buffer.
+///
+// TODO: This blanket impl requires `ElementRef: AsRef<[f32]>`, which only works for
+// accessors that return full-precision f32 vectors. It will not match strategies whose
+// accessors yield quantized vectors (e.g. `&[u8]` or `Hybrid<&[f32], &[u8]>`).
+// For those cases, we will need to provide concrete `PostProcess<RagSearchParams>`
+// implementations on specific strategies that can retrieve the full-precision vector
+// (e.g. via a secondary full-precision accessor or by dequantizing).
+impl<S, Provider> PostProcess<RagSearchParams, Provider, [f32]> for S
+where
+    S: SearchStrategy<Provider, [f32]>,
+    Provider: DataProvider,
+    for<'x, 'y> <S::SearchAccessor<'x> as Accessor>::ElementRef<'y>: AsRef<[f32]>,
+{
+    async fn post_process_with<'a, I, B>(
+        &self,
+        processor: &RagSearchParams,
+        accessor: &mut Self::SearchAccessor<'a>,
+        query: &[f32],
+        _computer: &Self::QueryComputer,
+        candidates: I,
+        output: &mut B,
+    ) -> ANNResult<usize>
+    where
+        I: Iterator<Item = Neighbor<Provider::InternalId>> + Send,
+        B: SearchOutputBuffer<Provider::InternalId> + Send + ?Sized,
+    {
+        // Collect candidates and fetch their vectors.
+        // TODO: This calls `get_element` which returns whatever the accessor's
+        // `Element` type is. For quantized accessors this would be quantized data,
+        // not full-precision f32. Specific strategy impls should override this to
+        // retrieve full-precision vectors when the default accessor is quantized.
+        let mut candidate_data: Vec<(Provider::InternalId, f32, Vec<f32>)> = Vec::new();
+        for neighbor in candidates {
+            let element = accessor
+                .get_element(neighbor.id)
+                .await
+                .escalate("failed to retrieve vector during RAG post-processing")?;
+            let vec_data: Vec<f32> = element.reborrow().as_ref().to_vec();
+            candidate_data.push((neighbor.id, neighbor.distance, vec_data));
+        }
+
+        if candidate_data.is_empty() {
+            return Ok(0);
+        }
+
+        // Determine k from the output buffer's remaining capacity.
+        let k = output
+            .size_hint()
+            .unwrap_or(candidate_data.len())
+            .min(candidate_data.len());
+
+        // Build input for rag_post_process using InternalId directly.
+        let rag_input: Vec<(Provider::InternalId, f32, &[f32])> = candidate_data
+            .iter()
+            .map(|(id, dist, v)| (*id, *dist, v.as_slice()))
+            .collect();
+
+        let reranked = super::rag_post_process::rag_post_process(
+            rag_input,
+            query,
+            k,
+            processor.rag_eta,
+            processor.rag_power,
+        );
+
+        // Write reranked results to output.
+        let count = output.extend(reranked);
+
+        Ok(count)
     }
 }
 

--- a/diskann/src/graph/search/rag_search.rs
+++ b/diskann/src/graph/search/rag_search.rs
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+//! RAG (Retrieval-Augmented Generation) search.
+//!
+//! This module provides a post-process-only RAG search that composes a standard k-NN
+//! graph search with RAG-specific reranking in post-processing. The reranking uses
+//! greedy orthogonalization to maximize diversity among the returned results.
+//!
+//! # Design
+//!
+//! `RagSearch` is a thin wrapper around [`KnnWith<RagSearchParams>`]. The core
+//! graph traversal is delegated entirely to [`Knn`]'s `search_core`, while the
+//! RAG-specific reranking (greedy orthogonalization / ridge-aware log-det) is applied
+//! purely in the post-processing phase.
+//!
+//! Strategy implementations must implement
+//! `PostProcess<RagSearchParams, Provider, T, O>` to bridge their accessor
+//! to the RAG reranking logic.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use diskann::graph::search::RagSearch;
+//! use diskann::graph::search::Knn;
+//!
+//! let rag = RagSearch::new(Knn::new(10, 100, None)?, 0.01, 2.0);
+//! let stats = index.search(rag, &strategy, &context, &query, &mut output).await?;
+//! ```
+
+use std::num::NonZeroUsize;
+
+use diskann_utils::future::SendFuture;
+
+use super::{Knn, KnnWith, Search};
+use crate::{
+    ANNResult,
+    graph::{
+        glue::PostProcess,
+        index::{DiskANNIndex, SearchStats},
+        search_output_buffer::SearchOutputBuffer,
+    },
+    provider::DataProvider,
+};
+
+/// Parameters for RAG post-processing.
+///
+/// `RagSearchParams` applies diversity-maximizing reranking purely in post-processing
+/// using greedy orthogonalization. This means it can be composed with **any** search algorithm
+/// (e.g., [`Knn`] via [`KnnWith`]) without duplicating search logic.
+///
+/// The reranking algorithm scales candidate vectors by their similarity to the query raised
+/// to `rag_power`, then greedily selects vectors that maximize the determinant of the
+/// Gram matrix (i.e., maximize volume/diversity).
+///
+/// # Parameters
+///
+/// - `rag_eta` - Ridge regularization parameter. Use 0.0 for pure greedy orthogonalization.
+/// - `rag_power` - Power to raise similarity scores to before scaling vectors.
+///
+/// # Usage
+///
+/// Strategy implementations should implement
+/// `PostProcess<RagSearchParams, Provider, T, O>` to bridge their accessor
+/// to the RAG reranking logic.
+///
+/// ```ignore
+/// use diskann::graph::search::{Knn, KnnWith, RagSearchParams};
+///
+/// let rag_pp = RagSearchParams::new(0.01, 2.0);
+/// let search = KnnWith::new(Knn::new(10, 100, None)?, rag_pp);
+/// let stats = index.search(search, &strategy, &context, &query, &mut output).await?;
+/// ```
+#[derive(Debug, Clone)]
+pub struct RagSearchParams {
+    /// Ridge regularization parameter. Use 0.0 for pure greedy orthogonalization.
+    pub rag_eta: f64,
+    /// Power to raise similarity scores to before scaling vectors.
+    pub rag_power: f64,
+}
+
+impl RagSearchParams {
+    /// Create new RAG search parameters.
+    pub fn new(rag_eta: f64, rag_power: f64) -> Self {
+        Self { rag_eta, rag_power }
+    }
+}
+
+/// RAG (Retrieval-Augmented Generation) search.
+///
+/// Performs a standard k-NN graph search followed by RAG-specific post-processing
+/// that reranks results for diversity using greedy orthogonalization.
+///
+/// # Example
+///
+/// ```ignore
+/// use diskann::graph::search::{Knn, RagSearch};
+///
+/// let knn = Knn::new(10, 100, None)?;
+/// let rag = RagSearch::new(knn, 0.01, 2.0);
+/// let stats = index.search(rag, &strategy, &context, &query, &mut output).await?;
+/// ```
+#[derive(Debug, Clone)]
+pub struct RagSearch {
+    /// The inner `KnnWith` that composes k-NN search with RAG post-processing.
+    inner: KnnWith<RagSearchParams>,
+}
+
+impl RagSearch {
+    /// Create new RAG search parameters.
+    ///
+    /// # Arguments
+    ///
+    /// * `knn` - Base k-NN search parameters (k, l, beam_width).
+    /// * `rag_eta` - Ridge regularization parameter. Use 0.0 for pure greedy orthogonalization.
+    /// * `rag_power` - Power to raise similarity scores to before scaling vectors.
+    pub fn new(knn: Knn, rag_eta: f64, rag_power: f64) -> Self {
+        let post_processor = RagSearchParams::new(rag_eta, rag_power);
+        Self {
+            inner: KnnWith::new(knn, post_processor),
+        }
+    }
+
+    /// Returns a reference to the inner k-NN parameters.
+    #[inline]
+    pub fn knn(&self) -> &Knn {
+        self.inner.inner()
+    }
+
+    /// Returns the RAG eta (ridge regularization) parameter.
+    #[inline]
+    pub fn rag_eta(&self) -> f64 {
+        self.inner.post_processor().rag_eta
+    }
+
+    /// Returns the RAG power parameter.
+    #[inline]
+    pub fn rag_power(&self) -> f64 {
+        self.inner.post_processor().rag_power
+    }
+
+    /// Returns the number of results to return (k in k-NN).
+    #[inline]
+    pub fn k_value(&self) -> NonZeroUsize {
+        self.inner.inner().k_value()
+    }
+
+    /// Returns the search list size.
+    #[inline]
+    pub fn l_value(&self) -> NonZeroUsize {
+        self.inner.inner().l_value()
+    }
+}
+
+impl<DP, S, T, O, OB> Search<DP, S, T, O, OB> for RagSearch
+where
+    DP: DataProvider,
+    T: Sync + ?Sized,
+    S: PostProcess<RagSearchParams, DP, T, O>,
+    O: Send,
+    OB: SearchOutputBuffer<O> + Send + ?Sized,
+{
+    type Output = SearchStats;
+
+    /// Execute the RAG search on the given index.
+    ///
+    /// This performs a standard k-NN graph traversal followed by RAG-specific
+    /// post-processing that reranks results for diversity.
+    ///
+    /// # Arguments
+    ///
+    /// * `index` - The DiskANN index to search.
+    /// * `strategy` - The search strategy (must implement `PostProcess<RagSearchParams>`).
+    /// * `context` - The context to pass through to providers.
+    /// * `query` - The query vector for which nearest neighbors are sought.
+    /// * `output` - A mutable buffer to store the search results.
+    ///
+    /// # Returns
+    ///
+    /// Returns [`SearchStats`] containing distance computations, hops, and timing.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if there is a failure accessing elements or computing distances.
+    fn search(
+        self,
+        index: &DiskANNIndex<DP>,
+        strategy: &S,
+        context: &DP::Context,
+        query: &T,
+        output: &mut OB,
+    ) -> impl SendFuture<ANNResult<Self::Output>> {
+        self.inner.search(index, strategy, context, query, output)
+    }
+}
+
+///////////
+// Tests //
+///////////
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::search::knn_search::KnnSearchError;
+
+    #[test]
+    fn test_rag_search_creation() {
+        let knn = Knn::new(10, 100, None).unwrap();
+        let rag = RagSearch::new(knn, 0.01, 2.0);
+
+        assert_eq!(rag.k_value().get(), 10);
+        assert_eq!(rag.l_value().get(), 100);
+        assert_eq!(rag.rag_eta(), 0.01);
+        assert_eq!(rag.rag_power(), 2.0);
+    }
+
+    #[test]
+    fn test_rag_search_zero_eta() {
+        let knn = Knn::new(5, 50, Some(4)).unwrap();
+        let rag = RagSearch::new(knn, 0.0, 1.0);
+
+        assert_eq!(rag.k_value().get(), 5);
+        assert_eq!(rag.l_value().get(), 50);
+        assert_eq!(rag.rag_eta(), 0.0);
+        assert_eq!(rag.rag_power(), 1.0);
+    }
+
+    #[test]
+    fn test_rag_search_invalid_knn() {
+        // k > l should fail at the Knn level
+        assert!(matches!(
+            Knn::new(100, 10, None),
+            Err(KnnSearchError::LLessThanK { .. })
+        ));
+    }
+}

--- a/diskann/src/graph/search/range_search.rs
+++ b/diskann/src/graph/search/range_search.rs
@@ -5,7 +5,7 @@
 
 //! Range-based search within a distance radius.
 
-use diskann_utils::future::{AssertSend, SendFuture};
+use diskann_utils::future::SendFuture;
 use thiserror::Error;
 
 use super::{Search, scratch::SearchScratch};
@@ -13,7 +13,9 @@ use crate::{
     ANNError, ANNErrorKind, ANNResult,
     error::IntoANNResult,
     graph::{
-        glue::{self, ExpandBeam, SearchExt, SearchPostProcess, SearchStrategy},
+        glue::{
+            self, DefaultPostProcess, ExpandBeam, PostProcess, SearchExt,
+        },
         index::{DiskANNIndex, InternalSearchStats, SearchStats},
         search::record::NoopSearchRecord,
         search_output_buffer,
@@ -171,7 +173,7 @@ impl<DP, S, T, O> Search<DP, S, T, O, ()> for Range
 where
     DP: DataProvider,
     T: Sync + ?Sized,
-    S: SearchStrategy<DP, T, O>,
+    S: PostProcess<DefaultPostProcess, DP, T, O>,
     O: Send + Default + Clone,
 {
     type Output = RangeSearchOutput<O>;
@@ -251,17 +253,15 @@ where
             );
 
             let _ = strategy
-                .post_processor()
-                .post_process(
+                .post_process_with(
+                    &DefaultPostProcess,
                     &mut accessor,
                     query,
                     &computer,
                     scratch.in_range.iter().copied(),
                     &mut output_buffer,
                 )
-                .send()
-                .await
-                .into_ann_result()?;
+                .await?;
 
             // Filter by inner/outer radius
             let inner_cutoff = if let Some(inner_radius) = self.inner_radius() {

--- a/diskann/src/graph/search/range_search.rs
+++ b/diskann/src/graph/search/range_search.rs
@@ -13,9 +13,7 @@ use crate::{
     ANNError, ANNErrorKind, ANNResult,
     error::IntoANNResult,
     graph::{
-        glue::{
-            self, DefaultPostProcess, ExpandBeam, PostProcess, SearchExt,
-        },
+        glue::{self, DefaultPostProcess, ExpandBeam, PostProcess, SearchExt},
         index::{DiskANNIndex, InternalSearchStats, SearchStats},
         search::record::NoopSearchRecord,
         search_output_buffer,


### PR DESCRIPTION
## This PR is replaced by [817](https://github.com/microsoft/DiskANN/pull/817) . This PR is for reference to compare 817 and will be abandoned after 817 merges.

## Post-Process Refactor: Composable `PostProcess` Trait & RAG Search

### Summary

Introduces a composable `PostProcess<Processor, Provider, T, O>` trait that decouples post-processing logic from the core search algorithm, and uses it to implement RAG-aware search as the first concrete consumer.

### Changes

#### New: `PostProcess` trait (`glue.rs`)
- Generic trait parameterized by a `Processor` marker type, enabling different post-processing strategies to be composed with any `SearchStrategy` without duplicating the search loop.
- `DefaultPostProcess` marker type with a blanket impl that delegates to the strategy's existing `SearchPostProcess`or -- every `SearchStrategy` gets default post-processing for free.

#### New: `rag_post_process.rs`
- Greedy orthogonalization algorithm for RAG result diversification.
- Ridge-aware log-determinant reranking (`eta > 0` path).
- SIMD-accelerated `dot_product` via `InnerProduct`.
- Comprehensive unit tests (3 tests).

#### New: `rag_search.rs`
- `RagSearchParams` struct (`rag_eta`, `rag_power`) -- the processor marker for RAG post-processing.
- `RagSearch` struct wrapping `KnnWith<RagSearchParams>`, implementing `Search` by delegating to the composed inner type.
- Accessor methods: `knn()`, `rag_eta()`, `rag_power()`, `k_value()`, `l_value()`.
- Unit tests (3 tests).

#### Modified: `knn_search.rs`
- `KnnWith<PP>` now accepts a generic `Processor` and requires `S: PostProcess<PP, ...>` instead of hardcoding a specific post-processor.
- Updated doc examples to reference `RagSearchParams`.

### Design

```
Search::search()
  -- KnnWith<PP>::search()
       -- search_core() -> greedy graph traversal
            -- PostProcess<PP>::post_process_with()
                 -- (e.g.) rag_post_process() for RagSearchParams
                 -- (e.g.) strategy.post_processor() for DefaultPostProcess
```

Any new post-processing strategy only needs to:
1. Define a marker struct (like `RagSearchParams`).
2. Implement `PostProcess<MarkerStruct>` on the relevant strategy.
3. Wrap `KnnWith<MarkerStruct>` in a search type.