### PR TITLE
Bump version to 0.53.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "diskann"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-core"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "diskann",
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-runner"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -713,7 +713,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-simd"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "diskann-benchmark-runner",
@@ -730,7 +730,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-bftree"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "bf-tree",
  "bytemuck",
@@ -752,7 +752,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-disk"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-label-filter"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-linalg"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "approx",
  "cfg-if",
@@ -843,7 +843,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-platform"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "io-uring",
  "libc",
@@ -853,7 +853,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-providers"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "approx",
  "arc-swap",
@@ -891,7 +891,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-quantization"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -912,7 +912,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-tools"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -945,7 +945,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-utils"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -961,7 +961,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-vector"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "approx",
  "bytemuck",
@@ -976,7 +976,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-wide"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "cfg-if",
  "half",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default-members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.52.0"      # Obeying semver
+version = "0.53.0"      # Obeying semver
 description = "DiskANN is a fast approximate nearest neighbor search library for high dimensional data"
 authors = ["Microsoft"]
 documentation = "https://github.com/microsoft/DiskANN"
@@ -49,22 +49,22 @@ undocumented_unsafe_blocks = "warn"
 
 [workspace.dependencies]
 # Base And Numerics
-diskann-wide = { path = "diskann-wide", version = "0.52.0" }
-diskann-vector = { path = "diskann-vector", version = "0.52.0" }
-diskann-linalg = { path = "diskann-linalg", version = "0.52.0" }
-diskann-utils = { path = "diskann-utils", default-features = false, version = "0.52.0" }
-diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.52.0" }
-diskann-platform = { path = "diskann-platform", version = "0.52.0" }
+diskann-wide = { path = "diskann-wide", version = "0.53.0" }
+diskann-vector = { path = "diskann-vector", version = "0.53.0" }
+diskann-linalg = { path = "diskann-linalg", version = "0.53.0" }
+diskann-utils = { path = "diskann-utils", default-features = false, version = "0.53.0" }
+diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.53.0" }
+diskann-platform = { path = "diskann-platform", version = "0.53.0" }
 # Algorithm
-diskann = { path = "diskann", version = "0.52.0" }
+diskann = { path = "diskann", version = "0.53.0" }
 # Providers
-diskann-providers = { path = "diskann-providers", default-features = false, version = "0.52.0" }
-diskann-disk = { path = "diskann-disk", version = "0.52.0" }
-diskann-label-filter = { path = "diskann-label-filter", version = "0.52.0" }
+diskann-providers = { path = "diskann-providers", default-features = false, version = "0.53.0" }
+diskann-disk = { path = "diskann-disk", version = "0.53.0" }
+diskann-label-filter = { path = "diskann-label-filter", version = "0.53.0" }
 # Infra
-diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.52.0" }
-diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.52.0" }
-diskann-tools = { path = "diskann-tools", version = "0.52.0" }
+diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.53.0" }
+diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.53.0" }
+diskann-tools = { path = "diskann-tools", version = "0.53.0" }
 
 # External dependencies (shared versions)
 anyhow = "1.0.98"


### PR DESCRIPTION
# DiskANN v0.53.0 Release Notes

## Breaking Changes

An AI generated, human reviewed list of changes is summarized below.

### Paged search overhauled — channel-based API ([#1078](https://github.com/microsoft/DiskANN/pull/1078))

