### PR TITLE
[diskann-wide] Test unaligned loads properly.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,7 @@ dependencies = [
 name = "diskann-wide"
 version = "0.52.0"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "half",
  "paste",

--- a/diskann-wide/Cargo.toml
+++ b/diskann-wide/Cargo.toml
@@ -14,7 +14,8 @@ clippy.uninlined_format_args = "allow"
 [dev-dependencies]
 paste.workspace = true
 rand.workspace = true
-half = { workspace = true, features = ["rand_distr", "num-traits"] }
+half = { workspace = true, features = ["rand_distr", "num-traits", "bytemuck"] }
+bytemuck = { workspace = true, features = ["must_cast"] }
 
 [dependencies]
 cfg-if.workspace = true

--- a/diskann-wide/src/test_utils/common.rs
+++ b/diskann-wide/src/test_utils/common.rs
@@ -9,6 +9,20 @@ use half::f16;
 
 use crate::{BitMask, Const, SIMDMask, SupportedLaneCount, arch, reference::ReferenceCast};
 
+pub(super) fn bytes<T>(x: &[T]) -> &[u8]
+where
+    T: bytemuck::Pod,
+{
+    bytemuck::must_cast_slice(x)
+}
+
+pub(super) fn bytes_mut<T>(x: &mut [T]) -> &mut [u8]
+where
+    T: bytemuck::Pod,
+{
+    bytemuck::must_cast_slice_mut(x)
+}
+
 // Helper trait to enable setting of values from unsigned 64-bit integers.
 pub(crate) trait USizeConvertTo<T> {
     fn test_convert(self) -> T;

--- a/diskann-wide/src/test_utils/load.rs
+++ b/diskann-wide/src/test_utils/load.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-use super::common::{USizeConvertTo, iota_slice};
+use super::common::{USizeConvertTo, bytes, bytes_mut, iota_slice};
 use crate::{
     bitmask,
     constant::Const,
@@ -19,91 +19,93 @@ use crate::{
 // initialization and comparison of the loaded result.
 pub(crate) fn test_load_simd<T, const N: usize, V>(arch: V::Arch)
 where
-    T: Default + std::marker::Copy + std::cmp::PartialEq + std::fmt::Debug,
+    T: Default + std::marker::Copy + std::cmp::PartialEq + std::fmt::Debug + bytemuck::Pod,
     usize: USizeConvertTo<T>,
     Const<N>: ArrayType<T, Type = [T; N]>,
     bitmask::BitMask<N, V::Arch>: SIMDMask<Arch = V::Arch>,
     V: SIMDVector<Scalar = T, ConstLanes = Const<N>>,
 {
-    // Test loads for all alignments.
-    // Our strategy is to create an array of twice the underlying vector width and perform a
-    // full-width load on each offset.
-    let mut input = vec![T::default(); 2 * N];
-    iota_slice(input.as_mut_slice());
+    let mut reference = [T::default(); N];
+    iota_slice(&mut reference);
 
-    for i in 0..N {
-        // SAFETY: By construction `input` is built to hold `2 * N` elements.
-        // The maximum offset we apply is `N`, so all reads are valid.
-        //
-        // `load_simd` does not have alignment requirements stricter than `N`.
-        let v = unsafe { V::load_simd(arch, input.as_ptr().add(i)) };
+    // Test full-width loads at every byte offset to verify unaligned load correctness.
+    // A `u8` buffer of `2 * N * elsize` bytes lets us slide the reference data to every
+    // byte position and confirm `load_simd` behaves like `ptr::read_unaligned`.
+    let elsize: usize = std::mem::size_of::<T>();
+    let mut input = vec![0u8; elsize * 2 * N];
+
+    for i in 0..=N * elsize {
+        input.fill(0);
+        input[i..i + elsize * N].copy_from_slice(bytes(&reference));
+
+        // SAFETY: `i + N * elsize <= 2 * N * elsize`, so the read is in bounds.
+        let v = unsafe { V::load_simd(arch, input.as_ptr().add(i).cast::<T>()) };
         let arr = v.to_array();
-        // Ensure we read the correct window of the input array.
-        for (j, value) in arr.iter().enumerate().take(N) {
-            assert_eq!(*value, (i + j).test_convert());
-        }
+        assert_eq!(arr, reference);
     }
 
-    // Test `load_first`.
-    // We will use a sliding window over an array so `miri` can check for out-of-bounds
-    // reads.
-    let mut input = [T::default(); N];
-    iota_slice(input.as_mut_slice());
+    // Test predicated loads at every byte offset.
+    //
+    // `reference` is `N + 1` elements so the window can slide by up to one full element
+    // while still having room for a full-width masked load. The pointer is placed so that
+    // reading beyond `kept` elements would exceed the allocation, letting miri catch
+    // over-reads.
+    let mut reference = vec![T::default(); N + 1];
+    iota_slice(&mut reference);
 
-    // Set the loop bounds from 0 to one greater than the number of lanes.
-    // Set up each load so that reading beyond the requested number of lanes will generate
-    // an out-of-bounds read.
     for keep_first in 0..=N + 5 {
-        let offset = N - keep_first.min(N);
+        let kept = keep_first.min(N);
 
-        // SAFETY: `offset` less than or equal to `N`, the memory between `input.as_ptr()`
-        // and `ptr` is valid and is contained within a single allocated object.
-        let ptr = unsafe { input.as_ptr().add(offset) };
+        for sub in 0..(elsize + 1) {
+            let offset = elsize * (N - kept + 1) - sub;
 
-        // A helper lambda to provide uniform checking for the various ways we can invoke
-        // predicated loads.
-        let check = |arr: [T; N]| {
-            for (i, value) in arr.iter().enumerate().take(N) {
-                if i < keep_first {
-                    assert_eq!(*value, (N - keep_first.min(N) + i).test_convert());
-                } else {
-                    assert_eq!(*value, 0.test_convert());
-                }
-            }
-        };
+            let mut expected = [T::default(); N];
+            bytes_mut(&mut expected[..kept])
+                .copy_from_slice(&bytes(&reference)[offset..offset + kept * elsize]);
 
-        // Need miri to ensure the safety of this load.
+            // SAFETY: `offset + kept * elsize <= (N + 1) * elsize`, so `ptr` through
+            // `ptr + kept` elements is within the allocation.
+            let ptr = unsafe { reference.as_ptr().byte_add(offset) };
 
-        // Load using the `load_simd_first` API.
-        // SAFETY: `ptr` points to valid memory and the contract of `V::load_simd_first`
-        // must guarantee that nothing beyond the `keep_first` elements is accessed.
-        let v = unsafe { V::load_simd_first(arch, ptr, keep_first) };
-        let arr = v.to_array();
-        println!("Array From First = {:?}", arr);
-        check(arr);
+            // SAFETY:
+            // * `ptr` is valid for `kept` elements.
+            // * Each API must not read beyond `keep_first` elements.
+            let v = unsafe { V::load_simd_first(arch, ptr, keep_first) };
+            assert_eq!(
+                v.to_array(),
+                expected,
+                "Failed `load_simd_first` for keep_first = {}, sub = {}",
+                keep_first,
+                sub
+            );
 
-        // Check by constructing a logical mask.
-        // SAFETY: `ptr` points to valid memory and the contract of `V::load_simd_first`
-        // must guarantee that nothing beyond the `keep_first` elements is accessed.
-        let v = unsafe {
-            V::load_simd_masked_logical(arch, ptr, V::Mask::keep_first(arch, keep_first))
-        };
-        let arr = v.to_array();
-        println!("Array Logical Mask = {:?}", arr);
-        check(arr);
+            // SAFETY: Same a `V::load_simd_first`.
+            let v = unsafe {
+                V::load_simd_masked_logical(arch, ptr, V::Mask::keep_first(arch, keep_first))
+            };
+            assert_eq!(
+                v.to_array(),
+                expected,
+                "Failed `load_simd_masked_logical` for keep_first = {}, sub = {}",
+                keep_first,
+                sub
+            );
 
-        // Check by constructing a bit-mask mask.
-        // SAFETY: `ptr` points to valid memory and the contract of `V::load_simd_first`
-        // must guarantee that nothing beyond the `keep_first` elements is accessed.
-        let v = unsafe {
-            V::load_simd_masked(
-                arch,
-                ptr,
-                <Const<N> as BitMaskType<V::Arch>>::Type::keep_first(arch, keep_first),
-            )
-        };
-        let arr = v.to_array();
-        println!("Array Logical Mask = {:?}", arr);
-        check(arr);
+            // SAFETY: Same a `V::load_simd_first`.
+            let v = unsafe {
+                V::load_simd_masked(
+                    arch,
+                    ptr,
+                    <Const<N> as BitMaskType<V::Arch>>::Type::keep_first(arch, keep_first),
+                )
+            };
+            assert_eq!(
+                v.to_array(),
+                expected,
+                "Failed `load_simd_masked` for keep_first = {}, sub = {}",
+                keep_first,
+                sub
+            );
+        }
     }
 }

--- a/diskann-wide/src/test_utils/load.rs
+++ b/diskann-wide/src/test_utils/load.rs
@@ -79,7 +79,7 @@ where
                 sub
             );
 
-            // SAFETY: Same a `V::load_simd_first`.
+            // SAFETY: Same as `V::load_simd_first`.
             let v = unsafe {
                 V::load_simd_masked_logical(arch, ptr, V::Mask::keep_first(arch, keep_first))
             };
@@ -91,7 +91,7 @@ where
                 sub
             );
 
-            // SAFETY: Same a `V::load_simd_first`.
+            // SAFETY: Same as `V::load_simd_first`.
             let v = unsafe {
                 V::load_simd_masked(
                     arch,

--- a/diskann-wide/src/test_utils/store.rs
+++ b/diskann-wide/src/test_utils/store.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-use super::common::{USizeConvertTo, iota_slice};
+use super::common::{USizeConvertTo, bytes, iota_slice};
 use crate::{
     bitmask,
     constant::Const,
@@ -14,21 +14,78 @@ use crate::{
 // Since the pattern of tests is the same for many different implementations, we keep
 // testing utilities together in one place to ensure uniformity of testing methodology.
 
+fn check(output: &[u8], target: &[u8], offset: usize, message: &dyn std::fmt::Display) {
+    let iszero = |x: &u8| *x == 0;
+
+    assert!(
+        output[..offset].iter().all(iszero),
+        "prefix of {:?} up to {} is not zero -- {}",
+        output,
+        offset,
+        message
+    );
+
+    assert_eq!(
+        &output[offset..offset + target.len()],
+        target,
+        "output window from {} not equal to target -- {}",
+        offset,
+        message
+    );
+
+    assert!(
+        output[offset + target.len()..].iter().all(iszero),
+        "suffix of {:?} starting from {} is not zero -- {}",
+        output,
+        offset + target.len(),
+        message
+    );
+}
+
+struct FullStore(usize);
+impl std::fmt::Display for FullStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "full SIMD store at byte offset {}", self.0)
+    }
+}
+
+struct PredicatedStore {
+    api: &'static str,
+    keep_first: usize,
+    sub: usize,
+}
+impl std::fmt::Display for PredicatedStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "`{}` with `keep_first` = {}, `sub` = {}",
+            self.api, self.keep_first, self.sub
+        )
+    }
+}
+
 // Test the store operations in `SIMDVector`.
 // Require that the input type is constructible from an unsigned, 64-bit integer to enable
 // initialization and comparison of the loaded result.
 pub(crate) fn test_store_simd<T, const N: usize, V>(arch: V::Arch)
 where
-    T: Default + std::marker::Copy + std::cmp::PartialEq + std::fmt::Debug + std::ops::AddAssign,
+    T: Default
+        + std::marker::Copy
+        + std::cmp::PartialEq
+        + std::fmt::Debug
+        + std::ops::AddAssign
+        + bytemuck::Pod,
     usize: USizeConvertTo<T>,
     Const<N>: ArrayType<T, Type = [T; N]>,
     bitmask::BitMask<N, V::Arch>: SIMDMask<Arch = V::Arch>,
     V: SIMDVector<Scalar = T, ConstLanes = Const<N>>,
 {
-    // Test stores for all alignments.
-    // Our strategy is to create an array of twice the underlying vector width and perform a
-    // full-width stores on each offset.
-    let mut output = vec![T::default(); 2 * N];
+    let elsize = std::mem::size_of::<T>();
+
+    // Test full-width stores at every byte offset to verify unaligned store correctness.
+    // A `u8` buffer of `2 * N * elsize` bytes lets us place the write at every byte
+    // position and confirm `store_simd` behaves like `ptr::write_unaligned`.
+    let mut output = vec![0u8; elsize * 2 * N];
 
     let mut input = [T::default(); N];
     iota_slice(input.as_mut_slice());
@@ -38,98 +95,65 @@ where
     }
     let v = V::from_array(arch, input);
 
-    for i in 0..N {
-        output.fill(T::default());
+    for i in 0..=N * elsize {
+        output.fill(0);
 
-        // SAFETY: By construction `input` is built to hold `2 * N` elements.
-        // The maximum offset we apply is `N`, so all stores are valid.
-        //
-        // `store_simd` does not have alignment requirements stricter than `N`.
-        unsafe { v.store_simd(output.as_mut_ptr().add(i)) };
-        // Ensure we read the correct window of the input array.
-        for (j, value) in output.iter().enumerate() {
-            if j < i {
-                assert_eq!(
-                    *value,
-                    T::default(),
-                    "values before the write pointer should not be accessed"
-                );
-            } else if j < i + N {
-                assert_eq!(
-                    *value,
-                    (j - i + 1).test_convert(),
-                    "expected index {} to be set to {}",
-                    j,
-                    (j - i + 1)
-                );
-            } else {
-                assert_eq!(
-                    *value,
-                    T::default(),
-                    "values after the write section should not be accessed"
-                );
-            }
-        }
+        // SAFETY: `i + N * elsize <= 2 * N * elsize`, so the write is in bounds.
+        unsafe { v.store_simd(output.as_mut_ptr().add(i).cast::<T>()) };
+
+        check(&output, bytes(&input), i, &FullStore(i));
     }
 
-    // Set up each store so that writing beyond the requested number of lanes will generate
-    // an out-of-bounds write.
+    let mut output = vec![0u8; elsize * (N + 1)];
+    let base = output.as_mut_ptr();
+
+    // Test predicated stores at every byte offset.
+    // The buffer is `(N + 1) * elsize` bytes so that writing beyond `kept` elements would
+    // exceed the allocation, letting miri catch over-writes.
     for keep_first in 0..=N + 5 {
-        let offset = N - keep_first.min(N);
+        let kept = keep_first.min(N);
+        let expected = bytes(&input[..kept]);
+        for sub in 0..(elsize + 1) {
+            let offset = elsize * (N - kept + 1) - sub;
 
-        // A helper lambda to provide uniform checking for the various ways we can invoke
-        // predicated loads.
-        let check = |arr: [T; N]| {
-            for (i, value) in arr.iter().enumerate() {
-                if i < offset {
-                    assert_eq!(*value, 0.test_convert());
-                } else {
-                    assert_eq!(*value, (i - offset + 1).test_convert());
-                }
-            }
-        };
+            // SAFETY: for all three stores below: `offset + kept * elsize <= (N + 1) * elsize`,
+            // so `ptr` through `ptr + kept` elements is within the allocation.
+            // Each API must not write beyond `keep_first` elements.
+            let ptr = unsafe { base.add(offset).cast::<T>() };
 
-        // Need miri to ensure the safety of these stores.
+            let label = |api| PredicatedStore {
+                api,
+                keep_first,
+                sub,
+            };
 
-        let mut output = [T::default(); N];
-        // SAFETY: `offset` is less than or equal to `N`, so the memory between
-        // `output.as_mut_ptr()` and `ptr` is valid and is contained within a single
-        // allocated object.
-        let ptr = unsafe { output.as_mut_ptr().add(offset) };
+            output.fill(0);
 
-        // Store using the `store_simd_first` API.
-        // SAFETY: `ptr` points to valid memory and the contract of `V::store_simd_first`
-        // must guarantee that nothing beyond the `keep_first` elements is accessed.
-        unsafe { v.store_simd_first(ptr, keep_first) };
-        check(output);
+            // SAFETY:
+            // * `ptr` is valid for `kept` elements.
+            // * Each API must not read beyond `keep_first` elements.
+            unsafe { v.store_simd_first(ptr, keep_first) };
+            check(&output, expected, offset, &label("store_simd_first"));
 
-        let mut output = [T::default(); N];
-        // SAFETY: `offset` is less than or equal to `N`, so the memory between
-        // `output.as_mut_ptr()` and `ptr` is valid and is contained within a single
-        // allocated object.
-        let ptr = unsafe { output.as_mut_ptr().add(offset) };
+            output.fill(0);
+            // SAFETY: Same as `store_simd_first`.
+            unsafe { v.store_simd_masked_logical(ptr, V::Mask::keep_first(arch, keep_first)) };
+            check(
+                &output,
+                expected,
+                offset,
+                &label("store_simd_masked_logical"),
+            );
 
-        // Check by constructing a logical mask.
-        // SAFETY: `ptr` points to valid memory and the contract of `V::store_simd_first`
-        // must guarantee that nothing beyond the `keep_first` elements is accessed.
-        unsafe { v.store_simd_masked_logical(ptr, V::Mask::keep_first(arch, keep_first)) };
-        check(output);
-
-        let mut output = [T::default(); N];
-        // SAFETY: `offset` is less than or equal to `N`, so the memory between
-        // `output.as_mut_ptr()` and `ptr` is valid and is contained within a single
-        // allocated object.
-        let ptr = unsafe { output.as_mut_ptr().add(offset) };
-
-        // Check by constructing a bit-mask mask.
-        // SAFETY: `ptr` points to valid memory and the contract of `V::store_simd_first`
-        // must guarantee that nothing beyond the `keep_first` elements is accessed.
-        unsafe {
-            v.store_simd_masked(
-                ptr,
-                <Const<N> as BitMaskType<V::Arch>>::Type::keep_first(arch, keep_first),
-            )
-        };
-        check(output);
+            output.fill(0);
+            // SAFETY: Same as `store_simd_first`.
+            unsafe {
+                v.store_simd_masked(
+                    ptr,
+                    <Const<N> as BitMaskType<V::Arch>>::Type::keep_first(arch, keep_first),
+                )
+            };
+            check(&output, expected, offset, &label("store_simd_masked"));
+        }
     }
 }

--- a/diskann-wide/src/test_utils/store.rs
+++ b/diskann-wide/src/test_utils/store.rs
@@ -131,7 +131,7 @@ where
 
             // SAFETY:
             // * `ptr` is valid for `kept` elements.
-            // * Each API must not read beyond `keep_first` elements.
+            // * Each API must not write beyond `keep_first` elements.
             unsafe { v.store_simd_first(ptr, keep_first) };
             check(&output, expected, offset, &label("store_simd_first"));
 

--- a/diskann-wide/src/traits.rs
+++ b/diskann-wide/src/traits.rs
@@ -278,8 +278,7 @@ pub trait SIMDVector: Copy + std::fmt::Debug {
     /// Load `<Self as SIMDVector>::LANES` number of elements starting at the provided
     /// pointer.
     ///
-    /// The alignment of `ptr` must be the same as `<Self as SIMDVector>::Scalar`, but does
-    /// not need to be stricter.
+    /// There are no alignment requirements on `ptr`.
     ///
     /// # Safety
     ///
@@ -289,8 +288,7 @@ pub trait SIMDVector: Copy + std::fmt::Debug {
     /// Load `<Self as SIMDVector>::LANES` number of elements starting at the provided
     /// pointer.
     ///
-    /// The alignment of `ptr` must be the same as `<Self as SIMDVector>::Scalar`, but does
-    /// not need to be stricter.
+    /// There are no alignment requirements on `ptr`.
     ///
     /// Entries in the mask that evaluate to `false` will not be accessed.
     /// This makes it safe to use this function with lanes masked out that would otherwise
@@ -307,6 +305,8 @@ pub trait SIMDVector: Copy + std::fmt::Debug {
     ) -> Self;
 
     /// The same as `load_simd_masked_logical` but taking a BitMask instead.
+    ///
+    /// There are no alignment requirements on `ptr`.
     ///
     /// No load attempt will be made to lanes that are masked out.
     ///
@@ -354,8 +354,7 @@ pub trait SIMDVector: Copy + std::fmt::Debug {
     /// Store `<Self as SIMDVector>::LANES` number of elements contiguously starting at the
     /// provided pointer.
     ///
-    /// The alignment of `ptr` must be the same as `<Self as SIMDVector>::Scalar`, but does
-    /// not need to be stricter.
+    /// There are no alignment requirements on `ptr`.
     ///
     /// # Safety
     ///
@@ -367,8 +366,7 @@ pub trait SIMDVector: Copy + std::fmt::Debug {
     /// Store `<Self as SIMDVector>::LANES` number of elements starting at the provided
     /// pointer.
     ///
-    /// The alignment of `ptr` must be the same as `<Self as SIMDVector>::Scalar`, but does
-    /// not need to be stricter.
+    /// There are no alignment requirements on `ptr`.
     ///
     /// Entries in the mask that evaluate to `false` will not be accessed.
     /// This makes it safe to use this function with lanes masked out that would otherwise
@@ -387,6 +385,8 @@ pub trait SIMDVector: Copy + std::fmt::Debug {
     );
 
     /// The same as `store_simd_masked_logical` but taking a BitMask instead.
+    ///
+    /// There are no alignment requirements on `ptr`.
     ///
     /// No store attempt will be made to lanes that are masked out.
     ///
@@ -415,6 +415,8 @@ pub trait SIMDVector: Copy + std::fmt::Debug {
     ///
     /// If `first` is greater than or equal to the number of lanes, then all lanes will be
     /// written.
+    ///
+    /// There are no alignment requirements on `ptr`.
     ///
     /// # Safety
     ///


### PR DESCRIPTION
Test under-aligned loads and stores in `diskann-wide` and documents that there are no alignment restrictions on the associated pointer.

This was supposed to be in #981 but somehow didn't make it into the diff.