### PR TITLE
[CI] add LLVM IR bloat regression check

### DIFF
--- a/.github/scripts/compare-llvm-lines.sh
+++ b/.github/scripts/compare-llvm-lines.sh
@@ -49,7 +49,7 @@ parse "$current_file" > "$current_parsed_file"
 echo "| Delta | Current | Baseline | Function |"
 echo "|-------|---------|----------|----------|"
 printf "| %+d | %s | %s | (TOTAL) |\n" "$delta_total" "$current_total" "$baseline_total"
-join -t$'\t' -j 2 -a1 -e 0 -o 1.2,1.1,2.1 \
+join -t$'\t' -j 2 -a1 -a2 -e 0 -o 0,1.1,2.1 \
   "$current_parsed_file" "$baseline_parsed_file" | \
   awk -F'\t' '{delta=$2-$3; printf "%d\t%s\t%s\t%s\n", delta, $2, $3, $1}' | \
   sort -t$'\t' -rn | \

--- a/.github/scripts/compare-llvm-lines.sh
+++ b/.github/scripts/compare-llvm-lines.sh
@@ -38,14 +38,19 @@ parse() {
   }' "$1" | sort -t$'\t' -k2
 }
 
-parse "$baseline_file" > /tmp/llvm_baseline_parsed.txt
-parse "$current_file" > /tmp/llvm_current_parsed.txt
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+baseline_parsed_file="$tmpdir/llvm_baseline_parsed.txt"
+current_parsed_file="$tmpdir/llvm_current_parsed.txt"
+
+parse "$baseline_file" > "$baseline_parsed_file"
+parse "$current_file" > "$current_parsed_file"
 
 echo "| Delta | Current | Baseline | Function |"
 echo "|-------|---------|----------|----------|"
 printf "| %+d | %s | %s | (TOTAL) |\n" "$delta_total" "$current_total" "$baseline_total"
 join -t$'\t' -j 2 -a1 -e 0 -o 1.2,1.1,2.1 \
-  /tmp/llvm_current_parsed.txt /tmp/llvm_baseline_parsed.txt | \
+  "$current_parsed_file" "$baseline_parsed_file" | \
   awk -F'\t' '{delta=$2-$3; printf "%d\t%s\t%s\t%s\n", delta, $2, $3, $1}' | \
   sort -t$'\t' -rn | \
   awk -F'\t' '{printf "| %+d | %s | %s | %s |\n", $1, $2, $3, $4}'

--- a/.github/scripts/compare-llvm-lines.sh
+++ b/.github/scripts/compare-llvm-lines.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT license.
+#
+# Compare two cargo-llvm-lines output files and produce a markdown regression report.
+#
+# Usage:
+#   ./compare-llvm-lines.sh <baseline.txt> <current.txt>
+
+set -euo pipefail
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <baseline.txt> <current.txt>" >&2
+  exit 1
+fi
+
+baseline_file="$1"
+current_file="$2"
+
+baseline_total=$(awk '/\(TOTAL\)/{print $1}' "$baseline_file")
+current_total=$(awk '/\(TOTAL\)/{print $1}' "$current_file")
+
+if [ "$baseline_total" -eq 0 ]; then
+  echo "Error: baseline total is 0, cannot compute growth." >&2
+  exit 1
+fi
+
+delta_total=$(( current_total - baseline_total ))
+
+# Parse llvm-lines output into "lines\tfunction_name" format.
+# Skip header (3 lines) and TOTAL row. Extract the first number (lines count)
+# and the function name (everything after the second parenthesized group).
+parse() {
+  awk 'NR>3 && !/TOTAL/{
+    lines = $1
+    sub(/^[^)]*\)[^)]*\) */, "")
+    print lines "\t" $0
+  }' "$1" | sort -t$'\t' -k2
+}
+
+parse "$baseline_file" > /tmp/llvm_baseline_parsed.txt
+parse "$current_file" > /tmp/llvm_current_parsed.txt
+
+echo "| Delta | Current | Baseline | Function |"
+echo "|-------|---------|----------|----------|"
+printf "| %+d | %s | %s | (TOTAL) |\n" "$delta_total" "$current_total" "$baseline_total"
+join -t$'\t' -j 2 -a1 -e 0 -o 1.2,1.1,2.1 \
+  /tmp/llvm_current_parsed.txt /tmp/llvm_baseline_parsed.txt | \
+  awk -F'\t' '{delta=$2-$3; printf "%d\t%s\t%s\t%s\n", delta, $2, $3, $1}' | \
+  sort -t$'\t' -rn | \
+  awk -F'\t' '{printf "| %+d | %s | %s | %s |\n", $1, $2, $3, $4}'
+echo ""