`PagedSearchState` and its `'static`-bound pause/resume model have been replaced with an async, channel-based interface. The recommended way to drive paged search is now via a `tokio::sync::mpsc` channel, with the searcher embedded in an otherwise-`'static` future. See the [rendered RFC](https://github.com/microsoft/DiskANN/blob/main/rfcs/01078-paged-search.md) for the new shape. Callers wired against `PagedSearchState` must migrate to the channel API. 

Users of paged search via `wrapped_async::DiskANNIndex` that know their inner futures will never suspend can use the new `wrapped_async::DiskANNIndex::paged_search_no_await`; this will efficiently run paged searches with minimal synchronization overhead.

### `DiskANNIndex::flat_search` removed ([#1076](https://github.com/microsoft/DiskANN/pull/1076))

`DiskANNIndex::flat_search` and the `IdIterator` trait have been removed from the `diskann` crate. Equivalent functionality lives on the new inherent method `DiskIndexSearcher::flat_search` in `diskann-disk`. This unblocks the experimental directions in #1067 and #983.

```rust
// Before
diskann_index.flat_search(query, ...)?;

// After
disk_index_searcher.flat_search(query, ...).await?;
```

### `DiskIndexSearcher::flat_search` now batched ([#1097](https://github.com/microsoft/DiskANN/pull/1097))

The new `DiskIndexSearcher::flat_search` uses the bulk `pq_distances` path instead of one-vector-at-a-time `Accessor::build_query_computer` + `evaluate_similarity`. Downstream behavior is equivalent but tighter resource bounds apply.

### `centroid` removed from PQ interfaces ([#1010](https://github.com/microsoft/DiskANN/pull/1010))

The dataset-centroid argument has been removed from `FixedChunkPQTable` construction, `populate`, and most other PQ APIs. The shift only ever worked for L2 distance and was silently ignored for inner-product / cosine, so passing it was a footgun. When an L2 shift is required, fold it into the PQ pivots instead (the library now does this internally).

```rust
// Before
let table = FixedChunkPQTable::new(.., centroid, ..);

// After — drop the centroid argument
let table = FixedChunkPQTable::new(.., ..);
```

### Flat search interface ([#983](https://github.com/microsoft/DiskANN/pull/983))

A new `flat` module in `diskann` adds a provider-agnostic brute-force search surface, mirroring the shape of graph search. Backends implement a single trait, `DistancesUnordered<C>` (in `flat/strategy.rs`), which fuses iteration and distance computation, allowing any backend (in-memory, quantized, disk, remote) to plug into a shared algorithm. See the [rendered RFC](https://github.com/microsoft/DiskANN/blob/main/rfcs/00983-flat-search.md). This is additive but is the new canonical surface — direct ad-hoc flat-search call sites should migrate.

### `bf_tree` extracted into `diskann-bftree` crate ([#1020](https://github.com/microsoft/DiskANN/pull/1020))

The bf_tree provider has been moved out of `diskann-providers` (previously at `diskann-providers/src/model/graph/provider/async_/bf_tree/`) into a new standalone `diskann-bftree` crate. Along with the move:

- Switched from PQ to spherical quantization.
- Dropped dependencies on `DeletionCheck`, `AsDeletionCheck`, and `RemoveDeletedIdsAndCopy`.
- Simplified generics.

Consumers must update their `Cargo.toml` to depend on `diskann-bftree` and update import paths.

### `direct_distance_impl` and `inner_product_raw` re-exposed ([#1081](https://github.com/microsoft/DiskANN/pull/1081))

`direct_distance_impl` (free function) and `FixedChunkPQTable::inner_product_raw` are `pub` again after being privatized in #1044. Restored to unblock a downstream user. Not breaking in the typical direction — this restores previously available API surface.

### MinMax `recompress` takes a grid-scale parameter ([#1109](https://github.com/microsoft/DiskANN/pull/1109))

The MinMax `recompress` API now accepts a grid-scale parameter. 

## New Features

- SIMD-optimized L2-squared norm ([#1107](https://github.com/microsoft/DiskANN/pull/1107))
- Significantly faster bitmap computation ([#1099](https://github.com/microsoft/DiskANN/pull/1099))
- Large speedup on the bitmap construction path used by filtered search.
- LLVM IR bloat regression check in CI ([#1083](https://github.com/microsoft/DiskANN/pull/1083))
- CI now flags regressions in generated LLVM IR size, helping catch unintended monomorphization blow-ups.
- Recall computation fix for under-k groundtruth ([#1069](https://github.com/microsoft/DiskANN/pull/1069))

## Merged PRs

* Revise README for DiskANN3 by @harsha-simhadri in https://github.com/microsoft/DiskANN/pull/1046
* [CI] Try to fix publishing step by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/1057
* [benchmark] Remove `DispatchRule` by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/1064
* [benchmark] Automatic Input Registration by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/1066
* Remove centroid from most PQ interfaces by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/1010
* [diskann/disk] Remove `flat_search` from `DiskANNIndex` by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/1076
* macos build and miri check to nightly by @harsha-simhadri in https://github.com/microsoft/DiskANN/pull/1058
* [API] Make some methods public again by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/1081
* [benchmark] Simply `Inputs` more by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/1077
* Turn on stack protection for the diskann-garnet NuGet build by @jackmoffitt in https://github.com/microsoft/DiskANN/pull/1082
* Fix options for diskann-garnet nuget pipeline by @jackmoffitt in https://github.com/microsoft/DiskANN/pull/1091
* [CI] add LLVM IR bloat regression check by @arazumov in https://github.com/microsoft/DiskANN/pull/1083
* Bump openssl from 0.10.79 to 0.10.80 by @dependabot[bot] in https://github.com/microsoft/DiskANN/pull/1093
* [Disk CI benchmarks] Use 1ES.Pool=diskann-github by @arazumov in https://github.com/microsoft/DiskANN/pull/869
* Fix recall computation for fewer than k groundtruth results by @magdalendobson in https://github.com/microsoft/DiskANN/pull/1069
* bf_tree migration away from diskann-providers by @JordanMaples in https://github.com/microsoft/DiskANN/pull/1020
* [RFC/diskann] Overhaul paged search by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/1078
* Remove unsafe code from compute_vec_l2sq by @arazumov in https://github.com/microsoft/DiskANN/pull/1094
* Remove direct accessor call in `diskann-garnet` by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/1098
* Refactor `DiskIndexSearcher::flat_search` to use batching by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/1097
* [flat index] Flat Search Interface by @arkrishn94 in https://github.com/microsoft/DiskANN/pull/983
* migrating multi-hop tests from diskann-providers to diskann by @JordanMaples in https://github.com/microsoft/DiskANN/pull/928
* Significantly speed up bitmap computation by @magdalendobson in https://github.com/microsoft/DiskANN/pull/1099
* `compute_vecs_l2sq`: Replace scalar L2 Squared norm with SIMD-optimized FastL2NormSquared by @arazumov in https://github.com/microsoft/DiskANN/pull/1107
* [minmax] Add grid scaling to recompress API by @arkrishn94 in https://github.com/microsoft/DiskANN/pull/1109

**Full Changelog**: https://github.com/microsoft/DiskANN/compare/v0.52.0...v0.53.0
