### PR TITLE
fix: redirect disk-index benchmark build artifacts to target/tmp

### DIFF
--- a/diskann-benchmark/perf_test_inputs/openai-100K-disk-index.json
+++ b/diskann-benchmark/perf_test_inputs/openai-100K-disk-index.json
@@ -18,7 +18,7 @@
                     "build_ram_limit_gb": 4.0,
                     "num_pq_chunks": 384,
                     "quantization_type": "SQ_1_2.0",
-                    "save_path": "openai_100k_benchmark_index"
+                    "save_path": "target/tmp/openai_100k_benchmark_index"
                 },
                 "search_phase": {
                     "queries": "OpenAIArXiv/openai_query.bin",

--- a/diskann-benchmark/perf_test_inputs/wikipedia-100K-disk-index.json
+++ b/diskann-benchmark/perf_test_inputs/wikipedia-100K-disk-index.json
@@ -18,7 +18,7 @@
                     "build_ram_limit_gb": 4.0,
                     "num_pq_chunks": 192,
                     "quantization_type": "SQ_1_2.0",
-                    "save_path": "wikipedia_100k_benchmark_index"
+                    "save_path": "target/tmp/wikipedia_100k_benchmark_index"
                 },
                 "search_phase": {
                     "queries": "wikipedia_cohere/wikipedia_query.bin",


### PR DESCRIPTION
The `save_path` in the disk-index perf test configs pointed to the repo root, causing build artifacts (`*_pq_compressed.bin`, `*_pq_pivots.bin`, `*_scalar_quantizer_proto.bin`) to be written as untracked files in the working directory.

Prefixed `save_path` with `target/tmp/` in both `openai-100K-disk-index.json` and `wikipedia-100K-disk-index.json`.