--- a/.github/scripts/compare-llvm-lines.sh
+++ b/.github/scripts/compare-llvm-lines.sh
@@ -52,6 +52,6 @@ printf "| %+d | %s | %s | (TOTAL) |\n" "$delta_total" "$current_total" "$baselin
 join -t$'\t' -j 2 -a1 -a2 -e 0 -o 0,1.1,2.1 \
   "$current_parsed_file" "$baseline_parsed_file" | \
   awk -F'\t' '{delta=$2-$3; printf "%d\t%s\t%s\t%s\n", delta, $2, $3, $1}' | \
-  sort -t$'\t' -rn | \
+  sort -t$'\t' -k1,1rn -k2,2rn | \
   awk -F'\t' '{printf "| %+d | %s | %s | %s |\n", $1, $2, $3, $4}'
 echo ""

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,7 +487,8 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
-  # LLVM IR bloat check: compare monomorphization cost against baseline
+  # LLVM IR bloat check: compare monomorphization cost against baseline.
+  # This job is not part of the required CI gate, so it won't block PR merges.
   llvm-lines:
     needs: basics
     name: LLVM Lines Regression Check
@@ -522,11 +523,11 @@ jobs:
 
       - name: Generate baseline LLVM lines
         working-directory: baseline
-        run: cargo llvm-lines --package diskann-benchmark --release --features "$DISKANN_FEATURES" | head -100 | tee ../baseline-llvm-lines.txt
+        run: cargo llvm-lines --package diskann-benchmark --release | head -100 | tee ../baseline-llvm-lines.txt
 
       - name: Generate current LLVM lines
         working-directory: diskann_rust
-        run: cargo llvm-lines --package diskann-benchmark --release --features "$DISKANN_FEATURES" | head -100 | tee ../current-llvm-lines.txt
+        run: cargo llvm-lines --package diskann-benchmark --release | head -100 | tee ../current-llvm-lines.txt
 
       - name: Compare LLVM lines
         run: |
@@ -534,9 +535,10 @@ jobs:
           current_total=$(awk '/\(TOTAL\)/{print $1}' current-llvm-lines.txt)
           growth=$(( (current_total - baseline_total) * 100 / baseline_total ))
 
-          if [ "$growth" -gt "$LLVM_LINES_GROWTH_THRESHOLD" ]; then
-            echo "::warning::LLVM IR grew ${growth}% ($baseline_total → $current_total lines)"
-          fi
-
           diskann_rust/.github/scripts/compare-llvm-lines.sh baseline-llvm-lines.txt current-llvm-lines.txt | head -100 | tee /tmp/llvm-lines-report.txt
           cat /tmp/llvm-lines-report.txt >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$growth" -gt "$LLVM_LINES_GROWTH_THRESHOLD" ]; then
+            echo "::error::LLVM IR grew ${growth}% ($baseline_total → $current_total lines), threshold is ${LLVM_LINES_GROWTH_THRESHOLD}%"
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,7 +530,7 @@ jobs:
         run: cargo llvm-lines --package diskann-benchmark --release | head -100 | tee ../current-llvm-lines.txt
 
       - name: Compare LLVM lines
