### PR TITLE
[CI] Try to fix publishing step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Verify tag is on main branch
         if: github.event_name == 'push'
         run: |
-          if ! git branch --contains "$GITHUB_SHA" | grep -qE '\bmain$'; then
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
             echo "::error::Tag must point to a commit on main"
             exit 1
           fi


### PR DESCRIPTION
The "Verify tag is on main branch" step always fails on tag pushes because `git branch --contains` only lists local branches. In GitHub Actions, `main` exists only as the remote-tracking ref `origin/main`, so the grep never matches. You can try this locally with a fresh clone from main and running `git checkout v0.52.0`. An example failure is [here](https://github.com/microsoft/DiskANN/actions/runs/25762294405/job/75666277326)

Replaced with `git merge-base --is-ancestor` which directly checks reachability from `origin/main` without requiring a local branch.
