### PR TITLE
Bump version to 0.47.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "diskann"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-core"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "diskann",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-runner"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-simd"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "diskann-benchmark-runner",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-disk"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-label-filter"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-linalg"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "approx",
  "cfg-if",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-platform"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "io-uring",
  "libc",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-providers"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-quantization"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-tools"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-utils"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "cfg-if",
  "diskann-vector",
@@ -703,7 +703,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-vector"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "approx",
  "cfg-if",
@@ -717,7 +717,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-wide"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "cfg-if",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.46.0"      # Obeying semver
+version = "0.47.0"      # Obeying semver
 description = "DiskANN is a fast approximate nearest neighbor search library for high dimensional data"
 authors = ["Microsoft"]
 documentation = "https://github.com/microsoft/DiskANN"
@@ -46,22 +46,22 @@ undocumented_unsafe_blocks = "warn"
 
 [workspace.dependencies]
 # Base And Numerics
-diskann-wide = { path = "diskann-wide", version = "0.46.0" }
-diskann-vector = { path = "diskann-vector", version = "0.46.0" }
-diskann-linalg = { path = "diskann-linalg", version = "0.46.0" }
-diskann-utils = { path = "diskann-utils", default-features = false, version = "0.46.0" }
-diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.46.0" }
-diskann-platform = { path = "diskann-platform", version = "0.46.0" }
+diskann-wide = { path = "diskann-wide", version = "0.47.0" }
+diskann-vector = { path = "diskann-vector", version = "0.47.0" }
+diskann-linalg = { path = "diskann-linalg", version = "0.47.0" }
+diskann-utils = { path = "diskann-utils", default-features = false, version = "0.47.0" }
+diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.47.0" }
+diskann-platform = { path = "diskann-platform", version = "0.47.0" }
 # Algorithm
-diskann = { path = "diskann", version = "0.46.0" }
+diskann = { path = "diskann", version = "0.47.0" }
 # Providers
-diskann-providers = { path = "diskann-providers", default-features = false, version = "0.46.0" }
-diskann-disk = { path = "diskann-disk", version = "0.46.0" }
-diskann-label-filter = { path = "diskann-label-filter", version = "0.46.0" }
+diskann-providers = { path = "diskann-providers", default-features = false, version = "0.47.0" }
+diskann-disk = { path = "diskann-disk", version = "0.47.0" }
+diskann-label-filter = { path = "diskann-label-filter", version = "0.47.0" }
 # Infra
-diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.46.0" }
-diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.46.0" }
-diskann-tools = { path = "diskann-tools", version = "0.46.0" }
+diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.47.0" }
+diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.47.0" }
+diskann-tools = { path = "diskann-tools", version = "0.47.0" }
 
 # External dependencies (shared versions)
 anyhow = "1.0.98"


### PR DESCRIPTION
# DiskANN v0.47.0

## Summary
* This version contains a major breaking change to the search interface of `DiskANNIndex`. Please read the upgrade instructions below.
* An Aarch64 Neon has been added to `diskann-wide`.
* Various bug-fixes and code-quality improvements.

## Changes to Search
The search interface has been unified around a single `index.search()` entry point using the `Search` trait.
The old per-search-type methods on `DiskANNIndex` (`search`, `search_recorded`, `range_search`, `multihop_search`) have been removed and replaced by typed parameter structs that carry their own search logic.

### What Changed

| Removed                                                    | Replacement                                                  |
|------------------------------------------------------------|--------------------------------------------------------------|
| `SearchParams` struct                                      | `diskann::graph::search::Knn`                                |
| `RangeSearchParams` struct                                 | `diskann::graph::search::Range`                              |
| `SearchParamsError`                                        | `diskann::graph::KnnSearchError`                             |
| `RangeSearchParamsError`                                   | `diskann::graph::RangeSearchError`                           |
| `index.search(&strategy, &ctx, &query, &params, &mut out)` | `index.search(knn, &strategy, &ctx, &query, &mut out)`       |
| `index.search_recorded(..., &mut recorder)`                | `index.search(RecordedKnn::new(knn, &mut recorder), ...)`    |
| `index.range_search(&strategy, &ctx, &query, &params)`     | `index.search(range, &strategy, &ctx, &query, &mut ())`      |
| `index.multihop_search(..., &label_eval)`                  | `index.search(MultihopSearch::new(knn, &label_eval), ...)`   |
| `index.diverse_search(...)`                                | `index.search(Diverse::new(knn, diverse_params), ...)`       |

**`flat_search`** remains an inherent method on `DiskANNIndex`
Its `search_params` argument changed from `&SearchParams` to `&Knn`.

### Upgrade Instructions

#### 1. k-NN Search (`search`)

**Before:**

```rust
use diskann::graph::SearchParams;

let params = SearchParams::new(10, 100, None)?;
let stats = index.search(&strategy, &ctx, &query, &params, &mut output).await?;
```

**After:**

```rust
use diskann::graph::{Search, search::Knn};

let params = Knn::new(10, 100, None)?;
// Note: params is now the FIRST argument (moved before strategy)
let stats = index.search(params, &strategy, &ctx, &query, &mut output).await?;
```

Key differences:

- `SearchParams` -> `Knn` (import from `diskann::graph::search::Knn`)
- `SearchParamsError` -> `KnnSearchError` (import from `diskann::graph::KnnSearchError`)
- Search params moved to the **first** argument of `index.search()`
- `k_value`, `l_value` fields are now private; use `.k_value()`, `.l_value()` accessors (return `NonZeroUsize`)

