### PR TITLE
Remove unused method extract_best_l_candidates in NeighborPriorityQueue

### DIFF
--- a/diskann/src/neighbor/mod.rs
+++ b/diskann/src/neighbor/mod.rs
@@ -133,7 +133,7 @@ where
 {
     /// Construct a new [`BackInserter`] around the provided slice.
     ///
-    /// THe buffer will have a capacity equal to the length of `buffer`.
+    /// The buffer will have a capacity equal to the length of `buffer`.
     pub fn new(buffer: &'a mut [Neighbor<I>]) -> Self {
         Self {
             buffer,

--- a/diskann/src/neighbor/queue.rs
+++ b/diskann/src/neighbor/queue.rs
@@ -171,29 +171,6 @@ impl<I: NeighborPriorityQueueIdType> NeighborPriorityQueue<I> {
         }
     }
 
-    /// Extracts the first min(L, size_of_queue) best candidates from the priority queue moving
-    /// them to the result array and returns the count of extracted elements. The rest of the
-    /// candidates are shifted to the beginning of the array and the size and capacity are
-    /// updated accordingly.
-    pub fn extract_best_l_candidates(&mut self, result: &mut [Neighbor<I>]) -> usize {
-        let extract_size = self.search_param_l.min(self.size);
-
-        // Copy the first L best candidates to the result vector
-        for (i, res) in result.iter_mut().enumerate().take(extract_size) {
-            *res = Neighbor::new(self.id_visiteds[i].0, self.distances[i]);
-        }
-
-        // Remove the first L best candidates from the priority queue
-        self.id_visiteds.drain(0..extract_size);
-        self.distances.drain(0..extract_size);
-
-        // Update the size and cursor of the priority queue
-        self.size -= extract_size;
-        self.cursor = 0;
-
-        extract_size
-    }
-
     /// Drain candidates from the front, signaling that they have been consumed.
     pub fn drain_best(&mut self, count: usize) {
         let count = count.min(self.size);
@@ -850,25 +827,6 @@ mod neighbor_priority_queue_test {
         resizable_queue.insert(Neighbor::new(4, 2.0));
         assert_eq!(resizable_queue.size(), 4);
         assert_eq!(resizable_queue.capacity(), 4);
-    }
-
-    #[test]
-    fn test_extract_best_l_candidates() {
-        let mut queue = NeighborPriorityQueue::auto_resizable_with_search_param_l(3);
-        queue.insert(Neighbor::new(1, 1.0));
-        queue.insert(Neighbor::new(2, 0.5));
-        queue.insert(Neighbor::new(3, 0.1));
-        queue.insert(Neighbor::new(4, 5.0));
-        queue.insert(Neighbor::new(5, 0.2));
-
-        let mut result = vec![Neighbor::default(); 3];
-        queue.extract_best_l_candidates(&mut result);
-        assert_eq!(result.len(), 3);
-        assert_eq!(result[0].id, 3);
-        assert_eq!(result[1].id, 5);
-        assert_eq!(result[2].id, 2);
-        assert_eq!(queue.size(), 2);
-        assert_eq!(queue.cursor, 0);
     }
 
     #[test]


### PR DESCRIPTION
The method `extract_best_l_candidates` in `NeighborPriorityQueue` is not used in the repo nor returned in public interfaces, hence removing it.