### PR TITLE
Replace sgemm() panics with Result-based error handling

### DIFF
--- a/diskann-disk/src/utils/math_util.rs
+++ b/diskann-disk/src/utils/math_util.rs
@@ -172,7 +172,8 @@ pub fn compute_closest_centers_in_block(
         &ones_a,
         None, // Initialize the destination matrix
         dist_matrix,
-    );
+    )
+    .map_err(|e| ANNError::log_index_error(format_args!("{}", e)))?;
 
     diskann_linalg::sgemm(
         Transpose::None,
@@ -185,7 +186,8 @@ pub fn compute_closest_centers_in_block(
         centers_l2sq,
         Some(1.0), // Add to the destination matrix
         dist_matrix,
-    );
+    )
+    .map_err(|e| ANNError::log_index_error(format_args!("{}", e)))?;
 
     diskann_linalg::sgemm(
         Transpose::None,
@@ -198,7 +200,8 @@ pub fn compute_closest_centers_in_block(
         centers,
         Some(1.0), // Add to the destination matrix.
         dist_matrix,
-    );
+    )
+    .map_err(|e| ANNError::log_index_error(format_args!("{}", e)))?;
 
     if k == 1 {
         center_index

--- a/diskann-disk/src/utils/math_util.rs
+++ b/diskann-disk/src/utils/math_util.rs
@@ -12,7 +12,7 @@
 
 use std::{cmp::Ordering, collections::BinaryHeap};
 
-use diskann::{ANNError, ANNResult};
+use diskann::{ANNError, ANNErrorKind, ANNResult};
 use diskann_linalg::{self, Transpose};
 use diskann_providers::{
     forward_threadpool,
@@ -173,7 +173,7 @@ pub fn compute_closest_centers_in_block(
         None, // Initialize the destination matrix
         dist_matrix,
     )
-    .map_err(|e| ANNError::log_index_error(format_args!("{}", e)))?;
+    .map_err(|e| ANNError::new(ANNErrorKind::IndexError, e))?;
 
     diskann_linalg::sgemm(
         Transpose::None,
@@ -187,7 +187,7 @@ pub fn compute_closest_centers_in_block(
         Some(1.0), // Add to the destination matrix
         dist_matrix,
     )
-    .map_err(|e| ANNError::log_index_error(format_args!("{}", e)))?;
+    .map_err(|e| ANNError::new(ANNErrorKind::IndexError, e))?;
 
     diskann_linalg::sgemm(
         Transpose::None,
@@ -201,7 +201,7 @@ pub fn compute_closest_centers_in_block(
         Some(1.0), // Add to the destination matrix.
         dist_matrix,
     )
-    .map_err(|e| ANNError::log_index_error(format_args!("{}", e)))?;
+    .map_err(|e| ANNError::new(ANNErrorKind::IndexError, e))?;
 
     if k == 1 {
         center_index

--- a/diskann-linalg/src/lib.rs
+++ b/diskann-linalg/src/lib.rs
@@ -3,12 +3,79 @@
  * Licensed under the MIT license.
  */
 
+use std::fmt;
+
 pub mod common;
 pub use common::Transpose;
 
 mod faer;
 use faer::{random_distance_preserving_matrix_impl, sgemm_impl, svd_into_impl};
 use rand::Rng;
+
+/// Error type for SGEMM operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SgemmError {
+    /// Matrix `a` has incorrect dimensions.
+    InvalidMatrixADimensions {
+        expected_rows: usize,
+        expected_cols: usize,
+        expected_len: usize,
+        actual_len: usize,
+    },
+    /// Matrix `b` has incorrect dimensions.
+    InvalidMatrixBDimensions {
+        expected_rows: usize,
+        expected_cols: usize,
+        expected_len: usize,
+        actual_len: usize,
+    },
+    /// Matrix `c` has incorrect dimensions.
+    InvalidMatrixCDimensions {
+        expected_rows: usize,
+        expected_cols: usize,
+        expected_len: usize,
+        actual_len: usize,
+    },
+}
+
+impl fmt::Display for SgemmError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SgemmError::InvalidMatrixADimensions {
+                expected_rows,
+                expected_cols,
+                expected_len,
+                actual_len,
+            } => write!(
+                f,
+                "expected {}x{} matrix `a` to have length {}, instead got {}",
+                expected_rows, expected_cols, expected_len, actual_len
+            ),
+            SgemmError::InvalidMatrixBDimensions {
+                expected_rows,
+                expected_cols,
+                expected_len,
+                actual_len,
+            } => write!(
+                f,
+                "expected {}x{} matrix `b` to have length {}, instead got {}",
+                expected_rows, expected_cols, expected_len, actual_len
+            ),
+            SgemmError::InvalidMatrixCDimensions {
+                expected_rows,
+                expected_cols,
+                expected_len,
+                actual_len,
+            } => write!(
+                f,
+                "expected {}x{} matrix `c` to have length {}, instead got {}",
+                expected_rows, expected_cols, expected_len, actual_len
+            ),
+        }
+    }
+}
+
+impl std::error::Error for SgemmError {}
 
 // Make the reference implementation available for internal testing.
 #[cfg(test)]
@@ -62,15 +129,12 @@ mod reference;
 /// If the more esoteric features of the cblas `sgemm` API are needed, we can provide
 /// that as an interface extension.
 ///
-/// # Panics
+/// # Errors
 ///
-/// Panics if
+/// Returns an error if:
 /// * `a.len() != m * k`
 /// * `b.len() != k * n`
-/// * `c.len() != m * n`.
-///
-/// Additionally, if MKL is used, panics if any of `k, m, n` is not representable as a
-/// signed 32-bit integer due to `cblas` limitations.
+/// * `c.len() != m * n`
 #[allow(clippy::too_many_arguments)]
 pub fn sgemm(
     atranspose: Transpose,
@@ -83,38 +147,38 @@ pub fn sgemm(
     b: &[f32],
     beta: Option<f32>,
     c: &mut [f32],
-) {
+) -> Result<(), SgemmError> {
     // Check size requirements.
-    assert_eq!(
-        a.len(),
-        m * k,
-        "expected {}x{} matrix `a` to have length {}, instead got {}",
-        m,
-        k,
-        m * k,
-        a.len()
-    );
-    assert_eq!(
-        b.len(),
-        k * n,
-        "expected {}x{} matrix `b` to have length {}, instead got {}",
-        k,
-        n,
-        k * n,
-        b.len()
-    );
-    assert_eq!(
-        c.len(),
-        m * n,
-        "expected {}x{} matrix `c` to have length {}, instead got {}",
-        m,
-        n,
-        m * n,
-        c.len()
-    );
+    if a.len() != m * k {
+        return Err(SgemmError::InvalidMatrixADimensions {
+            expected_rows: m,
+            expected_cols: k,
+            expected_len: m * k,
+            actual_len: a.len(),
+        });
+    }
+
+    if b.len() != k * n {
+        return Err(SgemmError::InvalidMatrixBDimensions {
+            expected_rows: k,
+            expected_cols: n,
+            expected_len: k * n,
+            actual_len: b.len(),
+        });
+    }
+
+    if c.len() != m * n {
+        return Err(SgemmError::InvalidMatrixCDimensions {
+            expected_rows: m,
+            expected_cols: n,
+            expected_len: m * n,
+            actual_len: c.len(),
+        });
+    }
 
     // Invoke the actual implementation.
-    sgemm_impl(atranspose, btranspose, m, n, k, alpha, a, b, beta, c)
+    sgemm_impl(atranspose, btranspose, m, n, k, alpha, a, b, beta, c);
+    Ok(())
 }
 
 /// Compute the SVD of the provided matrix implicit row-major matrix `data`.
@@ -299,7 +363,8 @@ mod tests {
             &full_singular_values,
             None,
             &mut temp,
-        );
+        )
+        .unwrap();
 
         let mut output = vec![0.0; case.m * case.n];
         sgemm(
@@ -313,7 +378,8 @@ mod tests {
             &vt,
             None,
             &mut output,
-        );
+        )
+        .unwrap();
 
         for row in 0..case.m {
             for col in 0..case.n {

--- a/diskann-linalg/src/lib.rs
+++ b/diskann-linalg/src/lib.rs
@@ -289,9 +289,25 @@ mod tests {
 
     #[test]
     fn test_reference_implementation() {
+        #[allow(clippy::too_many_arguments)]
+        fn sgemm_wrapper(
+            atranspose: Transpose,
+            btranspose: Transpose,
+            m: usize,
+            n: usize,
+            k: usize,
+            alpha: f32,
+            a: &[f32],
+            b: &[f32],
+            beta: Option<f32>,
+            c: &mut [f32],
+        ) {
+            sgemm(atranspose, btranspose, m, n, k, alpha, a, b, beta, c).unwrap();
+        }
+
         let problems = reference::test_sgemm_problems();
         for (i, problem) in problems.iter().enumerate() {
-            let result = problem.check(sgemm);
+            let result = problem.check(sgemm_wrapper);
             if let Err(err) = result {
                 panic!("{} on iteration {}. Problem: {:?}", err, i, problem);
             }

--- a/diskann-linalg/src/lib.rs
+++ b/diskann-linalg/src/lib.rs
@@ -315,6 +315,75 @@ mod tests {
     }
 
     #[test]
+    fn test_sgemm_invalid_matrix_a_dimensions() {
+        let mut c = [0.0f32; 6];
+        let err = sgemm(
+            Transpose::None,
+            Transpose::None,
+            2,
+            3,
+            4,
+            1.0,
+            &[0.0; 5], // Should be 2 * 4 = 8
+            &[0.0; 12],
+            None,
+            &mut c,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "expected 2x4 matrix `a` to have length 8, instead got 5"
+        );
+    }
+
+    #[test]
+    fn test_sgemm_invalid_matrix_b_dimensions() {
+        let mut c = [0.0f32; 6];
+        let err = sgemm(
+            Transpose::None,
+            Transpose::None,
+            2,
+            3,
+            4,
+            1.0,
+            &[0.0; 8],
+            &[0.0; 10], // Should be 4 * 3 = 12
+            None,
+            &mut c,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "expected 4x3 matrix `b` to have length 12, instead got 10"
+        );
+    }
+
+    #[test]
+    fn test_sgemm_invalid_matrix_c_dimensions() {
+        let mut c = [0.0f32; 5]; // Should be 2 * 3 = 6
+        let err = sgemm(
+            Transpose::None,
+            Transpose::None,
+            2,
+            3,
+            4,
+            1.0,
+            &[0.0; 8],
+            &[0.0; 12],
+            None,
+            &mut c,
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            err.to_string(),
+            "expected 2x3 matrix `c` to have length 6, instead got 5"
+        );
+    }
+
+    #[test]
     fn test_sgemm_m_times_k_overflow() {
         let mut c = [0.0f32];
         let err = sgemm(
@@ -331,10 +400,13 @@ mod tests {
         )
         .unwrap_err();
 
-        let SgemmError::DimensionOverflow { operation, .. } = err else {
-            panic!("Expected DimensionOverflow, got {:?}", err);
-        };
-        assert!(operation.contains("matrix a (m * k)"));
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "dimension overflow in matrix a (m * k): {} * 2 would overflow usize",
+                usize::MAX
+            )
+        );
     }
 
     #[test]
@@ -354,10 +426,13 @@ mod tests {
         )
         .unwrap_err();
 
-        let SgemmError::DimensionOverflow { operation, .. } = err else {
-            panic!("Expected DimensionOverflow, got {:?}", err);
-        };
-        assert!(operation.contains("matrix b (k * n)"));
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "dimension overflow in matrix b (k * n): 10 * {} would overflow usize",
+                usize::MAX
+            )
+        );
     }
 
     #[test]
@@ -377,10 +452,13 @@ mod tests {
         )
         .unwrap_err();
 
-        let SgemmError::DimensionOverflow { operation, .. } = err else {
-            panic!("Expected DimensionOverflow, got {:?}", err);
-        };
-        assert!(operation.contains("matrix c (m * n)"));
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "dimension overflow in matrix c (m * n): 2 * {} would overflow usize",
+                usize::MAX
+            )
+        );
     }
 
     ///////////////

