### PR TITLE
Add synchronous `load_with` constructors and `run` escape hatch to `wrapped_async`

### DIFF
--- a/diskann-providers/src/index/wrapped_async.rs
+++ b/diskann-providers/src/index/wrapped_async.rs
@@ -427,7 +427,7 @@ mod tests {
     use std::sync::Arc;
 
     use diskann::{
-        graph::{self, config, search_output_buffer},
+        graph::{self, search_output_buffer},
         provider::DefaultContext,
         utils::ONE,
     };
@@ -511,14 +511,7 @@ mod tests {
             train_data.nrows(),
             ONE,
             1,
-            config::Builder::new(
-                30,
-                config::MaxDegree::default_slack(),
-                20,
-                Metric::L2.into(),
-            )
-            .build()
-            .unwrap(),
+            build_config,
         );
 
         type TestProvider = inmem::FullPrecisionProvider<


### PR DESCRIPTION
### Why

Sync callers who need to load a prebuilt index must manually create a tokio runtime and call the async `LoadWith` trait — leaking async internals. Similarly, there's no way to call an async method on the inner index if a sync wrapper doesn't exist for it yet.

### What

All changes are in `diskann-providers/src/index/wrapped_async.rs`.

- **`load_with_multi_thread_runtime`, `load_with_current_thread_runtime`, `load_with_handle`** — Sync constructors that load a prebuilt index from storage, mirroring the existing `new_with_*` pattern.
- **`run`** — Escape hatch: runs any async closure against the inner index on the wrapper's runtime, for methods that don't have a dedicated sync wrapper.
- **Extracted `create_multi_thread_runtime` / `create_current_thread_runtime`** helpers to reduce duplication.
- **`test_save_then_sync_load_round_trip`** — End-to-end test: build → insert → save (via `run`) → load → search.