### PR TITLE
refactor the filter code in the garnet provider 

### DIFF
--- a/diskann-garnet/src/dyn_index.rs
+++ b/diskann-garnet/src/dyn_index.rs
@@ -30,7 +30,7 @@ pub trait DynIndex: Send + Sync {
         context: &Context,
         data: &[u8],
         params: &search::Knn,
-        filter: Option<(&GarnetQueryLabelProvider<'static>, f32)>,
+        filter: Option<(&GarnetQueryLabelProvider, f32)>,
         output: &mut SearchResults<'_>,
     ) -> ANNResult<SearchStats>;
 
@@ -39,7 +39,7 @@ pub trait DynIndex: Send + Sync {
         context: &Context,
         id: &GarnetId,
         params: &search::Knn,
-        filter: Option<(&GarnetQueryLabelProvider<'static>, f32)>,
+        filter: Option<(&GarnetQueryLabelProvider, f32)>,
         output: &mut SearchResults<'_>,
     ) -> ANNResult<SearchStats>;
 
@@ -79,7 +79,7 @@ impl<T: VectorRepr> DynIndex for DiskANNIndex<GarnetProvider<T>> {
         context: &Context,
         data: &[u8],
         params: &search::Knn,
-        filter: Option<(&GarnetQueryLabelProvider<'static>, f32)>,
+        filter: Option<(&GarnetQueryLabelProvider, f32)>,
         output: &mut SearchResults<'_>,
     ) -> ANNResult<SearchStats> {
         let query = bytemuck::cast_slice::<u8, T>(data);
@@ -96,7 +96,7 @@ impl<T: VectorRepr> DynIndex for DiskANNIndex<GarnetProvider<T>> {
         context: &Context,
         id: &GarnetId,
         params: &search::Knn,
-        filter: Option<(&GarnetQueryLabelProvider<'static>, f32)>,
+        filter: Option<(&GarnetQueryLabelProvider, f32)>,
         output: &mut SearchResults<'_>,
     ) -> ANNResult<SearchStats> {
         let rt = tokio::runtime::Builder::new_current_thread()

--- a/diskann-garnet/src/labels.rs
+++ b/diskann-garnet/src/labels.rs
@@ -22,30 +22,43 @@ use diskann::graph::index::QueryLabelProvider;
 
 /// A zero-copy bitmap-based label provider for Garnet filtered vector search.
 ///
-/// Borrows the bitmap data for lifetime `'a`. No allocation — bit lookups
-/// are performed directly on the caller's memory.
+/// Holds a raw pointer to the bitmap data owned by the FFI caller.
+/// No allocation — bit lookups are performed directly on the caller's memory.
 ///
-/// For FFI usage, [`from_raw`](Self::from_raw) constructs a
-/// `GarnetQueryLabelProvider<'static>` from a raw pointer; the caller must
-/// guarantee the pointer remains valid for the duration of the search call.
-#[derive(Clone)]
-pub struct GarnetQueryLabelProvider<'a> {
-    data: &'a [u8],
+/// # Safety
+///
+/// The bitmap pointer must remain valid and unmodified for the lifetime of
+/// this struct. In practice, the struct is created and dropped within a
+/// single FFI search call.
+pub struct GarnetQueryLabelProvider {
+    data: *const u8,
+    len: usize,
 }
 
-impl std::fmt::Debug for GarnetQueryLabelProvider<'_> {
+// Safety: the bitmap data is read-only and the caller guarantees the pointer
+// is valid for the duration of the search call.
+unsafe impl Send for GarnetQueryLabelProvider {}
+unsafe impl Sync for GarnetQueryLabelProvider {}
+
+impl std::fmt::Debug for GarnetQueryLabelProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("GarnetQueryLabelProvider")
-            .field("len", &self.data.len())
+            .field("len", &self.len)
             .finish()
     }
 }
 
-impl GarnetQueryLabelProvider<'static> {
-    /// Construct a `GarnetQueryLabelProvider` from a raw pointer.
-    ///
-    /// Returns a `GarnetQueryLabelProvider<'static>` suitable for use with
-    /// `Arc<dyn QueryLabelProvider<u32>>`.
+impl Clone for GarnetQueryLabelProvider {
+    fn clone(&self) -> Self {
+        Self {
+            data: self.data,
+            len: self.len,
+        }
+    }
+}
+
+impl GarnetQueryLabelProvider {
+    /// Construct a `GarnetQueryLabelProvider` from raw bitmap bytes.
     ///
     /// # Arguments
     ///
@@ -59,42 +72,49 @@ impl GarnetQueryLabelProvider<'static> {
     /// of this struct.
     pub unsafe fn from_raw(data: *const u8, len: usize) -> Self {
         if data.is_null() || len == 0 {
-            return Self { data: &[] };
+            return Self {
+                data: std::ptr::null(),
+                len: 0,
+            };
         }
-        Self {
-            data: unsafe { std::slice::from_raw_parts(data, len) },
-        }
+        Self { data, len }
     }
-}
 
-impl<'a> GarnetQueryLabelProvider<'a> {
     /// Construct a `GarnetQueryLabelProvider` from a byte slice.
     #[allow(dead_code)]
-    pub fn from_bytes(bytes: &'a [u8]) -> Self {
-        Self { data: bytes }
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        if bytes.is_empty() {
+            Self {
+                data: std::ptr::null(),
+                len: 0,
+            }
+        } else {
+            Self {
+                data: bytes.as_ptr(),
+                len: bytes.len(),
+            }
+        }
     }
 
     /// Check if the given internal ID has its bit set in the bitmap.
-    /// Empty bitmap matches all IDs (no filter).
-    /// If the bitmap is smaller than the ID being checked, it's considered a
-    /// partial bitmap and out-of-range IDs are treated as matching (not filtered out).
+    /// Empty bitmap (len == 0) matches all IDs (no filter).
+    /// If the bitmap is smaller than the ID being checked, it's considered a partial bitmap and out-of-range IDs are treated as matching (not filtered out)
     #[inline(always)]
     fn is_set(&self, id: u32) -> bool {
-        if self.data.is_empty() {
+        if self.len == 0 {
             return true;
         }
         let byte_idx = (id / 8) as usize;
-        match self.data.get(byte_idx) {
-            Some(&byte) => {
-                let bit_idx = id % 8;
-                (byte >> bit_idx) & 1 == 1
-            }
-            None => true, // partial bitmap — out-of-range matches
+        if byte_idx >= self.len {
+            return true;
         }
+        let bit_idx = id % 8;
+        let byte = unsafe { *self.data.add(byte_idx) };
+        (byte >> bit_idx) & 1 == 1
     }
 }
 
-impl QueryLabelProvider<u32> for GarnetQueryLabelProvider<'_> {
+impl QueryLabelProvider<u32> for GarnetQueryLabelProvider {
     /// Check if the vector at `internal_id` passes the filter.
     ///
     /// Returns `true` if the corresponding bit is set in the bitmap,


### PR DESCRIPTION

### Label Provider Refactor

* Changed `GarnetQueryLabelProvider` from a raw pointer-based struct to a lifetime-parameterized struct that borrows a slice.  

### Removal of Obsolete Wrapper

* Removed the `FilteredSearchResults` wrapper, which previously handled conversion between internal and external IDs for search results. This is no longer needed with previous change to expose generic external id in the beta search strategy.

 