### PR TITLE
Saving and loading in-memory btrees to disk

### DIFF
--- a/diskann-providers/src/model/graph/provider/async_/bf_tree/neighbor_provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/bf_tree/neighbor_provider.rs
@@ -52,15 +52,9 @@ impl<I: VectorId> NeighborProvider<I> {
         self.adjacency_list_index.config()
     }
 
-    /// Create a snapshot of the adjacency list index
-    ///
-    pub fn snapshot(&self) -> std::path::PathBuf {
-        self.adjacency_list_index.snapshot()
-    }
-
-    /// Snapshot an in-memory adjacency list index to a file on disk.
-    pub fn snapshot_to_disk(&self, path: impl AsRef<std::path::Path>) -> std::path::PathBuf {
-        self.adjacency_list_index.snapshot_memory_to_disk(path)
+    /// Access the underlying BfTree
+    pub(crate) fn bftree(&self) -> &BfTree {
+        &self.adjacency_list_index
     }
 
     /// Return the maximum degree (number of neighbors per vector)
@@ -365,7 +359,7 @@ mod tests {
         neighbor_provider.set_neighbors(2, &[1, 3, 5]).unwrap();
 
         // Call snapshot - should not panic
-        neighbor_provider.snapshot();
+        neighbor_provider.adjacency_list_index.snapshot();
 
         // Verify data is still accessible after snapshot
         let mut result = AdjacencyList::with_capacity(10);

--- a/diskann-providers/src/model/graph/provider/async_/bf_tree/provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/bf_tree/provider.rs
@@ -1947,6 +1947,19 @@ async fn copy_snapshot_if_needed(
     Ok(())
 }
 
+/// Save a BfTree to disk, handling both in-memory and on-disk cases.
+/// For in-memory trees, uses `snapshot_memory_to_disk` to serialize all records.
+/// For on-disk trees, snapshots in place and copies if the target path differs.
+async fn save_bftree(tree: &BfTree, target_path: std::path::PathBuf) -> ANNResult<()> {
+    if tree.config().is_memory_backend() {
+        tree.snapshot_memory_to_disk(&target_path);
+    } else {
+        let snapshot_path = tree.snapshot();
+        copy_snapshot_if_needed(snapshot_path, target_path).await?;
+    }
+    Ok(())
+}
+
 /// Load a BfTree from a snapshot file, restoring it as in-memory or on-disk
 /// depending on `is_memory`. Builds the Config from `params` internally.
 fn load_bftree(
@@ -2017,31 +2030,16 @@ where
         }
 
         // Save vectors and neighbors
-        // Note: snapshot calls perform synchronous I/O on the current thread.
-        // This is consistent with the on-disk snapshot() path which also blocks.
-        // spawn_blocking requires a 'static closure, but &self is a borrow,
-        // so it cannot be moved into spawn_blocking without an API change.
-        if self.full_vectors.config().is_memory_backend() {
-            self.full_vectors
-                .snapshot_to_disk(BfTreePaths::vectors_bftree(&saved_params.prefix));
-            self.neighbor_provider
-                .snapshot_to_disk(BfTreePaths::neighbors_bftree(&saved_params.prefix));
-        } else {
-            let vectors_snapshot_path = self.full_vectors.snapshot();
-            let neighbors_snapshot_path = self.neighbor_provider.snapshot();
-
-            // Copy snapshot files to the target prefix location if they differ
-            copy_snapshot_if_needed(
-                vectors_snapshot_path,
-                BfTreePaths::vectors_bftree(&saved_params.prefix),
-            )
-            .await?;
-            copy_snapshot_if_needed(
-                neighbors_snapshot_path,
-                BfTreePaths::neighbors_bftree(&saved_params.prefix),
-            )
-            .await?;
-        }
+        save_bftree(
+            self.full_vectors.bftree(),
+            BfTreePaths::vectors_bftree(&saved_params.prefix),
+        )
+        .await?;
+        save_bftree(
+            self.neighbor_provider.bftree(),
+            BfTreePaths::neighbors_bftree(&saved_params.prefix),
+        )
+        .await?;
 
         // Save delete bitmap
         {
@@ -2192,39 +2190,21 @@ where
         }
 
         // Save vectors, neighbors, and quant vectors
-        // Note: snapshot calls perform synchronous I/O on the current thread.
-        // This is consistent with the on-disk snapshot() path which also blocks.
-        // spawn_blocking requires a 'static closure, but &self is a borrow,
-        // so it cannot be moved into spawn_blocking without an API change.
-        if self.full_vectors.config().is_memory_backend() {
-            self.full_vectors
-                .snapshot_to_disk(BfTreePaths::vectors_bftree(&saved_params.prefix));
-            self.neighbor_provider
-                .snapshot_to_disk(BfTreePaths::neighbors_bftree(&saved_params.prefix));
-            self.quant_vectors
-                .snapshot_to_disk(BfTreePaths::quant_bftree(&saved_params.prefix));
-        } else {
-            let vectors_snapshot_path = self.full_vectors.snapshot();
-            let neighbors_snapshot_path = self.neighbor_provider.snapshot();
-            let quant_snapshot_path = self.quant_vectors.snapshot();
-
-            // Copy snapshot files to the target prefix location if they differ
-            copy_snapshot_if_needed(
-                vectors_snapshot_path,
-                BfTreePaths::vectors_bftree(&saved_params.prefix),
-            )
-            .await?;
-            copy_snapshot_if_needed(
-                neighbors_snapshot_path,
-                BfTreePaths::neighbors_bftree(&saved_params.prefix),
-            )
-            .await?;
-            copy_snapshot_if_needed(
-                quant_snapshot_path,
-                BfTreePaths::quant_bftree(&saved_params.prefix),
-            )
-            .await?;
-        }
+        save_bftree(
+            self.full_vectors.bftree(),
+            BfTreePaths::vectors_bftree(&saved_params.prefix),
+        )
+        .await?;
+        save_bftree(
+            self.neighbor_provider.bftree(),
+            BfTreePaths::neighbors_bftree(&saved_params.prefix),
+        )
+        .await?;
+        save_bftree(
+            self.quant_vectors.bftree(),
+            BfTreePaths::quant_bftree(&saved_params.prefix),
+        )
+        .await?;
 
         // Save PQ table metadata and data using PQStorage format
         let filename = BfTreePaths::pq_pivots_bin(&saved_params.prefix);

--- a/diskann-providers/src/model/graph/provider/async_/bf_tree/quant_vector_provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/bf_tree/quant_vector_provider.rs
@@ -74,15 +74,9 @@ impl QuantVectorProvider {
         self.quant_vector_index.config()
     }
 
-    /// Create a snapshot of the quant vector index
-    ///
-    pub fn snapshot(&self) -> std::path::PathBuf {
-        self.quant_vector_index.snapshot()
-    }
-
-    /// Snapshot an in-memory quant vector index to a file on disk.
-    pub fn snapshot_to_disk(&self, path: impl AsRef<std::path::Path>) -> std::path::PathBuf {
-        self.quant_vector_index.snapshot_memory_to_disk(path)
+    /// Access the underlying BfTree
+    pub(crate) fn bftree(&self) -> &BfTree {
+        &self.quant_vector_index
     }
 
     /// Create a new instance from an existing BfTree (for loading from snapshot)

--- a/diskann-providers/src/model/graph/provider/async_/bf_tree/vector_provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/bf_tree/vector_provider.rs
@@ -101,16 +101,9 @@ impl<T: VectorRepr, I: VectorId> VectorProvider<T, I> {
         self.vector_index.config()
     }
 
-    /// Create a snapshot of the vector index
-    ///
-    #[inline(always)]
-    pub fn snapshot(&self) -> std::path::PathBuf {
-        self.vector_index.snapshot()
-    }
-
-    /// Snapshot an in-memory vector index to a file on disk.
-    pub fn snapshot_to_disk(&self, path: impl AsRef<std::path::Path>) -> std::path::PathBuf {
-        self.vector_index.snapshot_memory_to_disk(path)
+    /// Access the underlying BfTree
+    pub(crate) fn bftree(&self) -> &BfTree {
+        &self.vector_index
     }
 
     /// Set vector with Id, `i``, to `v`


### PR DESCRIPTION
This PR allows to save and load in-memory (`:memory:`) indices. Previously, it was possible to save/load only on-disk indices.

It also adds `is_memory` variable to `SavedParams` struct so that we know whether the original bf-tree index was in-memory or on-disk.

We also add two tests on whether in-memory saving/loading works both in pq and non-pq settings.