### PR TITLE
compute_vecs_l2sq: Replace scalar L2 Squared norm with SIMD-optimized FastL2NormSquared

### DIFF
--- a/diskann-disk/benches/benchmarks/kmeans_bench.rs
+++ b/diskann-disk/benches/benchmarks/kmeans_bench.rs
@@ -39,6 +39,7 @@ pub fn benchmark_kmeans(c: &mut Criterion) {
                     &mut false,
                     pool.as_ref(),
                 )
+                .expect("k_means_clustering call failed");
             },
             BatchSize::SmallInput,
         )
@@ -48,7 +49,8 @@ pub fn benchmark_kmeans(c: &mut Criterion) {
         f.iter_batched(
             || (data.clone(), vec![0.0f32; NUM_POINTS]),
             |(data_copy, mut docs_l2sq)| {
-                compute_vecs_l2sq(&mut docs_l2sq, &data_copy, DIM, pool.as_ref()).unwrap();
+                compute_vecs_l2sq(&mut docs_l2sq, &data_copy, DIM, pool.as_ref())
+                    .expect("compute_vecs_l2sq call failed");
             },
             BatchSize::SmallInput,
         )

--- a/diskann-disk/benches/benchmarks/kmeans_bench.rs
+++ b/diskann-disk/benches/benchmarks/kmeans_bench.rs
@@ -3,15 +3,64 @@
  * Licensed under the MIT license.
  */
 
-use criterion::Criterion;
+use criterion::{BatchSize, Criterion};
+use diskann::{ANNError, ANNResult};
 use diskann_disk::utils::{compute_vecs_l2sq, k_means_clustering};
 use diskann_providers::utils::{create_thread_pool_for_bench, RayonThreadPoolRef};
 use rand::Rng;
+use rayon::prelude::*;
+
+use diskann_providers::utils::ParallelIteratorInPool;
 
 const NUM_POINTS: usize = 100000;
 const DIM: usize = 4;
 const NUM_CENTERS: usize = 256;
 const MAX_KMEANS_REPS: usize = 12;
+
+/// Original scalar implementation for comparison.
+fn compute_vecs_l2sq_scalar(
+    vecs_l2sq: &mut [f32],
+    data: &[f32],
+    dim: usize,
+    pool: RayonThreadPoolRef<'_>,
+) -> ANNResult<()> {
+    if dim == 0 {
+        return Err(ANNError::log_index_error(format_args!(
+            "dim must be non-zero"
+        )));
+    }
+
+    let expected_data_len = vecs_l2sq.len().checked_mul(dim).ok_or_else(|| {
+        ANNError::log_index_error(format_args!(
+            "vecs_l2sq.len() * dim overflowed: vecs_l2sq.len() ({}) * dim ({})",
+            vecs_l2sq.len(),
+            dim
+        ))
+    })?;
+
+    if data.len() != expected_data_len {
+        return Err(ANNError::log_index_error(format_args!(
+            "data.len() ({}) should be vecs_l2sq.len() ({}) * dim ({})",
+            data.len(),
+            vecs_l2sq.len(),
+            dim
+        )));
+    }
+
+    if dim < 5 {
+        for (vec_l2sq, chunk) in vecs_l2sq.iter_mut().zip(data.chunks_exact(dim)) {
+            *vec_l2sq = chunk.iter().map(|v| v * v).sum();
+        }
+    } else {
+        vecs_l2sq
+            .par_iter_mut()
+            .zip(data.par_chunks_exact(dim))
+            .for_each_in_pool(pool, |(vec_l2sq, chunk)| {
+                *vec_l2sq = chunk.iter().map(|v| v * v).sum();
+            });
+    }
+    Ok(())
+}
 
 pub fn benchmark_kmeans(c: &mut Criterion) {
     let rng = &mut diskann_providers::utils::create_rnd_from_seed(42);
@@ -25,33 +74,42 @@ pub fn benchmark_kmeans(c: &mut Criterion) {
     group.sample_size(50);
 
     group.bench_function("K-Means Rust Run", |f| {
-        f.iter(|| {
-            let data_copy = data.clone();
-            let mut centers_copy = centers.clone();
-            k_means_clustering(
-                &data_copy,
-                NUM_POINTS,
-                DIM,
-                &mut centers_copy,
-                NUM_CENTERS,
-                MAX_KMEANS_REPS,
-                rng,
-                &mut false,
-                pool.as_ref(),
-            )
-        })
+        f.iter_batched(
+            || (data.clone(), centers.clone()),
+            |(data_copy, mut centers_copy)| {
+                k_means_clustering(
+                    &data_copy,
+                    NUM_POINTS,
+                    DIM,
+                    &mut centers_copy,
+                    NUM_CENTERS,
+                    MAX_KMEANS_REPS,
+                    rng,
+                    &mut false,
+                    pool.as_ref(),
+                )
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    group.bench_function("Snrm2 Scalar", |f| {
+        f.iter_batched(
+            || (data.clone(), vec![0.0f32; NUM_POINTS]),
+            |(data_copy, mut docs_l2sq)| {
+                compute_vecs_l2sq_scalar(&mut docs_l2sq, &data_copy, DIM, pool.as_ref()).unwrap();
+            },
+            BatchSize::SmallInput,
+        )
     });
 
     group.bench_function("Snrm2 Rust Run", |f| {
-        f.iter(|| {
-            let data_copy = data.clone();
-            snrm2_benchmark_rust(&data_copy, NUM_POINTS, DIM, pool.as_ref());
-        })
+        f.iter_batched(
+            || (data.clone(), vec![0.0f32; NUM_POINTS]),
+            |(data_copy, mut docs_l2sq)| {
+                compute_vecs_l2sq(&mut docs_l2sq, &data_copy, DIM, pool.as_ref()).unwrap();
+            },
+            BatchSize::SmallInput,
+        )
     });
-}
-
-/// compute_vecs_l2sq benchmark
-fn snrm2_benchmark_rust(data: &[f32], num_points: usize, dim: usize, pool: RayonThreadPoolRef<'_>) {
-    let mut docs_l2sq = vec![0.0; num_points];
-    compute_vecs_l2sq(&mut docs_l2sq, data, dim, pool).unwrap();
 }

--- a/diskann-disk/benches/benchmarks/kmeans_bench.rs
+++ b/diskann-disk/benches/benchmarks/kmeans_bench.rs
@@ -4,63 +4,14 @@
  */
 
 use criterion::{BatchSize, Criterion};
-use diskann::{ANNError, ANNResult};
 use diskann_disk::utils::{compute_vecs_l2sq, k_means_clustering};
-use diskann_providers::utils::{create_thread_pool_for_bench, RayonThreadPoolRef};
+use diskann_providers::utils::create_thread_pool_for_bench;
 use rand::Rng;
-use rayon::prelude::*;
-
-use diskann_providers::utils::ParallelIteratorInPool;
 
 const NUM_POINTS: usize = 100000;
 const DIM: usize = 4;
 const NUM_CENTERS: usize = 256;
 const MAX_KMEANS_REPS: usize = 12;
-
-/// Original scalar implementation for comparison.
-fn compute_vecs_l2sq_scalar(
-    vecs_l2sq: &mut [f32],
-    data: &[f32],
-    dim: usize,
-    pool: RayonThreadPoolRef<'_>,
-) -> ANNResult<()> {
-    if dim == 0 {
-        return Err(ANNError::log_index_error(format_args!(
-            "dim must be non-zero"
-        )));
-    }
-
-    let expected_data_len = vecs_l2sq.len().checked_mul(dim).ok_or_else(|| {
-        ANNError::log_index_error(format_args!(
-            "vecs_l2sq.len() * dim overflowed: vecs_l2sq.len() ({}) * dim ({})",
-            vecs_l2sq.len(),
-            dim
-        ))
-    })?;
-
-    if data.len() != expected_data_len {
-        return Err(ANNError::log_index_error(format_args!(
-            "data.len() ({}) should be vecs_l2sq.len() ({}) * dim ({})",
-            data.len(),
-            vecs_l2sq.len(),
-            dim
-        )));
-    }
-
-    if dim < 5 {
-        for (vec_l2sq, chunk) in vecs_l2sq.iter_mut().zip(data.chunks_exact(dim)) {
-            *vec_l2sq = chunk.iter().map(|v| v * v).sum();
-        }
-    } else {
-        vecs_l2sq
-            .par_iter_mut()
-            .zip(data.par_chunks_exact(dim))
-            .for_each_in_pool(pool, |(vec_l2sq, chunk)| {
-                *vec_l2sq = chunk.iter().map(|v| v * v).sum();
-            });
-    }
-    Ok(())
-}
 
 pub fn benchmark_kmeans(c: &mut Criterion) {
     let rng = &mut diskann_providers::utils::create_rnd_from_seed(42);
@@ -88,16 +39,6 @@ pub fn benchmark_kmeans(c: &mut Criterion) {
                     &mut false,
                     pool.as_ref(),
                 )
-            },
-            BatchSize::SmallInput,
-        )
-    });
-
-    group.bench_function("Snrm2 Scalar", |f| {
-        f.iter_batched(
-            || (data.clone(), vec![0.0f32; NUM_POINTS]),
-            |(data_copy, mut docs_l2sq)| {
-                compute_vecs_l2sq_scalar(&mut docs_l2sq, &data_copy, DIM, pool.as_ref()).unwrap();
             },
             BatchSize::SmallInput,
         )

--- a/diskann-disk/benches/benchmarks_iai/kmeans_bench_iai.rs
+++ b/diskann-disk/benches/benchmarks_iai/kmeans_bench_iai.rs
@@ -3,9 +3,18 @@
  * Licensed under the MIT license.
  */
 
+use std::hint::black_box;
+
+use diskann::{ANNError, ANNResult};
 use diskann_disk::utils::{compute_vecs_l2sq, k_means_clustering};
-use diskann_providers::utils::create_thread_pool_for_bench;
+use diskann_providers::utils::{
+    create_thread_pool_for_bench, ParallelIteratorInPool, RayonThreadPool, RayonThreadPoolRef,
+};
 use rand::Rng;
+use rayon::{
+    iter::{IndexedParallelIterator, IntoParallelRefMutIterator},
+    slice::ParallelSlice,
+};
 
 const NUM_POINTS: usize = 100000;
 const DIM: usize = 4;
@@ -14,30 +23,75 @@ const MAX_KMEANS_REPS: usize = 12;
 
 iai_callgrind::library_benchmark_group!(
     name = kmeans_bench_iai;
-    benchmarks = benchmark_kmeans_iai, snrm2_benchmark_rust_iai,
+    benchmarks = benchmark_kmeans_iai, snrm2_benchmark_rust_iai, snrm2_benchmark_scalar_iai,
 );
 
-fn setup_data() -> Vec<f32> {
+/// Original scalar implementation for comparison.
+fn compute_vecs_l2sq_scalar(
+    vecs_l2sq: &mut [f32],
+    data: &[f32],
+    dim: usize,
+    pool: RayonThreadPoolRef<'_>,
+) -> ANNResult<()> {
+    if dim == 0 {
+        return Err(ANNError::log_index_error(format_args!(
+            "dim must be non-zero"
+        )));
+    }
+
+    let expected_data_len = vecs_l2sq.len().checked_mul(dim).ok_or_else(|| {
+        ANNError::log_index_error(format_args!(
+            "vecs_l2sq.len() * dim overflowed: vecs_l2sq.len() ({}) * dim ({})",
+            vecs_l2sq.len(),
+            dim
+        ))
+    })?;
+
+    if data.len() != expected_data_len {
+        return Err(ANNError::log_index_error(format_args!(
+            "data.len() ({}) should be vecs_l2sq.len() ({}) * dim ({})",
+            data.len(),
+            vecs_l2sq.len(),
+            dim
+        )));
+    }
+
+    if dim < 5 {
+        for (vec_l2sq, chunk) in vecs_l2sq.iter_mut().zip(data.chunks_exact(dim)) {
+            *vec_l2sq = chunk.iter().map(|v| v * v).sum();
+        }
+    } else {
+        vecs_l2sq
+            .par_iter_mut()
+            .zip(data.par_chunks_exact(dim))
+            .for_each_in_pool(pool, |(vec_l2sq, chunk)| {
+                *vec_l2sq = chunk.iter().map(|v| v * v).sum();
+            });
+    }
+    Ok(())
+}
+
+fn setup_data() -> (Vec<f32>, RayonThreadPool) {
     let rng = &mut diskann_providers::utils::create_rnd_from_seed(42);
     let data: Vec<f32> = (0..NUM_POINTS * DIM)
         .map(|_| rng.random_range(-1.0..1.0))
         .collect();
+    let pool = create_thread_pool_for_bench();
 
-    data
+    (data, pool)
 }
 #[iai_callgrind::library_benchmark(setup = setup_data)]
-pub fn benchmark_kmeans_iai(data: Vec<f32>) {
-    let pool = create_thread_pool_for_bench();
+pub fn benchmark_kmeans_iai((data, pool): (Vec<f32>, RayonThreadPool)) {
     let centers: Vec<f32> = vec![0.0; NUM_CENTERS * DIM];
     let rng = &mut diskann_providers::utils::create_rnd_from_seed(42);
 
     let data_copy = data.clone();
     let mut centers_copy = centers.clone();
     k_means_clustering(
-        &data_copy,
+        black_box(&data_copy),
         NUM_POINTS,
         DIM,
-        &mut centers_copy,
+        black_box(&mut centers_copy),
         NUM_CENTERS,
         MAX_KMEANS_REPS,
         rng,
@@ -45,20 +99,19 @@ pub fn benchmark_kmeans_iai(data: Vec<f32>) {
         pool.as_ref(),
     )
     .unwrap();
-
-    let data_copy = data.clone();
-    snrm2_benchmark_rust(&data_copy, NUM_POINTS, DIM);
+    black_box(centers_copy);
 }
 
 #[iai_callgrind::library_benchmark(setup = setup_data)]
-pub fn snrm2_benchmark_rust_iai(data: Vec<f32>) {
-    let data_copy = data.clone();
-    snrm2_benchmark_rust(&data_copy, NUM_POINTS, DIM);
+pub fn snrm2_benchmark_rust_iai((data, pool): (Vec<f32>, RayonThreadPool)) {
+    let mut docs_l2sq = vec![0.0; NUM_POINTS];
+    compute_vecs_l2sq(&mut docs_l2sq, black_box(&data), DIM, pool.as_ref()).unwrap();
+    black_box(docs_l2sq);
 }
 
-/// compute_vecs_l2sq benchmark
-pub fn snrm2_benchmark_rust(data: &[f32], num_points: usize, dim: usize) {
-    let mut docs_l2sq = vec![0.0; num_points];
-    let pool = create_thread_pool_for_bench();
-    compute_vecs_l2sq(&mut docs_l2sq, data, dim, pool.as_ref()).unwrap();
+#[iai_callgrind::library_benchmark(setup = setup_data)]
+pub fn snrm2_benchmark_scalar_iai((data, pool): (Vec<f32>, RayonThreadPool)) {
+    let mut docs_l2sq = vec![0.0; NUM_POINTS];
+    compute_vecs_l2sq_scalar(&mut docs_l2sq, black_box(&data), DIM, pool.as_ref()).unwrap();
+    black_box(docs_l2sq);
 }

--- a/diskann-disk/benches/benchmarks_iai/kmeans_bench_iai.rs
+++ b/diskann-disk/benches/benchmarks_iai/kmeans_bench_iai.rs
@@ -43,13 +43,14 @@ pub fn benchmark_kmeans_iai((data, pool): (Vec<f32>, RayonThreadPool)) {
         &mut false,
         pool.as_ref(),
     )
-    .unwrap();
+    .expect("k_means_clustering call failed");
     black_box(centers);
 }
 
 #[iai_callgrind::library_benchmark(setup = setup_data)]
 pub fn snrm2_benchmark_rust_iai((data, pool): (Vec<f32>, RayonThreadPool)) {
     let mut docs_l2sq = vec![0.0; NUM_POINTS];
-    compute_vecs_l2sq(&mut docs_l2sq, black_box(&data), DIM, pool.as_ref()).unwrap();
+    compute_vecs_l2sq(&mut docs_l2sq, black_box(&data), DIM, pool.as_ref())
+        .expect("compute_vecs_l2sq call failed");
     black_box(docs_l2sq);
 }

--- a/diskann-disk/benches/benchmarks_iai/kmeans_bench_iai.rs
+++ b/diskann-disk/benches/benchmarks_iai/kmeans_bench_iai.rs
@@ -5,16 +5,9 @@
 
 use std::hint::black_box;
 
-use diskann::{ANNError, ANNResult};
 use diskann_disk::utils::{compute_vecs_l2sq, k_means_clustering};
-use diskann_providers::utils::{
-    create_thread_pool_for_bench, ParallelIteratorInPool, RayonThreadPool, RayonThreadPoolRef,
-};
+use diskann_providers::utils::{create_thread_pool_for_bench, RayonThreadPool};
 use rand::Rng;
-use rayon::{
-    iter::{IndexedParallelIterator, IntoParallelRefMutIterator},
-    slice::ParallelSlice,
-};
 
 const NUM_POINTS: usize = 100000;
 const DIM: usize = 4;
@@ -23,53 +16,8 @@ const MAX_KMEANS_REPS: usize = 12;
 
 iai_callgrind::library_benchmark_group!(
     name = kmeans_bench_iai;
-    benchmarks = benchmark_kmeans_iai, snrm2_benchmark_rust_iai, snrm2_benchmark_scalar_iai,
+    benchmarks = benchmark_kmeans_iai, snrm2_benchmark_rust_iai,
 );
-
-/// Original scalar implementation for comparison.
-fn compute_vecs_l2sq_scalar(
-    vecs_l2sq: &mut [f32],
-    data: &[f32],
-    dim: usize,
-    pool: RayonThreadPoolRef<'_>,
-) -> ANNResult<()> {
-    if dim == 0 {
-        return Err(ANNError::log_index_error(format_args!(
-            "dim must be non-zero"
-        )));
-    }
-
-    let expected_data_len = vecs_l2sq.len().checked_mul(dim).ok_or_else(|| {
-        ANNError::log_index_error(format_args!(
-            "vecs_l2sq.len() * dim overflowed: vecs_l2sq.len() ({}) * dim ({})",
-            vecs_l2sq.len(),
-            dim
-        ))
-    })?;
-
-    if data.len() != expected_data_len {
-        return Err(ANNError::log_index_error(format_args!(
-            "data.len() ({}) should be vecs_l2sq.len() ({}) * dim ({})",
-            data.len(),
-            vecs_l2sq.len(),
-            dim
-        )));
-    }
-
-    if dim < 5 {
-        for (vec_l2sq, chunk) in vecs_l2sq.iter_mut().zip(data.chunks_exact(dim)) {
-            *vec_l2sq = chunk.iter().map(|v| v * v).sum();
-        }
-    } else {
-        vecs_l2sq
-            .par_iter_mut()
-            .zip(data.par_chunks_exact(dim))
-            .for_each_in_pool(pool, |(vec_l2sq, chunk)| {
-                *vec_l2sq = chunk.iter().map(|v| v * v).sum();
-            });
-    }
-    Ok(())
-}
 
 fn setup_data() -> (Vec<f32>, RayonThreadPool) {
     let rng = &mut diskann_providers::utils::create_rnd_from_seed(42);
@@ -106,12 +54,5 @@ pub fn benchmark_kmeans_iai((data, pool): (Vec<f32>, RayonThreadPool)) {
 pub fn snrm2_benchmark_rust_iai((data, pool): (Vec<f32>, RayonThreadPool)) {
     let mut docs_l2sq = vec![0.0; NUM_POINTS];
     compute_vecs_l2sq(&mut docs_l2sq, black_box(&data), DIM, pool.as_ref()).unwrap();
-    black_box(docs_l2sq);
-}
-
-#[iai_callgrind::library_benchmark(setup = setup_data)]
-pub fn snrm2_benchmark_scalar_iai((data, pool): (Vec<f32>, RayonThreadPool)) {
-    let mut docs_l2sq = vec![0.0; NUM_POINTS];
-    compute_vecs_l2sq_scalar(&mut docs_l2sq, black_box(&data), DIM, pool.as_ref()).unwrap();
     black_box(docs_l2sq);
 }

--- a/diskann-disk/benches/benchmarks_iai/kmeans_bench_iai.rs
+++ b/diskann-disk/benches/benchmarks_iai/kmeans_bench_iai.rs
@@ -30,16 +30,13 @@ fn setup_data() -> (Vec<f32>, RayonThreadPool) {
 }
 #[iai_callgrind::library_benchmark(setup = setup_data)]
 pub fn benchmark_kmeans_iai((data, pool): (Vec<f32>, RayonThreadPool)) {
-    let centers: Vec<f32> = vec![0.0; NUM_CENTERS * DIM];
+    let mut centers: Vec<f32> = vec![0.0; NUM_CENTERS * DIM];
     let rng = &mut diskann_providers::utils::create_rnd_from_seed(42);
-
-    let data_copy = data.clone();
-    let mut centers_copy = centers.clone();
     k_means_clustering(
-        black_box(&data_copy),
+        black_box(&data),
         NUM_POINTS,
         DIM,
-        black_box(&mut centers_copy),
+        black_box(&mut centers),
         NUM_CENTERS,
         MAX_KMEANS_REPS,
         rng,
@@ -47,7 +44,7 @@ pub fn benchmark_kmeans_iai((data, pool): (Vec<f32>, RayonThreadPool)) {
         pool.as_ref(),
     )
     .unwrap();
-    black_box(centers_copy);
+    black_box(centers);
 }
 
 #[iai_callgrind::library_benchmark(setup = setup_data)]

--- a/diskann-disk/src/utils/math_util.rs
+++ b/diskann-disk/src/utils/math_util.rs
@@ -15,6 +15,7 @@ use std::{cmp::Ordering, collections::BinaryHeap};
 use diskann::{ANNError, ANNErrorKind, ANNResult};
 use diskann_linalg::{self, Transpose};
 use diskann_providers::utils::{ParallelIteratorInPool, RayonThreadPoolRef};
+use diskann_vector::{norm::FastL2NormSquared, Norm};
 use rayon::prelude::*;
 
 // This is the chunk size applied when computing the closest centers in a block.
@@ -73,15 +74,6 @@ impl PartialEq for PivotContainer {
 
 impl Eq for PivotContainer {}
 
-/// Compute the L2-squared norm of a single vector slice.
-fn compute_vec_l2sq(slice: &[f32]) -> f32 {
-    let mut sum_squared = 0.0;
-    for &value in slice {
-        sum_squared += value * value;
-    }
-    sum_squared
-}
-
 /// Compute L2-squared norms of data stored in row-major num_points * dim,
 /// need to be pre-allocated
 pub fn compute_vecs_l2sq(
@@ -115,14 +107,14 @@ pub fn compute_vecs_l2sq(
 
     if dim < 5 {
         for (vec_l2sq, chunk) in vecs_l2sq.iter_mut().zip(data.chunks_exact(dim)) {
-            *vec_l2sq = compute_vec_l2sq(chunk);
+            *vec_l2sq = FastL2NormSquared.evaluate(chunk);
         }
     } else {
         vecs_l2sq
             .par_iter_mut()
             .zip(data.par_chunks_exact(dim))
             .for_each_in_pool(pool, |(vec_l2sq, chunk)| {
-                *vec_l2sq = compute_vec_l2sq(chunk);
+                *vec_l2sq = FastL2NormSquared.evaluate(chunk);
             });
     }
 


### PR DESCRIPTION
### Changes

 - `diskann-disk/src/utils/math_util.rs`:
    - Replaced the private `compute_vec_l2sq()` helper function with `FastL2NormSquared.evaluate(chunk)`
 - [Unrelated improvements] `kmeans_bench.rs` (criterion):
    - Switched from iter() to iter_batched with BatchSize::SmallInput to avoid measuring setup costs (clone, allocation)
    - Inlined snrm2_benchmark_rust() helper into the benchmark closure
 - [Unrelated improvements] `kmeans_bench_iai.rs` (iai-callgrind):
    - Moved thread pool creation into setup_data() so it's excluded from measurement
    - Removed unnecessary data.clone() calls, since there are no multiple loops (the benchmark is executed only once)
    - Added black_box to prevent dead-code elimination of outputs

### Performance

 `iai-callgrind` shows 60% CPU cost reduction (see `Estimated Cycles` metric) after switching to `FastL2NormSquared.evaluate(chunk)`.
The measurement was taken in a single-threaded run with 896 dimensions.
```
bench_main_iai::kmeans_bench_iai::snrm2_benchmark_rust_iai
  Instructions:                    29000796|304003517            (-90.4604%) [-10.4826x]
  L1 Hits:                         34794766|388098122            (-91.0345%) [-11.1539x]
  L2 Hits:                                2|15                   (-86.6667%) [-7.50000x]
  RAM Hits:                         5606322|5606321              (+0.00002%) [+1.00000x]
  Total read+write:                40401090|393704458            (-89.7382%) [-9.74490x]
  Estimated Cycles:               231016046|584319432            (-60.4641%) [-2.52935x]
```

`criterion` shows 61% latency reduction.
The measurement was taken in a single-threaded run with 896 dimensions.
```
.\bench_main-a1fa58ecbc5b2232.exe --bench Snrm2 --color=never
Gnuplot not found, using plotters backend
Benchmarking kmeans-computation/Snrm2 Rust Run
Benchmarking kmeans-computation/Snrm2 Rust Run: Warming up for 3.0000 s

Warning: Unable to complete 50 samples in 5.0s. You may wish to increase target time to 8.3s, or reduce sample count to 30.
Benchmarking kmeans-computation/Snrm2 Rust Run: Collecting 50 samples in estimated 8.2595 s (50 iterations)
Benchmarking kmeans-computation/Snrm2 Rust Run: Analyzing
kmeans-computation/Snrm2 Rust Run
                        time:   [45.687 ms 46.349 ms 47.244 ms]
                        change: [-61.988% -61.410% -60.611%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 50 measurements (26.00%)
  2 (4.00%) low severe
  4 (8.00%) low mild
  1 (2.00%) high mild
  6 (12.00%) high severe
```

P.S. Neither tool shows noticeable performance improvements for 4-dimensional vectors.