### PR TITLE
DiskANN v0.49.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "diskann"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-core"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "diskann",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-runner"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-simd"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "diskann-benchmark-runner",
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-disk"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -781,7 +781,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-label-filter"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -804,7 +804,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-linalg"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "approx",
  "cfg-if",
@@ -818,7 +818,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-platform"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "io-uring",
  "libc",
@@ -828,7 +828,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-providers"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -872,7 +872,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-quantization"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-tools"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -923,7 +923,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-utils"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -938,7 +938,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-vector"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "approx",
  "cfg-if",
@@ -952,7 +952,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-wide"
-version = "0.48.0"
+version = "0.49.0"
 dependencies = [
  "cfg-if",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ default-members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.48.0"                                                                                      # Obeying semver
+version = "0.49.0"      # Obeying semver
 description = "DiskANN is a fast approximate nearest neighbor search library for high dimensional data"
 authors = ["Microsoft"]
 documentation = "https://github.com/microsoft/DiskANN"
@@ -48,22 +48,22 @@ undocumented_unsafe_blocks = "warn"
 
 [workspace.dependencies]
 # Base And Numerics
-diskann-wide = { path = "diskann-wide", version = "0.48.0" }
-diskann-vector = { path = "diskann-vector", version = "0.48.0" }
-diskann-linalg = { path = "diskann-linalg", version = "0.48.0" }
-diskann-utils = { path = "diskann-utils", default-features = false, version = "0.48.0" }
-diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.48.0" }
-diskann-platform = { path = "diskann-platform", version = "0.48.0" }
+diskann-wide = { path = "diskann-wide", version = "0.49.0" }
+diskann-vector = { path = "diskann-vector", version = "0.49.0" }
+diskann-linalg = { path = "diskann-linalg", version = "0.49.0" }
+diskann-utils = { path = "diskann-utils", default-features = false, version = "0.49.0" }
+diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.49.0" }
+diskann-platform = { path = "diskann-platform", version = "0.49.0" }
 # Algorithm
-diskann = { path = "diskann", version = "0.48.0" }
+diskann = { path = "diskann", version = "0.49.0" }
 # Providers
-diskann-providers = { path = "diskann-providers", default-features = false, version = "0.48.0" }
-diskann-disk = { path = "diskann-disk", version = "0.48.0" }
-diskann-label-filter = { path = "diskann-label-filter", version = "0.48.0" }
+diskann-providers = { path = "diskann-providers", default-features = false, version = "0.49.0" }
+diskann-disk = { path = "diskann-disk", version = "0.49.0" }
+diskann-label-filter = { path = "diskann-label-filter", version = "0.49.0" }
 # Infra
-diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.48.0" }
-diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.48.0" }
-diskann-tools = { path = "diskann-tools", version = "0.48.0" }
+diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.49.0" }
+diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.49.0" }
+diskann-tools = { path = "diskann-tools", version = "0.49.0" }
 
 # External dependencies (shared versions)
 anyhow = "1.0.98"


### PR DESCRIPTION
   ## What's Changed
   * [quantization] 8bit distance kernels and ZipUnzip by @arkrishn94 in https://github.com/microsoft/DiskANN/pull/798
   * bumping up bf-tree version by @backurs in https://github.com/microsoft/DiskANN/pull/819
   * Import diskann-garnet and vectorset by @metajack in https://github.com/microsoft/DiskANN/pull/800
   * Saving and loading in-memory btrees to disk by @backurs in https://github.com/microsoft/DiskANN/pull/820

   ## New Contributors
   * @metajack made their first contribution in https://github.com/microsoft/DiskANN/pull/800

   **Full Changelog**: https://github.com/microsoft/DiskANN/compare/v0.48.0...v0.49.0

