### PR TITLE
[API] Make some methods public again.

### DIFF
--- a/diskann-providers/src/model/pq/fixed_chunk_pq_table.rs
+++ b/diskann-providers/src/model/pq/fixed_chunk_pq_table.rs
@@ -29,7 +29,7 @@ pub struct FixedChunkPQTable {
 // These free functions use internals of the `FixedChunkPQTable`.
 //
 // We should clean up the API in the FFI.
-fn direct_distance_impl<T>(
+pub fn direct_distance_impl<T>(
     pq_table: &[f32],
     chunk_offsets: &[usize],
     dim: usize,
@@ -252,7 +252,7 @@ impl FixedChunkPQTable {
     /// Calculate the distance between query and given centroid by inner product
     /// * `query_vec` - query vector: 1 * dim
     /// * `base_vec` - given centroid array: 1 * num_pq_chunks
-    fn inner_product_raw(&self, query_vec: &[f32], base_vec: &[u8]) -> f32 {
+    pub fn inner_product_raw(&self, query_vec: &[f32], base_vec: &[u8]) -> f32 {
         direct_distance_impl::<distance::simd::ResumableIP<diskann_wide::arch::Current>>(
             self.table.view_pivots().as_slice(),
             self.table.view_offsets().as_slice(),

--- a/diskann-providers/src/model/pq/mod.rs
+++ b/diskann-providers/src/model/pq/mod.rs
@@ -5,7 +5,7 @@
 mod fixed_chunk_pq_table;
 pub use fixed_chunk_pq_table::{
     FixedChunkPQTable, compute_pq_distance, compute_pq_distance_for_pq_coordinates,
-    pq_dist_lookup_single,
+    direct_distance_impl, pq_dist_lookup_single,
 };
 
 mod pq_construction;


### PR DESCRIPTION
These methods were made private in #1044. Unfortunately, they are still being used by a downstream user.
