### PR TITLE
Migrate test_flaky_consolidate from diskann_providers to diskann

### DIFF
--- a/diskann-benchmark-core/src/search/graph/knn.rs
+++ b/diskann-benchmark-core/src/search/graph/knn.rs
@@ -381,7 +381,7 @@ mod tests {
         let err = KNN::new(
             index,
             queries.clone(),
-            Strategy::collection([strategy, strategy]),
+            Strategy::collection([strategy.clone(), strategy.clone()]),
         )
         .unwrap_err();
         let msg = err.to_string();

--- a/diskann-benchmark-core/src/search/graph/multihop.rs
+++ b/diskann-benchmark-core/src/search/graph/multihop.rs
@@ -262,7 +262,7 @@ mod tests {
         let err = MultiHop::new(
             index.clone(),
             queries.clone(),
-            Strategy::collection([strategy]),
+            Strategy::collection([strategy.clone()]),
             labels.clone(),
         )
         .unwrap_err();
@@ -276,7 +276,7 @@ mod tests {
         let err = MultiHop::new(
             index,
             queries.clone(),
-            Strategy::broadcast(strategy),
+            Strategy::broadcast(strategy.clone()),
             labels.clone(),
         )
         .unwrap_err();

--- a/diskann-providers/src/index/diskann_async.rs
+++ b/diskann-providers/src/index/diskann_async.rs
@@ -167,7 +167,7 @@ pub(crate) mod tests {
     use crate::storage::VirtualStorageProvider;
     use diskann::{
         graph::{
-            self, AdjacencyList, ConsolidateKind, InplaceDeleteMethod, StartPointStrategy,
+            self, AdjacencyList, InplaceDeleteMethod, StartPointStrategy,
             config::IntraBatchCandidates,
             glue::{
                 DefaultSearchStrategy, InplaceDeleteStrategy, InsertStrategy, MultiInsertStrategy,
@@ -3605,80 +3605,6 @@ pub(crate) mod tests {
 
             assert_top_k_exactly_match(q, &gt, &ids, &distances, top_k);
         }
-    }
-
-    // This test uses a "Flaky" accessor that spuriously fails with non-critical errors to
-    // check that such errors are not propagated by DiskANN.
-    #[tokio::test]
-    async fn test_flaky_consolidate() {
-        // What we need to do is populate a graph with an element that has an adjacency list
-        // that exceeds the configured maximum degree.
-        //
-        // We then need to try to consolidate that element and ensure that retrieval of
-        // that element's data results in a transient error.
-
-        // create small index instance
-        let dim = 2;
-        let (config, parameters) = simplified_builder(
-            10,         // l_search
-            4,          // max_degree
-            Metric::L2, // metric
-            dim,        // dim
-            10,         // max_points
-            no_modify,
-        )
-        .unwrap();
-
-        let pqtable = model::pq::FixedChunkPQTable::new(
-            dim,
-            Box::new([0.0, 0.0]),
-            Box::new([0.0, 0.0]),
-            Box::new([0, 2]),
-        )
-        .unwrap();
-
-        let index =
-            new_quant_index::<f32, _, _>(config, parameters, pqtable, TableBasedDeletes).unwrap();
-
-        let start_point: &[f32] = &[0.5, 0.5];
-
-        index
-            .provider()
-            .set_start_points(std::iter::once(start_point))
-            .unwrap();
-
-        // vectors are the four corners of a square, with the start point in the middle
-        // the middle point forms an edge to each corner, while corners form an edge
-        // to their opposite vertex vertically and horizontally as well as the middle
-        let vectors = [
-            vec![0.0, 0.0], // point 0
-            vec![0.0, 1.0], // point 1
-            vec![1.0, 0.0], // point 2
-            vec![1.0, 1.0], // point 3
-            vec![2.0, 2.0], // point 4
-            vec![0.0, 2.0], // point 5
-            vec![2.0, 0.0], // point 6
-        ];
-        let adjacency_lists = [
-            AdjacencyList::from_iter_untrusted([1, 2, 3, 4, 5]), // point 0
-            AdjacencyList::from_iter_untrusted([4, 0, 3, 6]),    // point 1
-            AdjacencyList::from_iter_untrusted([4, 3, 0, 6]),    // point 2
-            AdjacencyList::from_iter_untrusted([4, 2, 1, 6]),    // point 3
-            AdjacencyList::from_iter_untrusted([0, 1, 2, 3, 6]), // point 4
-            AdjacencyList::from_iter_untrusted([0, 1, 2, 5, 6]), // point 5
-            AdjacencyList::from_iter_untrusted([0, 1, 2, 5, 3]), // point 6 -- start point
-        ];
-
-        let ctx = &DefaultContext;
-        let neighbor_accessor = &mut index.provider().neighbors();
-        populate_graph(neighbor_accessor, &adjacency_lists).await;
-        populate_data(&index.data_provider, ctx, &vectors).await;
-
-        let r = index
-            .consolidate_vector(&inmem::test::SuperFlaky, ctx, 0)
-            .await
-            .unwrap();
-        assert_eq!(r, ConsolidateKind::FailedVectorRetrieval);
     }
 
     async fn create_retry_saturated_index(

--- a/diskann-providers/src/model/graph/provider/async_/caching/example.rs
+++ b/diskann-providers/src/model/graph/provider/async_/caching/example.rs
@@ -748,7 +748,14 @@ mod tests {
         paged_tests.push(async_tests::PagedSearch::new(start_point.clone(), gt));
 
         vectors.push(start_point.clone());
-        async_tests::check_grid_search(&index, &vectors, &paged_tests, strategy, strategy).await;
+        async_tests::check_grid_search(
+            &index,
+            &vectors,
+            &paged_tests,
+            strategy.clone(),
+            strategy.clone(),
+        )
+        .await;
     }
 
     fn check_stats(caching: &CachingProvider<test_provider::Provider, ExampleCache>) {
@@ -844,14 +851,21 @@ mod tests {
             let index = init_index();
             for (i, v) in vectors.iter().take(num_points).enumerate() {
                 index
-                    .insert(strategy, ctx, &(i as u32), v.as_slice())
+                    .insert(strategy.clone(), ctx, &(i as u32), v.as_slice())
                     .await
                     .unwrap();
             }
 
             check_stats(index.provider());
 
-            async_tests::check_grid_search(&index, &vectors, &[], strategy, strategy).await;
+            async_tests::check_grid_search(
+                &index,
+                &vectors,
+                &[],
+                strategy.clone(),
+                strategy.clone(),
+            )
+            .await;
             check_stats(index.provider());
         }
 
@@ -862,11 +876,18 @@ mod tests {
             let ids: Arc<[u32]> = (0..num_points as u32).collect();
 
             index
-                .multi_insert::<_, Matrix<f32>>(strategy, ctx, batch, ids)
+                .multi_insert::<_, Matrix<f32>>(strategy.clone(), ctx, batch, ids)
                 .await
                 .unwrap();
 
-            async_tests::check_grid_search(&index, &vectors, &[], strategy, strategy).await;
+            async_tests::check_grid_search(
+                &index,
+                &vectors,
+                &[],
+                strategy.clone(),
+                strategy.clone(),
+            )
+            .await;
             check_stats(index.provider());
         }
     }
@@ -936,7 +957,7 @@ mod tests {
 
         index
             .inplace_delete(
-                strategy,
+                strategy.clone(),
                 ctx,
                 &3, // id to delete
                 3,  // num_to_replace

--- a/diskann-providers/src/model/graph/provider/async_/inmem/test.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/test.rs
@@ -16,7 +16,7 @@ use diskann::{
             CopyIds, DefaultPostProcessor, ExpandBeam, InsertStrategy, MultiInsertStrategy,
             PruneStrategy, SearchExt, SearchStrategy,
         },
-        workingset::{self, map},
+        workingset::map,
     },
     neighbor::Neighbor,
     provider::{
@@ -323,27 +323,5 @@ impl MultiInsertStrategy<TestProvider, Matrix<f32>> for Flaky {
     {
         std::future::ready(Ok(map::Builder::new(map::Capacity::Default)
             .with_overlay(map::Overlay::from_batch(batch.clone(), ids))))
-    }
-}
-
-// Directed test to fail vector retrieval during consolidation.
-pub(crate) struct SuperFlaky;
-
-impl PruneStrategy<TestProvider> for SuperFlaky {
-    type DistanceComputer = <FullAccessor<'static> as BuildDistanceComputer>::DistanceComputer;
-    type PruneAccessor<'a> = FlakyAccessor<'a>;
-    type PruneAccessorError = diskann::error::Infallible;
-    type WorkingSet = workingset::Map<u32, Box<[f32]>, map::Ref<[f32]>>;
-
-    fn prune_accessor<'a>(
-        &'a self,
-        provider: &'a TestProvider,
-        _context: &'a DefaultContext,
-    ) -> Result<Self::PruneAccessor<'a>, Self::PruneAccessorError> {
-        Ok(FlakyAccessor::new(provider, 1, 1))
-    }
-
-    fn create_working_set(&self, capacity: usize) -> Self::WorkingSet {
-        map::Builder::new(map::Capacity::None).build(capacity)
     }
 }

--- a/diskann/src/graph/test/cases/consolidate.rs
+++ b/diskann/src/graph/test/cases/consolidate.rs
@@ -85,9 +85,10 @@ fn setup_consolidation_index(
     let start_neighbors =
         AdjacencyList::from_iter_untrusted((0..num_points as u32).take(provider_max_degree));
 
-    let points = vectors.iter().enumerate().map(|(id, vec)| {
-        (id as u32, vec.clone(), adjacency_lists[id].clone())
-    });
+    let points = vectors
+        .iter()
+        .enumerate()
+        .map(|(id, vec)| (id as u32, vec.clone(), adjacency_lists[id].clone()));
 
     let provider = Provider::new_from(
         provider_config,

--- a/diskann/src/graph/test/cases/consolidate.rs
+++ b/diskann/src/graph/test/cases/consolidate.rs
@@ -106,7 +106,10 @@ fn flaky_consolidate_returns_failed_retrieval() {
     // Make only the consolidated node (0) transient. During robust_prune_list, fill()
     // requests node 0's vector first — the transient error causes view.get(0) to return
     // None, triggering the FailedVectorRetrieval path.
-    let flaky_strategy = Strategy::with_transient([0]);
+    let flaky_strategy = Strategy::builder(
+        true, // working_set_reuse
+        [0],  // transient ids
+    );
 
     let result = rt
         .block_on(index.consolidate_vector(&flaky_strategy, &ctx, 0))

--- a/diskann/src/graph/test/cases/consolidate.rs
+++ b/diskann/src/graph/test/cases/consolidate.rs
@@ -107,7 +107,7 @@ fn flaky_consolidate_returns_failed_retrieval() {
     // Make only the consolidated node (0) transient. During robust_prune_list, fill()
     // requests node 0's vector first — the transient error causes view.get(0) to return
     // None, triggering the FailedVectorRetrieval path.
-    let flaky_strategy = Strategy::builder(
+    let flaky_strategy = Strategy::with_transient(
         true, // working_set_reuse
         [0],  // transient ids
     );

--- a/diskann/src/graph/test/cases/consolidate.rs
+++ b/diskann/src/graph/test/cases/consolidate.rs
@@ -9,54 +9,17 @@
 //! the inmem provider's `FlakyAccessor` which fails every Nth `get_element` call.
 //! This version uses `test_provider::Accessor::flaky()` which fails for specific IDs.
 
-use std::{collections::HashSet, iter, sync::Arc};
+use std::{iter, sync::Arc};
 
 use diskann_vector::distance::Metric;
 
 use crate::{
-    error::Infallible,
     graph::{
         self, AdjacencyList, ConsolidateKind, DiskANNIndex,
-        glue::PruneStrategy,
-        test::provider::{self as test_provider, Accessor, Provider},
-        workingset,
+        test::provider::{self as test_provider, Provider, Strategy},
     },
     test::tokio::current_thread_runtime,
-    utils::VectorRepr,
 };
-
-/// A [`PruneStrategy`] that produces a flaky accessor returning transient errors
-/// for the specified IDs. Everything else delegates to the default [`test_provider::Strategy`].
-struct FlakyPruneStrategy {
-    transient_ids: HashSet<u32>,
-}
-
-impl FlakyPruneStrategy {
-    fn new(transient_ids: impl IntoIterator<Item = u32>) -> Self {
-        Self {
-            transient_ids: transient_ids.into_iter().collect(),
-        }
-    }
-}
-
-impl PruneStrategy<Provider> for FlakyPruneStrategy {
-    type WorkingSet = workingset::Map<u32, Box<[f32]>, workingset::map::Ref<[f32]>>;
-    type DistanceComputer = <f32 as VectorRepr>::Distance;
-    type PruneAccessor<'a> = Accessor<'a>;
-    type PruneAccessorError = Infallible;
-
-    fn create_working_set(&self, capacity: usize) -> Self::WorkingSet {
-        workingset::map::Builder::new(workingset::map::Capacity::None).build(capacity)
-    }
-
-    fn prune_accessor<'a>(
-        &'a self,
-        provider: &'a Provider,
-        _context: &'a test_provider::Context,
-    ) -> Result<Self::PruneAccessor<'a>, Self::PruneAccessorError> {
-        Ok(Accessor::flaky(provider, self.transient_ids.clone()))
-    }
-}
 
 /// Build a small index with explicit vectors and adjacency lists for consolidation testing.
 ///
@@ -143,7 +106,7 @@ fn flaky_consolidate_returns_failed_retrieval() {
     // Make only the consolidated node (0) transient. During robust_prune_list, fill()
     // requests node 0's vector first — the transient error causes view.get(0) to return
     // None, triggering the FailedVectorRetrieval path.
-    let flaky_strategy = FlakyPruneStrategy::new([0]);
+    let flaky_strategy = Strategy::with_transient([0]);
 
     let result = rt
         .block_on(index.consolidate_vector(&flaky_strategy, &ctx, 0))

--- a/diskann/src/graph/test/cases/consolidate.rs
+++ b/diskann/src/graph/test/cases/consolidate.rs
@@ -26,8 +26,8 @@ use crate::{
 /// The provider's `max_degree` is set higher than the index's `pruned_degree` so that
 /// adjacency lists can exceed the index limit, forcing `consolidate_vector` to prune.
 fn setup_consolidation_index(
-    vectors: &[Vec<f32>],
-    adjacency_lists: &[AdjacencyList<u32>],
+    vectors: Vec<Vec<f32>>,
+    adjacency_lists: Vec<AdjacencyList<u32>>,
 ) -> Arc<DiskANNIndex<Provider>> {
     let num_points = vectors.len();
     let dim = vectors[0].len();
@@ -49,9 +49,10 @@ fn setup_consolidation_index(
         AdjacencyList::from_iter_untrusted((0..num_points as u32).take(provider_max_degree));
 
     let points = vectors
-        .iter()
+        .into_iter()
+        .zip(adjacency_lists)
         .enumerate()
-        .map(|(id, vec)| (id as u32, vec.clone(), adjacency_lists[id].clone()));
+        .map(|(id, (vec, adj))| (id as u32, vec, adj));
 
     let provider = Provider::new_from(
         provider_config,
@@ -90,7 +91,7 @@ fn flaky_consolidate_returns_failed_retrieval() {
         vec![0.0, 2.0], // point 5
         vec![2.0, 0.0], // point 6
     ];
-    let adjacency_lists = [
+    let adjacency_lists = vec![
         AdjacencyList::from_iter_untrusted([1, 2, 3, 4, 5]), // point 0: 5 neighbors > max_degree
         AdjacencyList::from_iter_untrusted([0, 3, 4]),
         AdjacencyList::from_iter_untrusted([0, 3, 4]),
@@ -100,7 +101,7 @@ fn flaky_consolidate_returns_failed_retrieval() {
         AdjacencyList::from_iter_untrusted([0, 1, 2, 3, 5]),
     ];
 
-    let index = setup_consolidation_index(&vectors, &adjacency_lists);
+    let index = setup_consolidation_index(vectors, adjacency_lists);
     let ctx = test_provider::Context::new();
 
     // Make only the consolidated node (0) transient. During robust_prune_list, fill()

--- a/diskann/src/graph/test/cases/consolidate.rs
+++ b/diskann/src/graph/test/cases/consolidate.rs
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+//! Tests for `consolidate_vector` behavior under transient (flaky) errors.
+//!
+//! Migrated from `diskann-providers/src/index/diskann_async.rs`. The original used
+//! the inmem provider's `FlakyAccessor` which fails every Nth `get_element` call.
+//! This version uses `test_provider::Accessor::flaky()` which fails for specific IDs.
+
+use std::{collections::HashSet, iter, sync::Arc};
+
+use diskann_vector::distance::Metric;
+
+use crate::{
+    error::Infallible,
+    graph::{
+        self, AdjacencyList, ConsolidateKind, DiskANNIndex,
+        glue::PruneStrategy,
+        test::provider::{self as test_provider, Accessor, Provider},
+        workingset,
+    },
+    test::tokio::current_thread_runtime,
+    utils::VectorRepr,
+};
+
+/// A [`PruneStrategy`] that produces a flaky accessor returning transient errors
+/// for the specified IDs. Everything else delegates to the default [`test_provider::Strategy`].
+struct FlakyPruneStrategy {
+    transient_ids: HashSet<u32>,
+}
+
+impl FlakyPruneStrategy {
+    fn new(transient_ids: impl IntoIterator<Item = u32>) -> Self {
+        Self {
+            transient_ids: transient_ids.into_iter().collect(),
+        }
+    }
+}
+
+impl PruneStrategy<Provider> for FlakyPruneStrategy {
+    type WorkingSet = workingset::Map<u32, Box<[f32]>, workingset::map::Ref<[f32]>>;
+    type DistanceComputer = <f32 as VectorRepr>::Distance;
+    type PruneAccessor<'a> = Accessor<'a>;
+    type PruneAccessorError = Infallible;
+
+    fn create_working_set(&self, capacity: usize) -> Self::WorkingSet {
+        workingset::map::Builder::new(workingset::map::Capacity::None).build(capacity)
+    }
+
+    fn prune_accessor<'a>(
+        &'a self,
+        provider: &'a Provider,
+        _context: &'a test_provider::Context,
+    ) -> Result<Self::PruneAccessor<'a>, Self::PruneAccessorError> {
+        Ok(Accessor::flaky(provider, self.transient_ids.clone()))
+    }
+}
+
+/// Build a small index with explicit vectors and adjacency lists for consolidation testing.
+///
+/// The provider's `max_degree` is set higher than the index's `pruned_degree` so that
+/// adjacency lists can exceed the index limit, forcing `consolidate_vector` to prune.
+fn setup_consolidation_index(
+    vectors: &[Vec<f32>],
+    adjacency_lists: &[AdjacencyList<u32>],
+) -> Arc<DiskANNIndex<Provider>> {
+    let num_points = vectors.len();
+    let dim = vectors[0].len();
+    let start_id = num_points as u32;
+
+    // The provider accepts up to 5 neighbors per node, but the index only targets 4.
+    // This mismatch lets us populate adjacency lists that consolidate_vector must prune.
+    let provider_max_degree = 5;
+    let pruned_degree = 4;
+
+    let provider_config = test_provider::Config::new(
+        Metric::L2,
+        provider_max_degree,
+        test_provider::StartPoint::new(start_id, vec![0.5; dim]),
+    )
+    .unwrap();
+
+    let start_neighbors =
+        AdjacencyList::from_iter_untrusted((0..num_points as u32).take(provider_max_degree));
+
+    let points = vectors.iter().enumerate().map(|(id, vec)| {
+        (id as u32, vec.clone(), adjacency_lists[id].clone())
+    });
+
+    let provider = Provider::new_from(
+        provider_config,
+        iter::once((start_id, start_neighbors)),
+        points,
+    )
+    .unwrap();
+
+    let index_config = graph::config::Builder::new(
+        pruned_degree,
+        graph::config::MaxDegree::same(),
+        10,
+        Metric::L2.into(),
+    )
+    .build()
+    .unwrap();
+
+    Arc::new(DiskANNIndex::new(index_config, provider, None))
+}
+
+/// When `consolidate_vector` encounters a transient error during `fill` (vector retrieval),
+/// it should gracefully return `ConsolidateKind::FailedVectorRetrieval` rather than
+/// propagating the error.
+#[test]
+fn flaky_consolidate_returns_failed_retrieval() {
+    let rt = current_thread_runtime();
+
+    // Build a graph where node 0 has 5 neighbors (exceeds max_degree=4),
+    // forcing consolidate_vector to attempt pruning.
+    let vectors = vec![
+        vec![0.0, 0.0], // point 0
+        vec![0.0, 1.0], // point 1
+        vec![1.0, 0.0], // point 2
+        vec![1.0, 1.0], // point 3
+        vec![2.0, 2.0], // point 4
+        vec![0.0, 2.0], // point 5
+        vec![2.0, 0.0], // point 6
+    ];
+    let adjacency_lists = [
+        AdjacencyList::from_iter_untrusted([1, 2, 3, 4, 5]), // point 0: 5 neighbors > max_degree
+        AdjacencyList::from_iter_untrusted([0, 3, 4]),
+        AdjacencyList::from_iter_untrusted([0, 3, 4]),
+        AdjacencyList::from_iter_untrusted([1, 2, 4]),
+        AdjacencyList::from_iter_untrusted([0, 1, 2, 3]),
+        AdjacencyList::from_iter_untrusted([0, 1, 2]),
+        AdjacencyList::from_iter_untrusted([0, 1, 2, 3, 5]),
+    ];
+
+    let index = setup_consolidation_index(&vectors, &adjacency_lists);
+    let ctx = test_provider::Context::new();
+
+    // Make ALL non-start-point IDs transient — this ensures that fill() will encounter
+    // a transient error when trying to retrieve any data point's vector.
+    let transient_ids: HashSet<u32> = (0..vectors.len() as u32).collect();
+    let flaky_strategy = FlakyPruneStrategy::new(transient_ids);
+
+    let result = rt
+        .block_on(index.consolidate_vector(&flaky_strategy, &ctx, 0))
+        .unwrap();
+
+    assert_eq!(
+        result,
+        ConsolidateKind::FailedVectorRetrieval,
+        "consolidate should handle transient errors gracefully"
+    );
+}

--- a/diskann/src/graph/test/cases/consolidate.rs
+++ b/diskann/src/graph/test/cases/consolidate.rs
@@ -140,10 +140,10 @@ fn flaky_consolidate_returns_failed_retrieval() {
     let index = setup_consolidation_index(&vectors, &adjacency_lists);
     let ctx = test_provider::Context::new();
 
-    // Make ALL non-start-point IDs transient — this ensures that fill() will encounter
-    // a transient error when trying to retrieve any data point's vector.
-    let transient_ids: HashSet<u32> = (0..vectors.len() as u32).collect();
-    let flaky_strategy = FlakyPruneStrategy::new(transient_ids);
+    // Make only the consolidated node (0) transient. During robust_prune_list, fill()
+    // requests node 0's vector first — the transient error causes view.get(0) to return
+    // None, triggering the FailedVectorRetrieval path.
+    let flaky_strategy = FlakyPruneStrategy::new([0]);
 
     let result = rt
         .block_on(index.consolidate_vector(&flaky_strategy, &ctx, 0))

--- a/diskann/src/graph/test/cases/grid_insert.rs
+++ b/diskann/src/graph/test/cases/grid_insert.rs
@@ -132,7 +132,7 @@ fn run_build(
         None => {
             for (id, vector) in data.row_iter().enumerate() {
                 runtime
-                    .block_on(index.insert(strategy, &context, &(id as u32), vector))
+                    .block_on(index.insert(strategy.clone(), &context, &(id as u32), vector))
                     .unwrap();
             }
         }
@@ -143,7 +143,7 @@ fn run_build(
                 let batch = Arc::new(data.subview(start..stop).unwrap().to_owned());
                 runtime
                     .block_on(index.multi_insert::<test_provider::Strategy, _>(
-                        strategy,
+                        strategy.clone(),
                         &context,
                         batch,
                         (start..stop).map(|i| i as u32).collect(),

--- a/diskann/src/graph/test/cases/inplace_delete.rs
+++ b/diskann/src/graph/test/cases/inplace_delete.rs
@@ -50,13 +50,19 @@ async fn basic_single() {
 
     for i in 1..6 {
         index
-            .insert(strat, &ctx, &i, &[i as f32, i as f32])
+            .insert(strat.clone(), &ctx, &i, &[i as f32, i as f32])
             .await
             .unwrap();
     }
 
     index
-        .inplace_delete(strat, &ctx, &3, 3, graph::InplaceDeleteMethod::OneHop)
+        .inplace_delete(
+            strat.clone(),
+            &ctx,
+            &3,
+            3,
+            graph::InplaceDeleteMethod::OneHop,
+        )
         .await
         .unwrap();
 }
@@ -75,14 +81,14 @@ async fn basic_multi() {
 
     for i in 1..6 {
         index
-            .insert(strat, &ctx, &i, &[i as f32, i as f32])
+            .insert(strat.clone(), &ctx, &i, &[i as f32, i as f32])
             .await
             .unwrap();
     }
 
     index
         .multi_inplace_delete(
-            strat,
+            strat.clone(),
             &ctx,
             Arc::new([3, 4]),
             3,

--- a/diskann/src/graph/test/cases/mod.rs
+++ b/diskann/src/graph/test/cases/mod.rs
@@ -3,6 +3,7 @@
  * Licensed under the MIT license.
  */
 
+mod consolidate;
 mod grid_insert;
 mod grid_search;
 mod inplace_delete;

--- a/diskann/src/graph/test/provider.rs
+++ b/diskann/src/graph/test/provider.rs
@@ -1130,7 +1130,10 @@ impl Strategy {
         }
     }
 
-    pub fn builder(working_set_reuse: bool, transient_ids: impl IntoIterator<Item = u32>) -> Self {
+    pub fn with_transient(
+        working_set_reuse: bool,
+        transient_ids: impl IntoIterator<Item = u32>,
+    ) -> Self {
         Self {
             working_set_reuse,
             transient_ids: Some(Arc::new(transient_ids.into_iter().collect())),

--- a/diskann/src/graph/test/provider.rs
+++ b/diskann/src/graph/test/provider.rs
@@ -1112,7 +1112,7 @@ pub struct Strategy {
     // Set this flag to enable reuse within the [`workingset::Map`]. For multi-threaded
     // baseline tests, this must be set to `false` to obtain repeatable `get_vector` calls.
     working_set_reuse: bool,
-    transient_ids: Option<HashSet<u32>>,
+    transient_ids: Option<Arc<HashSet<u32>>>,
 }
 
 impl Strategy {
@@ -1133,7 +1133,7 @@ impl Strategy {
     pub fn builder(working_set_reuse: bool, transient_ids: impl IntoIterator<Item = u32>) -> Self {
         Self {
             working_set_reuse,
-            transient_ids: Some(transient_ids.into_iter().collect()),
+            transient_ids: Some(Arc::new(transient_ids.into_iter().collect())),
         }
     }
 }

--- a/diskann/src/graph/test/provider.rs
+++ b/diskann/src/graph/test/provider.rs
@@ -1130,9 +1130,9 @@ impl Strategy {
         }
     }
 
-    pub fn with_transient(transient_ids: impl IntoIterator<Item = u32>) -> Self {
+    pub fn builder(working_set_reuse: bool, transient_ids: impl IntoIterator<Item = u32>) -> Self {
         Self {
-            working_set_reuse: true,
+            working_set_reuse,
             transient_ids: Some(transient_ids.into_iter().collect()),
         }
     }

--- a/diskann/src/graph/test/provider.rs
+++ b/diskann/src/graph/test/provider.rs
@@ -6,6 +6,7 @@
 //! A pedantic provider implementation used for testing alorithmic logic.
 
 use std::{
+    borrow::Cow,
     collections::{HashMap, HashSet},
     num::NonZeroUsize,
     sync::Arc,
@@ -981,7 +982,7 @@ pub struct Accessor<'a> {
     buffer: Box<[f32]>,
     get_vector: LocalCounter<'a>,
     /// IDs that will produce transient errors when accessed.
-    transient_ids: Option<HashSet<u32>>,
+    transient_ids: Option<Cow<'a, HashSet<u32>>>,
 }
 
 impl<'a> Accessor<'a> {
@@ -998,11 +999,11 @@ impl<'a> Accessor<'a> {
     /// Creates an accessor where `get_element` returns a transient error for
     /// any ID in `transient_ids`. The ID must still exist in the provider —
     /// accessing a truly missing ID remains a critical `InvalidId` error.
-    pub fn flaky(provider: &'a Provider, transient_ids: HashSet<u32>) -> Self {
+    pub fn flaky(provider: &'a Provider, transient_ids: Cow<'a, HashSet<u32>>) -> Self {
         Self::new_inner(provider, Some(transient_ids))
     }
 
-    fn new_inner(provider: &'a Provider, transient_ids: Option<HashSet<u32>>) -> Self {
+    fn new_inner(provider: &'a Provider, transient_ids: Option<Cow<'a, HashSet<u32>>>) -> Self {
         let buffer = (0..provider.dim()).map(|_| 0.0).collect();
         Self {
             provider,
@@ -1106,22 +1107,34 @@ impl provider::CacheableAccessor for Accessor<'_> {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct Strategy {
     // Set this flag to enable reuse within the [`workingset::Map`]. For multi-threaded
     // baseline tests, this must be set to `false` to obtain repeatable `get_vector` calls.
     working_set_reuse: bool,
+    transient_ids: Option<HashSet<u32>>,
 }
 
 impl Strategy {
     pub fn new() -> Self {
         Self {
             working_set_reuse: true,
+            transient_ids: None,
         }
     }
 
     pub fn with_options(working_set_reuse: bool) -> Self {
-        Self { working_set_reuse }
+        Self {
+            working_set_reuse,
+            transient_ids: None,
+        }
+    }
+
+    pub fn with_transient(transient_ids: impl IntoIterator<Item = u32>) -> Self {
+        Self {
+            working_set_reuse: true,
+            transient_ids: Some(transient_ids.into_iter().collect()),
+        }
     }
 }
 
@@ -1170,7 +1183,10 @@ impl glue::PruneStrategy<Provider> for Strategy {
         provider: &'a Provider,
         _context: &'a Context,
     ) -> Result<Self::PruneAccessor<'a>, Self::PruneAccessorError> {
-        Ok(Accessor::new(provider))
+        match &self.transient_ids {
+            Some(ids) => Ok(Accessor::flaky(provider, Cow::Borrowed(ids))),
+            None => Ok(Accessor::new(provider)),
+        }
     }
 }
 
@@ -1178,7 +1194,7 @@ impl glue::InsertStrategy<Provider, &[f32]> for Strategy {
     type PruneStrategy = Self;
 
     fn prune_strategy(&self) -> Self::PruneStrategy {
-        *self
+        self.clone()
     }
 
     fn insert_search_accessor<'a>(
@@ -1197,7 +1213,7 @@ impl glue::MultiInsertStrategy<Provider, Matrix<f32>> for Strategy {
     type InsertStrategy = Self;
 
     fn insert_strategy(&self) -> Self::InsertStrategy {
-        *self
+        self.clone()
     }
 
     fn finish<Itr>(
@@ -1272,11 +1288,11 @@ impl glue::InplaceDeleteStrategy<Provider> for Strategy {
     type SearchPostProcessor = glue::Pipeline<FilterDeleted, glue::CopyIds>;
 
     fn prune_strategy(&self) -> Self::PruneStrategy {
-        *self
+        self.clone()
     }
 
     fn search_strategy(&self) -> Self::SearchStrategy {
-        *self
+        self.clone()
     }
 
     fn search_post_processor(&self) -> Self::SearchPostProcessor {

--- a/diskann/src/graph/workingset/map.rs
+++ b/diskann/src/graph/workingset/map.rs
@@ -1992,8 +1992,9 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn fill_skips_transient_errors() {
         let provider = fill_provider();
-        let flakyset = std::collections::HashSet::from([1]);
-        let mut accessor = TestAccessor::flaky(&provider, Cow::Borrowed(&flakyset));
+
+        let mut accessor =
+            TestAccessor::flaky(&provider, Cow::Owned(std::collections::HashSet::from([1])));
         let mut map: TestMap = Builder::new(Capacity::Unbounded).build(0);
 
         // ID 1 is transient — should be skipped, not propagated.

--- a/diskann/src/graph/workingset/map.rs
+++ b/diskann/src/graph/workingset/map.rs
@@ -971,7 +971,7 @@ where
 mod tests {
     use super::*;
 
-    use std::sync::Arc;
+    use std::{borrow::Cow, sync::Arc};
 
     use diskann_utils::views::Matrix;
 
@@ -1992,7 +1992,8 @@ mod tests {
     #[tokio::test(flavor = "current_thread")]
     async fn fill_skips_transient_errors() {
         let provider = fill_provider();
-        let mut accessor = TestAccessor::flaky(&provider, std::collections::HashSet::from([1]));
+        let flakyset = std::collections::HashSet::from([1]);
+        let mut accessor = TestAccessor::flaky(&provider, Cow::Borrowed(&flakyset));
         let mut map: TestMap = Builder::new(Capacity::Unbounded).build(0);
 
         // ID 1 is transient — should be skipped, not propagated.


### PR DESCRIPTION
This is in service of the #927 work item. After talking with @hildebrandmw, the test_flaky_consolidate was identified as an "easy" target to migrate. 

This change creates a consolidate.rs test file and implements the new flaky test. 
- Remove test_flaky_consolidate and SuperFlaky from diskann-providers
- Clean up unused imports (ConsolidateKind, workingset::self)
- Adds transients to the test provider strategy

