### PR TITLE
Save/Load support for attribute information associated with DocumentProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,8 +786,10 @@ version = "0.50.0"
 dependencies = [
  "anyhow",
  "bf-tree",
+ "byteorder",
  "criterion",
  "diskann",
+ "diskann-providers",
  "diskann-utils",
  "diskann-vector",
  "futures-util",

--- a/diskann-label-filter/Cargo.toml
+++ b/diskann-label-filter/Cargo.toml
@@ -22,6 +22,8 @@ bf-tree.workspace = true
 scc = "3.3.2"
 diskann-utils = { workspace = true, default-features = false }
 diskann-vector.workspace = true
+diskann-providers = { workspace = true }
+byteorder.workspace = true
 tracing.workspace = true
 
 
@@ -34,7 +36,9 @@ anyhow.workspace = true
 futures-util.workspace = true
 tracing.workspace = true
 diskann = { workspace = true, features = ["testing"] }
+diskann-providers = { workspace = true, features = ["virtual_storage"] }
 tokio = { workspace = true, features = ["rt"] }
+diskann-utils = { workspace = true, features = ["testing"] }
 
 
 

--- a/diskann-label-filter/src/encoded_attribute_provider/attribute_encoder.rs
+++ b/diskann-label-filter/src/encoded_attribute_provider/attribute_encoder.rs
@@ -33,13 +33,11 @@ impl InternalAttribute {
     }
 
     /// Get the field name
-    #[expect(dead_code, reason = "Callers will be added in the next PR")]
     pub(crate) fn field_name(&self) -> &str {
         &self.field_name
     }
 
     /// Get the attribute value
-    #[expect(dead_code, reason = "Callers will be added in the next PR")]
     pub(crate) fn attr_value(&self) -> &AttributeValue {
         &self.attr_value
     }
@@ -96,20 +94,34 @@ impl AttributeEncoder {
     }
 
     ///Return the number of entries in the attribute map.
-    #[expect(dead_code, reason = "Will be used in the next PR")]
     pub(crate) fn len(&self) -> usize {
         self.attribute_index.len()
     }
 
-    /// Apply a function to each entry in the attribute map
-    /// This allows iteration over the internal attribute mappings
-    #[expect(dead_code, reason = "Will be used in the next PR")]
-    pub(crate) fn for_each<F>(&self, mut func: F)
+    /// Apply a function to each entry in the attribute map.
+    ///
+    /// Iteration stops on the first error returned by `func`.
+    pub(crate) fn for_each<E, F>(&self, mut func: F) -> Result<(), E>
     where
-        F: FnMut(&InternalAttribute, u64),
+        F: FnMut(&InternalAttribute, u64) -> Result<(), E>,
     {
         for (attr, &id) in &self.attribute_index {
-            func(attr, id);
+            func(attr, id)?;
+        }
+        Ok(())
+    }
+
+    /// Insert an attribute with a specific pre-assigned id.
+    ///
+    /// If the attribute already exists in the map its stored id is kept unchanged.
+    /// `running_index` is advanced past `id` if necessary so that future plain
+    /// `insert` calls still assign unique ids.
+    pub(crate) fn insert_with_id(&mut self, attribute: &Attribute, id: u64) {
+        self.attribute_index
+            .entry(InternalAttribute::new(attribute))
+            .or_insert(id);
+        if id >= self.running_index {
+            self.running_index = id + 1;
         }
     }
 }

--- a/diskann-label-filter/src/encoded_attribute_provider/roaring_attribute_store.rs
+++ b/diskann-label-filter/src/encoded_attribute_provider/roaring_attribute_store.rs
@@ -54,6 +54,14 @@ where
         self.index.clone()
     }
 
+    pub(crate) fn get_index_for_serialization(&self) -> Arc<RwLock<RoaringTreemapSetProvider<IT>>> {
+        self.index.clone()
+    }
+
+    pub(crate) fn get_inv_index(&self) -> Arc<RwLock<RoaringTreemapSetProvider<u64>>> {
+        self.inv_index.clone()
+    }
+
     pub(crate) fn attribute_map(&self) -> Arc<RwLock<AttributeEncoder>> {
         self.attribute_map.clone()
     }

--- a/diskann-label-filter/src/encoded_attribute_provider/roaring_attribute_store.rs
+++ b/diskann-label-filter/src/encoded_attribute_provider/roaring_attribute_store.rs
@@ -49,12 +49,7 @@ where
         }
     }
 
-    #[cfg(test)]
     pub fn get_index(&self) -> Arc<RwLock<RoaringTreemapSetProvider<IT>>> {
-        self.index.clone()
-    }
-
-    pub(crate) fn get_index_for_serialization(&self) -> Arc<RwLock<RoaringTreemapSetProvider<IT>>> {
         self.index.clone()
     }
 

--- a/diskann-label-filter/src/encoded_attribute_provider/roaring_attribute_store.rs
+++ b/diskann-label-filter/src/encoded_attribute_provider/roaring_attribute_store.rs
@@ -49,7 +49,7 @@ where
         }
     }
 