--- a/diskann-linalg/src/lib.rs
+++ b/diskann-linalg/src/lib.rs
@@ -36,6 +36,12 @@ pub enum SgemmError {
         expected_len: usize,
         actual_len: usize,
     },
+    /// Dimension overflow when computing matrix size.
+    DimensionOverflow {
+        operation: &'static str,
+        dim1: usize,
+        dim2: usize,
+    },
 }
 
 impl fmt::Display for SgemmError {
@@ -70,6 +76,15 @@ impl fmt::Display for SgemmError {
                 f,
                 "expected {}x{} matrix `c` to have length {}, instead got {}",
                 expected_rows, expected_cols, expected_len, actual_len
+            ),
+            SgemmError::DimensionOverflow {
+                operation,
+                dim1,
+                dim2,
+            } => write!(
+                f,
+                "dimension overflow in {}: {} * {} would overflow usize",
+                operation, dim1, dim2
             ),
         }
     }
@@ -132,6 +147,9 @@ mod reference;
 /// # Errors
 ///
 /// Returns an error if:
+/// * `m * k` would overflow `usize`
+/// * `k * n` would overflow `usize`
+/// * `m * n` would overflow `usize`
 /// * `a.len() != m * k`
 /// * `b.len() != k * n`
 /// * `c.len() != m * n`