-        run: diskann_rust/.github/scripts/compare-llvm-lines.sh baseline-llvm-lines.txt current-llvm-lines.txt
+        run: bash diskann_rust/.github/scripts/compare-llvm-lines.sh baseline-llvm-lines.txt current-llvm-lines.txt
 
       - name: Check LLVM lines growth threshold
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -499,7 +499,7 @@ jobs:
       - name: Checkout current branch
         uses: actions/checkout@v4
         with:
-          path: diskann_rust
+          path: pr
 
       - name: Checkout baseline (main)
         uses: actions/checkout@v4
@@ -510,7 +510,7 @@ jobs:
       - name: Install Rust
         shell: bash
         run: rustup show
-        working-directory: diskann_rust
+        working-directory: pr
 
       - name: Install cargo-llvm-lines
         run: cargo install cargo-llvm-lines --locked
@@ -518,7 +518,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           workspaces: |
-            diskann_rust -> target
+            pr -> target
             baseline -> target
 
       - name: Generate baseline LLVM lines
@@ -526,11 +526,11 @@ jobs:
         run: cargo llvm-lines --package diskann-benchmark --release | head -100 | tee ../baseline-llvm-lines.txt
 
       - name: Generate current LLVM lines
-        working-directory: diskann_rust
+        working-directory: pr
         run: cargo llvm-lines --package diskann-benchmark --release | head -100 | tee ../current-llvm-lines.txt
 
       - name: Compare LLVM lines
-        run: bash diskann_rust/.github/scripts/compare-llvm-lines.sh baseline-llvm-lines.txt current-llvm-lines.txt
+        run: bash pr/.github/scripts/compare-llvm-lines.sh baseline-llvm-lines.txt current-llvm-lines.txt
 
       - name: Check LLVM lines growth threshold
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,3 +487,56 @@ jobs:
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
+  # LLVM IR bloat check: compare monomorphization cost against baseline
+  llvm-lines:
+    needs: basics
+    name: LLVM Lines Regression Check
+    runs-on: ubuntu-latest
+    env:
+      LLVM_LINES_GROWTH_THRESHOLD: 5
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          path: diskann_rust
+
+      - name: Checkout baseline (main)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: baseline
+
+      - name: Install Rust
+        shell: bash
+        run: rustup show
+        working-directory: diskann_rust
+
+      - name: Install cargo-llvm-lines
+        run: cargo install cargo-llvm-lines --locked
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            diskann_rust -> target
+            baseline -> target
+
+      - name: Generate baseline LLVM lines
+        working-directory: baseline
+        run: cargo llvm-lines --package diskann-benchmark --release | head -100 | tee ../baseline-llvm-lines.txt
+
+      - name: Generate current LLVM lines
+        working-directory: diskann_rust
+        run: cargo llvm-lines --package diskann-benchmark --release | head -100 | tee ../current-llvm-lines.txt
+
+      - name: Compare LLVM lines
+        run: |
+          baseline_total=$(awk '/\(TOTAL\)/{print $1}' baseline-llvm-lines.txt)
+          current_total=$(awk '/\(TOTAL\)/{print $1}' current-llvm-lines.txt)
+          growth=$(( (current_total - baseline_total) * 100 / baseline_total ))
+
+          if [ "$growth" -gt "$LLVM_LINES_GROWTH_THRESHOLD" ]; then
+            echo "::warning::LLVM IR grew ${growth}% ($baseline_total → $current_total lines)"
+          fi
+
+          diskann_rust/.github/scripts/compare-llvm-lines.sh baseline-llvm-lines.txt current-llvm-lines.txt | head -100 | tee /tmp/llvm-lines-report.txt
+          cat /tmp/llvm-lines-report.txt >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -490,6 +490,7 @@ jobs:
   # LLVM IR bloat check: compare monomorphization cost against baseline.
   # This job is not part of the required CI gate, so it won't block PR merges.
   llvm-lines:
+    if: github.event_name == 'pull_request'
     needs: basics
     name: LLVM Lines Regression Check
     runs-on: ubuntu-latest
