### PR TITLE
[CI] Fix publish dry-run check to skip non-publishable crates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -120,7 +120,7 @@ jobs:
             fi
           done
           if [ ${#bad_crates[@]} -gt 0 ]; then
-            echo "::error::The following crates do not use version.workspace = true: ${bad_crates[*]}"
+            echo "::error::The following publishable crates do not use version.workspace = true: ${bad_crates[*]}"
             exit 1
           fi
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,13 +102,20 @@ jobs:
             exit 1
           fi
 
-      - name: Verify all crates use workspace version
+      - name: Verify all publishable crates use workspace version
         run: |
           bad_crates=()
           for manifest in $(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].manifest_path'); do
             dir=$(dirname "$manifest")
             name=$(basename "$dir")
-            if [ "$manifest" != "$(pwd)/Cargo.toml" ] && ! grep -qE 'version\s*=\s*\{\s*workspace\s*=\s*true\s*\}|version\.workspace\s*=\s*true' "$manifest"; then
+            # Skip the root manifest and crates with publish = false
+            if [ "$manifest" = "$(pwd)/Cargo.toml" ]; then
+              continue
+            fi
+            if grep -qE '^\s*publish\s*=\s*false' "$manifest"; then
+              continue
+            fi
+            if ! grep -qE 'version\s*=\s*\{\s*workspace\s*=\s*true\s*\}|version\.workspace\s*=\s*true' "$manifest"; then
               bad_crates+=("$name")
             fi
           done


### PR DESCRIPTION
The "Verify all crates use workspace version" step now skips crates with publish = false (e.g., diskann-garnet, vectorset), which intentionally use independent versioning and are never published to crates.io.
