### PR TITLE
Fix options for diskann-garnet nuget pipeline

### DIFF
--- a/.github/workflows/publish-diskann-garnet-nuget.yml
+++ b/.github/workflows/publish-diskann-garnet-nuget.yml
@@ -27,7 +27,7 @@ jobs:
             lib-path: target/release/libdiskann_garnet.so
           - os: windows-latest
             env:
-              EXTRA_RUSTFLAGS: control-flow-guard
+              EXTRA_RUSTFLAGS: -C control-flow-guard
             artifact-name: windows
             lib-path: target/release/diskann_garnet.dll
             pdb-path: target/release/diskann_garnet.pdb
@@ -40,7 +40,7 @@ jobs:
         env:
           RUSTC_BOOTSTRAP: 1
           # NOTE: this overrides flags in /.cargo/config.toml so those must be manually merged in here.
-          RUSTFLAGS: -Z stack-protector=all,target-cpu=x86-64-v3${{ env.EXTRA_RUSTFLAGS && format(',{0}', env.EXTRA_RUSTFLAGS) || '' }}
+          RUSTFLAGS: -Z stack-protector=all -C target-cpu=x86-64-v3 ${{ env.EXTRA_RUSTFLAGS }}
         run: cargo build --locked --release --package diskann-garnet
 
       - name: Stage native library


### PR DESCRIPTION
`-Z` flags must be specified individually and can't be combined. This corrects the syntax.