#### 2. Recorded/Debug Search (`search_recorded`)

**Before:**

```rust
use diskann::graph::SearchParams;

let params = SearchParams::new(10, 100, None)?;
let stats = index
   .search_recorded(&strategy, &ctx, &query, &params, &mut output, &mut recorder)
   .await?;
```

**After:**

```rust
use diskann::graph::{Search, search::{Knn, RecordedKnn}};

let params = Knn::new(10, 100, None)?;
let recorded = RecordedKnn::new(params, &mut recorder);
let stats = index.search(recorded, &strategy, &ctx, &query, &mut output).await?;
```

#### 3. Range Search (`range_search`)

**Before:**

```rust
use diskann::graph::RangeSearchParams;

let params = RangeSearchParams::new(None, 100, None, 0.5, None, 1.0, 1.0)?;
let (stats, ids, distances) = index
   .range_search(&strategy, &ctx, &query, &params)
   .await?;
```

**After:**

```rust
use diskann::graph::{
    Search,
    search::Range,
    RangeSearchOutput,
};

// Simple form:
let params = Range::new(100, 0.5)?;
// Or full options form:
let params = Range::with_options(None, 100, None, 0.5, None, 1.0, 1.0)?;

// Note: output buffer is `&mut ()` — results come back in the return type
let result: RangeSearchOutput<_> = index
   .search(params, &strategy, &ctx, &query, &mut ())
   .await?;

// Access results:
let stats = result.stats;
let ids = result.ids;           // Vec<O>
let distances = result.distances; // Vec<f32>
```

Key differences:

- `RangeSearchParams` -> `Range` (import from `diskann::graph::search::Range`)
- `RangeSearchParamsError` -> `RangeSearchError` (import from `diskann::graph::RangeSearchError`)
- Return type changed from `(SearchStats, Vec<O>, Vec<f32>)` to `RangeSearchOutput<O>` (a struct with `.stats`, `.ids`, `.distances` fields)
- Pass `&mut ()` as the output buffer
- Field `starting_l_value` -> constructor arg `starting_l` (accessor: `.starting_l()`)
- Field `initial_search_slack` -> constructor arg `initial_slack` (accessor: `.initial_slack()`)
- Field `range_search_slack` -> constructor arg `range_slack` (accessor: `.range_slack()`)

#### 4. Multihop / Label-Filtered Search (`multihop_search`)

**Before:**

```rust
use diskann::graph::SearchParams;

let params = SearchParams::new(10, 100, None)?;
let stats = index
   .multihop_search(&strategy, &ctx, &query, &params, &mut output, &label_eval)
   .await?;
```

**After:**

```rust
use diskann::graph::{Search, search::{Knn, MultihopSearch}};

let knn = Knn::new(10, 100, None)?;
let params = MultihopSearch::new(knn, &label_eval);
let stats = index.search(params, &strategy, &ctx, &query, &mut output).await?;
```

Key differences:

- `MultihopSearch` wraps a `Knn` -> label evaluator into a single params object
- The label evaluator is part of the params, not a separate argument

#### 5. Flat Search (unchanged method, new param type)

**Before:**

```rust
use diskann::graph::SearchParams;

let params = SearchParams::new(10, 100, None)?;
index.flat_search(&strategy, &ctx, &query, &filter, &params, &mut output).await?;
```

**After:**

```rust
use diskann::graph::search::Knn;

let params = Knn::new(10, 100, None)?;
index.flat_search(&strategy, &ctx, &query, &filter, &params, &mut output).await?;
```

Only the parameter type changed (`SearchParams` -> `Knn`).

### Import Path Changes

| Old                                      | New                                                    |
|------------------------------------------|--------------------------------------------------------|
| `diskann::graph::SearchParams`           | `diskann::graph::search::Knn`                          |
| `diskann::graph::RangeSearchParams`      | `diskann::graph::search::Range`                        |
| `diskann::graph::SearchParamsError`      | `diskann::graph::KnnSearchError`                       |
| `diskann::graph::RangeSearchParamsError` | `diskann::graph::RangeSearchError`                     |
| —                                        | `diskann::graph::search::MultihopSearch` (new)         |
| —                                        | `diskann::graph::search::RecordedKnn` (new)            |
| —                                        | `diskann::graph::search::Diverse` (new, feature-gated) |
| —                                        | `diskann::graph::Search` (trait, re-exported)          |
| —                                        | `diskann::graph::RangeSearchOutput` (re-exported)      |

## Change List
* copy bftrees from the snapshot location to the save location by @backurs in https://github.com/microsoft/DiskANN/pull/783
* (RFC) Refactor search interface with unified SearchDispatch trait by @narendatha in https://github.com/microsoft/DiskANN/pull/773
* Make queue.closest_notvisited() safe and update call sites by @arrayka in https://github.com/microsoft/DiskANN/pull/787
* git ignore: Ignore local settings for claude code AI agent by @arrayka in https://github.com/microsoft/DiskANN/pull/789
* Enabling flag support in codecov by @arrayka in https://github.com/microsoft/DiskANN/pull/790
* Increase unit test coverage for diskann-tools crate by @Copilot in https://github.com/microsoft/DiskANN/pull/763
* Neon MVP by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/777
* Adding GraphParams to be able to save graph parameters of index to SavedParams by @backurs in https://github.com/microsoft/DiskANN/pull/786

## New Contributors
* @narendatha made their first contribution in https://github.com/microsoft/DiskANN/pull/773

**Full Changelog**: https://github.com/microsoft/DiskANN/compare/0.46.0...v0.47.0