@@ -501,10 +502,10 @@ jobs:
         with:
           path: pr
 
-      - name: Checkout baseline (main)
+      - name: Checkout base ref
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.event.pull_request.base.sha }}
           path: baseline
 
       - name: Install Rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,11 +523,11 @@ jobs:
 
       - name: Generate baseline LLVM lines
         working-directory: baseline
-        run: cargo llvm-lines --package diskann-benchmark --release | head -100 | tee ../baseline-llvm-lines.txt
+        run: cargo llvm-lines --package diskann-benchmark --all-features --release | head -100 | tee ../baseline-llvm-lines.txt
 
       - name: Generate current LLVM lines
         working-directory: pr
-        run: cargo llvm-lines --package diskann-benchmark --release | head -100 | tee ../current-llvm-lines.txt
+        run: cargo llvm-lines --package diskann-benchmark --all-features --release | head -100 | tee ../current-llvm-lines.txt
 
       - name: Compare LLVM lines
         run: bash pr/.github/scripts/compare-llvm-lines.sh baseline-llvm-lines.txt current-llvm-lines.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -522,11 +522,11 @@ jobs:
 
       - name: Generate baseline LLVM lines
         working-directory: baseline
-        run: cargo llvm-lines --package diskann-benchmark --release | head -100 | tee ../baseline-llvm-lines.txt
+        run: cargo llvm-lines --package diskann-benchmark --release --features "$DISKANN_FEATURES" | head -100 | tee ../baseline-llvm-lines.txt
 
       - name: Generate current LLVM lines
         working-directory: diskann_rust
-        run: cargo llvm-lines --package diskann-benchmark --release | head -100 | tee ../current-llvm-lines.txt
+        run: cargo llvm-lines --package diskann-benchmark --release --features "$DISKANN_FEATURES" | head -100 | tee ../current-llvm-lines.txt
 
       - name: Compare LLVM lines
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -530,13 +530,13 @@ jobs:
         run: cargo llvm-lines --package diskann-benchmark --release | head -100 | tee ../current-llvm-lines.txt
 
       - name: Compare LLVM lines
+        run: diskann_rust/.github/scripts/compare-llvm-lines.sh baseline-llvm-lines.txt current-llvm-lines.txt
+
+      - name: Check LLVM lines growth threshold
         run: |
           baseline_total=$(awk '/\(TOTAL\)/{print $1}' baseline-llvm-lines.txt)
           current_total=$(awk '/\(TOTAL\)/{print $1}' current-llvm-lines.txt)
           growth=$(( (current_total - baseline_total) * 100 / baseline_total ))
-
-          diskann_rust/.github/scripts/compare-llvm-lines.sh baseline-llvm-lines.txt current-llvm-lines.txt | head -100 | tee /tmp/llvm-lines-report.txt
-          cat /tmp/llvm-lines-report.txt >> "$GITHUB_STEP_SUMMARY"
 
           if [ "$growth" -gt "$LLVM_LINES_GROWTH_THRESHOLD" ]; then
             echo "::error::LLVM IR grew ${growth}% ($baseline_total → $current_total lines), threshold is ${LLVM_LINES_GROWTH_THRESHOLD}%"


### PR DESCRIPTION
This pull request introduces an automated check in the CI workflow to monitor and report on LLVM IR code size growth, helping to detect regressions in monomorphization cost. The main changes include adding a new CI job and a supporting shell script for comparing LLVM IR line counts between the current branch and the baseline.

**CI workflow enhancements:**

* Added a new `llvm-lines` job to `.github/workflows/ci.yml` that compares the LLVM IR line counts of the current branch against the `main` branch using `cargo-llvm-lines`. This job is not required for PR merges but provides regression reports and enforces a configurable growth threshold.

**Supporting scripts:**

* Introduced `.github/scripts/compare-llvm-lines.sh`, a Bash script that parses and compares the output of `cargo-llvm-lines` for the baseline and current builds, generating a markdown-formatted regression report for easier review.