-    pub fn get_index(&self) -> Arc<RwLock<RoaringTreemapSetProvider<IT>>> {
+    pub(crate) fn get_index(&self) -> Arc<RwLock<RoaringTreemapSetProvider<IT>>> {
         self.index.clone()
     }
 

--- a/diskann-label-filter/src/encoded_attribute_provider/serialization.rs
+++ b/diskann-label-filter/src/encoded_attribute_provider/serialization.rs
@@ -180,7 +180,7 @@ where
         let attr_map_guard = attr_map_arc
             .read()
             .map_err(|_| lock_poison("attribute_map (read)"))?;
-        let index_arc = self.get_index_for_serialization();
+        let index_arc = self.get_index();
         let index_guard = index_arc.read().map_err(|_| lock_poison("index (read)"))?;
 
         let num_attribute_entries = attr_map_guard.len() as u64;
@@ -322,7 +322,7 @@ where
             .map_err(|e| io_error(e, "read num_nodes_with_labels"))?;
 
         {
-            let index_arc = store.get_index_for_serialization();
+            let index_arc = store.get_index();
             let inv_index_arc = store.get_inv_index();
             let mut index = index_arc
                 .write()

--- a/diskann-label-filter/src/encoded_attribute_provider/serialization.rs
+++ b/diskann-label-filter/src/encoded_attribute_provider/serialization.rs
@@ -518,7 +518,8 @@ fn read_dict_entry<R: Read>(r: &mut R) -> Result<(u64, Attribute), ANNError> {
         AttrTypeTag::String => {
             let slen = r
                 .read_u32::<LittleEndian>()
-                .map_err(|e| io_error(e, "read String byte_len"))? as usize;
+                .map_err(|e| io_error(e, "read String byte_len"))?
+                as usize;
             let mut sb = vec![0u8; slen];
             r.read_exact(&mut sb)
                 .map_err(|e| io_error(e, "read String bytes"))?;

--- a/diskann-label-filter/src/encoded_attribute_provider/serialization.rs
+++ b/diskann-label-filter/src/encoded_attribute_provider/serialization.rs
@@ -1,0 +1,614 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+//! `SaveWith` / `LoadWith` implementations for [`RoaringAttributeStore`] and
+//! [`DocumentProvider`].
+//!
+//! # File format
+//!
+//! Label data is persisted to `{prefix}.labels.bin`.  The format uses
+//! little-endian byte order throughout.
+//!
+//! ```text
+//! Header (17 bytes)
+//!   [u64] num_attribute_entries
+//!   [u64] forward_index_offset   (byte offset from file start to Section 2)
+//!   [u8]  vector_id_type_tag     (0 = u32, 1 = u64)
+//!
+//! Section 1 – Attribute Dictionary  (repeated num_attribute_entries times)
+//!   [u64] attribute_id
+//!   [u32] field_name_byte_len
+//!   [u8…] UTF-8 field name
+//!   [u8]  type_tag  (0=Bool, 1=Integer, 2=Real, 3=String, 4=Empty)
+//!   value bytes:
+//!     Bool:    1 byte  (0=false, 1=true)
+//!     Integer: 8 bytes (i64 little-endian)
+//!     Real:    8 bytes (f64 little-endian)
+//!     String: [u32 byte_len][u8…  UTF-8]
+//!     Empty:   0 bytes
+//!
+//! Section 2 – Forward Index
+//!   [u64] num_nodes_with_labels
+//!   (repeated num_nodes_with_labels times)
+//!     [N bytes] node_internal_id   (4 bytes for u32, 8 bytes for u64)
+//!     [u32]     num_attribute_ids
+//!     [u64…]    attribute IDs (in RoaringTreemap iteration order, ascending)
+//! ```
+//!
+//! The inverted index is **not** persisted; it is rebuilt from the forward
+//! index during [`LoadWith::load_with`].
+
+use std::io::{BufReader, BufWriter, Read, Seek, SeekFrom, Write};
+use std::mem;
+
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use diskann::{utils::VectorId, ANNError, ANNErrorKind};
+use diskann_providers::storage::{
+    AsyncIndexMetadata, AsyncQuantLoadContext, LoadWith, SaveWith, StorageReadProvider,
+    StorageWriteProvider,
+};
+use diskann_utils::future::AsyncFriendly;
+use roaring::RoaringTreemap;
+
+use crate::set::traits::SetProvider;
+use crate::{
+    attribute::{Attribute, AttributeValue},
+    encoded_attribute_provider::{
+        attribute_encoder::InternalAttribute,
+        document_provider::DocumentProvider,
+        roaring_attribute_store::RoaringAttributeStore,
+    },
+    traits::attribute_store::AttributeStore,
+};
+
+// ────────────────────────────────────────────────────────────────────────────
+// Internal helper: derive the label file path from the auxiliary context.
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Trait implemented for the auxiliary types recognised by this module.
+/// Returns the path at which label data should be written / read.
+pub(crate) trait LabelFilePath {
+    fn label_file_path(&self) -> String;
+}
+
+impl LabelFilePath for String {
+    fn label_file_path(&self) -> String {
+        format!("{}.labels.bin", self)
+    }
+}
+
+impl LabelFilePath for AsyncIndexMetadata {
+    fn label_file_path(&self) -> String {
+        format!("{}.labels.bin", self.prefix())
+    }
+}
+
+impl LabelFilePath for (u32, AsyncIndexMetadata) {
+    fn label_file_path(&self) -> String {
+        format!("{}.labels.bin", self.1.prefix())
+    }
+}
+
+impl LabelFilePath for AsyncQuantLoadContext {
+    fn label_file_path(&self) -> String {
+        format!("{}.labels.bin", self.metadata.prefix())
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Type-tag helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Wire tag for the vector-ID integer width stored in the label file header.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
+enum VectorIdTypeTag {
+    U32 = 0,
+    U64 = 1,
+}
+
+impl VectorIdTypeTag {
+    fn from_u8(byte: u8) -> Result<Self, ANNError> {
+        match byte {
+            0 => Ok(Self::U32),
+            1 => Ok(Self::U64),
+            tag => Err(ANNError::message(
+                ANNErrorKind::IndexError,
+                format!("unknown vector_id_type_tag: {tag}"),
+            )),
+        }
+    }
+}
+
+fn vector_id_type_tag<IT: VectorId>() -> VectorIdTypeTag {
+    match mem::size_of::<IT>() {
+        4 => VectorIdTypeTag::U32,
+        8 => VectorIdTypeTag::U64,
+        _ => panic!("unsupported VectorId width: {}", mem::size_of::<IT>()),
+    }
+}
+
+/// Wire tag for the attribute value type stored in Section 1 entries.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[repr(u8)]
+enum AttrTypeTag {
+    Bool    = 0,
+    Integer = 1,
+    Real    = 2,
+    String  = 3,
+    Empty   = 4,
+}
+
+impl AttrTypeTag {
+    fn from_u8(byte: u8) -> Result<Self, ANNError> {
+        match byte {
+            0 => Ok(Self::Bool),
+            1 => Ok(Self::Integer),
+            2 => Ok(Self::Real),
+            3 => Ok(Self::String),
+            4 => Ok(Self::Empty),
+            tag => Err(ANNError::message(
+                ANNErrorKind::IndexError,
+                format!("unknown attribute type tag: {tag}"),
+            )),
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// RoaringAttributeStore – SaveWith
+// ────────────────────────────────────────────────────────────────────────────
+
+impl<IT, T> SaveWith<T> for RoaringAttributeStore<IT>
+where
+    IT: VectorId + AsyncFriendly,
+    T: LabelFilePath + Send + Sync,
+{
+    type Ok = ();
+    type Error = ANNError;
+
+    async fn save_with<P>(&self, provider: &P, auxiliary: &T) -> Result<(), ANNError>
+    where
+        P: StorageWriteProvider,
+    {
+        let path = auxiliary.label_file_path();
+
+        // Bind the Arcs to named variables so the guards don't hold a reference
+        // to a temporary that is immediately dropped.
+        let attr_map_arc = self.attribute_map();
+        let attr_map_guard = attr_map_arc
+            .read()
+            .map_err(|_| lock_poison("attribute_map (read)"))?;
+        let index_arc = self.get_index_for_serialization();
+        let index_guard = index_arc
+            .read()
+            .map_err(|_| lock_poison("index (read)"))?;
+
+        let num_attribute_entries = attr_map_guard.len() as u64;
+
+        let file = provider
+            .create_for_write(&path)
+            .map_err(|e| io_error(e, "create label file"))?;
+        let mut w = BufWriter::new(file);
+
+        // ------- Header -------
+        // Byte 0–7:  num_attribute_entries (u64)
+        // Byte 8–15: forward_index_offset  (u64, patched after section 1)
+        // Byte 16:   vector_id_type_tag    (u8)
+        w.write_u64::<LittleEndian>(num_attribute_entries)
+            .map_err(|e| io_error(e, "write num_attribute_entries"))?;
+        w.write_u64::<LittleEndian>(0_u64) // placeholder for forward_index_offset
+            .map_err(|e| io_error(e, "write forward_index_offset placeholder"))?;
+        let type_tag = vector_id_type_tag::<IT>();
+        w.write_u8(type_tag as u8)
+            .map_err(|e| io_error(e, "write vector_id_type_tag"))?;
+
+        // ------- Section 1: Attribute Dictionary -------
+        attr_map_guard.for_each(|attr, id| write_dict_entry(&mut w, id, attr))?;
+
+        // Flush so the inner writer's position reflects all bytes written so far.
+        w.flush()
+            .map_err(|e| io_error(e, "flush before forward index"))?;
+
+        // ------- Patch forward_index_offset and write Section 2 -------
+        {
+            let mut inner = w
+                .into_inner()
+                .map_err(|e| io_error(e.into_error(), "flush BufWriter into inner"))?;
+
+            // Record where section 2 will start (current end of section 1).
+            let fwd_offset = inner
+                .stream_position()
+                .map_err(|e| io_error(e, "seek to current position"))?;
+
+            // Patch the placeholder at byte offset 8.
+            inner
+                .seek(SeekFrom::Start(8))
+                .map_err(|e| io_error(e, "seek to forward_index_offset field"))?;
+            inner
+                .write_u64::<LittleEndian>(fwd_offset)
+                .map_err(|e| io_error(e, "write forward_index_offset"))?;
+
+            // Seek back to end to append section 2.
+            inner
+                .seek(SeekFrom::Start(fwd_offset))
+                .map_err(|e| io_error(e, "seek back to section 2"))?;
+
+            let mut w2 = BufWriter::new(inner);
+
+            // Section 2 header: number of nodes with labels.
+            let num_nodes = index_guard.count().map_err(|e| {
+                ANNError::new(ANNErrorKind::IndexError, e).context("count forward index")
+            })?;
+            w2.write_u64::<LittleEndian>(num_nodes as u64)
+                .map_err(|e| io_error(e, "write num_nodes_with_labels"))?;
+
+            index_guard.for_each(|node_id, set| -> Result<(), ANNError> {
+                write_forward_entry::<IT, _>(&mut w2, type_tag, *node_id, set)
+            })?;
+
+            w2.flush().map_err(|e| io_error(e, "flush section 2"))?;
+        }
+
+        Ok(())
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// RoaringAttributeStore – LoadWith
+// ────────────────────────────────────────────────────────────────────────────
+
+impl<IT, T> LoadWith<T> for RoaringAttributeStore<IT>
+where
+    IT: VectorId + AsyncFriendly,
+    T: LabelFilePath + Send + Sync,
+{
+    type Error = ANNError;
+
+    async fn load_with<P>(provider: &P, auxiliary: &T) -> Result<Self, ANNError>
+    where
+        P: StorageReadProvider,
+    {
+        let path = auxiliary.label_file_path();
+        let file = provider
+            .open_reader(&path)
+            .map_err(|e| io_error(e, "open label file"))?;
+        let mut r = BufReader::new(file);
+
+        // ------- Header -------
+        let num_attribute_entries = r
+            .read_u64::<LittleEndian>()
+            .map_err(|e| io_error(e, "read num_attribute_entries"))?;
+        let forward_index_offset = r
+            .read_u64::<LittleEndian>()
+            .map_err(|e| io_error(e, "read forward_index_offset"))?;
+        let type_tag_byte = r
+            .read_u8()
+            .map_err(|e| io_error(e, "read vector_id_type_tag"))?;
+        let type_tag = VectorIdTypeTag::from_u8(type_tag_byte)?;
+
+        // Validate that the stored type tag matches the current IT.
+        let expected_tag = vector_id_type_tag::<IT>();
+        if type_tag != expected_tag {
+            return Err(ANNError::message(
+                ANNErrorKind::IndexError,
+                format!(
+                    "Label file type tag mismatch: file has {:?}, expected {:?}",
+                    type_tag, expected_tag
+                ),
+            ));
+        }
+
+        // ------- Section 1: Attribute Dictionary -------
+        let store = RoaringAttributeStore::<IT>::new();
+        {
+            let attr_map_arc = store.attribute_map();
+            let mut attr_map = attr_map_arc
+                .write()
+                .map_err(|_| lock_poison("attribute_map (write)"))?;
+            for _ in 0..num_attribute_entries {
+                let (attr_id, attr) = read_dict_entry(&mut r)?;
+                // Re-insert with the exact same id that was persisted.
+                attr_map.insert_with_id(&attr, attr_id);
+            }
+        }
+
+        // ------- Seek to Section 2 -------
+        r.seek(SeekFrom::Start(forward_index_offset))
+            .map_err(|e| io_error(e, "seek to forward index"))?;
+
+        // ------- Section 2: Forward Index -------
+        let num_nodes = r
+            .read_u64::<LittleEndian>()
+            .map_err(|e| io_error(e, "read num_nodes_with_labels"))?;
+
+        {
+            let index_arc = store.get_index_for_serialization();
+            let inv_index_arc = store.get_inv_index();
+            let mut index = index_arc
+                .write()
+                .map_err(|_| lock_poison("index (write)"))?;
+            let mut inv_index = inv_index_arc
+                .write()
+                .map_err(|_| lock_poison("inv_index (write)"))?;
+
+            for _ in 0..num_nodes {
+                let (node_id, attr_ids) = read_forward_entry::<IT, _>(&mut r, type_tag)?;
+                let node_u64: u64 = node_id.into();
+                for &attr_id in &attr_ids {
+                    index.insert(&node_id, &attr_id).map_err(|e| {
+                        ANNError::new(ANNErrorKind::IndexError, e)
+                            .context("rebuild forward index")
+                    })?;
+                    inv_index.insert(&attr_id, &node_u64).map_err(|e| {
+                        ANNError::new(ANNErrorKind::IndexError, e)
+                            .context("rebuild inverted index")
+                    })?;
+                }
+            }
+        }
+
+        Ok(store)
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// DocumentProvider – SaveWith
+// ────────────────────────────────────────────────────────────────────────────
+
+impl<DP, AS, T> SaveWith<T> for DocumentProvider<DP, AS>
+where
+    DP: diskann::provider::DataProvider + SaveWith<T, Error = ANNError>,
+    AS: AttributeStore<DP::InternalId>
+        + SaveWith<T, Ok = (), Error = ANNError>
+        + AsyncFriendly,
+    T: Send + Sync,
+{
+    type Ok = ();
+    type Error = ANNError;
+
+    async fn save_with<P>(&self, provider: &P, auxiliary: &T) -> Result<(), ANNError>
+    where
+        P: StorageWriteProvider,
+    {
+        // Delegate to inner provider.
+        self.inner_provider()
+            .save_with(provider, auxiliary)
+            .await?;
+
+        // Persist the attribute store.
+        self.attribute_store()
+            .save_with(provider, auxiliary)
+            .await?;
+
+        Ok(())
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// DocumentProvider – LoadWith
+// ────────────────────────────────────────────────────────────────────────────
+
+impl<DP, AS, T> LoadWith<T> for DocumentProvider<DP, AS>
+where
+    DP: diskann::provider::DataProvider + LoadWith<T, Error = ANNError>,
+    AS: AttributeStore<DP::InternalId>
+        + LoadWith<T, Error = ANNError>
+        + AsyncFriendly,
+    T: Send + Sync,
+{
+    type Error = ANNError;
+
+    async fn load_with<P>(provider: &P, auxiliary: &T) -> Result<Self, ANNError>
+    where
+        P: StorageReadProvider,
+    {
+        // Load the inner provider.
+        let inner_provider = DP::load_with(provider, auxiliary).await?;
+
+        // Load the attribute store.
+        let attribute_store = AS::load_with(provider, auxiliary).await?;
+
+        Ok(Self::new(inner_provider, attribute_store))
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Private helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+fn lock_poison(field: &str) -> ANNError {
+    ANNError::message(
+        ANNErrorKind::LockPoisonError,
+        format!("poisoned lock on {field}"),
+    )
+}
+
+fn io_error(e: std::io::Error, context: &str) -> ANNError {
+    ANNError::message(
+        ANNErrorKind::IndexError,
+        format!("IO error while {context}: {e}"),
+    )
+}
+
+fn write_dict_entry<W: Write>(
+    w: &mut W,
+    attr_id: u64,
+    attr: &InternalAttribute,
+) -> Result<(), ANNError> {
+    w.write_u64::<LittleEndian>(attr_id)
+        .map_err(|e| io_error(e, "write attribute_id"))?;
+
+    let field = attr.field_name();
+    let field_bytes = field.as_bytes();
+    w.write_u32::<LittleEndian>(field_bytes.len() as u32)
+        .map_err(|e| io_error(e, "write field_name_byte_len"))?;
+    w.write_all(field_bytes)
+        .map_err(|e| io_error(e, "write field_name bytes"))?;
+
+    match attr.attr_value() {
+        AttributeValue::Bool(b) => {
+            w.write_u8(AttrTypeTag::Bool as u8)
+                .map_err(|e| io_error(e, "write Bool tag"))?;
+            w.write_u8(if *b { 1 } else { 0 })
+                .map_err(|e| io_error(e, "write Bool value"))?;
+        }
+        AttributeValue::Integer(i) => {
+            w.write_u8(AttrTypeTag::Integer as u8)
+                .map_err(|e| io_error(e, "write Integer tag"))?;
+            w.write_i64::<LittleEndian>(*i)
+                .map_err(|e| io_error(e, "write Integer value"))?;
+        }
+        AttributeValue::Real(f) => {
+            w.write_u8(AttrTypeTag::Real as u8)
+                .map_err(|e| io_error(e, "write Real tag"))?;
+            w.write_f64::<LittleEndian>(*f)
+                .map_err(|e| io_error(e, "write Real value"))?;
+        }
+        AttributeValue::String(s) => {
+            w.write_u8(AttrTypeTag::String as u8)
+                .map_err(|e| io_error(e, "write String tag"))?;
+            let sb = s.as_bytes();
+            w.write_u32::<LittleEndian>(sb.len() as u32)
+                .map_err(|e| io_error(e, "write String byte_len"))?;
+            w.write_all(sb)
+                .map_err(|e| io_error(e, "write String bytes"))?;
+        }
+        AttributeValue::Empty => {
+            w.write_u8(AttrTypeTag::Empty as u8)
+                .map_err(|e| io_error(e, "write Empty tag"))?;
+        }
+    }
+    Ok(())
+}
+
+fn read_dict_entry<R: Read>(r: &mut R) -> Result<(u64, Attribute), ANNError> {
+    let attr_id = r
+        .read_u64::<LittleEndian>()
+        .map_err(|e| io_error(e, "read attribute_id"))?;
+
+    let field_len = r
+        .read_u32::<LittleEndian>()
+        .map_err(|e| io_error(e, "read field_name_byte_len"))? as usize;
+    let mut field_bytes = vec![0u8; field_len];
+    r.read_exact(&mut field_bytes)
+        .map_err(|e| io_error(e, "read field_name bytes"))?;
+    let field_name = String::from_utf8(field_bytes).map_err(|e| {
+        ANNError::message(
+            ANNErrorKind::IndexError,
+            format!("invalid UTF-8 in field name: {e}"),
+        )
+    })?;
+
+    let type_tag = AttrTypeTag::from_u8(
+        r.read_u8().map_err(|e| io_error(e, "read type_tag"))?,
+    )?;
+
+    let value = match type_tag {
+        AttrTypeTag::Bool => {
+            let b = r.read_u8().map_err(|e| io_error(e, "read Bool value"))?;
+            AttributeValue::Bool(b != 0)
+        }
+        AttrTypeTag::Integer => {
+            let i = r
+                .read_i64::<LittleEndian>()
+                .map_err(|e| io_error(e, "read Integer value"))?;
+            AttributeValue::Integer(i)
+        }
+        AttrTypeTag::Real => {
+            let f = r
+                .read_f64::<LittleEndian>()
+                .map_err(|e| io_error(e, "read Real value"))?;
+            AttributeValue::Real(f)
+        }
+        AttrTypeTag::String => {
+            let slen = r
+                .read_u32::<LittleEndian>()
+                .map_err(|e| io_error(e, "read String byte_len"))? as usize;
+            let mut sb = vec![0u8; slen];
+            r.read_exact(&mut sb)
+                .map_err(|e| io_error(e, "read String bytes"))?;
+            let s = String::from_utf8(sb).map_err(|e| {
+                ANNError::message(
+                    ANNErrorKind::IndexError,
+                    format!("invalid UTF-8 in String value: {e}"),
+                )
+            })?;
+            AttributeValue::String(s)
+        }
+        AttrTypeTag::Empty => AttributeValue::Empty,
+    };
+
+    Ok((attr_id, Attribute::from_value(field_name, value)))
+}
+
+fn write_forward_entry<IT, W>(
+    w: &mut W,
+    type_tag: VectorIdTypeTag,
+    node_id: IT,
+    set: &RoaringTreemap,
+) -> Result<(), ANNError>
+where
+    IT: VectorId,
+    W: Write,
+{
+    match type_tag {
+        VectorIdTypeTag::U32 => {
+            let id32: u32 = node_id.into() as u32;
+            w.write_u32::<LittleEndian>(id32)
+                .map_err(|e| io_error(e, "write node_id u32"))?;
+        }
+        VectorIdTypeTag::U64 => {
+            let id64: u64 = node_id.into();
+            w.write_u64::<LittleEndian>(id64)
+                .map_err(|e| io_error(e, "write node_id u64"))?;
+        }
+    }
+
+    w.write_u32::<LittleEndian>(set.len() as u32)
+        .map_err(|e| io_error(e, "write num_attribute_ids"))?;
+    for id in set.iter() {
+        w.write_u64::<LittleEndian>(id)
+            .map_err(|e| io_error(e, "write attribute_id in forward entry"))?;
+    }
+    Ok(())
+}
+
+fn read_forward_entry<IT, R>(r: &mut R, type_tag: VectorIdTypeTag) -> Result<(IT, Vec<u64>), ANNError>
+where
+    IT: VectorId,
+    R: Read,
+{
+    let node_id: IT = match type_tag {
+        VectorIdTypeTag::U32 => {
+            let raw = r
+                .read_u32::<LittleEndian>()
+                .map_err(|e| io_error(e, "read node_id u32"))?;
+            IT::from_u32(raw).ok_or_else(|| {
+                ANNError::message(ANNErrorKind::IndexError, "node_id u32 conversion failed")
+            })?
+        }
+        VectorIdTypeTag::U64 => {
+            let raw = r
+                .read_u64::<LittleEndian>()
+                .map_err(|e| io_error(e, "read node_id u64"))?;
+            IT::from_u64(raw).ok_or_else(|| {
+                ANNError::message(ANNErrorKind::IndexError, "node_id u64 conversion failed")
+            })?
+        }
+    };
+
+    let num_attr = r
+        .read_u32::<LittleEndian>()
+        .map_err(|e| io_error(e, "read num_attribute_ids"))? as usize;
+    let mut attr_ids = Vec::with_capacity(num_attr);
+    for _ in 0..num_attr {
+        let id = r
+            .read_u64::<LittleEndian>()
+            .map_err(|e| io_error(e, "read attribute_id in forward entry"))?;
+        attr_ids.push(id);
+    }
+    Ok((node_id, attr_ids))
+}

--- a/diskann-label-filter/src/encoded_attribute_provider/serialization.rs
+++ b/diskann-label-filter/src/encoded_attribute_provider/serialization.rs
@@ -46,8 +46,7 @@ use std::mem;
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use diskann::{utils::VectorId, ANNError, ANNErrorKind};
 use diskann_providers::storage::{
-    AsyncIndexMetadata, AsyncQuantLoadContext, LoadWith, SaveWith, StorageReadProvider,
-    StorageWriteProvider,
+    AsyncIndexMetadata, AsyncQuantLoadContext, DiskGraphOnly, LoadWith, SaveWith, StorageReadProvider, StorageWriteProvider
 };
 use diskann_utils::future::AsyncFriendly;
 use roaring::RoaringTreemap;
@@ -87,6 +86,12 @@ impl LabelFilePath for AsyncIndexMetadata {
 impl LabelFilePath for (u32, AsyncIndexMetadata) {
     fn label_file_path(&self) -> String {
         format!("{}.labels.bin", self.1.prefix())
+    }
+}
+
+impl LabelFilePath for (u32, u32, DiskGraphOnly) {
+    fn label_file_path(&self) -> String {
+        format!("{}.labels.bin", self.2.prefix())
     }
 }
 

--- a/diskann-label-filter/src/encoded_attribute_provider/serialization.rs
+++ b/diskann-label-filter/src/encoded_attribute_provider/serialization.rs
@@ -56,8 +56,7 @@ use crate::set::traits::SetProvider;
 use crate::{
     attribute::{Attribute, AttributeValue},
     encoded_attribute_provider::{
-        attribute_encoder::InternalAttribute,
-        document_provider::DocumentProvider,
+        attribute_encoder::InternalAttribute, document_provider::DocumentProvider,
         roaring_attribute_store::RoaringAttributeStore,
     },
     traits::attribute_store::AttributeStore,
@@ -134,11 +133,11 @@ fn vector_id_type_tag<IT: VectorId>() -> VectorIdTypeTag {
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(u8)]
 enum AttrTypeTag {
-    Bool    = 0,
+    Bool = 0,
     Integer = 1,
-    Real    = 2,
-    String  = 3,
-    Empty   = 4,
+    Real = 2,
+    String = 3,
+    Empty = 4,
 }
 
 impl AttrTypeTag {
@@ -182,9 +181,7 @@ where
             .read()
             .map_err(|_| lock_poison("attribute_map (read)"))?;
         let index_arc = self.get_index_for_serialization();
-        let index_guard = index_arc
-            .read()
-            .map_err(|_| lock_poison("index (read)"))?;
+        let index_guard = index_arc.read().map_err(|_| lock_poison("index (read)"))?;
 
         let num_attribute_entries = attr_map_guard.len() as u64;
 
@@ -339,12 +336,10 @@ where
                 let node_u64: u64 = node_id.into();
                 for &attr_id in &attr_ids {
                     index.insert(&node_id, &attr_id).map_err(|e| {
-                        ANNError::new(ANNErrorKind::IndexError, e)
-                            .context("rebuild forward index")
+                        ANNError::new(ANNErrorKind::IndexError, e).context("rebuild forward index")
                     })?;
                     inv_index.insert(&attr_id, &node_u64).map_err(|e| {
-                        ANNError::new(ANNErrorKind::IndexError, e)
-                            .context("rebuild inverted index")
+                        ANNError::new(ANNErrorKind::IndexError, e).context("rebuild inverted index")
                     })?;
                 }
             }
@@ -361,9 +356,7 @@ where
 impl<DP, AS, T> SaveWith<T> for DocumentProvider<DP, AS>
 where
     DP: diskann::provider::DataProvider + SaveWith<T, Error = ANNError>,
-    AS: AttributeStore<DP::InternalId>
-        + SaveWith<T, Ok = (), Error = ANNError>
-        + AsyncFriendly,
+    AS: AttributeStore<DP::InternalId> + SaveWith<T, Ok = (), Error = ANNError> + AsyncFriendly,
     T: Send + Sync,
 {
     type Ok = ();
@@ -374,9 +367,7 @@ where
         P: StorageWriteProvider,
     {
         // Delegate to inner provider.
-        self.inner_provider()
-            .save_with(provider, auxiliary)
-            .await?;
+        self.inner_provider().save_with(provider, auxiliary).await?;
 
         // Persist the attribute store.
         self.attribute_store()
@@ -394,9 +385,7 @@ where
 impl<DP, AS, T> LoadWith<T> for DocumentProvider<DP, AS>
 where
     DP: diskann::provider::DataProvider + LoadWith<T, Error = ANNError>,
-    AS: AttributeStore<DP::InternalId>
-        + LoadWith<T, Error = ANNError>
-        + AsyncFriendly,
+    AS: AttributeStore<DP::InternalId> + LoadWith<T, Error = ANNError> + AsyncFriendly,
     T: Send + Sync,
 {
     type Error = ANNError;
@@ -502,9 +491,7 @@ fn read_dict_entry<R: Read>(r: &mut R) -> Result<(u64, Attribute), ANNError> {
         )
     })?;
 
-    let type_tag = AttrTypeTag::from_u8(
-        r.read_u8().map_err(|e| io_error(e, "read type_tag"))?,
-    )?;
+    let type_tag = AttrTypeTag::from_u8(r.read_u8().map_err(|e| io_error(e, "read type_tag"))?)?;
 
     let value = match type_tag {
         AttrTypeTag::Bool => {
@@ -576,7 +563,10 @@ where
     Ok(())
 }
 
-fn read_forward_entry<IT, R>(r: &mut R, type_tag: VectorIdTypeTag) -> Result<(IT, Vec<u64>), ANNError>
+fn read_forward_entry<IT, R>(
+    r: &mut R,
+    type_tag: VectorIdTypeTag,
+) -> Result<(IT, Vec<u64>), ANNError>
 where
     IT: VectorId,
     R: Read,

--- a/diskann-label-filter/src/lib.rs
+++ b/diskann-label-filter/src/lib.rs
@@ -45,6 +45,7 @@ pub mod encoded_attribute_provider {
     pub mod encoded_attribute_accessor;
     pub(crate) mod encoded_filter_expr;
     pub mod roaring_attribute_store;
+    pub(crate) mod serialization;
 }
 
 pub mod tests {
@@ -58,6 +59,8 @@ pub mod tests {
     pub mod inline_beta_filter_test;
     #[cfg(test)]
     pub mod roaring_attribute_store_test;
+    #[cfg(test)]
+    pub mod serialization_test;
 }
 
 pub mod attribute;

--- a/diskann-label-filter/src/set/roaring_set_provider.rs
+++ b/diskann-label-filter/src/set/roaring_set_provider.rs
@@ -168,6 +168,19 @@ where
             index: HashMap::with_hasher(BuildIdentityHasher::default()),
         }
     }
+
+    /// Iterate over all `(key, set)` pairs, calling `f` for each.
+    ///
+    /// Returns the first error returned by `f`, or `Ok(())` if all calls succeed.
+    pub(crate) fn for_each<E, F>(&self, mut f: F) -> Result<(), E>
+    where
+        F: FnMut(&Key, &RoaringTreemap) -> Result<(), E>,
+    {
+        for (key, set) in &self.index {
+            f(key, set)?;
+        }
+        Ok(())
+    }
 }
 
 // RoaringTreemap provider with u64 values

--- a/diskann-label-filter/src/tests/serialization_test.rs
+++ b/diskann-label-filter/src/tests/serialization_test.rs
@@ -145,6 +145,57 @@ fn test_roundtrip_with_data() {
             loaded_attr.len(),
             "attribute map size mismatch"
         );
+
+        // ensure attribute values are deserialized correctly.
+        for attrs in [attrs_0, attrs_1, attrs_2] {
+            for attr in &attrs {
+                let orig_id = orig_attr.get(&attr).unwrap();
+                let loaded_id = loaded_attr.get(&attr).unwrap();
+                assert_eq!(
+                    orig_id, loaded_id,
+                    "attribute ID mismatch for attribute {attr:?}"
+                );
+            }
+        }
+
+        // Inverted index must contain the same node sets for every attribute ID.
+        let orig_inv_arc = store.get_inv_index();
+        let orig_inv = orig_inv_arc.read().unwrap();
+        let loaded_inv_arc = loaded.get_inv_index();
+        let loaded_inv = loaded_inv_arc.read().unwrap();
+        assert_eq!(
+            orig_inv.count().unwrap(),
+            loaded_inv.count().unwrap(),
+            "inverted index entry count mismatch"
+        );
+        let mut attr_ids: Vec<u64> = Vec::new();
+        orig_attr
+            .for_each(|_, id| -> Result<(), ()> {
+                attr_ids.push(id);
+                Ok(())
+            })
+            .unwrap();
+        for attr_id in attr_ids {
+            let orig_nodes = orig_inv
+                .get(&attr_id)
+                .unwrap()
+                .expect("attribute missing from original inverted index");
+            let loaded_nodes = loaded_inv
+                .get(&attr_id)
+                .unwrap()
+                .unwrap_or_else(|| panic!("attribute id {attr_id} missing from loaded inverted index"));
+            assert_eq!(
+                orig_nodes.len(),
+                loaded_nodes.len(),
+                "inverted index node-set len mismatch for attribute id {attr_id}"
+            );
+            for node_id in orig_nodes.iter() {
+                assert!(
+                    loaded_nodes.contains(node_id),
+                    "node {node_id} missing from loaded inverted index for attribute id {attr_id}"
+                );
+            }
+        }
     });
 }
 

--- a/diskann-label-filter/src/tests/serialization_test.rs
+++ b/diskann-label-filter/src/tests/serialization_test.rs
@@ -336,9 +336,10 @@ fn test_document_provider_round_trip() {
     // Every inserted external ID must map to a valid internal ID.
     let ctx = DefaultContext;
     for i in 0..train_data.nrows() as u32 {
-        inner
-            .to_internal_id(&ctx, &i)
-            .unwrap_or_else(|_| panic!("external id {i} missing after round trip"));
+        assert!(
+            inner.to_internal_id(&ctx, &i).is_ok(),
+            "external id {i} missing after round trip"
+        );
     }
 
     // --- Assert labels survived the round trip ---

--- a/diskann-label-filter/src/tests/serialization_test.rs
+++ b/diskann-label-filter/src/tests/serialization_test.rs
@@ -149,8 +149,8 @@ fn test_roundtrip_with_data() {
         // ensure attribute values are deserialized correctly.
         for attrs in [attrs_0, attrs_1, attrs_2] {
             for attr in &attrs {
-                let orig_id = orig_attr.get(&attr).unwrap();
-                let loaded_id = loaded_attr.get(&attr).unwrap();
+                let orig_id = orig_attr.get(attr).unwrap();
+                let loaded_id = loaded_attr.get(attr).unwrap();
                 assert_eq!(
                     orig_id, loaded_id,
                     "attribute ID mismatch for attribute {attr:?}"

--- a/diskann-label-filter/src/tests/serialization_test.rs
+++ b/diskann-label-filter/src/tests/serialization_test.rs
@@ -180,15 +180,30 @@ fn test_roundtrip_u64_node_ids() {
             let index = index_arc.read().unwrap();
             assert_eq!(index.count().unwrap(), 2);
         } // index guard dropped before next await
+    });
+}
 
-        // Loading the same file as u32 must fail with a type-tag mismatch.
+/// Loading a u64 label file as a u32 store must be rejected.
+#[test]
+fn test_load_u64_file_as_u32_fails() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+
+    let store: RoaringAttributeStore<u64> = RoaringAttributeStore::new();
+    let attrs = vec![Attribute::from_value(
+        "kind",
+        AttributeValue::String("doc".into()),
+    )];
+    store.set_element(&(u32::MAX as u64 + 1), &attrs).unwrap();
+
+    let provider = VirtualStorageProvider::new_memory();
+    let prefix = String::from("/idx64");
+
+    rt.block_on(async {
+        store.save_with(&provider, &prefix).await.unwrap();
         let result = RoaringAttributeStore::<u32>::load_with(&provider, &prefix).await;
         assert!(result.is_err(), "expected error loading u64 file as u32");
-        let err = result.err().unwrap();
-        assert!(
-            err.to_string().contains("type tag mismatch"),
-            "unexpected error: {err}"
-        );
     });
 }
 

--- a/diskann-label-filter/src/tests/serialization_test.rs
+++ b/diskann-label-filter/src/tests/serialization_test.rs
@@ -59,7 +59,7 @@ fn test_roundtrip_empty_store() {
                 .await
                 .unwrap();
 
-        let index_arc = loaded.get_index_for_serialization();
+        let index_arc = loaded.get_index();
         let index = index_arc.read().unwrap();
         assert_eq!(index.count().unwrap(), 0);
     });
@@ -102,9 +102,9 @@ fn test_roundtrip_with_data() {
                 .await
                 .unwrap();
 
-        let orig_index_arc = store.get_index_for_serialization();
+        let orig_index_arc = store.get_index();
         let orig_index = orig_index_arc.read().unwrap();
-        let loaded_index_arc = loaded.get_index_for_serialization();
+        let loaded_index_arc = loaded.get_index();
         let loaded_index = loaded_index_arc.read().unwrap();
 
         assert_eq!(
@@ -228,7 +228,7 @@ fn test_roundtrip_u64_node_ids() {
                 .unwrap();
 
         {
-            let index_arc = loaded.get_index_for_serialization();
+            let index_arc = loaded.get_index();
             let index = index_arc.read().unwrap();
             assert_eq!(index.count().unwrap(), 2);
         } // index guard dropped before next await

--- a/diskann-label-filter/src/tests/serialization_test.rs
+++ b/diskann-label-filter/src/tests/serialization_test.rs
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+//! Round-trip tests for `SaveWith` / `LoadWith` on `RoaringAttributeStore` and
+//! `DocumentProvider`.
+
+use std::sync::Arc;
+
+use diskann::{
+    graph::config::{Builder as ConfigBuilder, MaxDegree},
+    provider::{DataProvider, DefaultContext},
+    utils::ONE,
+};
+use diskann_providers::{
+    index::{diskann_async, wrapped_async::DiskANNIndex},
+    model::{
+        configuration::IndexConfiguration,
+        graph::provider::async_::{
+            common::{FullPrecision, TableBasedDeletes},
+            inmem::{self, CreateFullPrecision, DefaultProvider, DefaultProviderParameters},
+        },
+    },
+    storage::{AsyncIndexMetadata, LoadWith, SaveWith, StorageReadProvider, VirtualStorageProvider},
+    utils::create_rnd_from_seed_in_tests,
+};
+use diskann_utils::test_data_root;
+use diskann_vector::distance::Metric;
+
+use crate::{
+    attribute::{Attribute, AttributeValue},
+    document::Document,
+    encoded_attribute_provider::{
+        document_insert_strategy::DocumentInsertStrategy,
+        document_provider::DocumentProvider,
+        roaring_attribute_store::RoaringAttributeStore,
+    },
+    set::traits::SetProvider,
+    traits::attribute_store::AttributeStore,
+};
+
+/// Verify that an empty store round-trips correctly.
+#[test]
+fn test_roundtrip_empty_store() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+
+    let store: RoaringAttributeStore<u32> = RoaringAttributeStore::new();
+    let provider = VirtualStorageProvider::new_memory();
+    let prefix = String::from("/index");
+
+    rt.block_on(async {
+        store.save_with(&provider, &prefix).await.unwrap();
+        let loaded: RoaringAttributeStore<u32> =
+            RoaringAttributeStore::load_with(&provider, &prefix)
+                .await
+                .unwrap();
+
+        let index_arc = loaded.get_index_for_serialization();
+        let index = index_arc.read().unwrap();
+        assert_eq!(index.count().unwrap(), 0);
+    });
+}
+
+/// Verify a store with several vectors and attribute types round-trips identically.
+#[test]
+fn test_roundtrip_with_data() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+
+    let store: RoaringAttributeStore<u32> = RoaringAttributeStore::new();
+
+    let attrs_0 = vec![
+        Attribute::from_value("category", AttributeValue::String("electronics".into())),
+        Attribute::from_value("price", AttributeValue::Real(299.99)),
+        Attribute::from_value("available", AttributeValue::Bool(true)),
+    ];
+    let attrs_1 = vec![
+        Attribute::from_value("category", AttributeValue::String("books".into())),
+        Attribute::from_value("pages", AttributeValue::Integer(320)),
+    ];
+    let attrs_2 = vec![
+        Attribute::from_value("flag", AttributeValue::Empty),
+        Attribute::from_value("category", AttributeValue::String("electronics".into())),
+    ];
+
+    store.set_element(&0u32, &attrs_0).unwrap();
+    store.set_element(&1u32, &attrs_1).unwrap();
+    store.set_element(&2u32, &attrs_2).unwrap();
+
+    let provider = VirtualStorageProvider::new_memory();
+    let prefix = String::from("/index");
+
+    rt.block_on(async {
+        store.save_with(&provider, &prefix).await.unwrap();
+        let loaded: RoaringAttributeStore<u32> =
+            RoaringAttributeStore::load_with(&provider, &prefix)
+                .await
+                .unwrap();
+
+        let orig_index_arc = store.get_index_for_serialization();
+        let orig_index = orig_index_arc.read().unwrap();
+        let loaded_index_arc = loaded.get_index_for_serialization();
+        let loaded_index = loaded_index_arc.read().unwrap();
+
+        assert_eq!(
+            orig_index.count().unwrap(),
+            loaded_index.count().unwrap(),
+            "forward index entry count mismatch"
+        );
+
+        for node_id in [0u32, 1u32, 2u32] {
+            let orig_set = orig_index
+                .get(&node_id)
+                .unwrap()
+                .expect("original node missing");
+            let loaded_set = loaded_index
+                .get(&node_id)
+                .unwrap()
+                .expect("loaded node missing");
+            assert_eq!(
+                orig_set.len(),
+                loaded_set.len(),
+                "attribute-id set len mismatch for node {node_id}"
+            );
+            for id in orig_set.iter() {
+                assert!(
+                    loaded_set.contains(id),
+                    "attribute id {id} missing after round-trip for node {node_id}"
+                );
+            }
+        }
+
+        // Attribute map size should match.
+        let orig_attr_arc = store.attribute_map();
+        let orig_attr = orig_attr_arc.read().unwrap();
+        let loaded_attr_arc = loaded.attribute_map();
+        let loaded_attr = loaded_attr_arc.read().unwrap();
+        assert_eq!(
+            orig_attr.len(),
+            loaded_attr.len(),
+            "attribute map size mismatch"
+        );
+    });
+}
+
+/// A u64 internal-id store must round-trip correctly and reject a u32 file.
+#[test]
+fn test_roundtrip_u64_node_ids() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+
+    let store: RoaringAttributeStore<u64> = RoaringAttributeStore::new();
+    let attrs = vec![Attribute::from_value(
+        "kind",
+        AttributeValue::String("doc".into()),
+    )];
+    // Use large IDs that wouldn't fit in a u32.
+    store.set_element(&(u32::MAX as u64 + 1), &attrs).unwrap();
+    store.set_element(&(u32::MAX as u64 + 2), &attrs).unwrap();
+
+    let provider = VirtualStorageProvider::new_memory();
+    let prefix = String::from("/idx64");
+
+    rt.block_on(async {
+        store.save_with(&provider, &prefix).await.unwrap();
+
+        // Loading as u64 must succeed.
+        let loaded: RoaringAttributeStore<u64> =
+            RoaringAttributeStore::load_with(&provider, &prefix)
+                .await
+                .unwrap();
+
+        {
+            let index_arc = loaded.get_index_for_serialization();
+            let index = index_arc.read().unwrap();
+            assert_eq!(index.count().unwrap(), 2);
+        } // index guard dropped before next await
+
+        // Loading the same file as u32 must fail with a type-tag mismatch.
+        let result = RoaringAttributeStore::<u32>::load_with(&provider, &prefix).await;
+        assert!(result.is_err(), "expected error loading u64 file as u32");
+        let err = result.err().unwrap();
+        assert!(
+            err.to_string().contains("type tag mismatch"),
+            "unexpected error: {err}"
+        );
+    });
+}
+
+/// Verify that a `DocumentProvider<DefaultProvider, RoaringAttributeStore>` with a built
+/// index round-trips correctly: labels assigned during insertion survive save+load.
+#[test]
+fn test_document_provider_round_trip() {
+    let save_path = "/doc_index";
+    let file_path = "/sift/siftsmall_learn_256pts.fbin";
+
+    // --- Load training vectors ---
+    let train_data = {
+        let storage = VirtualStorageProvider::new_overlay(test_data_root());
+        let mut reader = storage.open_reader(file_path).unwrap();
+        diskann_utils::io::read_bin::<f32>(&mut reader).unwrap()
+    };
+
+    let pq_bytes = 8;
+    let pq_table = diskann_async::train_pq(
+        train_data.as_view(),
+        pq_bytes,
+        &mut create_rnd_from_seed_in_tests(0xe3c52ef001bc7ade),
+        2,
+    )
+    .unwrap();
+
+    let (build_config, parameters) = {
+        let config = ConfigBuilder::new_with(
+            32,
+            MaxDegree::default_slack(),
+            20,
+            Metric::L2.into(),
+            |_| {},
+        )
+        .build()
+        .unwrap();
+        let params = DefaultProviderParameters {
+            max_points: train_data.nrows(),
+            frozen_points: ONE,
+            metric: Metric::L2,
+            dim: train_data.ncols(),
+            prefetch_lookahead: None,
+            prefetch_cache_line_level: None,
+            max_degree: config.max_degree_u32().get(),
+        };
+        (config, params)
+    };
+
+    let fp_precursor =
+        CreateFullPrecision::new(parameters.dim, parameters.prefetch_cache_line_level);
+    let inner_provider =
+        DefaultProvider::new_empty(parameters, fp_precursor, pq_table, TableBasedDeletes).unwrap();
+
+    // --- Wrap inner provider in DocumentProvider and build the index ---
+    let doc_provider =
+        DocumentProvider::new(inner_provider, RoaringAttributeStore::<u32>::new());
+    type InnerProvider = inmem::FullPrecisionProvider<
+        f32,
+        diskann_providers::model::graph::provider::async_::FastMemoryQuantVectorProviderAsync,
+        diskann_providers::model::graph::provider::async_::TableDeleteProviderAsync,
+    >;
+    type TestDocProvider = DocumentProvider<InnerProvider, RoaringAttributeStore<u32>>;
+    let index =
+        DiskANNIndex::<TestDocProvider>::new_with_current_thread_runtime(build_config.clone(), doc_provider);
+
+    let storage = VirtualStorageProvider::new_memory();
+    let ctx = DefaultContext;
+
+    // Insert each vector with a synthetic label cycling through 5 categories.
+    for (i, v) in train_data.row_iter().enumerate() {
+        let label = format!("category_{}", i % 5);
+        let attrs =
+            vec![Attribute::from_value("category", AttributeValue::String(label))];
+        let doc = Document::new(v, &attrs);
+        index
+            .insert(DocumentInsertStrategy::new(FullPrecision), &ctx, &(i as u32), &doc)
+            .unwrap();
+    }
+
+    // --- Save ---
+    // DiskANNIndex<DocumentProvider<...>> has no dedicated SaveWith impl, so we reach
+    // into data_provider and call save_with directly. The start_id required by
+    // DefaultProvider::save_with is read from the inner provider.
+    let save_metadata = AsyncIndexMetadata::new(save_path.to_string());
+    let storage_ref = &storage;
+    let metadata_ref = &save_metadata;
+    index
+        .run(|inner| {
+            let inner = Arc::clone(inner);
+            async move {
+                let start_ids = inner
+                    .data_provider
+                    .inner_provider()
+                    .starting_points()
+                    .unwrap();
+                let start_id =
+                    *start_ids.first().expect("index must have a start point after build");
+                inner
+                    .data_provider
+                    .save_with(storage_ref, &(start_id, metadata_ref.clone()))
+                    .await
+            }
+        })
+        .unwrap();
+
+    // --- Load DiskANNIndex<TestDocProvider> via LoadWith<(&str, IndexConfiguration)> ---
+    // DiskANNIndex<DP>: LoadWith<(&str, IndexConfiguration)> for any
+    // DP: DataProvider<InternalId=u32> + LoadWith<AsyncQuantLoadContext>,
+    // and TestDocProvider satisfies both.
+    let load_config = IndexConfiguration::new(
+        Metric::L2,
+        train_data.ncols(),
+        train_data.nrows(),
+        ONE,
+        1,
+        build_config,
+    );
+
+    let loaded: DiskANNIndex<TestDocProvider> =
+        DiskANNIndex::load_with_current_thread_runtime(&storage, &(save_path, load_config))
+            .unwrap();
+
+    // --- Assert inner DefaultProvider loaded correctly ---
+    let inner = &loaded.inner.data_provider;
+
+    // Graph must have at least one start point after rebuild.
+    let start_pts = inner.inner_provider().starting_points().unwrap();
+    assert!(!start_pts.is_empty(), "loaded index should have start points");
+
+    // Every inserted external ID must map to a valid internal ID.
+    let ctx = DefaultContext;
+    for i in 0..train_data.nrows() as u32 {
+        inner
+            .to_internal_id(&ctx, &i)
+            .unwrap_or_else(|_| panic!("external id {i} missing after round trip"));
+    }
+
+    // --- Assert labels survived the round trip ---
+    let attr_store = inner.attribute_store();
+    for i in 0..train_data.nrows() {
+        assert!(
+            attr_store.id_exists(&(i as u32)).unwrap(),
+            "node {i} should have labels after round trip",
+        );
+    }
+}

--- a/diskann-label-filter/src/tests/serialization_test.rs
+++ b/diskann-label-filter/src/tests/serialization_test.rs
@@ -22,7 +22,9 @@ use diskann_providers::{
             inmem::{self, CreateFullPrecision, DefaultProvider, DefaultProviderParameters},
         },
     },
-    storage::{AsyncIndexMetadata, LoadWith, SaveWith, StorageReadProvider, VirtualStorageProvider},
+    storage::{
+        AsyncIndexMetadata, LoadWith, SaveWith, StorageReadProvider, VirtualStorageProvider,
+    },
     utils::create_rnd_from_seed_in_tests,
 };
 use diskann_utils::test_data_root;
@@ -32,8 +34,7 @@ use crate::{
     attribute::{Attribute, AttributeValue},
     document::Document,
     encoded_attribute_provider::{
-        document_insert_strategy::DocumentInsertStrategy,
-        document_provider::DocumentProvider,
+        document_insert_strategy::DocumentInsertStrategy, document_provider::DocumentProvider,
         roaring_attribute_store::RoaringAttributeStore,
     },
     set::traits::SetProvider,
@@ -258,16 +259,17 @@ fn test_document_provider_round_trip() {
         DefaultProvider::new_empty(parameters, fp_precursor, pq_table, TableBasedDeletes).unwrap();
 
     // --- Wrap inner provider in DocumentProvider and build the index ---
-    let doc_provider =
-        DocumentProvider::new(inner_provider, RoaringAttributeStore::<u32>::new());
+    let doc_provider = DocumentProvider::new(inner_provider, RoaringAttributeStore::<u32>::new());
     type InnerProvider = inmem::FullPrecisionProvider<
         f32,
         diskann_providers::model::graph::provider::async_::FastMemoryQuantVectorProviderAsync,
         diskann_providers::model::graph::provider::async_::TableDeleteProviderAsync,
     >;
     type TestDocProvider = DocumentProvider<InnerProvider, RoaringAttributeStore<u32>>;
-    let index =
-        DiskANNIndex::<TestDocProvider>::new_with_current_thread_runtime(build_config.clone(), doc_provider);
+    let index = DiskANNIndex::<TestDocProvider>::new_with_current_thread_runtime(
+        build_config.clone(),
+        doc_provider,
+    );
 
     let storage = VirtualStorageProvider::new_memory();
     let ctx = DefaultContext;
@@ -275,11 +277,18 @@ fn test_document_provider_round_trip() {
     // Insert each vector with a synthetic label cycling through 5 categories.
     for (i, v) in train_data.row_iter().enumerate() {
         let label = format!("category_{}", i % 5);
-        let attrs =
-            vec![Attribute::from_value("category", AttributeValue::String(label))];
+        let attrs = vec![Attribute::from_value(
+            "category",
+            AttributeValue::String(label),
+        )];
         let doc = Document::new(v, &attrs);
         index
-            .insert(DocumentInsertStrategy::new(FullPrecision), &ctx, &(i as u32), &doc)
+            .insert(
+                DocumentInsertStrategy::new(FullPrecision),
+                &ctx,
+                &(i as u32),
+                &doc,
+            )
             .unwrap();
     }
 
@@ -299,8 +308,9 @@ fn test_document_provider_round_trip() {
                     .inner_provider()
                     .starting_points()
                     .unwrap();
-                let start_id =
-                    *start_ids.first().expect("index must have a start point after build");
+                let start_id = *start_ids
+                    .first()
+                    .expect("index must have a start point after build");
                 inner
                     .data_provider
                     .save_with(storage_ref, &(start_id, metadata_ref.clone()))
@@ -331,7 +341,10 @@ fn test_document_provider_round_trip() {
 
     // Graph must have at least one start point after rebuild.
     let start_pts = inner.inner_provider().starting_points().unwrap();
-    assert!(!start_pts.is_empty(), "loaded index should have start points");
+    assert!(
+        !start_pts.is_empty(),
+        "loaded index should have start points"
+    );
 
     // Every inserted external ID must map to a valid internal ID.
     let ctx = DefaultContext;


### PR DESCRIPTION
This PR adds ability to do Save/Load attribute information associated with DocumentProvider. The information is saved in the following binary format:

```text
┌────────────────────────────────────────────────────────────────────┐
│  Header (17 bytes)                                                 │
│  [u64: num_attribute_entries]                                      │
│  [u64: forward_index_offset]  (byte offset from file start to      │
│                                Section 2)                          │
│  [u8: vector_id_type_tag]                                          │
│      0 = u32                                                       │
│      1 = u64                                                       │
├────────────────────────────────────────────────────────────────────┤
│  Section 1: Attribute Dictionary                                   │
│  Repeated `num_attribute_entries` times:                           │
│                                                                    │
│  [u64: attribute_id]                                               │
│  [u32: field_name_byte_len]                                        │
│  [u8 * field_name_byte_len: UTF-8 field name]                      │
│  [u8: type_tag]                                                    │
│      0 = Bool                                                      │
│      1 = Integer                                                   │
│      2 = Real                                                      │
│      3 = String                                                    │
│      4 = Empty                                                     │
│  [value bytes, depends on type_tag]:                               │
│      Bool:    1 byte  (0 = false, 1 = true)                        │
│      Integer: 8 bytes (i64, little-endian)                         │
│      Real:    8 bytes (f64, little-endian)                         │
│      String:  [u32: byte_len] + [u8 * byte_len: UTF-8 value]       │
│      Empty:   0 bytes                                              │
├────────────────────────────────────────────────────────────────────┤
│  Section 2: Forward Index                                          │
│  [u64: num_nodes_with_labels]                                      │
│  Repeated `num_nodes_with_labels` times:                           │
│                                                                    │
│  [N bytes: node_internal_id (width per vector_id_type_tag)]        │
│  [u32: num_attribute_ids_for_this_node]                            │
│  [u64 * num_attribute_ids: attribute IDs (sorted ascending)]       │
└────────────────────────────────────────────────────────────────────┘
```

There's a draft RFC for this (#868). I went ahead and created a PR because the RFC had enough details. The PR currently targets an unmerged branch associated with #782. I will target this to main once that PR gets merged.