### PR TITLE
Set version to v0.52.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "diskann"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-core"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "diskann",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-runner"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-simd"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "diskann-benchmark-runner",
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-disk"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -784,7 +784,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-label-filter"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-linalg"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "approx",
  "cfg-if",
@@ -821,7 +821,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-platform"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "io-uring",
  "libc",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-providers"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "approx",
  "arc-swap",
@@ -871,7 +871,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-quantization"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -892,7 +892,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-tools"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -924,7 +924,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-utils"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-vector"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "approx",
  "bytemuck",
@@ -955,7 +955,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-wide"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "cfg-if",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ default-members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.51.0"      # Obeying semver
+version = "0.52.0"      # Obeying semver
 description = "DiskANN is a fast approximate nearest neighbor search library for high dimensional data"
 authors = ["Microsoft"]
 documentation = "https://github.com/microsoft/DiskANN"
@@ -48,22 +48,22 @@ undocumented_unsafe_blocks = "warn"
 
 [workspace.dependencies]
 # Base And Numerics
-diskann-wide = { path = "diskann-wide", version = "0.51.0" }
-diskann-vector = { path = "diskann-vector", version = "0.51.0" }
-diskann-linalg = { path = "diskann-linalg", version = "0.51.0" }
-diskann-utils = { path = "diskann-utils", default-features = false, version = "0.51.0" }
-diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.51.0" }
-diskann-platform = { path = "diskann-platform", version = "0.51.0" }
+diskann-wide = { path = "diskann-wide", version = "0.52.0" }
+diskann-vector = { path = "diskann-vector", version = "0.52.0" }
+diskann-linalg = { path = "diskann-linalg", version = "0.52.0" }
+diskann-utils = { path = "diskann-utils", default-features = false, version = "0.52.0" }
+diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.52.0" }
+diskann-platform = { path = "diskann-platform", version = "0.52.0" }
 # Algorithm
-diskann = { path = "diskann", version = "0.51.0" }
+diskann = { path = "diskann", version = "0.52.0" }
 # Providers
-diskann-providers = { path = "diskann-providers", default-features = false, version = "0.51.0" }
-diskann-disk = { path = "diskann-disk", version = "0.51.0" }
-diskann-label-filter = { path = "diskann-label-filter", version = "0.51.0" }
+diskann-providers = { path = "diskann-providers", default-features = false, version = "0.52.0" }
+diskann-disk = { path = "diskann-disk", version = "0.52.0" }
+diskann-label-filter = { path = "diskann-label-filter", version = "0.52.0" }
 # Infra
-diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.51.0" }
-diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.51.0" }
-diskann-tools = { path = "diskann-tools", version = "0.51.0" }
+diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.52.0" }
+diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.52.0" }
+diskann-tools = { path = "diskann-tools", version = "0.52.0" }
 
 # External dependencies (shared versions)
 anyhow = "1.0.98"


### PR DESCRIPTION
# DiskANN v0.52.0 Release Notes

## Breaking Changes

An AI generated, human reviewed list of changes is summarized below.

### `get_degree_stats` signature changed ([#998](https://github.com/microsoft/DiskANN/pull/998))

`DiskANNIndex::get_degree_stats` now takes an explicit iterator of IDs instead of requiring the data provider to implement `IntoIterator`.

```rust
// Before — provider had to impl IntoIterator
index.get_degree_stats(&mut accessor)?;

// After — caller supplies the ID iterator
index.get_degree_stats(&mut accessor, id_iter)?;
```

### PQ dimension contract tightened; entries now `&[f32]` only ([#1044](https://github.com/microsoft/DiskANN/pull/1044))

With `AlignedBoxWithSlice` removed from the PQ path, the dimension handling has been refactored into a three-layer contract:

| Layer | Where | Contract |
|---|---|---|
| **Boundary (inmem)** | `QueryComputer::new`, `MultiQueryComputer::new`, `DistanceComputer::evaluate_similarity` | `len == dim` (returns `Err` on mismatch) |
| **Boundary (disk)** | `PQScratch::set` | `len >= dim`, slices to `[..dim]` |
| **Internal** | `TableL2/IP/Cosine::{new, populate}` | Trusted — no re-validation |

