### PR TITLE
(Do not review) Refactor PostProcess and DefaultPostProcess: DelegatePostProcess blanket + delegate_default_post_process! macro

### DIFF
--- a/diskann-benchmark-core/src/search/graph/knn.rs
+++ b/diskann-benchmark-core/src/search/graph/knn.rs
@@ -88,7 +88,7 @@ pub struct Metrics {
 impl<DP, T, S> Search for KNN<DP, T, S>
 where
     DP: provider::DataProvider<Context: Default, ExternalId: search::Id>,
-    S: glue::SearchStrategy<DP, [T], DP::ExternalId> + Clone + AsyncFriendly,
+    S: glue::DefaultPostProcess<DP, [T], DP::ExternalId> + Clone + AsyncFriendly,
     T: AsyncFriendly + Clone,
 {
     type Id = DP::ExternalId;

--- a/diskann-benchmark-core/src/search/graph/multihop.rs
+++ b/diskann-benchmark-core/src/search/graph/multihop.rs
@@ -86,7 +86,7 @@ where
 impl<DP, T, S> Search for MultiHop<DP, T, S>
 where
     DP: provider::DataProvider<Context: Default, ExternalId: search::Id>,
-    S: glue::SearchStrategy<DP, [T], DP::ExternalId> + Clone + AsyncFriendly,
+    S: glue::DefaultPostProcess<DP, [T], DP::ExternalId> + Clone + AsyncFriendly,
     T: AsyncFriendly + Clone,
 {
     type Id = DP::ExternalId;

--- a/diskann-benchmark-core/src/search/graph/range.rs
+++ b/diskann-benchmark-core/src/search/graph/range.rs
@@ -79,7 +79,7 @@ pub struct Metrics {}
 impl<DP, T, S> Search for Range<DP, T, S>
 where
     DP: provider::DataProvider<Context: Default, ExternalId: search::Id>,
-    S: glue::SearchStrategy<DP, [T], DP::ExternalId> + Clone + AsyncFriendly,
+    S: glue::DefaultPostProcess<DP, [T], DP::ExternalId> + Clone + AsyncFriendly,
     T: AsyncFriendly + Clone,
 {
     type Id = DP::ExternalId;

--- a/diskann-benchmark/src/backend/index/benchmarks.rs
+++ b/diskann-benchmark/src/backend/index/benchmarks.rs
@@ -349,7 +349,7 @@ where
     DP: DataProvider<Context = DefaultContext, InternalId = u32, ExternalId = u32>
         + provider::SetElement<[T]>,
     T: SampleableForStart + std::fmt::Debug + Copy + AsyncFriendly + bytemuck::Pod,
-    S: glue::SearchStrategy<DP, [T]> + Clone + AsyncFriendly,
+    S: glue::DefaultPostProcess<DP, [T], u32> + Clone + AsyncFriendly,
 {
     match &input {
         SearchPhase::Topk(search_phase) => {

--- a/diskann-disk/src/search/provider/disk_provider.rs
+++ b/diskann-disk/src/search/provider/disk_provider.rs
@@ -18,7 +18,7 @@ use std::{
 use diskann::{
     graph::{
         self,
-        glue::{self, ExpandBeam, IdIterator, SearchExt, SearchPostProcess, SearchStrategy},
+        glue::{self, DefaultPostProcess, DelegatePostProcess, ExpandBeam, IdIterator, SearchExt, SearchPostProcess, SearchStrategy},
         search::Knn,
         search_output_buffer, AdjacencyList, DiskANNIndex, SearchOutputBuffer,
     },
@@ -351,7 +351,6 @@ where
     type QueryComputer = DiskQueryComputer;
     type SearchAccessor<'a> = DiskAccessor<'a, Data, ProviderFactory::VertexProviderType>;
     type SearchAccessorError = ANNError;
-    type PostProcessor = RerankAndFilter<'this>;
 
     fn search_accessor<'a>(
         &'a self,
@@ -366,8 +365,30 @@ where
             self.scratch_pool,
         )
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
+impl<'this, Data, ProviderFactory> DelegatePostProcess
+    for DiskSearchStrategy<'this, Data, ProviderFactory>
+where
+    Data: GraphDataType<VectorIdType = u32>,
+    ProviderFactory: VertexProviderFactory<Data>,
+{}
+
+impl<'this, Data, ProviderFactory>
+    DefaultPostProcess<
+        DiskProvider<Data>,
+        [Data::VectorDataType],
+        (
+            <DiskProvider<Data> as DataProvider>::InternalId,
+            Data::AssociatedDataType,
+        ),
+    > for DiskSearchStrategy<'this, Data, ProviderFactory>
+where
+    Data: GraphDataType<VectorIdType = u32>,
+    ProviderFactory: VertexProviderFactory<Data>,
+{
+    type Processor = RerankAndFilter<'this>;
+    fn create_processor(&self) -> Self::Processor {
         RerankAndFilter::new(self.vector_filter)
     }
 }

--- a/diskann-label-filter/src/inline_beta_search/inline_beta_filter.rs
+++ b/diskann-label-filter/src/inline_beta_search/inline_beta_filter.rs
@@ -4,7 +4,7 @@
  */
 
 use diskann::error::IntoANNResult;
-use diskann::graph::glue::{SearchPostProcess, SearchStrategy};
+use diskann::graph::glue::{DefaultPostProcess, DelegatePostProcess, SearchPostProcess, SearchStrategy};
 use diskann::neighbor::Neighbor;
 use diskann::provider::{Accessor, BuildQueryComputer, DataProvider};
 
@@ -37,7 +37,6 @@ where
     Q: AsyncFriendly + Clone,
 {
     type QueryComputer = InlineBetaComputer<Strategy::QueryComputer>;
-    type PostProcessor = FilterResults<Strategy::PostProcessor>;
     type SearchAccessorError = ANNError;
     type SearchAccessor<'a> = EncodedDocumentAccessor<Strategy::SearchAccessor<'a>>;
 
@@ -61,9 +60,24 @@ where
         ))
     }
 
-    fn post_processor(&self) -> Self::PostProcessor {
+}
+
+impl<Strategy> DelegatePostProcess for InlineBetaStrategy<Strategy> {}
+
+impl<DP, Strategy, Q>
+    DefaultPostProcess<DocumentProvider<DP, RoaringAttributeStore<DP::InternalId>>, FilteredQuery<Q>>
+    for InlineBetaStrategy<Strategy>
+where
+    DP: DataProvider,
+    Strategy: DefaultPostProcess<DP, Q>,
+    Strategy::Processor:
+        for<'a> SearchPostProcess<Strategy::SearchAccessor<'a>, Q> + Send + Sync,
+    Q: AsyncFriendly + Clone,
+{
+    type Processor = FilterResults<Strategy::Processor>;
+    fn create_processor(&self) -> Self::Processor {
         FilterResults {
-            inner_post_processor: self.inner.post_processor(),
+            inner_post_processor: self.inner.create_processor(),
         }
     }
 }

--- a/diskann-providers/src/index/diskann_async.rs
+++ b/diskann-providers/src/index/diskann_async.rs
@@ -175,7 +175,7 @@ pub(crate) mod tests {
         graph::{
             self, AdjacencyList, ConsolidateKind, InplaceDeleteMethod, StartPointStrategy,
             config::IntraBatchCandidates,
-            glue::{AsElement, InplaceDeleteStrategy, InsertStrategy, SearchStrategy, aliases},
+            glue::{AsElement, DefaultPostProcess, InplaceDeleteStrategy, InsertStrategy, PostProcess, SearchStrategy, aliases},
             index::{PartitionedNeighbors, QueryLabelProvider, QueryVisitDecision},
             search::{Knn, Range},
             search_output_buffer,
@@ -346,7 +346,7 @@ pub(crate) mod tests {
         mut checker: Checker,
     ) where
         DP: DataProvider<InternalId = u32>,
-        S: SearchStrategy<DP, Q>,
+        S: DefaultPostProcess<DP, Q, u32>,
         Q: std::fmt::Debug + Sync + ?Sized,
         Checker: FnMut(usize, (u32, f32)) -> Result<(), Box<dyn std::fmt::Display>>,
     {
@@ -394,7 +394,7 @@ pub(crate) mod tests {
         filter: &dyn QueryLabelProvider<DP::InternalId>,
     ) where
         DP: DataProvider<InternalId = u32>,
-        S: SearchStrategy<DP, Q>,
+        S: DefaultPostProcess<DP, Q, u32>,
         Q: std::fmt::Debug + Sync + ?Sized,
         Checker: FnMut(usize, (u32, f32)) -> Result<(), Box<dyn std::fmt::Display>>,
     {
@@ -500,8 +500,8 @@ pub(crate) mod tests {
         quant_strategy: QS,
     ) where
         DP: DataProvider<InternalId = u32, Context = DefaultContext>,
-        FS: SearchStrategy<DP, [T]> + Clone + 'static,
-        QS: SearchStrategy<DP, [T]> + Clone + 'static,
+        FS: DefaultPostProcess<DP, [T], u32> + Clone + 'static,
+        QS: DefaultPostProcess<DP, [T], u32> + Clone + 'static,
         T: Default + Clone + Send + Sync + std::fmt::Debug,
     {
         // Assume all vectors have the same length.
@@ -923,7 +923,7 @@ pub(crate) mod tests {
     ) where
         T: VectorRepr + GenerateSphericalData + Into<f32>,
         S: InsertStrategy<FullPrecisionProvider<T, DefaultQuant>, [T]>
-            + SearchStrategy<FullPrecisionProvider<T, DefaultQuant>, [T]>
+            + DefaultPostProcess<FullPrecisionProvider<T, DefaultQuant>, [T], u32>
             + Clone
             + 'static,
         rand::distr::StandardUniform: Distribution<T>,
@@ -1050,7 +1050,7 @@ pub(crate) mod tests {
     ) where
         T: VectorRepr + GenerateSphericalData + Into<f32>,
         S: InsertStrategy<FullPrecisionProvider<T, DefaultQuant>, [T]>
-            + SearchStrategy<FullPrecisionProvider<T, DefaultQuant>, [T]>
+            + DefaultPostProcess<FullPrecisionProvider<T, DefaultQuant>, [T], u32>
             + Clone
             + 'static,
         rand::distr::StandardUniform: Distribution<T>,
@@ -3065,6 +3065,7 @@ pub(crate) mod tests {
         S: InsertStrategy<TestProvider, [f32]>
             + SearchStrategy<TestProvider, [f32]>
             + for<'a> InplaceDeleteStrategy<TestProvider, DeleteElement<'a> = [f32]>
+            + for<'a> PostProcess<TestProvider, [f32], <S as InplaceDeleteStrategy<TestProvider>>::SearchPostProcessor>
             + Clone
             + Sync,
         for<'a> aliases::InsertPruneAccessor<'a, S, TestProvider, [f32]>: AsElement<&'a [f32]>,
@@ -3167,6 +3168,7 @@ pub(crate) mod tests {
         S: InsertStrategy<TestProvider, [f32]>
             + SearchStrategy<TestProvider, [f32]>
             + for<'a> InplaceDeleteStrategy<TestProvider, DeleteElement<'a> = [f32]>
+            + for<'a> PostProcess<TestProvider, [f32], <S as InplaceDeleteStrategy<TestProvider>>::SearchPostProcessor>
             + Clone
             + Sync,
         for<'a> aliases::InsertPruneAccessor<'a, S, TestProvider, [f32]>: AsElement<&'a [f32]>,

--- a/diskann-providers/src/index/wrapped_async.rs
+++ b/diskann-providers/src/index/wrapped_async.rs
@@ -10,7 +10,8 @@ use diskann::{
     graph::{
         self, ConsolidateKind, InplaceDeleteMethod,
         glue::{
-            self, AsElement, InplaceDeleteStrategy, InsertStrategy, PruneStrategy, SearchStrategy,
+            self, AsElement, DefaultPostProcess, InplaceDeleteStrategy, InsertStrategy,
+            PruneStrategy, SearchStrategy,
         },
         index::{DegreeStats, PartitionedNeighbors, SearchState, SearchStats},
         search::Knn,
@@ -232,7 +233,7 @@ where
     ) -> ANNResult<SearchStats>
     where
         T: Sync + ?Sized,
-        S: SearchStrategy<DP, T, O>,
+        S: DefaultPostProcess<DP, T, O>,
         O: Send,
         OB: search_output_buffer::SearchOutputBuffer<O> + Send,
     {

--- a/diskann-providers/src/model/graph/provider/async_/bf_tree/provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/bf_tree/provider.rs
@@ -18,11 +18,12 @@ use serde::{Deserialize, Serialize};
 use bf_tree::{BfTree, Config};
 use diskann::{
     ANNError, ANNResult,
+    error::IntoANNResult,
     graph::{
         AdjacencyList, DiskANNIndex, SearchOutputBuffer,
         glue::{
-            self, ExpandBeam, FillSet, InplaceDeleteStrategy, InsertStrategy, PruneStrategy,
-            SearchExt, SearchStrategy,
+            self, DefaultPostProcess, ExpandBeam, FillSet, InplaceDeleteStrategy,
+            InsertStrategy, PruneStrategy, SearchExt, SearchStrategy,
         },
     },
     neighbor::Neighbor,
@@ -1475,7 +1476,6 @@ where
     type QueryComputer = T::QueryDistance;
     type SearchAccessor<'a> = FullAccessor<'a, T, Q, D>;
     type SearchAccessorError = Panics;
-    type PostProcessor = RemoveDeletedIdsAndCopy;
 
     fn search_accessor<'a>(
         &'a self,
@@ -1484,10 +1484,16 @@ where
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
         Ok(FullAccessor::new(provider))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+
+impl<T, Q, D> DefaultPostProcess<BfTreeProvider<T, Q, D>, [T]> for Internal<FullPrecision>
+where
+    T: VectorRepr,
+    Q: AsyncFriendly,
+    D: AsyncFriendly + DeletionCheck,
+{
+    diskann::delegate_default_post_process!(RemoveDeletedIdsAndCopy);
 }
 
 /// Perform a search entirely in the full-precision space.
@@ -1502,7 +1508,6 @@ where
     type QueryComputer = T::QueryDistance;
     type SearchAccessor<'a> = FullAccessor<'a, T, Q, D>;
     type SearchAccessorError = Panics;
-    type PostProcessor = glue::Pipeline<glue::FilterStartPoints, RemoveDeletedIdsAndCopy>;
 
     fn search_accessor<'a>(
         &'a self,
@@ -1511,10 +1516,16 @@ where
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
         Ok(FullAccessor::new(provider))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+
+impl<T, Q, D> DefaultPostProcess<BfTreeProvider<T, Q, D>, [T]> for FullPrecision
+where
+    T: VectorRepr,
+    Q: AsyncFriendly,
+    D: AsyncFriendly + DeletionCheck,
+{
+    diskann::delegate_default_post_process!(glue::Pipeline<glue::FilterStartPoints, RemoveDeletedIdsAndCopy>);
 }
 
 /// An [`glue::SearchPostProcess`] implementation that reranks PQ vectors.
@@ -1580,7 +1591,6 @@ where
     type QueryComputer = pq::distance::QueryComputer<Arc<FixedChunkPQTable>>;
     type SearchAccessor<'a> = QuantAccessor<'a, T, D>;
     type SearchAccessorError = Panics;
-    type PostProcessor = Rerank;
 
     fn search_accessor<'a>(
         &'a self,
@@ -1589,10 +1599,16 @@ where
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
         Ok(QuantAccessor::new(provider))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+
+impl<T, D> DefaultPostProcess<BfTreeProvider<T, QuantVectorProvider, D>, [T]>
+    for Internal<Hybrid>
+where
+    T: VectorRepr,
+    D: AsyncFriendly + DeletionCheck,
+{
+    diskann::delegate_default_post_process!(Rerank);
 }
 
 /// Perform a search entirely in the quantized space.
@@ -1607,7 +1623,6 @@ where
     type QueryComputer = pq::distance::QueryComputer<Arc<FixedChunkPQTable>>;
     type SearchAccessor<'a> = QuantAccessor<'a, T, D>;
     type SearchAccessorError = Panics;
-    type PostProcessor = glue::Pipeline<glue::FilterStartPoints, Rerank>;
 
     fn search_accessor<'a>(
         &'a self,
@@ -1616,10 +1631,15 @@ where
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
         Ok(QuantAccessor::new(provider))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+
+impl<T, D> DefaultPostProcess<BfTreeProvider<T, QuantVectorProvider, D>, [T]> for Hybrid
+where
+    T: VectorRepr,
+    D: AsyncFriendly + DeletionCheck,
+{
+    diskann::delegate_default_post_process!(glue::Pipeline<glue::FilterStartPoints, Rerank>);
 }
 
 // Pruning
@@ -1731,8 +1751,13 @@ where
     type DeleteElementGuard = Box<[T]>;
     type PruneStrategy = Self;
     type SearchStrategy = Internal<Self>;
+    type SearchPostProcessor = RemoveDeletedIdsAndCopy;
     fn search_strategy(&self) -> Self::SearchStrategy {
         Internal(Self)
+    }
+
+    fn search_post_processor(&self) -> Self::SearchPostProcessor {
+        Default::default()
     }
 
     fn prune_strategy(&self) -> Self::PruneStrategy {
@@ -1765,8 +1790,13 @@ where
     type DeleteElementGuard = Box<[T]>;
     type PruneStrategy = Self;
     type SearchStrategy = Internal<Self>;
+    type SearchPostProcessor = Rerank;
     fn search_strategy(&self) -> Self::SearchStrategy {
         Internal(*self)
+    }
+
+    fn search_post_processor(&self) -> Self::SearchPostProcessor {
+        Default::default()
     }
 
     fn prune_strategy(&self) -> Self::PruneStrategy {

--- a/diskann-providers/src/model/graph/provider/async_/caching/provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/caching/provider.rs
@@ -69,8 +69,9 @@ use diskann::{
     graph::{
         AdjacencyList, SearchOutputBuffer,
         glue::{
-            self, AsElement, ExpandBeam, FillSet, InplaceDeleteStrategy, InsertStrategy, Pipeline,
-            PruneStrategy, SearchExt, SearchPostProcessStep, SearchStrategy,
+            self, AsElement, DefaultPostProcess, ExpandBeam, FillSet, InplaceDeleteStrategy,
+            InsertStrategy, PostProcess, PruneStrategy, SearchExt, SearchPostProcessStep,
+            SearchStrategy,
         },
     },
     neighbor::Neighbor,
@@ -465,6 +466,11 @@ impl<A, C> CachingAccessor<A, C> {
     /// Return a reference to the cache accessor.
     pub fn cache(&self) -> &C {
         &self.cache
+    }
+
+    /// Return a mutable reference to the inner accessor for the underlying provider.
+    pub fn inner_mut(&mut self) -> &mut A {
+        &mut self.inner
     }
 }
 
@@ -962,7 +968,6 @@ where
         <C as AsCacheAccessorFor<'a, SearchAccessor<'a, S, DP, T>>>::Accessor,
     >;
     type SearchAccessorError = CachingError<S::SearchAccessorError, E>;
-    type PostProcessor = Pipeline<Unwrap, S::PostProcessor>;
 
     fn search_accessor<'a>(
         &'a self,
@@ -979,9 +984,60 @@ where
             .as_cache_accessor_for(inner)
             .map_err(CachingError::Cache)
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Pipeline::new(Unwrap, self.strategy.post_processor())
+impl<DP, C, T, S, P, E> PostProcess<CachingProvider<DP, C>, T, P> for Cached<S>
+where
+    T: ?Sized,
+    DP: DataProvider,
+    S: for<'a> SearchStrategy<DP, T, SearchAccessor<'a>: CacheableAccessor>
+        + PostProcess<DP, T, P>,
+    C: for<'a> AsCacheAccessorFor<
+            'a,
+            SearchAccessor<'a, S, DP, T>,
+            Accessor: NeighborCache<DP::InternalId>,
+            Error = E,
+        > + AsyncFriendly,
+    P: Send + Sync,
+    E: StandardError,
+{
+    async fn post_process<'a, I, B>(
+        &self,
+        processor: &P,
+        accessor: &mut Self::SearchAccessor<'a>,
+        query: &T,
+        computer: &Self::QueryComputer,
+        candidates: I,
+        output: &mut B,
+    ) -> ANNResult<usize>
+    where
+        I: Iterator<Item = Neighbor<DP::InternalId>> + Send,
+        B: SearchOutputBuffer<DP::InternalId> + Send + ?Sized,
+    {
+        let inner = accessor.inner_mut();
+        self.strategy
+            .post_process(processor, inner, query, computer, candidates, output)
+            .await
+    }
+}
+
+impl<DP, C, T, S, E> DefaultPostProcess<CachingProvider<DP, C>, T> for Cached<S>
+where
+    T: ?Sized,
+    DP: DataProvider,
+    S: for<'a> SearchStrategy<DP, T, SearchAccessor<'a>: CacheableAccessor>
+        + DefaultPostProcess<DP, T>,
+    C: for<'a> AsCacheAccessorFor<
+            'a,
+            SearchAccessor<'a, S, DP, T>,
+            Accessor: NeighborCache<DP::InternalId>,
+            Error = E,
+        > + AsyncFriendly,
+    E: StandardError,
+{
+    type Processor = S::Processor;
+    fn create_processor(&self) -> Self::Processor {
+        self.strategy.create_processor()
     }
 }
 
@@ -1057,7 +1113,12 @@ where
     DP: DataProvider,
     S: InplaceDeleteStrategy<DP>,
     Cached<S::PruneStrategy>: PruneStrategy<CachingProvider<DP, C>>,
-    Cached<S::SearchStrategy>: for<'a> SearchStrategy<CachingProvider<DP, C>, S::DeleteElement<'a>>,
+    Cached<S::SearchStrategy>: for<'a> SearchStrategy<CachingProvider<DP, C>, S::DeleteElement<'a>>
+        + for<'a> PostProcess<
+            CachingProvider<DP, C>,
+            S::DeleteElement<'a>,
+            <S as InplaceDeleteStrategy<DP>>::SearchPostProcessor,
+        >,
     C: AsyncFriendly,
 {
     type DeleteElement<'a> = S::DeleteElement<'a>;
@@ -1065,6 +1126,7 @@ where
     type DeleteElementError = S::DeleteElementError;
 
     type PruneStrategy = Cached<S::PruneStrategy>;
+    type SearchPostProcessor = <S as InplaceDeleteStrategy<DP>>::SearchPostProcessor;
     type SearchStrategy = Cached<S::SearchStrategy>;
 
     fn prune_strategy(&self) -> Self::PruneStrategy {
@@ -1077,6 +1139,10 @@ where
         Cached {
             strategy: self.strategy.search_strategy(),
         }
+    }
+
+    fn search_post_processor(&self) -> Self::SearchPostProcessor {
+        self.strategy.search_post_processor()
     }
 
     fn get_delete_element<'a>(

--- a/diskann-providers/src/model/graph/provider/async_/common.rs
+++ b/diskann-providers/src/model/graph/provider/async_/common.rs
@@ -8,6 +8,7 @@ use std::{cell::UnsafeCell, mem, num::NonZeroUsize, ops::Deref, slice, sync::Arc
 use crate::storage::{StorageReadProvider, StorageWriteProvider};
 use arc_swap::Guard;
 use diskann::{ANNError, ANNResult, always_escalate, utils::IntoUsize};
+use diskann::graph::glue::DelegatePostProcess;
 use diskann_utils::future::AsyncFriendly;
 use diskann_vector::distance::Metric;
 
@@ -419,6 +420,12 @@ impl Hybrid {
 /// Internal variant of above strategy types to avoid start point filtering.
 #[derive(Debug)]
 pub struct Internal<T>(pub T);
+
+// Marker trait impls: strategies that simply delegate `PostProcess` to the processor.
+impl DelegatePostProcess for FullPrecision {}
+impl DelegatePostProcess for Quantized {}
+impl DelegatePostProcess for Hybrid {}
+impl<T> DelegatePostProcess for Internal<T> {}
 
 #[cfg(test)]
 pub struct TestCallCount {

--- a/diskann-providers/src/model/graph/provider/async_/debug_provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/debug_provider.rs
@@ -16,8 +16,9 @@ use diskann::{
     graph::{
         AdjacencyList,
         glue::{
-            AsElement, ExpandBeam, FillSet, FilterStartPoints, InplaceDeleteStrategy,
-            InsertStrategy, Pipeline, PruneStrategy, SearchExt, SearchStrategy,
+            AsElement, DefaultPostProcess, ExpandBeam, FillSet, FilterStartPoints,
+            InplaceDeleteStrategy, InsertStrategy, Pipeline, PruneStrategy, SearchExt,
+            SearchStrategy,
         },
     },
     provider::{
@@ -888,7 +889,6 @@ impl FillSet for HybridAccessor<'_> {
 
 impl SearchStrategy<DebugProvider, [f32]> for Internal<FullPrecision> {
     type QueryComputer = <f32 as VectorRepr>::QueryDistance;
-    type PostProcessor = postprocess::RemoveDeletedIdsAndCopy;
     type SearchAccessorError = Panics;
     type SearchAccessor<'a> = FullAccessor<'a>;
 
@@ -899,15 +899,15 @@ impl SearchStrategy<DebugProvider, [f32]> for Internal<FullPrecision> {
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
         Ok(FullAccessor::new(provider))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+
+impl DefaultPostProcess<DebugProvider, [f32]> for Internal<FullPrecision> {
+    diskann::delegate_default_post_process!(postprocess::RemoveDeletedIdsAndCopy);
 }
 
 impl SearchStrategy<DebugProvider, [f32]> for FullPrecision {
     type QueryComputer = <f32 as VectorRepr>::QueryDistance;
-    type PostProcessor = Pipeline<FilterStartPoints, postprocess::RemoveDeletedIdsAndCopy>;
     type SearchAccessorError = Panics;
     type SearchAccessor<'a> = FullAccessor<'a>;
 
@@ -918,15 +918,15 @@ impl SearchStrategy<DebugProvider, [f32]> for FullPrecision {
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
         Ok(FullAccessor::new(provider))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+
+impl DefaultPostProcess<DebugProvider, [f32]> for FullPrecision {
+    diskann::delegate_default_post_process!(Pipeline<FilterStartPoints, postprocess::RemoveDeletedIdsAndCopy>);
 }
 
 impl SearchStrategy<DebugProvider, [f32]> for Internal<Quantized> {
     type QueryComputer = pq::distance::QueryComputer<Arc<FixedChunkPQTable>>;
-    type PostProcessor = postprocess::RemoveDeletedIdsAndCopy;
     type SearchAccessorError = Panics;
     type SearchAccessor<'a> = QuantAccessor<'a>;
 
@@ -937,15 +937,15 @@ impl SearchStrategy<DebugProvider, [f32]> for Internal<Quantized> {
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
         Ok(QuantAccessor::new(provider))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+
+impl DefaultPostProcess<DebugProvider, [f32]> for Internal<Quantized> {
+    diskann::delegate_default_post_process!(postprocess::RemoveDeletedIdsAndCopy);
 }
 
 impl SearchStrategy<DebugProvider, [f32]> for Quantized {
     type QueryComputer = pq::distance::QueryComputer<Arc<FixedChunkPQTable>>;
-    type PostProcessor = Pipeline<FilterStartPoints, postprocess::RemoveDeletedIdsAndCopy>;
     type SearchAccessorError = Panics;
     type SearchAccessor<'a> = QuantAccessor<'a>;
 
@@ -956,10 +956,11 @@ impl SearchStrategy<DebugProvider, [f32]> for Quantized {
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
         Ok(QuantAccessor::new(provider))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+
+impl DefaultPostProcess<DebugProvider, [f32]> for Quantized {
+    diskann::delegate_default_post_process!(Pipeline<FilterStartPoints, postprocess::RemoveDeletedIdsAndCopy>);
 }
 
 impl PruneStrategy<DebugProvider> for FullPrecision {
@@ -1052,6 +1053,7 @@ impl InplaceDeleteStrategy<DebugProvider> for FullPrecision {
     type DeleteElementError = Panics;
     type PruneStrategy = Self;
     type SearchStrategy = Internal<Self>;
+    type SearchPostProcessor = postprocess::RemoveDeletedIdsAndCopy;
 
     fn prune_strategy(&self) -> Self::PruneStrategy {
         *self
@@ -1059,6 +1061,10 @@ impl InplaceDeleteStrategy<DebugProvider> for FullPrecision {
 
     fn search_strategy(&self) -> Self::SearchStrategy {
         Internal(*self)
+    }
+
+    fn search_post_processor(&self) -> Self::SearchPostProcessor {
+        Default::default()
     }
 
     fn get_delete_element<'a>(
@@ -1078,6 +1084,7 @@ impl InplaceDeleteStrategy<DebugProvider> for Quantized {
     type DeleteElementError = Panics;
     type PruneStrategy = Self;
     type SearchStrategy = Internal<Self>;
+    type SearchPostProcessor = postprocess::RemoveDeletedIdsAndCopy;
 
     fn prune_strategy(&self) -> Self::PruneStrategy {
         *self
@@ -1085,6 +1092,10 @@ impl InplaceDeleteStrategy<DebugProvider> for Quantized {
 
     fn search_strategy(&self) -> Self::SearchStrategy {
         Internal(*self)
+    }
+
+    fn search_post_processor(&self) -> Self::SearchPostProcessor {
+        Default::default()
     }
 
     fn get_delete_element<'a>(

--- a/diskann-providers/src/model/graph/provider/async_/inmem/full_precision.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/full_precision.rs
@@ -10,8 +10,8 @@ use diskann::{
     graph::{
         SearchOutputBuffer,
         glue::{
-            self, ExpandBeam, FillSet, FilterStartPoints, InplaceDeleteStrategy, InsertStrategy,
-            PruneStrategy, SearchExt, SearchStrategy,
+            self, DefaultPostProcess, ExpandBeam, FillSet, FilterStartPoints,
+            InplaceDeleteStrategy, InsertStrategy, PruneStrategy, SearchExt, SearchStrategy,
         },
     },
     neighbor::Neighbor,
@@ -453,7 +453,6 @@ where
     type QueryComputer = T::QueryDistance;
     type SearchAccessor<'a> = FullAccessor<'a, T, Q, D, Ctx>;
     type SearchAccessorError = Panics;
-    type PostProcessor = RemoveDeletedIdsAndCopy;
 
     fn search_accessor<'a>(
         &'a self,
@@ -462,10 +461,18 @@ where
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
         Ok(FullAccessor::new(provider))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+
+impl<T, Q, D, Ctx> DefaultPostProcess<FullPrecisionProvider<T, Q, D, Ctx>, [T]>
+    for Internal<FullPrecision>
+where
+    T: VectorRepr,
+    Q: AsyncFriendly,
+    D: AsyncFriendly + DeletionCheck,
+    Ctx: ExecutionContext,
+{
+    diskann::delegate_default_post_process!(RemoveDeletedIdsAndCopy);
 }
 
 /// Perform a search entirely in the full-precision space.
@@ -481,7 +488,6 @@ where
     type QueryComputer = T::QueryDistance;
     type SearchAccessor<'a> = FullAccessor<'a, T, Q, D, Ctx>;
     type SearchAccessorError = Panics;
-    type PostProcessor = glue::Pipeline<FilterStartPoints, RemoveDeletedIdsAndCopy>;
 
     fn search_accessor<'a>(
         &'a self,
@@ -490,10 +496,18 @@ where
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
         Ok(FullAccessor::new(provider))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+
+impl<T, Q, D, Ctx> DefaultPostProcess<FullPrecisionProvider<T, Q, D, Ctx>, [T]>
+    for FullPrecision
+where
+    T: VectorRepr,
+    Q: AsyncFriendly,
+    D: AsyncFriendly + DeletionCheck,
+    Ctx: ExecutionContext,
+{
+    diskann::delegate_default_post_process!(glue::Pipeline<FilterStartPoints, RemoveDeletedIdsAndCopy>);
 }
 
 // Pruning
@@ -561,12 +575,17 @@ where
     type DeleteElementGuard = Box<[T]>;
     type PruneStrategy = Self;
     type SearchStrategy = Internal<Self>;
+    type SearchPostProcessor = RemoveDeletedIdsAndCopy;
     fn search_strategy(&self) -> Self::SearchStrategy {
         Internal(Self)
     }
 
     fn prune_strategy(&self) -> Self::PruneStrategy {
         Self
+    }
+
+    fn search_post_processor(&self) -> Self::SearchPostProcessor {
+        Default::default()
     }
 
     async fn get_delete_element<'a>(

--- a/diskann-providers/src/model/graph/provider/async_/inmem/product.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/product.rs
@@ -7,9 +7,11 @@ use std::{collections::HashMap, future::Future, sync::Arc};
 
 use diskann::{
     ANNError, ANNResult,
-    graph::glue::{
-        self, ExpandBeam, FillSet, FilterStartPoints, InplaceDeleteStrategy, InsertStrategy,
-        PruneStrategy, SearchExt, SearchStrategy,
+    graph::{
+        glue::{
+            self, DefaultPostProcess, ExpandBeam, FillSet, FilterStartPoints,
+            InplaceDeleteStrategy, InsertStrategy, PruneStrategy, SearchExt, SearchStrategy,
+        },
     },
     provider::{
         Accessor, BuildDistanceComputer, BuildQueryComputer, DelegateNeighbor, ExecutionContext,
@@ -473,7 +475,6 @@ where
     type QueryComputer = pq::distance::QueryComputer<Arc<FixedChunkPQTable>>;
     type SearchAccessor<'a> = QuantAccessor<'a, FullPrecisionStore<T>, D, Ctx>;
     type SearchAccessorError = Panics;
-    type PostProcessor = Rerank;
 
     fn search_accessor<'a>(
         &'a self,
@@ -482,10 +483,17 @@ where
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
         Ok(QuantAccessor::new(provider))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+
+impl<T, D, Ctx> DefaultPostProcess<FullPrecisionProvider<T, DefaultQuant, D, Ctx>, [T]>
+    for Internal<Hybrid>
+where
+    T: VectorRepr,
+    D: AsyncFriendly + DeletionCheck,
+    Ctx: ExecutionContext,
+{
+    diskann::delegate_default_post_process!(Rerank);
 }
 
 /// Perform a search entirely in the quantized space.
@@ -501,7 +509,6 @@ where
     type QueryComputer = pq::distance::QueryComputer<Arc<FixedChunkPQTable>>;
     type SearchAccessor<'a> = QuantAccessor<'a, FullPrecisionStore<T>, D, Ctx>;
     type SearchAccessorError = Panics;
-    type PostProcessor = glue::Pipeline<FilterStartPoints, Rerank>;
 
     fn search_accessor<'a>(
         &'a self,
@@ -510,10 +517,17 @@ where
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
         Ok(QuantAccessor::new(provider))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+
+impl<T, D, Ctx> DefaultPostProcess<FullPrecisionProvider<T, DefaultQuant, D, Ctx>, [T]>
+    for Hybrid
+where
+    T: VectorRepr,
+    D: AsyncFriendly + DeletionCheck,
+    Ctx: ExecutionContext,
+{
+    diskann::delegate_default_post_process!(glue::Pipeline<FilterStartPoints, Rerank>);
 }
 
 impl<T, D, Ctx> PruneStrategy<FullPrecisionProvider<T, DefaultQuant, D, Ctx>> for Hybrid
@@ -579,8 +593,13 @@ where
     type DeleteElementGuard = Box<[T]>;
     type PruneStrategy = Self;
     type SearchStrategy = Internal<Self>;
+    type SearchPostProcessor = Rerank;
     fn search_strategy(&self) -> Self::SearchStrategy {
         Internal(*self)
+    }
+
+    fn search_post_processor(&self) -> Self::SearchPostProcessor {
+        Default::default()
     }
 
     fn prune_strategy(&self) -> Self::PruneStrategy {
@@ -613,7 +632,6 @@ where
     type QueryComputer = pq::distance::QueryComputer<Arc<FixedChunkPQTable>>;
     type SearchAccessor<'a> = QuantAccessor<'a, NoStore, D, Ctx>;
     type SearchAccessorError = Panics;
-    type PostProcessor = glue::Pipeline<FilterStartPoints, RemoveDeletedIdsAndCopy>;
 
     fn search_accessor<'a>(
         &'a self,
@@ -622,10 +640,17 @@ where
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
         Ok(QuantAccessor::new(provider))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+
+impl<T, D, Ctx> DefaultPostProcess<DefaultProvider<NoStore, DefaultQuant, D, Ctx>, [T]>
+    for Quantized
+where
+    T: VectorRepr,
+    D: AsyncFriendly + DeletionCheck,
+    Ctx: ExecutionContext,
+{
+    diskann::delegate_default_post_process!(glue::Pipeline<FilterStartPoints, RemoveDeletedIdsAndCopy>);
 }
 
 impl<D, Ctx> PruneStrategy<DefaultProvider<NoStore, DefaultQuant, D, Ctx>> for Quantized

--- a/diskann-providers/src/model/graph/provider/async_/inmem/scalar.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/scalar.rs
@@ -8,9 +8,11 @@ use std::{future::Future, sync::Mutex};
 use crate::storage::{StorageReadProvider, StorageWriteProvider};
 use diskann::{
     ANNError, ANNResult,
-    graph::glue::{
-        self, ExpandBeam, FillSet, FilterStartPoints, InsertStrategy, PruneStrategy, SearchExt,
-        SearchStrategy,
+    graph::{
+        glue::{
+            self, DefaultPostProcess, ExpandBeam, FillSet, FilterStartPoints, InsertStrategy,
+            PruneStrategy, SearchExt, SearchStrategy,
+        },
     },
     provider::{
         Accessor, BuildDistanceComputer, BuildQueryComputer, DelegateNeighbor, ExecutionContext,
@@ -612,7 +614,6 @@ where
     type QueryComputer = QueryComputer<NBITS>;
     type SearchAccessor<'a> = QuantAccessor<'a, NBITS, FullPrecisionStore<T>, D, Ctx>;
     type SearchAccessorError = ANNError;
-    type PostProcessor = glue::Pipeline<FilterStartPoints, Rerank>;
 
     fn search_accessor<'a>(
         &'a self,
@@ -621,10 +622,19 @@ where
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
         Ok(QuantAccessor::new(provider, true))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+
+impl<const NBITS: usize, D, Ctx, T>
+    DefaultPostProcess<FullPrecisionProvider<T, SQStore<NBITS>, D, Ctx>, [T]> for Quantized
+where
+    T: VectorRepr,
+    D: AsyncFriendly + DeletionCheck,
+    Ctx: ExecutionContext,
+    Unsigned: Representation<NBITS>,
+    QueryComputer<NBITS>: for<'a> PreprocessedDistanceFunction<CVRef<'a, NBITS>, f32>,
+{
+    diskann::delegate_default_post_process!(glue::Pipeline<FilterStartPoints, Rerank>);
 }
 
 /// SearchStrategy for quantized search when only the quantized store is present.
@@ -642,7 +652,6 @@ where
     type QueryComputer = QueryComputer<NBITS>;
     type SearchAccessor<'a> = QuantAccessor<'a, NBITS, NoStore, D, Ctx>;
     type SearchAccessorError = ANNError;
-    type PostProcessor = glue::Pipeline<FilterStartPoints, RemoveDeletedIdsAndCopy>;
 
     fn search_accessor<'a>(
         &'a self,
@@ -651,10 +660,20 @@ where
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
         Ok(QuantAccessor::new(provider, true))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+// DelegatePostProcess for Quantized is already implemented above.
+
+impl<const NBITS: usize, D, Ctx, T>
+    DefaultPostProcess<DefaultProvider<NoStore, SQStore<NBITS>, D, Ctx>, [T]> for Quantized
+where
+    T: VectorRepr,
+    D: AsyncFriendly + DeletionCheck,
+    Ctx: ExecutionContext,
+    Unsigned: Representation<NBITS>,
+    QueryComputer<NBITS>: for<'a> PreprocessedDistanceFunction<CVRef<'a, NBITS>, f32>,
+{
+    diskann::delegate_default_post_process!(glue::Pipeline<FilterStartPoints, RemoveDeletedIdsAndCopy>);
 }
 
 impl<const NBITS: usize, V, D, Ctx> PruneStrategy<DefaultProvider<V, SQStore<NBITS>, D, Ctx>>

--- a/diskann-providers/src/model/graph/provider/async_/inmem/spherical.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/spherical.rs
@@ -10,9 +10,11 @@ use std::{future::Future, sync::Mutex};
 use diskann::{
     ANNError, ANNErrorKind, ANNResult,
     error::IntoANNResult,
-    graph::glue::{
-        self, ExpandBeam, FillSet, FilterStartPoints, InsertStrategy, PruneStrategy, SearchExt,
-        SearchStrategy,
+    graph::{
+        glue::{
+            self, DefaultPostProcess, DelegatePostProcess, ExpandBeam, FillSet,
+            FilterStartPoints, InsertStrategy, PruneStrategy, SearchExt, SearchStrategy,
+        },
     },
     provider::{
         Accessor, BuildDistanceComputer, BuildQueryComputer, DelegateNeighbor, ExecutionContext,
@@ -528,6 +530,8 @@ pub struct Quantized {
     is_search: bool,
 }
 
+impl DelegatePostProcess for Quantized {}
+
 impl Quantized {
     /// Construct a new [`Quantized`] strategy for index construction.
     ///
@@ -561,7 +565,6 @@ where
         UnwrapErr<spherical::iface::QueryComputer, spherical::iface::QueryDistanceError>;
     type SearchAccessor<'a> = QuantAccessor<'a, FullPrecisionStore<T>, D, Ctx>;
     type SearchAccessorError = ANNError;
-    type PostProcessor = glue::Pipeline<FilterStartPoints, Rerank>;
 
     fn search_accessor<'a>(
         &'a self,
@@ -570,10 +573,17 @@ where
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
         Ok(QuantAccessor::new(provider, self.layout, self.is_search))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+
+impl<D, Ctx, T>
+    DefaultPostProcess<FullPrecisionProvider<T, SphericalStore, D, Ctx>, [T]> for Quantized
+where
+    T: VectorRepr,
+    D: AsyncFriendly + DeletionCheck,
+    Ctx: ExecutionContext,
+{
+    diskann::delegate_default_post_process!(glue::Pipeline<FilterStartPoints, Rerank>);
 }
 
 /// SearchStrategy for quantized search when only the quantized store is present.
@@ -589,7 +599,6 @@ where
         UnwrapErr<spherical::iface::QueryComputer, spherical::iface::QueryDistanceError>;
     type SearchAccessor<'a> = QuantAccessor<'a, NoStore, D, Ctx>;
     type SearchAccessorError = ANNError;
-    type PostProcessor = glue::Pipeline<FilterStartPoints, RemoveDeletedIdsAndCopy>;
 
     fn search_accessor<'a>(
         &'a self,
@@ -598,10 +607,18 @@ where
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
         Ok(QuantAccessor::new(provider, self.layout, self.is_search))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+// DelegatePostProcess for Quantized is already implemented above.
+
+impl<D, Ctx, T>
+    DefaultPostProcess<DefaultProvider<NoStore, SphericalStore, D, Ctx>, [T]> for Quantized
+where
+    T: VectorRepr,
+    D: AsyncFriendly + DeletionCheck,
+    Ctx: ExecutionContext,
+{
+    diskann::delegate_default_post_process!(glue::Pipeline<FilterStartPoints, RemoveDeletedIdsAndCopy>);
 }
 
 impl<V, D, Ctx> PruneStrategy<DefaultProvider<V, SphericalStore, D, Ctx>> for Quantized

--- a/diskann-providers/src/model/graph/provider/async_/inmem/test.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/test.rs
@@ -8,9 +8,11 @@ use std::{future::Future, sync::Mutex};
 use diskann::{
     ANNError, ANNResult,
     error::{RankedError, ToRanked, TransientError},
-    graph::glue::{
-        AsElement, CopyIds, ExpandBeam, FillSet, InsertStrategy, PruneStrategy, SearchExt,
-        SearchStrategy,
+    graph::{
+        glue::{
+            AsElement, CopyIds, DefaultPostProcess, DelegatePostProcess, ExpandBeam, FillSet,
+            InsertStrategy, PruneStrategy, SearchExt, SearchStrategy,
+        },
     },
     neighbor::Neighbor,
     provider::{
@@ -236,7 +238,6 @@ impl SearchStrategy<TestProvider, [f32]> for Flaky {
     type QueryComputer = <FullAccessor<'static> as BuildQueryComputer<[f32]>>::QueryComputer;
     type SearchAccessor<'a> = FlakyAccessor<'a>;
     type SearchAccessorError = ANNError;
-    type PostProcessor = CopyIds;
 
     fn search_accessor<'a>(
         &'a self,
@@ -249,10 +250,12 @@ impl SearchStrategy<TestProvider, [f32]> for Flaky {
             self.fail_every,
         ))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+impl DelegatePostProcess for Flaky {}
+
+impl DefaultPostProcess<TestProvider, [f32]> for Flaky {
+    diskann::delegate_default_post_process!(CopyIds);
 }
 
 impl FillSet for FlakyAccessor<'_> {}

--- a/diskann-providers/src/model/graph/provider/layers/betafilter.rs
+++ b/diskann-providers/src/model/graph/provider/layers/betafilter.rs
@@ -17,10 +17,9 @@ use std::{future::Future, sync::Arc};
 
 use diskann::{
     ANNResult,
-    error::StandardError,
     graph::{
         SearchOutputBuffer,
-        glue::{self, ExpandBeam, SearchExt, SearchPostProcessStep, SearchStrategy},
+        glue::{DefaultPostProcess, ExpandBeam, PostProcess, SearchExt, SearchStrategy},
         index::QueryLabelProvider,
     },
     neighbor::Neighbor,
@@ -63,47 +62,6 @@ impl<Strategy, I> BetaFilter<Strategy, I> {
     }
 }
 
-/// A post processor step the delegates [`BetaAccessor`] to the inner accessor.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct Unwrap;
-
-/// Delegate post-processing to the inner strategy's post-processing routine.
-impl<A, T, O> SearchPostProcessStep<BetaAccessor<A>, T, O> for Unwrap
-where
-    T: ?Sized,
-    A: BuildQueryComputer<T>,
-{
-    type Error<NextError>
-        = NextError
-    where
-        NextError: StandardError;
-
-    type NextAccessor = A;
-
-    fn post_process_step<I, B, Next>(
-        &self,
-        next: &Next,
-        accessor: &mut BetaAccessor<A>,
-        query: &T,
-        computer: &BetaComputer<A::QueryComputer, A::Id>,
-        candidates: I,
-        output: &mut B,
-    ) -> impl Future<Output = Result<usize, Next::Error>> + Send
-    where
-        I: Iterator<Item = Neighbor<A::Id>> + Send,
-        B: SearchOutputBuffer<O> + Send + ?Sized,
-        Next: glue::SearchPostProcess<Self::NextAccessor, T, O>,
-    {
-        next.post_process(
-            &mut accessor.inner,
-            query,
-            computer.inner(),
-            candidates,
-            output,
-        )
-    }
-}
-
 /// Allow `BetaFilter` to be used as a [`SearchStrategy`] for `Provider` when its enclosing
 /// strategy is a valid search strategy.
 ///
@@ -143,12 +101,49 @@ where
         })
     }
 
-    /// Forward the post-processing error from the inner strategy.
-    type PostProcessor = glue::Pipeline<Unwrap, Strategy::PostProcessor>;
+}
 
-    /// Delegate post-processing to the inner strategy's post-processing routine.
-    fn post_processor(&self) -> Self::PostProcessor {
-        glue::Pipeline::new(Unwrap, self.strategy.post_processor())
+impl<Provider, Strategy, T, I, O, P> PostProcess<Provider, T, P, O> for BetaFilter<Strategy, I>
+where
+    T: ?Sized + Sync,
+    I: VectorId,
+    O: Send,
+    Provider: DataProvider<InternalId = I>,
+    Strategy: PostProcess<Provider, T, P, O>,
+    P: Send + Sync,
+{
+    async fn post_process<'a, Itr, B>(
+        &self,
+        processor: &P,
+        accessor: &mut Self::SearchAccessor<'a>,
+        query: &T,
+        computer: &Self::QueryComputer,
+        candidates: Itr,
+        output: &mut B,
+    ) -> ANNResult<usize>
+    where
+        Itr: Iterator<Item = Neighbor<I>> + Send,
+        B: SearchOutputBuffer<O> + Send + ?Sized,
+    {
+        let inner_accessor = &mut accessor.inner;
+        let inner_computer = computer.inner();
+        self.strategy
+            .post_process(processor, inner_accessor, query, inner_computer, candidates, output)
+            .await
+    }
+}
+
+impl<Provider, Strategy, T, I, O> DefaultPostProcess<Provider, T, O> for BetaFilter<Strategy, I>
+where
+    T: ?Sized + Sync,
+    I: VectorId,
+    O: Send,
+    Provider: DataProvider<InternalId = I>,
+    Strategy: DefaultPostProcess<Provider, T, O>,
+{
+    type Processor = Strategy::Processor;
+    fn create_processor(&self) -> Self::Processor {
+        self.strategy.create_processor()
     }
 }
 
@@ -388,7 +383,7 @@ mod tests {
     use diskann::{
         ANNError, ANNResult, always_escalate,
         graph::AdjacencyList,
-        graph::glue::CopyIds,
+        graph::glue::{CopyIds, SearchPostProcess},
         provider::{DefaultContext, NeighborAccessor},
     };
     use futures_util::future;
@@ -538,7 +533,6 @@ mod tests {
     impl SearchStrategy<SimpleProvider, u64> for SimpleStrategy {
         type SearchAccessor<'a> = Doubler;
         type QueryComputer = AddingComputer;
-        type PostProcessor = CopyIds;
         type SearchAccessorError = ANNError;
 
         fn search_accessor<'a>(
@@ -548,10 +542,34 @@ mod tests {
         ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError> {
             Ok(Doubler::default())
         }
+    }
 
-        fn post_processor(&self) -> Self::PostProcessor {
-            Default::default()
+    impl<P> PostProcess<SimpleProvider, u64, P> for SimpleStrategy
+    where
+        P: SearchPostProcess<Doubler, u64> + Send + Sync,
+    {
+        async fn post_process<'a, I, B>(
+            &self,
+            processor: &P,
+            accessor: &mut Self::SearchAccessor<'a>,
+            query: &u64,
+            computer: &Self::QueryComputer,
+            candidates: I,
+            output: &mut B,
+        ) -> ANNResult<usize>
+        where
+            I: Iterator<Item = Neighbor<u32>> + Send,
+            B: SearchOutputBuffer<u32> + Send + ?Sized,
+        {
+            processor
+                .post_process(accessor, query, computer, candidates, output)
+                .await
+                .map_err(|e| ANNError::log_async_error(e))
         }
+    }
+
+    impl DefaultPostProcess<SimpleProvider, u64> for SimpleStrategy {
+        diskann::delegate_default_post_process!(CopyIds);
     }
 
     /// A simple `QueryLabelProvider` that matches multiples of 3.

--- a/diskann/src/graph/glue.rs
+++ b/diskann/src/graph/glue.rs
@@ -297,6 +297,10 @@ where
 /// but it can differ depending on the use case. For example, it might represent
 /// associated data or alternative identifiers.
 ///
+/// Post-processing of search results is handled by the separate [`PostProcess`]
+/// and [`DefaultPostProcess`] traits, which decouple the post-processing logic
+/// from the core search strategy.
+///
 /// [`crate::index::diskann_async::DiskANNIndex::search`].
 pub trait SearchStrategy<Provider, T, O = <Provider as DataProvider>::InternalId>:
     Send + Sync
@@ -316,9 +320,6 @@ where
         + Sync
         + 'static;
 
-    /// The associated [`SearchPostProcess`]or for the final results.
-    type PostProcessor: for<'a> SearchPostProcess<Self::SearchAccessor<'a>, T, O> + Send + Sync;
-
     /// An error that can occur when getting a search_accessor.
     type SearchAccessorError: StandardError;
 
@@ -334,10 +335,129 @@ where
         provider: &'a Provider,
         context: &'a Provider::Context,
     ) -> Result<Self::SearchAccessor<'a>, Self::SearchAccessorError>;
+}
 
-    /// Construct the [`SearchPostProcess`] struct to post-process the results of search and
-    /// store them into the output container.
-    fn post_processor(&self) -> Self::PostProcessor;
+/// A sub-trait of [`SearchStrategy`] that defines how post-processing is performed
+/// with a given processor type `P`.
+///
+/// This trait decouples the post-processing logic from the search strategy itself,
+/// allowing different processor types `P` to be used with the same strategy. This
+/// provides flexibility to pass different kinds of parameters or use different
+/// post-processing pipelines for different scenarios.
+///
+/// For the default search infrastructure (e.g., [`crate::graph::search::Knn`]),
+/// see [`DefaultPostProcess`] which selects a specific processor type automatically.
+pub trait PostProcess<Provider, T, P, O = <Provider as DataProvider>::InternalId>:
+    SearchStrategy<Provider, T, O>
+where
+    Provider: DataProvider,
+    T: ?Sized,
+    O: Send,
+    P: Send + Sync,
+{
+    /// Perform post-processing on search results using the provided `processor`.
+    ///
+    /// Implementations prepare the parameters (accessor, candidates, etc.) as needed
+    /// and delegate to the processor's post-processing logic.
+    fn post_process<'a, I, B>(
+        &self,
+        processor: &P,
+        accessor: &mut Self::SearchAccessor<'a>,
+        query: &T,
+        computer: &Self::QueryComputer,
+        candidates: I,
+        output: &mut B,
+    ) -> impl Future<Output = ANNResult<usize>> + Send
+    where
+        I: Iterator<Item = Neighbor<Provider::InternalId>> + Send,
+        B: SearchOutputBuffer<O> + Send + ?Sized;
+}
+
+/// Marker trait for strategies whose [`PostProcess`] implementation simply delegates
+/// to the processor's [`SearchPostProcess::post_process`] method.
+///
+/// Implementing this trait provides a blanket [`PostProcess`] implementation that calls
+/// `processor.post_process(accessor, query, computer, candidates, output)` and converts
+/// the result via [`IntoANNResult`](crate::error::IntoANNResult).
+///
+/// Strategies that need custom post-processing (e.g., unwrapping layered accessors)
+/// should **not** implement this trait and should provide their own [`PostProcess`] impl
+/// instead.
+pub trait DelegatePostProcess {}
+
+impl<S, Provider, T, P, O> PostProcess<Provider, T, P, O> for S
+where
+    S: SearchStrategy<Provider, T, O> + DelegatePostProcess,
+    Provider: DataProvider,
+    T: ?Sized + Sync,
+    O: Send,
+    P: for<'a> SearchPostProcess<S::SearchAccessor<'a>, T, O> + Send + Sync,
+{
+    async fn post_process<'a, I, B>(
+        &self,
+        processor: &P,
+        accessor: &mut Self::SearchAccessor<'a>,
+        query: &T,
+        computer: &Self::QueryComputer,
+        candidates: I,
+        output: &mut B,
+    ) -> ANNResult<usize>
+    where
+        I: Iterator<Item = Neighbor<Provider::InternalId>> + Send,
+        B: SearchOutputBuffer<O> + Send + ?Sized,
+    {
+        use crate::error::IntoANNResult;
+        processor
+            .post_process(accessor, query, computer, candidates, output)
+            .await
+            .into_ann_result()
+    }
+}
+
+/// A strategy that provides a default post-processor.
+///
+/// This trait is used by the search infrastructure to obtain the appropriate
+/// post-processor for a given strategy without requiring callers to specify the
+/// concrete processor type.
+///
+/// For advanced use cases where a custom processor is needed, use
+/// [`PostProcess`] directly.
+pub trait DefaultPostProcess<Provider, T, O = <Provider as DataProvider>::InternalId>:
+    PostProcess<Provider, T, Self::Processor, O>
+where
+    Provider: DataProvider,
+    T: ?Sized,
+    O: Send,
+{
+    /// The default processor type for this strategy.
+    type Processor: Send + Sync;
+
+    /// Create the default processor instance.
+    fn create_processor(&self) -> Self::Processor;
+}
+
+/// Generates the body of a [`DefaultPostProcess`] implementation where the processor
+/// is constructed via [`Default::default()`].
+///
+/// Use this macro inside an `impl DefaultPostProcess<Provider, T> for Strategy { ... }`
+/// block to avoid repeating the boilerplate `type Processor` and `fn create_processor`
+/// items.
+///
+/// # Example
+///
+/// ```ignore
+/// impl DefaultPostProcess<MyProvider, [f32]> for MyStrategy {
+///     delegate_default_post_process!(CopyIds);
+/// }
+/// ```
+#[macro_export]
+macro_rules! delegate_default_post_process {
+    ($Processor:ty) => {
+        type Processor = $Processor;
+        fn create_processor(&self) -> Self::Processor {
+            Default::default()
+        }
+    };
 }
 
 /// Perform post-processing on the results of search, storing the results in an output buffer.
@@ -741,14 +861,21 @@ where
     /// The pruning strategy to use after the initial search is complete.
     type PruneStrategy: PruneStrategy<Provider>;
 
+    /// The post-processor type used during the search phase of inplace deletion.
+    type SearchPostProcessor: Send + Sync;
+
     /// The type of the search strategy to use for graph traversal.
-    type SearchStrategy: for<'a> SearchStrategy<Provider, Self::DeleteElement<'a>>;
+    type SearchStrategy: for<'a> SearchStrategy<Provider, Self::DeleteElement<'a>>
+        + for<'a> PostProcess<Provider, Self::DeleteElement<'a>, Self::SearchPostProcessor>;
 
     /// Construct the prune strategy object.
     fn prune_strategy(&self) -> Self::PruneStrategy;
 
     /// Construct the search strategy object.
     fn search_strategy(&self) -> Self::SearchStrategy;
+
+    /// Create the search post-processor for the deletion search phase.
+    fn search_post_processor(&self) -> Self::SearchPostProcessor;
 
     /// Construct the accessor used to retrieve the item being deleted.
     fn get_delete_element<'a>(
@@ -1012,7 +1139,6 @@ mod tests {
 
     impl SearchStrategy<SimpleProvider, f32> for Strategy {
         type QueryComputer = QueryComputer;
-        type PostProcessor = CopyIds;
         type SearchAccessorError = ANNError;
         type SearchAccessor<'a> = Retriever<'a>;
 
@@ -1027,10 +1153,12 @@ mod tests {
                 self.errors_are_unrecoverable,
             ))
         }
+    }
 
-        fn post_processor(&self) -> Self::PostProcessor {
-            Default::default()
-        }
+    impl DelegatePostProcess for Strategy {}
+
+    impl DefaultPostProcess<SimpleProvider, f32> for Strategy {
+        delegate_default_post_process!(CopyIds);
     }
 
     // Use the provided implementation.
@@ -1080,9 +1208,10 @@ mod tests {
             for output_len in 0..10 {
                 let mut output = vec![Neighbor::<u32>::default(); output_len];
 
+                let processor = strategy.create_processor();
                 let count = strategy
-                    .post_processor()
                     .post_process(
+                        &processor,
                         &mut accessor,
                         &query,
                         &computer,

--- a/diskann/src/graph/index.rs
+++ b/diskann/src/graph/index.rs
@@ -26,8 +26,9 @@ use tokio::task::JoinSet;
 use super::{
     AdjacencyList, Config, ConsolidateKind, InplaceDeleteMethod,
     glue::{
-        self, AsElement, ExpandBeam, FillSet, IdIterator, InplaceDeleteStrategy, InsertStrategy,
-        PruneStrategy, SearchExt, SearchPostProcess, SearchStrategy, aliases,
+        self, AsElement, DefaultPostProcess, ExpandBeam, FillSet, IdIterator,
+        InplaceDeleteStrategy, InsertStrategy, PostProcess, PruneStrategy, SearchExt,
+        SearchStrategy, aliases,
     },
     internal::{BackedgeBuffer, SortedNeighbors, prune},
     search::{
@@ -1296,9 +1297,10 @@ where
             // NOTE: We rely on `post_process` to remove deleted items from the results
             // placed into the output.
             let proxy = v.async_lower();
+            let post_processor = strategy.search_post_processor();
             let num_results = search_strategy
-                .post_processor()
                 .post_process(
+                    &post_processor,
                     &mut search_accessor,
                     &*proxy,
                     &computer,
@@ -1306,8 +1308,7 @@ where
                     &mut neighbor::BackInserter::new(output.as_mut_slice()),
                 )
                 .send()
-                .await
-                .into_ann_result()?;
+                .await?;
 
             let mut undeleted_ids: Vec<_> = output
                 .iter()
@@ -1440,7 +1441,7 @@ where
     where
         Self: 'static + Send + Sync,
         S: InplaceDeleteStrategy<DP>
-            + for<'a> SearchStrategy<DP, S::DeleteElement<'a>>
+            + for<'a> PostProcess<DP, S::DeleteElement<'a>, S::SearchPostProcessor>
             + Send
             + Sync
             + Clone,
@@ -2198,7 +2199,7 @@ where
     ) -> ANNResult<SearchStats>
     where
         T: ?Sized,
-        S: SearchStrategy<DP, T, O, SearchAccessor<'a>: IdIterator<I>>,
+        S: DefaultPostProcess<DP, T, O, SearchAccessor<'a>: IdIterator<I>>,
         I: Iterator<Item = <DP as DataProvider>::InternalId>,
         O: Send,
         OB: search_output_buffer::SearchOutputBuffer<O> + Send,
@@ -2232,9 +2233,10 @@ where
             }
         }
 
+        let processor = strategy.create_processor();
         let result_count = strategy
-            .post_processor()
             .post_process(
+                &processor,
                 &mut accessor,
                 query,
                 &computer,
@@ -2242,8 +2244,7 @@ where
                 output,
             )
             .send()
-            .await
-            .into_ann_result()?;
+            .await?;
 
         Ok(SearchStats {
             cmps: scratch.cmps,

--- a/diskann/src/graph/search/diverse_search.rs
+++ b/diskann/src/graph/search/diverse_search.rs
@@ -14,7 +14,7 @@ use crate::{
     error::IntoANNResult,
     graph::{
         DiverseSearchParams,
-        glue::{SearchExt, SearchPostProcess, SearchStrategy},
+        glue::{DefaultPostProcess, SearchExt},
         index::{DiskANNIndex, SearchStats},
         search_output_buffer::SearchOutputBuffer,
     },
@@ -96,7 +96,7 @@ impl<DP, S, T, O, OB, P> Search<DP, S, T, O, OB> for Diverse<P>
 where
     DP: DataProvider,
     T: Sync + ?Sized,
-    S: SearchStrategy<DP, T, O>,
+    S: DefaultPostProcess<DP, T, O>,
     O: Send,
     OB: SearchOutputBuffer<O> + Send,
     P: AttributeValueProvider<Id = DP::InternalId>,
@@ -135,9 +135,10 @@ where
             // Post-process diverse results
             diverse_scratch.best.post_process();
 
+            let processor = strategy.create_processor();
             let result_count = strategy
-                .post_processor()
                 .post_process(
+                    &processor,
                     &mut accessor,
                     query,
                     &computer,
@@ -145,8 +146,7 @@ where
                     output,
                 )
                 .send()
-                .await
-                .into_ann_result()?;
+                .await?;
 
             Ok(stats.finish(result_count as u32))
         }

--- a/diskann/src/graph/search/knn_search.rs
+++ b/diskann/src/graph/search/knn_search.rs
@@ -15,7 +15,7 @@ use crate::{
     ANNError, ANNErrorKind, ANNResult,
     error::IntoANNResult,
     graph::{
-        glue::{SearchExt, SearchPostProcess, SearchStrategy},
+        glue::{DefaultPostProcess, SearchExt},
         index::{DiskANNIndex, SearchStats},
         search::record::NoopSearchRecord,
         search_output_buffer::SearchOutputBuffer,
@@ -147,7 +147,7 @@ impl<DP, S, T, O, OB> Search<DP, S, T, O, OB> for Knn
 where
     DP: DataProvider,
     T: Sync + ?Sized,
-    S: SearchStrategy<DP, T, O>,
+    S: DefaultPostProcess<DP, T, O>,
     O: Send,
     OB: SearchOutputBuffer<O> + Send + ?Sized,
 {
@@ -206,9 +206,10 @@ where
                 )
                 .await?;
 
+            let processor = strategy.create_processor();
             let result_count = strategy
-                .post_processor()
                 .post_process(
+                    &processor,
                     &mut accessor,
                     query,
                     &computer,
@@ -216,8 +217,7 @@ where
                     output,
                 )
                 .send()
-                .await
-                .into_ann_result()?;
+                .await?;
 
             Ok(stats.finish(result_count as u32))
         }
@@ -250,7 +250,7 @@ impl<'r, DP, S, T, O, OB, SR> Search<DP, S, T, O, OB> for RecordedKnn<'r, SR>
 where
     DP: DataProvider,
     T: Sync + ?Sized,
-    S: SearchStrategy<DP, T, O>,
+    S: DefaultPostProcess<DP, T, O>,
     O: Send,
     OB: SearchOutputBuffer<O> + Send + ?Sized,
     SR: super::record::SearchRecord<DP::InternalId> + ?Sized,
@@ -286,9 +286,10 @@ where
                 )
                 .await?;
 
+            let processor = strategy.create_processor();
             let result_count = strategy
-                .post_processor()
                 .post_process(
+                    &processor,
                     &mut accessor,
                     query,
                     &computer,
@@ -299,8 +300,7 @@ where
                     output,
                 )
                 .send()
-                .await
-                .into_ann_result()?;
+                .await?;
 
             Ok(stats.finish(result_count as u32))
         }

--- a/diskann/src/graph/search/multihop_search.rs
+++ b/diskann/src/graph/search/multihop_search.rs
@@ -16,8 +16,8 @@ use crate::{
     error::{ErrorExt, IntoANNResult},
     graph::{
         glue::{
-            self, ExpandBeam, HybridPredicate, Predicate, PredicateMut, SearchExt,
-            SearchPostProcess, SearchStrategy,
+            self, DefaultPostProcess, ExpandBeam, HybridPredicate, Predicate, PredicateMut,
+            SearchExt,
         },
         index::{
             DiskANNIndex, InternalSearchStats, QueryLabelProvider, QueryVisitDecision, SearchStats,
@@ -57,7 +57,7 @@ impl<'q, DP, S, T, O, OB> Search<DP, S, T, O, OB> for MultihopSearch<'q, DP::Int
 where
     DP: DataProvider,
     T: Sync + ?Sized,
-    S: SearchStrategy<DP, T, O>,
+    S: DefaultPostProcess<DP, T, O>,
     O: Send,
     OB: SearchOutputBuffer<O> + Send,
 {
@@ -92,9 +92,10 @@ where
             )
             .await?;
 
+            let processor = strategy.create_processor();
             let result_count = strategy
-                .post_processor()
                 .post_process(
+                    &processor,
                     &mut accessor,
                     query,
                     &computer,
@@ -102,8 +103,7 @@ where
                     output,
                 )
                 .send()
-                .await
-                .into_ann_result()?;
+                .await?;
 
             Ok(stats.finish(result_count as u32))
         }

--- a/diskann/src/graph/search/range_search.rs
+++ b/diskann/src/graph/search/range_search.rs
@@ -13,7 +13,7 @@ use crate::{
     ANNError, ANNErrorKind, ANNResult,
     error::IntoANNResult,
     graph::{
-        glue::{self, ExpandBeam, SearchExt, SearchPostProcess, SearchStrategy},
+        glue::{self, DefaultPostProcess, ExpandBeam, SearchExt},
         index::{DiskANNIndex, InternalSearchStats, SearchStats},
         search::record::NoopSearchRecord,
         search_output_buffer,
@@ -171,7 +171,7 @@ impl<DP, S, T, O> Search<DP, S, T, O, ()> for Range
 where
     DP: DataProvider,
     T: Sync + ?Sized,
-    S: SearchStrategy<DP, T, O>,
+    S: DefaultPostProcess<DP, T, O>,
     O: Send + Default + Clone,
 {
     type Output = RangeSearchOutput<O>;
@@ -250,9 +250,10 @@ where
                 result_dists.as_mut_slice(),
             );
 
+            let processor = strategy.create_processor();
             let _ = strategy
-                .post_processor()
                 .post_process(
+                    &processor,
                     &mut accessor,
                     query,
                     &computer,
@@ -260,8 +261,7 @@ where
                     &mut output_buffer,
                 )
                 .send()
-                .await
-                .into_ann_result()?;
+                .await?;
 
             // Filter by inner/outer radius
             let inner_cutoff = if let Some(inner_radius) = self.inner_radius() {

--- a/diskann/src/graph/test/provider.rs
+++ b/diskann/src/graph/test/provider.rs
@@ -17,6 +17,7 @@ use thiserror::Error;
 
 use crate::{
     ANNError, ANNResult,
+    delegate_default_post_process,
     error::{Infallible, message},
     graph::{AdjacencyList, glue, test::synthetic},
     internal::counter::{Counter, LocalCounter},
@@ -952,7 +953,6 @@ impl Strategy {
 
 impl glue::SearchStrategy<Provider, [f32]> for Strategy {
     type QueryComputer = <f32 as VectorRepr>::QueryDistance;
-    type PostProcessor = glue::CopyIds;
     type SearchAccessorError = Infallible;
     type SearchAccessor<'a> = Accessor<'a>;
 
@@ -963,10 +963,12 @@ impl glue::SearchStrategy<Provider, [f32]> for Strategy {
     ) -> Result<Accessor<'a>, Infallible> {
         Ok(Accessor::new(provider))
     }
+}
 
-    fn post_processor(&self) -> Self::PostProcessor {
-        Default::default()
-    }
+impl glue::DelegatePostProcess for Strategy {}
+
+impl glue::DefaultPostProcess<Provider, [f32]> for Strategy {
+    delegate_default_post_process!(glue::CopyIds);
 }
 
 impl glue::PruneStrategy<Provider> for Strategy {
@@ -1015,6 +1017,7 @@ impl glue::InplaceDeleteStrategy<Provider> for Strategy {
     type DeleteElementGuard = Box<[f32]>;
     type DeleteElementError = AccessedInvalidId;
     type PruneStrategy = Self;
+    type SearchPostProcessor = glue::CopyIds;
     type SearchStrategy = Self;
 
     fn prune_strategy(&self) -> Self::PruneStrategy {
@@ -1023,6 +1026,10 @@ impl glue::InplaceDeleteStrategy<Provider> for Strategy {
 
     fn search_strategy(&self) -> Self::SearchStrategy {
         *self
+    }
+
+    fn search_post_processor(&self) -> Self::SearchPostProcessor {
+        Default::default()
     }
 
     async fn get_delete_element<'a>(


### PR DESCRIPTION
## This is replaced by PR 817. This PR is only for reference and will be abandoned after 817 merges.

## Summary

Reduces boilerplate across `PostProcess` and `DefaultPostProcess` trait implementations using two complementary techniques:

### 1. `DelegatePostProcess` marker trait + blanket `PostProcess` impl

20 `PostProcess` impls across the workspace shared an identical body:

```rust
processor.post_process(accessor, query, computer, candidates, output)
    .await
    .into_ann_result()
```

These are now replaced by a single blanket impl gated on a `DelegatePostProcess` marker trait. Each strategy type only needs:

```rust
impl DelegatePostProcess for MyStrategy {}
```

### 2. `delegate_default_post_process!` macro

21 `DefaultPostProcess` impls all constructed their processor via `Default::default()`. A blanket impl was attempted but hit Rust coherence conflicts (wrapper types like `InlineBetaStrategy<S>` with manual impls block downstream blankets). Instead, a macro eliminates the repeated body:

```rust
// Before (repeated 21 times):
impl DefaultPostProcess<Provider, [T]> for Strategy {
    type Processor = SomeProcessor;
    fn create_processor(&self) -> Self::Processor {
        Default::default()
    }
}

// After:
impl DefaultPostProcess<Provider, [T]> for Strategy {
    diskann::delegate_default_post_process!(SomeProcessor);
}
```

### Untouched (4 custom impls)

- **BetaFilter** / **Cached** - delegate to inner strategy's `create_processor()`
- **DiskSearchStrategy** / **InlineBetaStrategy** - use runtime parameters for construction

### Other

- Fixed 18 `clippy::manual_async_fn` warnings (converted `-> impl Future<...> + Send` to `async fn`)

## Validation

- `cargo check --workspace --tests` - 0 errors, 0 warnings
- `cargo clippy --workspace --all-targets -- -D warnings` - clean
- `cargo test -p diskann` - 232 passed
- `cargo test -p diskann-providers` - 547 passed
- `cargo test -p diskann-label-filter -p diskann-benchmark-core -p diskann-disk` - 540 passed
