### PR TITLE
Remove unnecessary `Default` bound from `Neighbor`'s `VectorIdType`

### DIFF
--- a/diskann/src/graph/internal/sorted_neighbors.rs
+++ b/diskann/src/graph/internal/sorted_neighbors.rs
@@ -13,11 +13,11 @@ use crate::neighbor::Neighbor;
 #[derive(Debug)]
 pub struct SortedNeighbors<'a, I>(&'a [Neighbor<I>])
 where
-    I: Default + Eq;
+    I: Eq;
 
 impl<'a, I> SortedNeighbors<'a, I>
 where
-    I: Default + Eq + std::fmt::Debug,
+    I: Eq + std::fmt::Debug,
 {
     /// Create a new `SortedNeighbors` around `neighbors` truncated to `max` length.
     ///
@@ -45,7 +45,7 @@ where
 
 impl<I> Deref for SortedNeighbors<'_, I>
 where
-    I: Default + Eq,
+    I: Eq,
 {
     type Target = [Neighbor<I>];
     fn deref(&self) -> &Self::Target {

--- a/diskann/src/graph/search/record.rs
+++ b/diskann/src/graph/search/record.rs
@@ -7,7 +7,7 @@ use std::fmt::Display;
 
 use crate::neighbor::Neighbor;
 
-/// An logger provided to various search tasks
+/// A logger provided to various search tasks
 pub trait SearchRecord<T>: Send + Sync + 'static
 where
     T: Eq,

--- a/diskann/src/graph/search/record.rs
+++ b/diskann/src/graph/search/record.rs
@@ -10,7 +10,7 @@ use crate::neighbor::Neighbor;
 /// An logger provided to various search tasks
 pub trait SearchRecord<T>: Send + Sync + 'static
 where
-    T: Default + Eq,
+    T: Eq,
 {
     /// Provides a customization point for logging done during search.
     ///
@@ -52,19 +52,19 @@ impl NoopSearchRecord {
     }
 }
 
-impl<T> SearchRecord<T> for NoopSearchRecord where T: Default + Eq {}
+impl<T> SearchRecord<T> for NoopSearchRecord where T: Eq {}
 
 #[derive(Default)]
 pub struct VisitedSearchRecord<T>
 where
-    T: Default + Eq + Clone + Send + Sync + 'static,
+    T: Eq + Clone + Send + Sync + 'static,
 {
     pub visited: Vec<Neighbor<T>>,
 }
 
 impl<T> std::fmt::Display for VisitedSearchRecord<T>
 where
-    T: Default + Eq + Clone + Send + Sync + 'static,
+    T: Eq + Clone + Send + Sync + 'static,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "visited search record")
@@ -73,7 +73,7 @@ where
 
 impl<T> VisitedSearchRecord<T>
 where
-    T: Default + Eq + Clone + Send + Sync + 'static,
+    T: Eq + Clone + Send + Sync + 'static,
 {
     pub fn new(initial_reservation: usize) -> Self {
         Self {
@@ -92,7 +92,7 @@ where
 
 impl<T> SearchRecord<T> for VisitedSearchRecord<T>
 where
-    T: Default + Eq + Clone + Send + Sync + 'static,
+    T: Eq + Clone + Send + Sync + 'static,
 {
     fn record(&mut self, neighbor: Neighbor<T>, _hops: u32, _cmps: u32) {
         self.push(neighbor);
@@ -101,7 +101,7 @@ where
 
 pub struct RecallSearchRecord<T>
 where
-    T: Default + Eq + Clone + Send + Sync + 'static,
+    T: Eq + Clone + Send + Sync + 'static,
 {
     groundtruth: Vec<T>,
     running_recall: usize,
@@ -112,7 +112,7 @@ where
 
 impl<T> std::fmt::Display for RecallSearchRecord<T>
 where
-    T: Default + Eq + Clone + Send + Sync + 'static,
+    T: Eq + Clone + Send + Sync + 'static,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "recall search record")
@@ -121,7 +121,7 @@ where
 
 impl<T> RecallSearchRecord<T>
 where
-    T: Default + Eq + Clone + Send + Sync + 'static,
+    T: Eq + Clone + Send + Sync + 'static,
 {
     pub fn new(initial_reservation: usize, groundtruth: Vec<T>) -> Self {
         Self {
@@ -143,7 +143,7 @@ where
 
 impl<T> SearchRecord<T> for RecallSearchRecord<T>
 where
-    T: Default + Eq + Clone + Send + Sync + 'static,
+    T: Eq + Clone + Send + Sync + 'static,
 {
     fn record(&mut self, neighbor: Neighbor<T>, hops: u32, _cmps: u32) {
         self.push(neighbor, hops);

--- a/diskann/src/neighbor/mod.rs
+++ b/diskann/src/neighbor/mod.rs
@@ -27,7 +27,7 @@ pub use diverse_priority_queue::{
 #[derive(Debug, Clone, Copy)]
 pub struct Neighbor<VectorIdType>
 where
-    VectorIdType: Default + Eq,
+    VectorIdType: Eq,
 {
     /// The id of the node
     pub id: VectorIdType,
@@ -38,7 +38,7 @@ where
 
 impl<VectorIdType> Neighbor<VectorIdType>
 where
-    VectorIdType: Default + Eq,
+    VectorIdType: Eq,
 {
     /// Create the neighbor node and it has not been visited
     pub fn new(id: VectorIdType, distance: f32) -> Self {
@@ -65,7 +65,7 @@ where
 
 impl<VectorIdType> PartialEq for Neighbor<VectorIdType>
 where
-    VectorIdType: Default + Eq,
+    VectorIdType: Eq,
 {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
@@ -73,13 +73,13 @@ where
     }
 }
 
-impl<VectorIdType> Eq for Neighbor<VectorIdType> where VectorIdType: Default + Eq {}
+impl<VectorIdType> Eq for Neighbor<VectorIdType> where VectorIdType: Eq {}
 
 /// PERF SENSITIVE: does not do well with comparing item with self.
 /// Not doing so, allows for a 1% gain. So use it with care.
 impl<VectorIdType> Ord for Neighbor<VectorIdType>
 where
-    VectorIdType: Default + Eq + Debug,
+    VectorIdType: Eq + Debug,
 {
     fn cmp(&self, other: &Self) -> Ordering {
         debug_assert!(
@@ -98,7 +98,7 @@ where
 /// Not doing so, allows for a 1% gain. So use it with care.
 impl<VectorIdType> PartialOrd for Neighbor<VectorIdType>
 where
-    VectorIdType: Default + Eq + Debug,
+    VectorIdType: Eq + Debug,
 {
     #[inline]
     fn lt(&self, other: &Self) -> bool {
@@ -121,7 +121,7 @@ where
 #[derive(Debug)]
 pub struct BackInserter<'a, I>
 where
-    I: Default + Eq,
+    I: Eq,
 {
     buffer: &'a mut [Neighbor<I>],
     position: usize,
@@ -129,7 +129,7 @@ where
 
 impl<'a, I> BackInserter<'a, I>
 where
-    I: Default + Eq,
+    I: Eq,
 {
     /// Construct a new [`BackInserter`] around the provided slice.
     ///
@@ -149,7 +149,7 @@ where
 
 impl<I> SearchOutputBuffer<I> for BackInserter<'_, I>
 where
-    I: Default + Eq,
+    I: Eq,
 {
     fn size_hint(&self) -> Option<usize> {
         // We maintain the invariant that `self.position <= self.buffer.len()`, so this
@@ -197,7 +197,7 @@ where
 
 impl<I> SearchOutputBuffer<I> for Vec<Neighbor<I>>
 where
-    I: Default + Eq,
+    I: Eq,
 {
     fn size_hint(&self) -> Option<usize> {
         None

--- a/diskann/src/neighbor/queue.rs
+++ b/diskann/src/neighbor/queue.rs
@@ -3,30 +3,28 @@
  * Licensed under the MIT license.
  */
 
+use std::{
+    fmt::{Debug, Display},
+    marker::PhantomData,
+};
+
 use diskann_wide::{SIMDMask, SIMDPartialOrd, SIMDVector};
-use std::marker::PhantomData;
 
 use super::Neighbor;
 
 /// Shared trait for type the generic `I` parameter used by the
 /// `NeighborPeriorityQueue`.
-pub trait NeighborPriorityQueueIdType:
-    Default + Eq + Clone + Copy + std::fmt::Debug + std::fmt::Display + Send + Sync
-{
-}
+pub trait NeighborPriorityQueueIdType: Eq + Clone + Copy + Debug + Display + Send + Sync {}
 
 /// Any type that implements all the individual requirements for
 /// `NeighborPriorityQueueIdType` implements the full trait.
-impl<T> NeighborPriorityQueueIdType for T where
-    T: Default + Eq + Clone + Copy + std::fmt::Debug + std::fmt::Display + Send + Sync
-{
-}
+impl<T> NeighborPriorityQueueIdType for T where T: Eq + Clone + Copy + Debug + Display + Send + Sync {}
 
 /// Trait defining the interface for a neighbor priority queue.
 ///
 /// This trait abstracts the core functionality of a priority queue that manages
 /// neighbors ordered by distance, supporting both fixed-size and resizable queues.
-pub trait NeighborQueue<I: NeighborPriorityQueueIdType>: std::fmt::Debug + Send + Sync {
+pub trait NeighborQueue<I: NeighborPriorityQueueIdType>: Debug + Send + Sync {
     /// The iterator type returned by `iter()`.
     type Iter<'a>: ExactSizeIterator<Item = Neighbor<I>> + Send + Sync
     where

--- a/diskann/src/neighbor/queue.rs
+++ b/diskann/src/neighbor/queue.rs
@@ -12,8 +12,7 @@ use diskann_wide::{SIMDMask, SIMDPartialOrd, SIMDVector};
 
 use super::Neighbor;
 
-/// Shared trait for type the generic `I` parameter used by the
-/// `NeighborPeriorityQueue`.
+/// Shared trait for the generic `I` parameter used by `NeighborQueue`.
 pub trait NeighborPriorityQueueIdType: Eq + Clone + Copy + Debug + Display + Send + Sync {}
 
 /// Any type that implements all the individual requirements for


### PR DESCRIPTION
The `Default` trait on `VectorIdType` is an unnecessary constraint that restricts using the neighbor priority queue with `!Default` types like reference, hence removing it.