@@ -148,30 +166,48 @@ pub fn sgemm(
     beta: Option<f32>,
     c: &mut [f32],
 ) -> Result<(), SgemmError> {
-    // Check size requirements.
-    if a.len() != m * k {
+    // Check size requirements with overflow protection.
+    let expected_a_len = m.checked_mul(k).ok_or(SgemmError::DimensionOverflow {
+        operation: "matrix a (m * k)",
+        dim1: m,
+        dim2: k,
+    })?;
+
+    if a.len() != expected_a_len {
         return Err(SgemmError::InvalidMatrixADimensions {
             expected_rows: m,
             expected_cols: k,
-            expected_len: m * k,
+            expected_len: expected_a_len,
             actual_len: a.len(),
         });
     }
 
-    if b.len() != k * n {
+    let expected_b_len = k.checked_mul(n).ok_or(SgemmError::DimensionOverflow {
+        operation: "matrix b (k * n)",
+        dim1: k,
+        dim2: n,
+    })?;
+
+    if b.len() != expected_b_len {
         return Err(SgemmError::InvalidMatrixBDimensions {
             expected_rows: k,
             expected_cols: n,
-            expected_len: k * n,
+            expected_len: expected_b_len,
             actual_len: b.len(),
         });
     }
 
-    if c.len() != m * n {
+    let expected_c_len = m.checked_mul(n).ok_or(SgemmError::DimensionOverflow {
+        operation: "matrix c (m * n)",
+        dim1: m,
+        dim2: n,
+    })?;
+
+    if c.len() != expected_c_len {
         return Err(SgemmError::InvalidMatrixCDimensions {
             expected_rows: m,
             expected_cols: n,
-            expected_len: m * n,
+            expected_len: expected_c_len,
             actual_len: c.len(),
         });
     }
@@ -260,6 +296,75 @@ mod tests {
                 panic!("{} on iteration {}. Problem: {:?}", err, i, problem);
             }
         }
+    }
+
+    #[test]
+    fn test_sgemm_m_times_k_overflow() {
+        let mut c = [0.0f32];
+        let err = sgemm(
+            Transpose::None,
+            Transpose::None,
+            usize::MAX,
+            1,
+            2,
+            1.0,
+            &[],
+            &[0.0],
+            None,
+            &mut c,
+        )
+        .unwrap_err();
+
+        let SgemmError::DimensionOverflow { operation, .. } = err else {
+            panic!("Expected DimensionOverflow, got {:?}", err);
+        };
+        assert!(operation.contains("matrix a (m * k)"));
+    }
+
+    #[test]
+    fn test_sgemm_k_times_n_overflow() {
+        let mut c = vec![0.0f32; 10];
+        let err = sgemm(
+            Transpose::None,
+            Transpose::None,
+            1,
+            usize::MAX,
+            10,
+            1.0,
+            &[0.0f32; 10],
+            &[],
+            None,
+            &mut c,
+        )
+        .unwrap_err();
+
+        let SgemmError::DimensionOverflow { operation, .. } = err else {
+            panic!("Expected DimensionOverflow, got {:?}", err);
+        };
+        assert!(operation.contains("matrix b (k * n)"));
+    }
+
+    #[test]
+    fn test_sgemm_m_times_n_overflow() {
+        let mut c = [];
+        let err = sgemm(
+            Transpose::None,
+            Transpose::None,
+            2,
+            usize::MAX,
+            0,
+            1.0,
+            &[],
+            &[],
+            None,
+            &mut c,
+        )
+        .unwrap_err();
+
+        let SgemmError::DimensionOverflow { operation, .. } = err else {
+            panic!("Expected DimensionOverflow, got {:?}", err);
+        };
+        assert!(operation.contains("matrix c (m * n)"));
     }
 
     ///////////////

--- a/diskann-linalg/src/lib.rs
+++ b/diskann-linalg/src/lib.rs
@@ -15,22 +15,9 @@ use rand::Rng;
 /// Error type for SGEMM operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SgemmError {
-    /// Matrix `a` has incorrect dimensions.
-    InvalidMatrixADimensions {
-        expected_rows: usize,
-        expected_cols: usize,
-        expected_len: usize,
-        actual_len: usize,
-    },
-    /// Matrix `b` has incorrect dimensions.
-    InvalidMatrixBDimensions {
-        expected_rows: usize,
-        expected_cols: usize,
-        expected_len: usize,
-        actual_len: usize,
-    },
-    /// Matrix `c` has incorrect dimensions.
-    InvalidMatrixCDimensions {
+    /// Matrix has incorrect dimensions.
+    InvalidMatrixDimensions {
+        matrix_name: &'static str,
         expected_rows: usize,
         expected_cols: usize,
         expected_len: usize,
@@ -47,35 +34,16 @@ pub enum SgemmError {
 impl fmt::Display for SgemmError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            SgemmError::InvalidMatrixADimensions {
+            SgemmError::InvalidMatrixDimensions {
+                matrix_name,
                 expected_rows,
                 expected_cols,
                 expected_len,
                 actual_len,
             } => write!(
                 f,
-                "expected {}x{} matrix `a` to have length {}, instead got {}",
-                expected_rows, expected_cols, expected_len, actual_len
-            ),
-            SgemmError::InvalidMatrixBDimensions {
-                expected_rows,
-                expected_cols,
-                expected_len,
-                actual_len,
-            } => write!(
-                f,
-                "expected {}x{} matrix `b` to have length {}, instead got {}",
-                expected_rows, expected_cols, expected_len, actual_len
-            ),
-            SgemmError::InvalidMatrixCDimensions {
-                expected_rows,
-                expected_cols,
-                expected_len,
-                actual_len,
-            } => write!(
-                f,
-                "expected {}x{} matrix `c` to have length {}, instead got {}",
-                expected_rows, expected_cols, expected_len, actual_len
+                "expected {}x{} matrix `{}` to have length {}, instead got {}",
+                expected_rows, expected_cols, matrix_name, expected_len, actual_len
             ),
             SgemmError::DimensionOverflow {
                 operation,
@@ -174,7 +142,8 @@ pub fn sgemm(
     })?;
 
     if a.len() != expected_a_len {
-        return Err(SgemmError::InvalidMatrixADimensions {
+        return Err(SgemmError::InvalidMatrixDimensions {
+            matrix_name: "a",
             expected_rows: m,
             expected_cols: k,
             expected_len: expected_a_len,
@@ -189,7 +158,8 @@ pub fn sgemm(
     })?;
 
     if b.len() != expected_b_len {
-        return Err(SgemmError::InvalidMatrixBDimensions {
+        return Err(SgemmError::InvalidMatrixDimensions {
+            matrix_name: "b",
             expected_rows: k,
             expected_cols: n,
             expected_len: expected_b_len,
@@ -204,7 +174,8 @@ pub fn sgemm(
     })?;
 
     if c.len() != expected_c_len {
-        return Err(SgemmError::InvalidMatrixCDimensions {
+        return Err(SgemmError::InvalidMatrixDimensions {
+            matrix_name: "c",
             expected_rows: m,
             expected_cols: n,
             expected_len: expected_c_len,

--- a/diskann-linalg/src/lib.rs
+++ b/diskann-linalg/src/lib.rs
@@ -277,25 +277,9 @@ mod tests {
 
     #[test]
     fn test_reference_implementation() {
-        #[allow(clippy::too_many_arguments)]
-        fn sgemm_wrapper(
-            atranspose: Transpose,
-            btranspose: Transpose,
-            m: usize,
-            n: usize,
-            k: usize,
-            alpha: f32,
-            a: &[f32],
-            b: &[f32],
-            beta: Option<f32>,
-            c: &mut [f32],
-        ) {
-            sgemm(atranspose, btranspose, m, n, k, alpha, a, b, beta, c).unwrap();
-        }
-
         let problems = reference::test_sgemm_problems();
         for (i, problem) in problems.iter().enumerate() {
-            let result = problem.check(sgemm_wrapper);
+            let result = problem.check(sgemm);
             if let Err(err) = result {
                 panic!("{} on iteration {}. Problem: {:?}", err, i, problem);
             }

--- a/diskann-linalg/src/lib.rs
+++ b/diskann-linalg/src/lib.rs
@@ -12,22 +12,39 @@ mod faer;
 use faer::{random_distance_preserving_matrix_impl, sgemm_impl, svd_into_impl};
 use rand::Rng;
 
+/// Matrix identifier for SGEMM operations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatrixName {
+    A,
+    B,
+    C,
+}
+
+impl fmt::Display for MatrixName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MatrixName::A => write!(f, "a (m * k)"),
+            MatrixName::B => write!(f, "b (k * n)"),
+            MatrixName::C => write!(f, "c (m * n)"),
+        }
+    }
+}
+
 /// Error type for SGEMM operations.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SgemmError {
     /// Matrix has incorrect dimensions.
     InvalidMatrixDimensions {
-        matrix_name: &'static str,
+        matrix_name: MatrixName,
         expected_rows: usize,
         expected_cols: usize,
-        expected_len: usize,
         actual_len: usize,
     },
     /// Dimension overflow when computing matrix size.
     DimensionOverflow {
-        operation: &'static str,
-        dim1: usize,
-        dim2: usize,
+        matrix_name: MatrixName,
+        rows: usize,
+        cols: usize,
     },
 }
 
@@ -38,21 +55,24 @@ impl fmt::Display for SgemmError {
                 matrix_name,
                 expected_rows,
                 expected_cols,
-                expected_len,
                 actual_len,
             } => write!(
                 f,
-                "expected {}x{} matrix `{}` to have length {}, instead got {}",
-                expected_rows, expected_cols, matrix_name, expected_len, actual_len
+                "expected {}x{} matrix {} to have length {}, instead got {}",
+                expected_rows,
+                expected_cols,
+                matrix_name,
+                expected_rows * expected_cols,
+                actual_len
             ),
             SgemmError::DimensionOverflow {
-                operation,
-                dim1,
-                dim2,
+                matrix_name,
+                rows,
+                cols,
             } => write!(
                 f,
-                "dimension overflow in {}: {} * {} would overflow usize",
-                operation, dim1, dim2
+                "dimension overflow in matrix {}: {} * {} would overflow usize",
+                matrix_name, rows, cols
             ),
         }
     }
@@ -136,49 +156,46 @@ pub fn sgemm(
 ) -> Result<(), SgemmError> {
     // Check size requirements with overflow protection.
     let expected_a_len = m.checked_mul(k).ok_or(SgemmError::DimensionOverflow {
-        operation: "matrix a (m * k)",
-        dim1: m,
-        dim2: k,
+        matrix_name: MatrixName::A,
+        rows: m,
+        cols: k,
     })?;
 
     if a.len() != expected_a_len {
         return Err(SgemmError::InvalidMatrixDimensions {
-            matrix_name: "a",
+            matrix_name: MatrixName::A,
             expected_rows: m,
             expected_cols: k,
-            expected_len: expected_a_len,
             actual_len: a.len(),
         });
     }
 
     let expected_b_len = k.checked_mul(n).ok_or(SgemmError::DimensionOverflow {
-        operation: "matrix b (k * n)",
-        dim1: k,
-        dim2: n,
+        matrix_name: MatrixName::B,
+        rows: k,
+        cols: n,
     })?;
 
     if b.len() != expected_b_len {
         return Err(SgemmError::InvalidMatrixDimensions {
-            matrix_name: "b",
+            matrix_name: MatrixName::B,
             expected_rows: k,
             expected_cols: n,
-            expected_len: expected_b_len,
             actual_len: b.len(),
         });
     }
 
     let expected_c_len = m.checked_mul(n).ok_or(SgemmError::DimensionOverflow {
-        operation: "matrix c (m * n)",
-        dim1: m,
-        dim2: n,
+        matrix_name: MatrixName::C,
+        rows: m,
+        cols: n,
     })?;
 
     if c.len() != expected_c_len {
         return Err(SgemmError::InvalidMatrixDimensions {
-            matrix_name: "c",
+            matrix_name: MatrixName::C,
             expected_rows: m,
             expected_cols: n,
-            expected_len: expected_c_len,
             actual_len: c.len(),
         });
     }
@@ -304,7 +321,7 @@ mod tests {
 
         assert_eq!(
             err.to_string(),
-            "expected 2x4 matrix `a` to have length 8, instead got 5"
+            "expected 2x4 matrix a (m * k) to have length 8, instead got 5"
         );
     }
 
@@ -327,7 +344,7 @@ mod tests {
 
         assert_eq!(
             err.to_string(),
-            "expected 4x3 matrix `b` to have length 12, instead got 10"
+            "expected 4x3 matrix b (k * n) to have length 12, instead got 10"
         );
     }
 
@@ -350,7 +367,7 @@ mod tests {
 
         assert_eq!(
             err.to_string(),
-            "expected 2x3 matrix `c` to have length 6, instead got 5"
+            "expected 2x3 matrix c (m * n) to have length 6, instead got 5"
         );
     }
 
@@ -429,6 +446,33 @@ mod tests {
                 "dimension overflow in matrix c (m * n): 2 * {} would overflow usize",
                 usize::MAX
             )
+        );
+    }
+
+    /// This test ensures the Result type doesn't grow unexpectedly.
+    /// A large Result size increases stack usage even for the Ok(()) case.
+    #[test]
+    fn test_sgemm_result_size() {
+        let mut c = [0.0f32; 6];
+        let result = sgemm(
+            Transpose::None,
+            Transpose::None,
+            2,
+            3,
+            4,
+            1.0,
+            &[0.0; 5],
+            &[0.0; 12],
+            None,
+            &mut c,
+        );
+
+        let result_size = std::mem::size_of_val(&result);
+        const EXPECTED_RESULT_SIZE: usize = 32;
+        assert_eq!(
+            result_size, EXPECTED_RESULT_SIZE,
+            "Result size is {} bytes, does not match the expected size of {} bytes.",
+            result_size, EXPECTED_RESULT_SIZE
         );
     }
 

--- a/diskann-linalg/src/reference.rs
+++ b/diskann-linalg/src/reference.rs
@@ -61,18 +61,42 @@ pub(crate) struct TestProblem {
 }
 
 #[derive(Debug, Error)]
-#[error("mismatch in test problem. got {:?}, expected {:?}", got, expected)]
-pub(crate) struct ReferenceError {
-    got: Vec<f32>,
-    expected: Vec<f32>,
+pub(crate) enum CheckError {
+    #[error("mismatch in test problem. got {:?}, expected {:?}", got, expected)]
+    ReferenceError { got: Vec<f32>, expected: Vec<f32> },
+    #[error(transparent)]
+    SgemmError(#[from] crate::SgemmError),
 }
 
 pub(crate) trait GemmFunction:
-    Fn(Transpose, Transpose, usize, usize, usize, f32, &[f32], &[f32], Option<f32>, &mut [f32])
+    Fn(
+    Transpose,
+    Transpose,
+    usize,
+    usize,
+    usize,
+    f32,
+    &[f32],
+    &[f32],
+    Option<f32>,
+    &mut [f32],
+) -> Result<(), crate::SgemmError>
 {
 }
+
 impl<F> GemmFunction for F where
-    F: Fn(Transpose, Transpose, usize, usize, usize, f32, &[f32], &[f32], Option<f32>, &mut [f32])
+    F: Fn(
+        Transpose,
+        Transpose,
+        usize,
+        usize,
+        usize,
+        f32,
+        &[f32],
+        &[f32],
+        Option<f32>,
+        &mut [f32],
+    ) -> Result<(), crate::SgemmError>
 {
 }
 
@@ -111,7 +135,7 @@ impl TestProblem {
         }
     }
 
-    pub(crate) fn check<F: GemmFunction>(&self, f: F) -> Result<(), ReferenceError> {
+    pub(crate) fn check<F: GemmFunction>(&self, f: F) -> Result<(), CheckError> {
         let mut result = self.c.clone();
         f(
             self.atranspose,
@@ -124,12 +148,12 @@ impl TestProblem {
             &self.b,
             self.beta,
             &mut result,
-        );
+        )?;
 
         if result == self.expected {
             Ok(())
         } else {
-            Err(ReferenceError {
+            Err(CheckError::ReferenceError {
                 got: result,
                 expected: self.expected.clone(),
             })
@@ -254,9 +278,26 @@ mod tests {
 
     #[test]
     fn test_reference_implementation() {
+        #[allow(clippy::too_many_arguments)]
+        fn sgemm_impl_wrapper(
+            atranspose: Transpose,
+            btranspose: Transpose,
+            m: usize,
+            n: usize,
+            k: usize,
+            alpha: f32,
+            a: &[f32],
+            b: &[f32],
+            beta: Option<f32>,
+            c: &mut [f32],
+        ) -> Result<(), crate::SgemmError> {
+            sgemm_impl(atranspose, btranspose, m, n, k, alpha, a, b, beta, c);
+            Ok(())
+        }
+
         let problems = test_sgemm_problems();
         for (i, problem) in problems.iter().enumerate() {
-            let result = problem.check(sgemm_impl);
+            let result = problem.check(sgemm_impl_wrapper);
             if let Err(err) = result {
                 panic!("{} on iteration {}. Problem: {:?}", err, i, problem);
             }

--- a/diskann-linalg/src/reference.rs
+++ b/diskann-linalg/src/reference.rs
@@ -68,11 +68,11 @@ pub(crate) struct ReferenceError {
 }
 
 pub(crate) trait GemmFunction:
-    Fn(Transpose, Transpose, usize, usize, usize, f32, &[f32], &[f32], Option<f32>, &mut [f32]) -> Result<(), crate::SgemmError>
+    Fn(Transpose, Transpose, usize, usize, usize, f32, &[f32], &[f32], Option<f32>, &mut [f32])
 {
 }
 impl<F> GemmFunction for F where
-    F: Fn(Transpose, Transpose, usize, usize, usize, f32, &[f32], &[f32], Option<f32>, &mut [f32]) -> Result<(), crate::SgemmError>
+    F: Fn(Transpose, Transpose, usize, usize, usize, f32, &[f32], &[f32], Option<f32>, &mut [f32])
 {
 }
 
@@ -124,11 +124,7 @@ impl TestProblem {
             &self.b,
             self.beta,
             &mut result,
-        )
-        .map_err(|_| ReferenceError {
-            got: vec![],
-            expected: vec![],
-        })?;
+        );
 
         if result == self.expected {
             Ok(())
@@ -256,27 +252,11 @@ pub(crate) fn test_sgemm_problems() -> Vec<TestProblem> {
 mod tests {
     use super::*;
 
-    fn sgemm_impl_wrapper(
-        atranspose: Transpose,
-        btranspose: Transpose,
-        m: usize,
-        n: usize,
-        k: usize,
-        alpha: f32,
-        a: &[f32],
-        b: &[f32],
-        beta: Option<f32>,
-        c: &mut [f32],
-    ) -> Result<(), crate::SgemmError> {
-        sgemm_impl(atranspose, btranspose, m, n, k, alpha, a, b, beta, c);
-        Ok(())
-    }
-
     #[test]
     fn test_reference_implementation() {
         let problems = test_sgemm_problems();
         for (i, problem) in problems.iter().enumerate() {
-            let result = problem.check(sgemm_impl_wrapper);
+            let result = problem.check(sgemm_impl);
             if let Err(err) = result {
                 panic!("{} on iteration {}. Problem: {:?}", err, i, problem);
             }

--- a/diskann-linalg/src/reference.rs
+++ b/diskann-linalg/src/reference.rs
@@ -68,11 +68,11 @@ pub(crate) struct ReferenceError {
 }
 
 pub(crate) trait GemmFunction:
-    Fn(Transpose, Transpose, usize, usize, usize, f32, &[f32], &[f32], Option<f32>, &mut [f32])
+    Fn(Transpose, Transpose, usize, usize, usize, f32, &[f32], &[f32], Option<f32>, &mut [f32]) -> Result<(), crate::SgemmError>
 {
 }
 impl<F> GemmFunction for F where
-    F: Fn(Transpose, Transpose, usize, usize, usize, f32, &[f32], &[f32], Option<f32>, &mut [f32])
+    F: Fn(Transpose, Transpose, usize, usize, usize, f32, &[f32], &[f32], Option<f32>, &mut [f32]) -> Result<(), crate::SgemmError>
 {
 }
 
@@ -124,7 +124,11 @@ impl TestProblem {
             &self.b,
             self.beta,
             &mut result,
-        );
+        )
+        .map_err(|_| ReferenceError {
+            got: vec![],
+            expected: vec![],
+        })?;
 
         if result == self.expected {
             Ok(())
@@ -252,11 +256,27 @@ pub(crate) fn test_sgemm_problems() -> Vec<TestProblem> {
 mod tests {
     use super::*;
 
+    fn sgemm_impl_wrapper(
+        atranspose: Transpose,
+        btranspose: Transpose,
+        m: usize,
+        n: usize,
+        k: usize,
+        alpha: f32,
+        a: &[f32],
+        b: &[f32],
+        beta: Option<f32>,
+        c: &mut [f32],
+    ) -> Result<(), crate::SgemmError> {
+        sgemm_impl(atranspose, btranspose, m, n, k, alpha, a, b, beta, c);
+        Ok(())
+    }
+
     #[test]
     fn test_reference_implementation() {
         let problems = test_sgemm_problems();
         for (i, problem) in problems.iter().enumerate() {
-            let result = problem.check(sgemm_impl);
+            let result = problem.check(sgemm_impl_wrapper);
             if let Err(err) = result {
                 panic!("{} on iteration {}. Problem: {:?}", err, i, problem);
             }

--- a/diskann-quantization/src/algorithms/transforms/random_rotation.rs
+++ b/diskann-quantization/src/algorithms/transforms/random_rotation.rs
@@ -162,7 +162,7 @@ impl RandomRotation {
             src,
             None,
             dst,
-        );
+        )?;
         Ok(())
     }
 }

--- a/diskann-quantization/src/algorithms/transforms/utils.rs
+++ b/diskann-quantization/src/algorithms/transforms/utils.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 
 use crate::alloc::{Allocator, AllocatorError, Poly};
 
-#[derive(Debug, Clone, Copy, Error, PartialEq)]
+#[derive(Debug, Clone, Error, PartialEq)]
 pub enum TransformFailed {
     #[error("incorrect transform input vector - expected length {expected} but got {found}")]
     SourceMismatch { expected: usize, found: usize },
@@ -16,6 +16,9 @@ pub enum TransformFailed {
     DestinationMismatch { expected: usize, found: usize },
     #[error(transparent)]
     AllocatorError(#[from] AllocatorError),
+    #[cfg(feature = "linalg")]
+    #[error("SGEMM operation failed: {0}")]
+    SgemmError(#[from] diskann_linalg::SgemmError),
 }
 
 pub(super) fn check_dims(

--- a/diskann-quantization/src/algorithms/transforms/utils.rs
+++ b/diskann-quantization/src/algorithms/transforms/utils.rs
@@ -17,7 +17,7 @@ pub enum TransformFailed {
     #[error(transparent)]
     AllocatorError(#[from] AllocatorError),
     #[cfg(feature = "linalg")]
-    #[error("SGEMM operation failed: {0}")]
+    #[error(transparent)]
     SgemmError(#[from] diskann_linalg::SgemmError),
 }
 

--- a/diskann-quantization/src/spherical/quantizer.rs
+++ b/diskann-quantization/src/spherical/quantizer.rs
@@ -761,6 +761,12 @@ where
                     "The sizes of these arrays should already be checked - this is a logic error"
                 );
             }
+            #[cfg(feature = "linalg")]
+            Err(TransformFailed::SgemmError(_)) => {
+                panic!(
+                    "SGEMM should not fail with valid dimensions - this is a logic error"
+                );
+            }
         }
 
         *into.meta_mut() = FullQueryMeta {
@@ -833,6 +839,12 @@ where
             | Err(TransformFailed::DestinationMismatch { .. }) => {
                 panic!(
                     "The sizes of these arrays should already be checked - this is a logic error"
+                );
+            }
+            #[cfg(feature = "linalg")]
+            Err(TransformFailed::SgemmError(_)) => {
+                panic!(
+                    "SGEMM should not fail with valid dimensions - this is a logic error"
                 );
             }
         }
@@ -1153,6 +1165,12 @@ where
             | Err(TransformFailed::DestinationMismatch { .. }) => {
                 panic!(
                     "The sizes of these arrays should already be checked - this is a logic error"
+                );
+            }
+            #[cfg(feature = "linalg")]
+            Err(TransformFailed::SgemmError(_)) => {
+                panic!(
+                    "SGEMM should not fail with valid dimensions - this is a logic error"
                 );
             }
         }

--- a/diskann-quantization/src/spherical/quantizer.rs
+++ b/diskann-quantization/src/spherical/quantizer.rs
@@ -763,9 +763,7 @@ where
             }
             #[cfg(feature = "linalg")]
             Err(TransformFailed::SgemmError(_)) => {
-                panic!(
-                    "SGEMM should not fail with valid dimensions - this is a logic error"
-                );
+                panic!("SGEMM should not fail with valid dimensions - this is a logic error");
             }
         }
 
@@ -843,9 +841,7 @@ where
             }
             #[cfg(feature = "linalg")]
             Err(TransformFailed::SgemmError(_)) => {
-                panic!(
-                    "SGEMM should not fail with valid dimensions - this is a logic error"
-                );
+                panic!("SGEMM should not fail with valid dimensions - this is a logic error");
             }
         }
 
@@ -1169,9 +1165,7 @@ where
             }
             #[cfg(feature = "linalg")]
             Err(TransformFailed::SgemmError(_)) => {
-                panic!(
-                    "SGEMM should not fail with valid dimensions - this is a logic error"
-                );
+                panic!("SGEMM should not fail with valid dimensions - this is a logic error");
             }
         }
 


### PR DESCRIPTION
## Summary

Refactors `diskann_linalg::sgemm()` to return `Result<(), SgemmError>` instead of panicking on invalid inputs. This change improves error handling and adds overflow protection for matrix dimension calculations.

**Principle:** DiskANN must not panic in production for recoverable errors; panics are reserved for catastrophic failures indicating undefined behavior.

## Changes

### 1. New Error Type (`SgemmError`)
- Added `SgemmError` enum with two variants:
  - `InvalidMatrixDimensions`: Matrix has incorrect dimensions
  - `DimensionOverflow`: Multiplication would overflow `usize`
- Implemented `Display` and `std::error::Error` traits for proper error reporting

### 2. Updated `sgemm()` Function Signature
**Before:**
```rust
pub fn sgemm(...) { ... }
```

**After:**
```rust
pub fn sgemm(...) -> Result<(), SgemmError> { ... }
```

### 3. Overflow Protection
Replaced unsafe multiplication with `checked_mul()` for all dimension calculations:
- `m * k` validation (matrix a)
- `k * n` validation (matrix b)
- `m * n` validation (matrix c)

This prevents integer overflow vulnerabilities that could lead to undefined behavior.

### 4. Updated Call Sites
Updated all callers of `sgemm()` to handle the `Result`:
- **diskann-quantization**: Propagates errors through `TransformFailed::SgemmError` variant
- **diskann-disk**: Converts errors to `ANNError` with descriptive messages
- **diskann-linalg tests**: Added wrapper function for compatibility

### 5. Comprehensive Test Coverage
Added 6 new unit tests:
- `test_sgemm_invalid_matrix_a_dimensions`: Validates dimension check for matrix a
- `test_sgemm_invalid_matrix_b_dimensions`: Validates dimension check for matrix b
- `test_sgemm_invalid_matrix_c_dimensions`: Validates dimension check for matrix c
- `test_sgemm_m_times_k_overflow`: Tests overflow detection for `m * k`
- `test_sgemm_k_times_n_overflow`: Tests overflow detection for `k * n`
- `test_sgemm_m_times_n_overflow`: Tests overflow detection for `m * n`

## Review Order

  1. Core Changes (5 min)

  📁 diskann-linalg/src/lib.rs
  - Lines 15-50: New `SgemmError` type
  - Lines 155-202: Overflow protection with `checked_mul()`

  2. Tests (3 min)

  📁 diskann-linalg/src/lib.rs (lines 318-461)
  - 6 new tests covering all error variants
  - Verify error messages are tested exactly

  3. Call Sites (2 min)

  📁 diskann-disk/src/utils/math_util.rs (lines 164-204)
  - Three .map_err() conversions to ANNError