### PR TITLE
Relax the `'static` bound on `DistanceComputer`.

### DIFF
--- a/diskann-garnet/src/provider.rs
+++ b/diskann-garnet/src/provider.rs
@@ -808,7 +808,7 @@ impl<T: VectorRepr> DefaultPostProcessor<GarnetProvider<T>, &[T], GarnetId> for 
 impl<T: VectorRepr> PruneStrategy<GarnetProvider<T>> for FullPrecision {
     type PruneAccessor<'a> = FullAccessor<'a, T>;
     type PruneAccessorError = GarnetProviderError;
-    type DistanceComputer = T::Distance;
+    type DistanceComputer<'a> = T::Distance;
     type WorkingSet = WorkingSet<T>;
 
     fn prune_accessor<'a>(

--- a/diskann-providers/src/model/graph/provider/async_/bf_tree/provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/bf_tree/provider.rs
@@ -1525,7 +1525,7 @@ where
     D: AsyncFriendly,
 {
     type WorkingSet = map::Map<u32, Box<[T]>, map::Ref<[T]>>;
-    type DistanceComputer = T::Distance;
+    type DistanceComputer<'a> = T::Distance;
     type PruneAccessor<'a> = FullAccessor<'a, T, Q, D>;
     type PruneAccessorError = diskann::error::Infallible;
 
@@ -1548,7 +1548,7 @@ where
     D: AsyncFriendly,
 {
     type WorkingSet = distances::pq::HybridMap<T, u8>;
-    type DistanceComputer = distances::pq::HybridComputer<T>;
+    type DistanceComputer<'a> = distances::pq::HybridComputer<T>;
     type PruneAccessor<'a> = HybridAccessor<'a, T, D>;
     type PruneAccessorError = diskann::error::Infallible;
 

--- a/diskann-providers/src/model/graph/provider/async_/caching/provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/caching/provider.rs
@@ -977,7 +977,7 @@ where
     E: StandardError,
 {
     type WorkingSet = Cached<S::WorkingSet>;
-    type DistanceComputer = S::DistanceComputer;
+    type DistanceComputer<'a> = S::DistanceComputer<'a>;
     type PruneAccessor<'a> = CachingAccessor<
         PruneAccessor<'a, S, DP>,
         <C as AsCacheAccessorFor<'a, PruneAccessor<'a, S, DP>>>::Accessor,

--- a/diskann-providers/src/model/graph/provider/async_/inmem/full_precision.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/full_precision.rs
@@ -441,7 +441,7 @@ where
     D: AsyncFriendly,
     Ctx: ExecutionContext,
 {
-    type DistanceComputer = T::Distance;
+    type DistanceComputer<'a> = T::Distance;
     type PruneAccessor<'a> = FullAccessor<'a, T, Q, D, Ctx>;
     type PruneAccessorError = diskann::error::Infallible;
     type WorkingSet = PassThrough;

--- a/diskann-providers/src/model/graph/provider/async_/inmem/product.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/product.rs
@@ -546,7 +546,7 @@ where
     D: AsyncFriendly + DeletionCheck,
     Ctx: ExecutionContext,
 {
-    type DistanceComputer = distances::pq::HybridComputer<T>;
+    type DistanceComputer<'a> = distances::pq::HybridComputer<T>;
     type PruneAccessor<'a> = HybridAccessor<'a, T, D, Ctx>;
     type PruneAccessorError = diskann::error::Infallible;
     type WorkingSet = FullPrecisionTracker;
@@ -692,7 +692,7 @@ where
     D: AsyncFriendly + DeletionCheck,
     Ctx: ExecutionContext,
 {
-    type DistanceComputer = pq::distance::DistanceComputer<Arc<FixedChunkPQTable>>;
+    type DistanceComputer<'a> = pq::distance::DistanceComputer<Arc<FixedChunkPQTable>>;
     type PruneAccessor<'a> = QuantAccessor<'a, NoStore, D, Ctx>;
     type PruneAccessorError = diskann::error::Infallible;
     type WorkingSet = PassThrough;

--- a/diskann-providers/src/model/graph/provider/async_/inmem/scalar.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/scalar.rs
@@ -674,7 +674,7 @@ where
     Unsigned: Representation<NBITS>,
     DistanceComputer: for<'a, 'b> DistanceFunction<CVRef<'a, NBITS>, CVRef<'b, NBITS>, f32>,
 {
-    type DistanceComputer = DistanceComputer;
+    type DistanceComputer<'a> = DistanceComputer;
     type PruneAccessor<'a> = QuantAccessor<'a, NBITS, V, D, Ctx>;
     type PruneAccessorError = diskann::error::Infallible;
     type WorkingSet = PassThrough;

--- a/diskann-providers/src/model/graph/provider/async_/inmem/spherical.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/spherical.rs
@@ -614,7 +614,7 @@ where
     D: AsyncFriendly + DeletionCheck,
     Ctx: ExecutionContext,
 {
-    type DistanceComputer =
+    type DistanceComputer<'a> =
         UnwrapErr<spherical::iface::DistanceComputer, spherical::iface::DistanceError>;
     type PruneAccessor<'a> = QuantAccessor<'a, V, D, Ctx>;
     type PruneAccessorError = diskann::error::Infallible;

--- a/diskann-providers/src/model/graph/provider/async_/inmem/test.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/test.rs
@@ -268,7 +268,7 @@ static START_COUNT: Mutex<usize> = Mutex::new(STATIC_PRUNE_THRESHOLD);
 type WorkingSet = map::Map<u32, Box<[f32]>, map::Ref<[f32]>>;
 
 impl PruneStrategy<TestProvider> for Flaky {
-    type DistanceComputer<'a> = <FullAccessor<'static> as BuildDistanceComputer>::DistanceComputer;
+    type DistanceComputer<'a> = <FullAccessor<'a> as BuildDistanceComputer>::DistanceComputer;
     type PruneAccessor<'a> = FlakyAccessor<'a>;
     type PruneAccessorError = diskann::error::Infallible;
     type WorkingSet = WorkingSet;

--- a/diskann-providers/src/model/graph/provider/async_/inmem/test.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/test.rs
@@ -268,7 +268,7 @@ static START_COUNT: Mutex<usize> = Mutex::new(STATIC_PRUNE_THRESHOLD);
 type WorkingSet = map::Map<u32, Box<[f32]>, map::Ref<[f32]>>;
 
 impl PruneStrategy<TestProvider> for Flaky {
-    type DistanceComputer = <FullAccessor<'static> as BuildDistanceComputer>::DistanceComputer;
+    type DistanceComputer<'a> = <FullAccessor<'static> as BuildDistanceComputer>::DistanceComputer;
     type PruneAccessor<'a> = FlakyAccessor<'a>;
     type PruneAccessorError = diskann::error::Infallible;
     type WorkingSet = WorkingSet;

--- a/diskann/src/graph/glue.rs
+++ b/diskann/src/graph/glue.rs
@@ -613,7 +613,7 @@ where
     ///
     /// We could grab this type from the `PruneAccessor` associated type, but it's
     /// useful enough that we move it up here.
-    type DistanceComputer: for<'a, 'b, 'c, 'd> DistanceFunction<
+    type DistanceComputer<'computer>: for<'a, 'b, 'c, 'd> DistanceFunction<
             <Self::PruneAccessor<'a> as Accessor>::ElementRef<'b>,
             <Self::PruneAccessor<'c> as Accessor>::ElementRef<'d>,
             f32,
@@ -630,7 +630,7 @@ where
     /// Implementations are encouraged to have [`Accessor::get_element`] return the
     /// highest-precision applicable value for a given element type.
     type PruneAccessor<'a>: Accessor<Id = Provider::InternalId>
-        + BuildDistanceComputer<DistanceComputer = Self::DistanceComputer>
+        + BuildDistanceComputer<DistanceComputer = Self::DistanceComputer<'a>>
         + AsNeighborMut
         + workingset::Fill<Self::WorkingSet>;
 

--- a/diskann/src/graph/glue.rs
+++ b/diskann/src/graph/glue.rs
@@ -618,8 +618,7 @@ where
             <Self::PruneAccessor<'c> as Accessor>::ElementRef<'d>,
             f32,
         > + Send
-        + Sync
-        + 'static;
+        + Sync;
 
     /// The concrete type of the accessor that is used to access `Self` during pruning.
     ///

--- a/diskann/src/graph/test/provider.rs
+++ b/diskann/src/graph/test/provider.rs
@@ -1188,7 +1188,7 @@ impl glue::DefaultPostProcessor<Provider, &[f32]> for Strategy {
 
 impl glue::PruneStrategy<Provider> for Strategy {
     type WorkingSet = workingset::Map<u32, Box<[f32]>, workingset::map::Ref<[f32]>>;
-    type DistanceComputer = <f32 as VectorRepr>::Distance;
+    type DistanceComputer<'a> = <f32 as VectorRepr>::Distance;
     type PruneAccessor<'a> = Accessor<'a>;
     type PruneAccessorError = Infallible;
 

--- a/diskann/src/provider.rs
+++ b/diskann/src/provider.rs
@@ -511,8 +511,7 @@ pub trait BuildDistanceComputer: Accessor {
     /// of elements yielded by the [`Accessor`].
     type DistanceComputer: for<'a, 'b> DistanceFunction<Self::ElementRef<'a>, Self::ElementRef<'b>>
         + Send
-        + Sync
-        + 'static;
+        + Sync;
 
     /// Build the random-access distance computer for this accessor.
     ///


### PR DESCRIPTION
# What
Remove the `'static` bound on `BuildDistanceComputer::DistanceComputer` and allow the `DistanceComputer` associated type of `PruneStrategy` to have a lifetime.

# Why
This bound is not really needed. Distance computers are almost exclusively used during prune loops, so there's no need for the `'static` bound. Relaxing that bound allows `DistanceComputer` implementations to borrow from the associated provider. This is helpful for PQ since this allows `DistanceComputer`s to borrow the central pivot table rather than requiring an `Arc` or some other  reference counting mechanism.

# Upgrade Guide
Since all current `DistanceComputers` are `'static`, the only change needed is to add a lifetime to the `DistanceComputer` generic associated type of all `PruneStrategy` implementations.