### PR TITLE
DiskANN v0.48.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ dependencies = [
 
 [[package]]
 name = "diskann"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -427,7 +427,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -464,7 +464,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-core"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "diskann",
@@ -481,7 +481,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-runner"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -495,7 +495,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-simd"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "diskann-benchmark-runner",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-disk"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -547,7 +547,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-label-filter"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -570,7 +570,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-linalg"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "approx",
  "cfg-if",
@@ -584,7 +584,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-platform"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "io-uring",
  "libc",
@@ -594,7 +594,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-providers"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -638,7 +638,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-quantization"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-tools"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -689,7 +689,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-utils"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-vector"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "approx",
  "cfg-if",
@@ -718,7 +718,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-wide"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "cfg-if",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.47.0"      # Obeying semver
+version = "0.48.0"      # Obeying semver
 description = "DiskANN is a fast approximate nearest neighbor search library for high dimensional data"
 authors = ["Microsoft"]
 documentation = "https://github.com/microsoft/DiskANN"
@@ -46,22 +46,22 @@ undocumented_unsafe_blocks = "warn"
 
 [workspace.dependencies]
 # Base And Numerics
-diskann-wide = { path = "diskann-wide", version = "0.47.0" }
-diskann-vector = { path = "diskann-vector", version = "0.47.0" }
-diskann-linalg = { path = "diskann-linalg", version = "0.47.0" }
-diskann-utils = { path = "diskann-utils", default-features = false, version = "0.47.0" }
-diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.47.0" }
-diskann-platform = { path = "diskann-platform", version = "0.47.0" }
+diskann-wide = { path = "diskann-wide", version = "0.48.0" }
+diskann-vector = { path = "diskann-vector", version = "0.48.0" }
+diskann-linalg = { path = "diskann-linalg", version = "0.48.0" }
+diskann-utils = { path = "diskann-utils", default-features = false, version = "0.48.0" }
+diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.48.0" }
+diskann-platform = { path = "diskann-platform", version = "0.48.0" }
 # Algorithm
-diskann = { path = "diskann", version = "0.47.0" }
+diskann = { path = "diskann", version = "0.48.0" }
 # Providers
-diskann-providers = { path = "diskann-providers", default-features = false, version = "0.47.0" }
-diskann-disk = { path = "diskann-disk", version = "0.47.0" }
-diskann-label-filter = { path = "diskann-label-filter", version = "0.47.0" }
+diskann-providers = { path = "diskann-providers", default-features = false, version = "0.48.0" }
+diskann-disk = { path = "diskann-disk", version = "0.48.0" }
+diskann-label-filter = { path = "diskann-label-filter", version = "0.48.0" }
 # Infra
-diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.47.0" }
-diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.47.0" }
-diskann-tools = { path = "diskann-tools", version = "0.47.0" }
+diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.48.0" }
+diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.48.0" }
+diskann-tools = { path = "diskann-tools", version = "0.48.0" }
 
 # External dependencies (shared versions)
 anyhow = "1.0.98"


### PR DESCRIPTION
## What's Changed
* Expand BetaFilter for External SearchStrategy Implementations by @hailangx in https://github.com/microsoft/DiskANN/pull/793
* Enable Miri tests in CI with non-blocking execution by @Copilot in https://github.com/microsoft/DiskANN/pull/697
* Increase unit test coverage for diskann-disk crate by @Copilot in https://github.com/microsoft/DiskANN/pull/761
* Add code review instructions for license headers by @harsha-simhadri in https://github.com/microsoft/DiskANN/pull/801
* Consolidate `load_bin` somewhat by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/792
* Add RFC process by @suri-kumkaran in https://github.com/microsoft/DiskANN/pull/804
* Fix variance issues with `Mat` and `MatMut`. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/806
* [Bugfix] NeighborPriorityQueue panics, when it is at capacity and NaN distance is inserted by @arrayka in https://github.com/microsoft/DiskANN/pull/796
* Enable `cache_only` mode for the BF-Tree cache by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/810
* Enable customization of Tokio runtimes in `diskann-benchmark-core` by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/809

## New Contributors
* @hailangx made their first contribution in https://github.com/microsoft/DiskANN/pull/793

**Full Changelog**: https://github.com/microsoft/DiskANN/compare/v0.47.0...v0.48.0