**Other changes:**
- PQ table populate/distance methods now accept `&[f32]` instead of `<U: Into<f32>>`. Callers must pre-decode quantized vectors via `VectorRepr::as_f32`.
- Generic trampoline impls (`&Vec<u8>`, `&&[u8]`) on `QueryComputer` / `DistanceComputer` have been removed.
###  `calculate_chunk_offsets` relocated to `ChunkOffsets` constructors ([#976](https://github.com/microsoft/DiskANN/pull/976))

The free functions `calculate_chunk_offsets` and `calculate_chunk_offsets_auto` have been moved into constructors on `ChunkOffsets` / `ChunkOffsetsView` in `diskann-quantization::views`.

```rust
// Before
let offsets = calculate_chunk_offsets(dim, num_chunks);

// After (allocating)
let offsets = ChunkOffsets::partition(dim, num_chunks)?;

// After (zero-alloc, borrows caller-owned scratch)
let view = ChunkOffsetsView::partition_into(dim, &mut scratch)?;
```

Additionally, `get_chunk_from_training_data` has been moved from public API.

### `CachingProvider` removed ([#1052](https://github.com/microsoft/DiskANN/pull/1052))

The entire `diskann_providers::model::graph::provider::async_::caching` module has been deleted.

**Why:** The `CachingProvider` was an experiment in transparent caching over `DataProvider`. In practice it required double monomorphization of the indexing code, didn't save integration work for bulk methods like `on_elements_unordered`/`distances_unordered`, and was complex to maintain. An internal user who …migrated off it removed ~1,000 lines of code, improved compile times by ~20%, and substantially reduced complexity.

**Upgrade:** Manage caching directly in your `DataProvider` implementation.

## New Features

### AVX-512 4-bit distance kernels ([#1045](https://github.com/microsoft/DiskANN/pull/1045))

Native V4 (AVX-512) specializations for 4-bit packed vector distance computations:

- **`SquaredL2`** — 16 × `u32` lanes per iteration via `_mm512_madd_epi16`.
- **`InnerProduct`** — AVX-512 VNNI (`_mm512_dpbusd_epi32`) over `u8x64` / `i8x64` operands.

Previously, V4 hardware fell back to two AVX2 (V3) kernel invocations per 512-bit chunk. The native kernels double per-instruction throughput. No API changes — existing code benefits automatically on AVX-512 capable hardware.

## Merged PRs
* Deprecate 32-bit targets by @suhasjs in https://github.com/microsoft/DiskANN/pull/1022
* Add a fast path to `Map::prepare`. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/1023
* Add boundary checks in gen_associated_data_from_range() by @Copilot in https://github.com/microsoft/DiskANN/pull/847
* [deps] Don't pull `rayon` as a dependency of `diskann`. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/1024
* Bump openssl from 0.10.78 to 0.10.79 by @dependabot[bot] in https://github.com/microsoft/DiskANN/pull/1026
* Cleaning up test work and changing the get_degree_stats signature. by @JordanMaples in https://github.com/microsoft/DiskANN/pull/998
* Reduce scalar-quantization benchmark monomorphization by @suri-kumkaran in https://github.com/microsoft/DiskANN/pull/1041
* [diskann-vector] Support truly unaligned distances. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/981
* rename spherical.json to graph index with spherical quantization by @harsha-simhadri in https://github.com/microsoft/DiskANN/pull/1042
* [PQ Cleanup] Part 2: Consolidate `calculate_chunk_offsets*`  by @arkrishn94 in https://github.com/microsoft/DiskANN/pull/976
* PQ: tighten dim contract; right-size scratch buffer by @wuw92 in https://github.com/microsoft/DiskANN/pull/1044
* Add v4 distance kernels (4-bit SquaredL2 / InnerProduct) by @m3hm3t in https://github.com/microsoft/DiskANN/pull/1045
* Remove the Caching Provider by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/1052

## New Contributors
* @suhasjs made their first contribution in https://github.com/microsoft/DiskANN/pull/1022
* @m3hm3t made their first contribution in https://github.com/microsoft/DiskANN/pull/1045

**Full Changelog**: https://github.com/microsoft/DiskANN/compare/v0.51.0...v0.52.0
