### PR TITLE
Fix variance issues with `Mat` and `MatMut`.

### DIFF
--- a/diskann-quantization/src/multi_vector/matrix.rs
+++ b/diskann-quantization/src/multi_vector/matrix.rs
@@ -559,6 +559,7 @@ where
 pub struct Mat<T: ReprOwned> {
     ptr: NonNull<u8>,
     repr: T,
+    _invariant: PhantomData<fn(T) -> T>,
 }
 
 // SAFETY: [`Repr`] is required to propagate its `Send` bound.
@@ -663,7 +664,11 @@ impl<T: ReprOwned> Mat<T> {
     /// 1. Point to memory compatible with [`Repr::layout`].
     /// 2. Be compatible with the drop logic in [`ReprOwned`].
     pub(crate) unsafe fn from_raw_parts(repr: T, ptr: NonNull<u8>) -> Self {
-        Self { ptr, repr }
+        Self {
+            ptr,
+            repr,
+            _invariant: PhantomData,
+        }
     }
 
     /// Return the base pointer for the [`Mat`].
@@ -714,7 +719,7 @@ pub struct MatRef<'a, T: Repr> {
     pub(crate) ptr: NonNull<u8>,
     pub(crate) repr: T,
     /// Marker to tie the lifetime to the borrowed data.
-    pub(crate) _lifetime: PhantomData<&'a [u8]>,
+    pub(crate) _lifetime: PhantomData<&'a T>,
 }
 
 // SAFETY: [`Repr`] is required to propagate its `Send` bound.
@@ -861,7 +866,7 @@ pub struct MatMut<'a, T: ReprMut> {
     pub(crate) ptr: NonNull<u8>,
     pub(crate) repr: T,
     /// Marker to tie the lifetime to the mutably borrowed data.
-    pub(crate) _lifetime: PhantomData<&'a mut [u8]>,
+    pub(crate) _lifetime: PhantomData<&'a mut T>,
 }
 
 // SAFETY: [`ReprMut`] is required to propagate its `Send` bound.
@@ -1135,6 +1140,35 @@ mod tests {
 
     /// Helper to assert a type is Copy.
     fn assert_copy<T: Copy>(_: &T) {}
+
+    // ── Variance assertions ──────────────────────────────────────
+    //
+    // These functions are never called. The test is that they compile:
+    // covariant positions must accept subtype coercions.
+    //
+    // The negative (invariance) counterparts live in
+    // `tests/compile-fail/multi/{mat,matmut}_invariant.rs`.
+
+    /// `MatRef` is covariant in `'a`: a longer borrow can shorten.
+    fn _assert_matref_covariant_lifetime<'long: 'short, 'short, T: Repr>(
+        v: MatRef<'long, T>,
+    ) -> MatRef<'short, T> {
+        v
+    }
+
+    /// `MatRef` is covariant in `T`: `Standard<&'long u8>` → `Standard<&'short u8>`.
+    fn _assert_matref_covariant_repr<'long: 'short, 'short, 'a>(
+        v: MatRef<'a, Standard<&'long u8>>,
+    ) -> MatRef<'a, Standard<&'short u8>> {
+        v
+    }
+
+    /// `MatMut` is covariant in `'a`: a longer borrow can shorten.
+    fn _assert_matmut_covariant_lifetime<'long: 'short, 'short, T: ReprMut>(
+        v: MatMut<'long, T>,
+    ) -> MatMut<'short, T> {
+        v
+    }
 
     fn edge_cases(nrows: usize) -> Vec<usize> {
         let max = usize::MAX;

--- a/diskann-quantization/tests/compile-fail/multi/mat_invariant.rs
+++ b/diskann-quantization/tests/compile-fail/multi/mat_invariant.rs
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+use diskann_quantization::multi_vector::{Mat, Standard};
+
+// Verify that `Mat` is invariant in any generic parameters.
+//
+// This must not compile because it would allow assigning references with a shorter lifetime
+// into the matrix
+fn bad<'long, 'short>(v: Mat<Standard<&'long u8>>) -> Mat<Standard<&'short u8>>
+where
+    'long: 'short,
+{
+    v
+}
+
+fn main() {
+    let b = 0u8;
+    let m = Mat::new(Standard::new(4, 3).unwrap(), &b).unwrap();
+    bad(m);
+}

--- a/diskann-quantization/tests/compile-fail/multi/mat_invariant.stderr
+++ b/diskann-quantization/tests/compile-fail/multi/mat_invariant.stderr
@@ -1,0 +1,15 @@
+error: lifetime may not live long enough
+  --> tests/compile-fail/multi/mat_invariant.rs:16:5
+   |
+12 | fn bad<'long, 'short>(v: Mat<Standard<&'long u8>>) -> Mat<Standard<&'short u8>>
+   |        -----  ------ lifetime `'short` defined here
+   |        |
+   |        lifetime `'long` defined here
+...
+16 |     v
+   |     ^ function was supposed to return data with lifetime `'long` but it is returning data with lifetime `'short`
+   |
+   = help: consider adding the following bound: `'short: 'long`
+   = note: requirement occurs because of the type `Mat<Standard<&u8>>`, which makes the generic argument `Standard<&u8>` invariant
+   = note: the struct `Mat<T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance

--- a/diskann-quantization/tests/compile-fail/multi/matmut_invariant.rs
+++ b/diskann-quantization/tests/compile-fail/multi/matmut_invariant.rs
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+use diskann_quantization::multi_vector::{Mat, MatMut, Standard};
+
+// Verify that `MatMut` is invariant in any generic parameters.
+//
+// This must not compile because it would allow assigning references with a shorter lifetime
+// into the matrix
+fn bad<'long, 'short, 'a>(v: MatMut<'a, Standard<&'long u8>>) -> MatMut<'a, Standard<&'short u8>>
+where
+    'long: 'short,
+{
+    v
+}
+
+fn main() {
+    let b = 0u8;
+    let mut m = Mat::new(Standard::new(4, 3).unwrap(), &b).unwrap();
+    bad(m.as_view_mut());
+}

--- a/diskann-quantization/tests/compile-fail/multi/matmut_invariant.stderr
+++ b/diskann-quantization/tests/compile-fail/multi/matmut_invariant.stderr
@@ -1,0 +1,15 @@
+error: lifetime may not live long enough
+  --> tests/compile-fail/multi/matmut_invariant.rs:16:5
+   |
+12 | fn bad<'long, 'short, 'a>(v: MatMut<'a, Standard<&'long u8>>) -> MatMut<'a, Standard<&'short u8>>
+   |        -----  ------ lifetime `'short` defined here
+   |        |
+   |        lifetime `'long` defined here
+...
+16 |     v
+   |     ^ function was supposed to return data with lifetime `'long` but it is returning data with lifetime `'short`
+   |
+   = help: consider adding the following bound: `'short: 'long`
+   = note: requirement occurs because of the type `MatMut<'_, Standard<&u8>>`, which makes the generic argument `Standard<&u8>` invariant
+   = note: the struct `MatMut<'a, T>` is invariant over the parameter `T`
+   = help: see <https://doc.rust-lang.org/nomicon/subtyping.html> for more information about variance


### PR DESCRIPTION
Ensure that `Mat` and `MatMut` are invariant in `T`. Without this change, the two compile-fail tests succeed, which could allow objects with shorter lifetimes to be assigned into a `Mat`/`MatRef` and lead to a dangling reference.

This is certainly a corner case since in all our current implementations, the representations `T` are `'static`, but it doesn't hurt to be extra careful here.