### PR TITLE
Add JobId labels to disk benchmark CI runners

### DIFF
--- a/.github/workflows/disk-benchmarks-aa.yml
+++ b/.github/workflows/disk-benchmarks-aa.yml
@@ -37,7 +37,7 @@ jobs:
   # A/A benchmark: run main vs main to detect environment noise.
   aa-benchmark:
     name: A/A - ${{ matrix.dataset }}
-    runs-on: [ self-hosted, 1ES.Pool=diskann-github, ubuntu-latest, "JobId=${{ github.workflow }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ strategy.job-index }}" ]
+    runs-on: [ self-hosted, 1ES.Pool=diskann-github, ubuntu-latest, "JobId=aa-benchmark-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ strategy.job-index }}" ]
     timeout-minutes: 120
     strategy:
       fail-fast: false

--- a/.github/workflows/disk-benchmarks-aa.yml
+++ b/.github/workflows/disk-benchmarks-aa.yml
@@ -37,7 +37,7 @@ jobs:
   # A/A benchmark: run main vs main to detect environment noise.
   aa-benchmark:
     name: A/A - ${{ matrix.dataset }}
-    runs-on: [ self-hosted, 1ES.Pool=diskann-github, ubuntu-latest ]
+    runs-on: [ self-hosted, 1ES.Pool=diskann-github, ubuntu-latest, "JobId=${{ github.workflow }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ strategy.job-index }}" ]
     timeout-minutes: 120
     strategy:
       fail-fast: false

--- a/.github/workflows/disk-benchmarks.yml
+++ b/.github/workflows/disk-benchmarks.yml
@@ -54,7 +54,7 @@ jobs:
   # Macro benchmark: compare current branch against baseline
   macro-benchmark:
     name: Macro Benchmark - ${{ matrix.dataset }}
-    runs-on: [ self-hosted, 1ES.Pool=diskann-github, ubuntu-latest ]
+    runs-on: [ self-hosted, 1ES.Pool=diskann-github, ubuntu-latest, "JobId=${{ github.workflow }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ strategy.job-index }}" ]
     # TODO: For production benchmarks, consider using a self-hosted runner with:
     # - NVMe storage for consistent I/O performance
     # - CPU pinning (taskset) for reduced variance

--- a/.github/workflows/disk-benchmarks.yml
+++ b/.github/workflows/disk-benchmarks.yml
@@ -54,7 +54,7 @@ jobs:
   # Macro benchmark: compare current branch against baseline
   macro-benchmark:
     name: Macro Benchmark - ${{ matrix.dataset }}
-    runs-on: [ self-hosted, 1ES.Pool=diskann-github, ubuntu-latest, "JobId=${{ github.workflow }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ strategy.job-index }}" ]
+    runs-on: [ self-hosted, 1ES.Pool=diskann-github, ubuntu-latest, "JobId=macro-benchmark-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}-${{ strategy.job-index }}" ]
     # TODO: For production benchmarks, consider using a self-hosted runner with:
     # - NVMe storage for consistent I/O performance
     # - CPU pinning (taskset) for reduced variance


### PR DESCRIPTION
# Why
- The benchmarking jobs are unexpectedly stopping because the agent disconnects for no apparent reason. Example:  https://github.com/microsoft/DiskANN/actions/runs/26750296444
```
The self-hosted runner lost communication with the server. Verify the machine is running and has a healthy network connection. Anything in your workflow that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error.
```
- The 1ES support recommended adding JobId before continuing the investigation, since it has helped other customers experiencing similar symptoms.