### PR TITLE
diskann-disk benchmark : add ndims() and npoints() instead of accessing internal vars

### DIFF
--- a/diskann-benchmark/src/backend/disk_index/build.rs
+++ b/diskann-benchmark/src/backend/disk_index/build.rs
@@ -94,13 +94,13 @@ where
     let build_parameters = DiskIndexBuildParameters::new(
         MemoryBudget::try_from_gb(params.build_ram_limit_gb)?,
         params.quantization_type,
-        NumPQChunks::new_with(params.num_pq_chunks.get(), metadata.ndims)?,
+        NumPQChunks::new_with(params.num_pq_chunks.get(), metadata.ndims())?,
     );
 
     let index_configuration = IndexConfiguration::new(
         metric,
-        metadata.ndims,
-        metadata.npoints,
+        metadata.ndims(),
+        metadata.npoints(),
         ONE,
         params.num_threads,
         config,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
- [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.

`cargo clippy --workspace --features disk-index` fails due to recent changes. This fixes it.

#### Any other comments?

