### PR TITLE
[diskann-garnet] Fix handling of missing quant vectors during delete()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-garnet"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "bytemuck",
  "crossbeam",

--- a/diskann-garnet/Cargo.toml
+++ b/diskann-garnet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diskann-garnet"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 authors.workspace = true
 license.workspace = true
@@ -22,3 +22,6 @@ foldhash = "0.2.0"
 rand.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync"] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["sync", "rt", "macros"] }

--- a/diskann-garnet/diskann-garnet.nuspec
+++ b/diskann-garnet/diskann-garnet.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>diskann-garnet</id>
-    <version>2.0.0</version>
+    <version>2.0.1</version>
     <readme>docs/README.md</readme>
     <authors>Microsoft</authors>
     <projectUrl>https://github.com/microsoft/DiskANN</projectUrl>

--- a/diskann-garnet/src/provider.rs
+++ b/diskann-garnet/src/provider.rs
@@ -730,13 +730,18 @@ impl<T: VectorRepr> Delete for GarnetProvider<T> {
         let mut ok = true;
         ok &= self.callbacks.delete_iid(&context.term(Term::ExtMap), id);
         ok &= self.callbacks.delete_eid(&context.term(Term::IntMap), gid);
-        ok &= self
+
+        // It is not an error to fail deleting attributes; they may not exist.
+        let _: bool = self
             .callbacks
             .delete_eid(&context.term(Term::Attributes), gid);
+
         // NOTE: Commented out until DiskANN fixes accessing neighbor data post-delete.
         //ok &= self.callbacks.delete_iid(context.term(Term::Neighbors), id);
         ok &= self.callbacks.delete_iid(&context.term(Term::Vector), id);
-        ok &= self
+
+        // It is not an error to fail deleting quantized terms; they may not exist yet.
+        let _: bool = self
             .callbacks
             .delete_iid(&context.term(Term::Quantized), id);
 
@@ -1533,5 +1538,41 @@ impl<T: VectorRepr> InplaceDeleteStrategy<GarnetProvider<T>> for DynamicQuantiza
             return future::ready(Err(GarnetError::Read.into()));
         }
         future::ready(Ok(v.into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use diskann::provider::{Delete, SetElement};
+    use diskann_vector::distance::Metric;
+
+    use crate::{
+        VectorQuantType,
+        garnet::{Context, GarnetId},
+        provider::GarnetProvider,
+        test_utils::Store,
+    };
+
+    #[tokio::test]
+    async fn simple_insert_delete() {
+        let store = Store;
+        let ctx = Context::new(0);
+        let provider = GarnetProvider::<f32>::new(
+            2,
+            VectorQuantType::NoQuant,
+            Metric::L2,
+            10,
+            store.callbacks(),
+            &ctx,
+        )
+        .unwrap();
+
+        let id = GarnetId::from(bytemuck::bytes_of(&0));
+
+        let res = provider.set_element(&ctx, &id, &[0f32, 0f32]).await;
+        assert!(res.is_ok());
+
+        let res = provider.delete(&ctx, &id).await;
+        assert!(res.is_ok());
     }
 }

--- a/diskann-garnet/src/test_utils.rs
+++ b/diskann-garnet/src/test_utils.rs
@@ -39,12 +39,19 @@ impl Store {
         STORE.with(|s| s.get(&k).map(|v| v.to_owned()))
     }
 
-    pub fn delete(&self, context: u64, key: &[u8]) {
+    pub fn delete(&self, context: u64, key: &[u8]) -> bool {
         let context = context & TERM_BITMASK;
         let mut k = Vec::new();
         k.extend_from_slice(bytemuck::bytes_of(&context));
         k.extend_from_slice(key);
-        STORE.with(|s| s.remove(&k));
+        STORE.with(|s| {
+            if s.contains_key(&k) {
+                s.remove(&k);
+                true
+            } else {
+                false
+            }
+        })
     }
 }
 
@@ -97,8 +104,7 @@ unsafe extern "C" fn test_delete(ctx: u64, id_bytes: *const u8, id_len: usize) -
     let id = unsafe { slice::from_raw_parts(id_bytes, id_len) };
 
     let store = Store;
-    store.delete(ctx, id);
-    true
+    store.delete(ctx, id)
 }
 
 unsafe extern "C" fn test_rmw(


### PR DESCRIPTION
Deleting an ID from the index removes several different keys associated with a vector: the internal and external ID mappings, the vector and quant vector data, the neighbor data, and the attributes.

For each of these associated keys, we returned an error from `delete()` whenever the key was not found, but for attributes and quant vectors, these errors are benign since it is normal for those keys to be missing. It is cheaper to attempt to delete a key than to check whether it exists and then delete it if it does.

A corresponding test for delete is added, although other tests would have also caught this had the `Store` test storage utility not unconditionally trued true for deletes. It now better models Garnet's behavior where deletes to non-existent keys returns false.