### PR TITLE
[deps] Don't pull `rayon` as a dependency of `diskann`.

### DIFF
--- a/diskann/Cargo.toml
+++ b/diskann/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "x86_64-pc-win
 [dependencies]
 anyhow.workspace = true
 bytemuck = { workspace = true, features = ["must_cast"]}
-diskann-utils = { workspace = true }
+diskann-utils = { workspace = true, default-features = false }
 futures-util = { workspace = true, default-features = false }
 half = { workspace = true, features = ["bytemuck", "num-traits"] }
 # Note: hashbrown not using workspace because diskann needs default-features = false


### PR DESCRIPTION
Avoid `rayon` as a direct dependency of `diskann` by disabling `default-features` in `diskann-utils`.