### PR TITLE
Turn on stack protection for the diskann-garnet NuGet build

### DIFF
--- a/.github/workflows/publish-diskann-garnet-nuget.yml
+++ b/.github/workflows/publish-diskann-garnet-nuget.yml
@@ -26,6 +26,8 @@ jobs:
             artifact-name: linux
             lib-path: target/release/libdiskann_garnet.so
           - os: windows-latest
+            env:
+              EXTRA_RUSTFLAGS: control-flow-guard
             artifact-name: windows
             lib-path: target/release/diskann_garnet.dll
             pdb-path: target/release/diskann_garnet.pdb
@@ -35,6 +37,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build diskann-garnet (release)
+        env:
+          RUSTC_BOOTSTRAP: 1
+          # NOTE: this overrides flags in /.cargo/config.toml so those must be manually merged in here.
+          RUSTFLAGS: -Z stack-protector=all,target-cpu=x86-64-v3${{ env.EXTRA_RUSTFLAGS && format(',{0}', env.EXTRA_RUSTFLAGS) || '' }}
         run: cargo build --locked --release --package diskann-garnet
 
       - name: Stage native library

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-garnet"
-version = "1.0.26"
+version = "1.0.27"
 dependencies = [
  "bytemuck",
  "crossbeam",

--- a/diskann-garnet/Cargo.toml
+++ b/diskann-garnet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diskann-garnet"
-version = "1.0.26"
+version = "1.0.27"
 edition = "2024"
 authors.workspace = true
 license.workspace = true

--- a/diskann-garnet/diskann-garnet.nuspec
+++ b/diskann-garnet/diskann-garnet.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>diskann-garnet</id>
-    <version>1.0.26</version>
+    <version>1.0.27</version>
     <readme>docs/README.md</readme>
     <authors>Microsoft</authors>
     <projectUrl>https://github.com/microsoft/DiskANN</projectUrl>


### PR DESCRIPTION
Garnet's release automation requires that stack protectors be enabled, so this sets RUSTFLAGS to set `stack-protectors=all` and uses RUSTC_BOOTSTRAP=1 to for the stable compiler into nightly mode.