### PR TITLE
Remove direct accessor call in `diskann-garnet`

### DIFF
--- a/diskann-garnet/src/dyn_index.rs
+++ b/diskann-garnet/src/dyn_index.rs
@@ -7,12 +7,12 @@ use crate::{
     SearchResults,
     garnet::{Context, GarnetId},
     labels::GarnetQueryLabelProvider,
-    provider::{self, GarnetProvider},
+    provider::GarnetProvider,
 };
 use diskann::{
-    ANNError, ANNResult,
-    graph::{InplaceDeleteMethod, glue::SearchStrategy, index::SearchStats, search},
-    provider::{Accessor, DataProvider},
+    ANNResult,
+    graph::{InplaceDeleteMethod, index::SearchStats, search},
+    provider::DataProvider,
     utils::VectorRepr,
 };
 use diskann_providers::{
@@ -102,19 +102,9 @@ impl<T: VectorRepr> DynIndex for DiskANNIndex<GarnetProvider<T>> {
         filter: Option<(&GarnetQueryLabelProvider, f32)>,
         output: &mut SearchResults<'_>,
     ) -> ANNResult<SearchStats> {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .build()
-            .map_err(|e| ANNError::new(diskann::ANNErrorKind::Opaque, e))?;
-        let mut accessor: provider::FullAccessor<'_, T> =
-            <FullPrecision as SearchStrategy<_, _>>::search_accessor(
-                &FullPrecision,
-                self.inner.provider(),
-                context,
-            )?;
-
         // Look up internal ID
         let iid = self.inner.provider().to_internal_id(context, id)?;
-        let data = rt.block_on(accessor.get_element(iid))?;
+        let data = self.inner.provider().get_vector(context, iid)?;
         let data_bytes = bytemuck::cast_slice::<T, u8>(&data);
         self.search_vector(context, data_bytes, params, filter, output)
     }

--- a/diskann-garnet/src/provider.rs
+++ b/diskann-garnet/src/provider.rs
@@ -240,6 +240,33 @@ impl<T: VectorRepr> GarnetProvider<T> {
     pub fn max_internal_id(&self) -> u32 {
         self.fsm.max_id()
     }
+
+    pub(crate) fn get_vector(
+        &self,
+        context: &Context,
+        iid: u32,
+    ) -> Result<Vec<T>, GarnetProviderError> {
+        let mut v = vec![T::default(); self.dim];
+
+        if iid == 0 {
+            let guard = if let Some(r) = self.start_point_cache.get(&iid) {
+                r
+            } else {
+                return Err(GarnetError::Read.into());
+            };
+            v.copy_from_slice(&guard);
+            return Ok(v);
+        }
+
+        if !self
+            .callbacks
+            .read_single_iid(context.term(Term::Vector), iid, &mut v)
+        {
+            return Err(GarnetError::Read.into());
+        }
+
+        Ok(v)
+    }
 }
 
 impl<T: VectorRepr> DataProvider for GarnetProvider<T> {
@@ -531,27 +558,7 @@ impl<T: VectorRepr> Accessor for FullAccessor<'_, T> {
         &mut self,
         id: Self::Id,
     ) -> impl Future<Output = Result<Self::Element<'_>, Self::GetError>> + Send {
-        let mut v = vec![T::default(); self.provider.dim];
-
-        if id == 0 {
-            let guard = if let Some(r) = self.provider.start_point_cache.get(&id) {
-                r
-            } else {
-                return future::ready(Err(GarnetError::Read.into()));
-            };
-            v.copy_from_slice(&guard);
-            return future::ready(Ok(v));
-        }
-
-        if !self
-            .provider
-            .callbacks
-            .read_single_iid(self.context.term(Term::Vector), id, &mut v)
-        {
-            return future::ready(Err(GarnetError::Read.into()));
-        }
-
-        future::ready(Ok(v))
+        std::future::ready(self.provider.get_vector(self.context, id))
     }
 }
 


### PR DESCRIPTION
In preparation for #1067, switch the implementation of `DynIndex::search_element` from using the `Accessor` trait to an inherent method on the underlying provider.