### PR TITLE
bumping up bf-tree version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,9 +105,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "bf-tree"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc59924517d26b63895ed60675e01a8dc27ee1d24d2b62cd6a272e7bd0af19a0"
+checksum = "07155f3f780c77c9ae58fcd1668140a6ac46a9b1e85bddf81489061291b3e80f"
 dependencies = [
  "cfg-if",
  "io-uring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ diskann-tools = { path = "diskann-tools", version = "0.48.0" }
 anyhow = "1.0.98"
 approx = "0.5.1"
 arc-swap = "1.7.1"
-bf-tree = "0.4.8"
+bf-tree = "0.4.9"
 bincode = "1.3.3"
 bit-set = "0.8.0"
 bytemuck = "1.23.0"


### PR DESCRIPTION
Bumping up bf-tree version from 0.4.8 to 0.4.9.