### PR TITLE
Deprecate 32-bit targets

### DIFF
--- a/diskann-disk/Cargo.toml
+++ b/diskann-disk/Cargo.toml
@@ -12,7 +12,6 @@ default-target = "x86_64-pc-windows-msvc"
 targets = [
     "x86_64-unknown-linux-gnu",
     "aarch64-pc-windows-msvc",
-    "i686-pc-windows-msvc",
     "x86_64-pc-windows-msvc",
 ]
 

--- a/diskann-platform/Cargo.toml
+++ b/diskann-platform/Cargo.toml
@@ -36,7 +36,7 @@ features = [
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
-targets = ["x86_64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "i686-pc-windows-msvc", "x86_64-pc-windows-msvc"]
+targets = ["x86_64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "x86_64-pc-windows-msvc"]
 
 [lints]
 # Commenting out for now. It would give warnings.

--- a/diskann-providers/Cargo.toml
+++ b/diskann-providers/Cargo.toml
@@ -69,7 +69,6 @@ default-target = "x86_64-pc-windows-msvc"
 targets = [
     "x86_64-unknown-linux-gnu",
     "aarch64-pc-windows-msvc",
-    "i686-pc-windows-msvc",
     "x86_64-pc-windows-msvc",
 ]
 

--- a/diskann/Cargo.toml
+++ b/diskann/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2024"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
-targets = ["x86_64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "i686-pc-windows-msvc", "x86_64-pc-windows-msvc"]
+targets = ["x86_64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "x86_64-pc-windows-msvc"]
 
 [dependencies]
 anyhow.workspace = true


### PR DESCRIPTION
We're currently building `diskann, diskann-platform, diskann-disk, diskann-providers` crates for `i686-pc-windows-msvc` targets. This is the only target that creates a difference in size for `usize/isize` (32-bit vs 64-bit) and other crates definitely do not have 32-bit targets, so this PR brings in uniformity with 3 distinct targets -- 64-bit `x64_64 Linux/Windows` + `AArch64 Windows`.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
- [x] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.
Remove 32-bit targets to enforce uniformity + resolve `usize/isize` 32-bit vs 64-bit issues (`usize/isize` is now 64-bit on all targets).

#### Any other comments?

