### PR TITLE
Add Documentation DO/DON'T section in `agents.md`

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -219,11 +219,11 @@ Less is more. Documentation goes out of date; rustdoc-generated output doesn't. 
 **DO**:
 - Document non-obvious behavior, errors, safety, and design intent
 - Use `# Errors`, `# Safety`, `# Panics`, `# Example` sections
+- Keep documentation for internal `pub(crate)` / `pub(super)` items concise and additive; critical items should still receive full documentation
 
 **DON'T**:
 - Maintain explicit lists of types/functions in module-level docs
 - Restate what the signature already shows (e.g. "owns an `Arc<T>`" on a struct whose only field is `Arc<T>`)
-- Document internal `pub(crate)` / `pub(super)` items unless intent isn't obvious from usage
 
 ---
 

--- a/agents.md
+++ b/agents.md
@@ -214,19 +214,16 @@ CI workflow is defined in [`.github/workflows/ci.yml`](.github/workflows/ci.yml)
 
 ### Documentation
 
-Less is more. Documentation goes out of date; rustdoc-generated output
-doesn't. Build with `cargo doc --no-deps` and read the rendered page to see
-what rustdoc already provides for free (type listings, signatures,
-re-exports, intra-doc links).
+Less is more. Documentation goes out of date; rustdoc-generated output doesn't. Don't duplicate what rustdoc already provides for free (type listings, signatures, re-exports, intra-doc links).
 
 **DO**:
-- Document non-obvious *behavior*, *errors*, *safety*, and *design intent*.
-- Use `# Errors`, `# Safety`, `# Panics`, `# Example` sections.
+- Document non-obvious behavior, errors, safety, and design intent
+- Use `# Errors`, `# Safety`, `# Panics`, `# Example` sections
 
 **DON'T**:
-- Maintain explicit lists of types/functions in module-level docs.
-- Restate what the signature already shows (e.g. "owns an `Arc<T>`" on a struct whose only field is `Arc<T>`).
-- Document internal `pub(crate)` / `pub(super)` items unless intent isn't obvious from usage.
+- Maintain explicit lists of types/functions in module-level docs
+- Restate what the signature already shows (e.g. "owns an `Arc<T>`" on a struct whose only field is `Arc<T>`)
+- Document internal `pub(crate)` / `pub(super)` items unless intent isn't obvious from usage
 
 ---
 

--- a/agents.md
+++ b/agents.md
@@ -212,6 +212,22 @@ CI workflow is defined in [`.github/workflows/ci.yml`](.github/workflows/ci.yml)
 - Add tests for derived traits (Clone, Debug, PartialEq)
 - Add tests for enums unless they have explicit functionality
 
+### Documentation
+
+Less is more. Documentation goes out of date; rustdoc-generated output
+doesn't. Build with `cargo doc --no-deps` and read the rendered page to see
+what rustdoc already provides for free (type listings, signatures,
+re-exports, intra-doc links).
+
+**DO**:
+- Document non-obvious *behavior*, *errors*, *safety*, and *design intent*.
+- Use `# Errors`, `# Safety`, `# Panics`, `# Example` sections.
+
+**DON'T**:
+- Maintain explicit lists of types/functions in module-level docs.
+- Restate what the signature already shows (e.g. "owns an `Arc<T>`" on a struct whose only field is `Arc<T>`).
+- Document internal `pub(crate)` / `pub(super)` items unless intent isn't obvious from usage.
+
 ---
 
 ## Pre-commit Checklist


### PR DESCRIPTION
Adds a `Documentation` DO/DON'T section to `agents.md` alongside the existing `Test Patterns` block.

Surfaced during review of #1027 and other PRs, where module- and item-level docs drifted toward manually-maintained type listings and signature restatements. New section captures the "less is more" framing, reminds agents not to duplicate what rustdoc already provides, and codifies the three patterns the reviewer called out as noise.
