### PR TITLE
Remove `try_into_vector_id` conversion in prune.

### DIFF
--- a/diskann/src/graph/config/defaults.rs
+++ b/diskann/src/graph/config/defaults.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-use std::num::NonZeroU32;
+use std::num::{NonZeroU16, NonZeroU32};
 
 use super::IntraBatchCandidates;
 
@@ -11,7 +11,7 @@ use super::IntraBatchCandidates;
 /// pruning. Since pruning has quadratic complexity in the number of candidates, a default
 /// value of 750 provides plenty of room for new candidates without leading to excessive
 /// prune times.
-pub const MAX_OCCLUSION_SIZE: NonZeroU32 = NonZeroU32::new(750).unwrap();
+pub const MAX_OCCLUSION_SIZE: NonZeroU16 = NonZeroU16::new(750).unwrap();
 
 /// "Adjacency list saturation" after pruning involves packing the adjcancy list until it
 /// reaches exactly the configured target degree.

--- a/diskann/src/graph/config/experimental.rs
+++ b/diskann/src/graph/config/experimental.rs
@@ -5,7 +5,7 @@
 
 use std::num::{NonZeroU32, NonZeroUsize};
 
-use super::to_nonzero_usize;
+use super::ToNonZeroUsize;
 
 /// An experimental addition to index construction that will retry the search and prune
 /// phase if an insufficient number of candidates are discovered.
@@ -49,11 +49,11 @@ impl InsertRetry {
     }
 
     pub fn max_retries(&self) -> NonZeroUsize {
-        to_nonzero_usize!(self.max_retries)
+        self.max_retries.to_nonzero_usize()
     }
 
     pub fn retry_if_candidates_shorter_than(&self) -> NonZeroUsize {
-        to_nonzero_usize!(self.retry_if_candidates_shorter_than)
+        self.retry_if_candidates_shorter_than.to_nonzero_usize()
     }
 
     pub fn saturate_on_last_attempt(&self) -> bool {

--- a/diskann/src/graph/config/mod.rs
+++ b/diskann/src/graph/config/mod.rs
@@ -6,7 +6,7 @@
 pub mod defaults;
 pub mod experimental;
 
-use std::num::{NonZeroU32, NonZeroUsize};
+use std::num::{NonZeroU16, NonZeroU32, NonZeroUsize};
 
 use thiserror::Error;
 
@@ -195,7 +195,7 @@ pub struct Config {
     prune_kind: PruneKind,
 
     /// The upper-bound of occlusion list sizes.
-    max_occlusion_size: NonZeroU32,
+    max_occlusion_size: NonZeroU16,
 
     /// Maximum number of backedges applied.
     max_backedges: NonZeroU32,
@@ -215,39 +215,54 @@ pub struct Config {
     experimental_insert_retry: Option<experimental::InsertRetry>,
 }
 
-/// Allow conversion from `NonZeroU32` to `NonZeroUsize`.
-///
-/// LLVM can recognice when this conversion is infallible and will emit code that never
-/// panics.
-macro_rules! to_nonzero_usize {
-    ($($x:tt)*) => {{
-        let y: NonZeroU32 = $($x)*;
-
-        const {
-            assert!(std::mem::size_of::<NonZeroUsize>() >= std::mem::size_of::<NonZeroU32>())
-        };
-
-        // Lint: Infallible on 64-bit systems.
-        #[allow(clippy::unwrap_used)]
-        <NonZeroUsize as TryFrom<NonZeroU32>>::try_from(y).unwrap()
-    }}
+trait ToNonZeroUsize {
+    fn to_nonzero_usize(self) -> NonZeroUsize;
 }
-pub(super) use to_nonzero_usize;
+
+impl ToNonZeroUsize for NonZeroU32 {
+    fn to_nonzero_usize(self) -> NonZeroUsize {
+        const { assert!(std::mem::size_of::<NonZeroUsize>() >= std::mem::size_of::<Self>()) };
+
+        // LLVM optimizes away the panic
+        #[expect(clippy::unwrap_used, reason = "infallible on 64-bit systems")]
+        self.try_into().unwrap()
+    }
+}
+
+trait TryFromUsize: Sized {
+    fn try_from_usize(x: usize) -> Result<Self, NotNonZero>;
+}
+
+impl TryFromUsize for NonZeroU32 {
+    fn try_from_usize(x: usize) -> Result<Self, NotNonZero> {
+        let y: u32 = x.try_into().map_err(|_| NotNonZero(x, Max::U32))?;
+        NonZeroU32::new(y).ok_or(NotNonZero(x, Max::U32))
+    }
+}
+
+impl TryFromUsize for NonZeroU16 {
+    fn try_from_usize(x: usize) -> Result<Self, NotNonZero> {
+        let y: u16 = x.try_into().map_err(|_| NotNonZero(x, Max::U16))?;
+        NonZeroU16::new(y).ok_or(NotNonZero(x, Max::U16))
+    }
+}
+
+fn non_zero_error<T>(param: &'static str, val: usize) -> Result<T, ConfigErrorInner>
+where
+    T: TryFromUsize,
+{
+    T::try_from_usize(val).map_err(|err| ConfigErrorInner::Parameter(param, err))
+}
 
 impl Config {
     /// Attempt to construct a [`Config`] from a builder.
     ///
     /// See: [`Builder::build`].
     pub fn try_from_builder(builder: Builder) -> Result<Self, ConfigError> {
-        let non_zero_error =
-            |param: &'static str, val: usize| -> Result<NonZeroU32, ConfigErrorInner> {
-                try_nonzero_u32(val).map_err(|err| ConfigErrorInner::Parameter(param, err))
-            };
-
         // TODO: Error checking for alpha.
         let alpha = builder.alpha.unwrap_or(defaults::ALPHA);
 
-        let pruned_degree = non_zero_error("pruned_degree", builder.pruned_degree)?;
+        let pruned_degree: NonZeroU32 = non_zero_error("pruned_degree", builder.pruned_degree)?;
 
         let max_degree = match builder.max_degree {
             MaxDegree::Value(max) => non_zero_error("max_degree", max)?,
@@ -328,18 +343,15 @@ impl Config {
     //-----------//
 
     pub fn pruned_degree(&self) -> NonZeroUsize {
-        const { assert!(std::mem::size_of::<usize>() >= std::mem::size_of::<u32>()) };
-        // Lint: Infallible on 64-bit systems.
-        #[expect(clippy::unwrap_used)]
-        self.pruned_degree_u32().try_into().unwrap()
+        self.pruned_degree_u32().to_nonzero_usize()
     }
 
     pub fn max_degree(&self) -> NonZeroUsize {
-        to_nonzero_usize!(self.max_degree_u32())
+        self.max_degree_u32().to_nonzero_usize()
     }
 
     pub fn l_build(&self) -> NonZeroUsize {
-        to_nonzero_usize!(self.l_build_u32())
+        self.l_build_u32().to_nonzero_usize()
     }
 
     pub fn alpha(&self) -> f32 {
@@ -351,15 +363,15 @@ impl Config {
     }
 
     pub fn max_occlusion_size(&self) -> NonZeroUsize {
-        to_nonzero_usize!(self.max_occlusion_size_u32())
+        self.max_occlusion_size_u32().to_nonzero_usize()
     }
 
     pub fn max_backedges(&self) -> NonZeroUsize {
-        to_nonzero_usize!(self.max_backedges_u32())
+        self.max_backedges_u32().to_nonzero_usize()
     }
 
     pub fn max_minibatch_par(&self) -> NonZeroUsize {
-        to_nonzero_usize!(self.max_minibatch_par_u32())
+        self.max_minibatch_par_u32().to_nonzero_usize()
     }
 
     pub fn intra_batch_candidates(&self) -> IntraBatchCandidates {
@@ -391,7 +403,7 @@ impl Config {
     }
 
     pub fn max_occlusion_size_u32(&self) -> NonZeroU32 {
-        self.max_occlusion_size
+        self.max_occlusion_size.into()
     }
 
     pub fn max_backedges_u32(&self) -> NonZeroU32 {
@@ -400,6 +412,14 @@ impl Config {
 
     pub fn max_minibatch_par_u32(&self) -> NonZeroU32 {
         self.max_minibatch_par
+    }
+
+    //---------------//
+    // u16 accessors //
+    //---------------//
+
+    pub fn max_occlusion_size_u16(&self) -> NonZeroU16 {
+        self.max_occlusion_size
     }
 }
 
@@ -422,7 +442,7 @@ impl From<ConfigError> for crate::ANNError {
 #[derive(Debug, Clone, Error)]
 enum ConfigErrorInner {
     #[error("parameter \"{0}\" invalid because {1}")]
-    Parameter(&'static str, NotNonZeroU32),
+    Parameter(&'static str, NotNonZero),
     #[error("parameter \"max_degree\" invalid because {0}")]
     Slack(InvalidSlack),
     #[error("parameter \"max_degree\" ({0}) must not be less than \"pruned_degree\" ({1})")]
@@ -433,24 +453,44 @@ enum ConfigErrorInner {
     BackedgeRatio(f32),
 }
 
-fn try_nonzero_u32(x: usize) -> Result<NonZeroU32, NotNonZeroU32> {
-    let y: u32 = x.try_into().map_err(|_| NotNonZeroU32(x))?;
-    NonZeroU32::new(y).ok_or(NotNonZeroU32(x))
-}
-
 #[derive(Debug, Clone)]
-struct NotNonZeroU32(usize);
+struct NotNonZero(usize, Max);
 
-impl std::fmt::Display for NotNonZeroU32 {
+impl std::fmt::Display for NotNonZero {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.0 == 0 {
             write!(f, "it cannot be zero")
-        } else if self.0 > (u32::MAX as usize) {
-            write!(f, "its value ({}) exceeds u32::MAX", self.0)
+        } else if self.0 > self.1.max() {
+            write!(f, "its value ({}) exceeds {}", self.0, self.1)
         } else {
             // Shouldn't reach here.
             Ok(())
         }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Max {
+    U32,
+    U16,
+}
+
+impl Max {
+    fn max(&self) -> usize {
+        match self {
+            Self::U32 => u32::MAX as usize,
+            Self::U16 => u16::MAX as usize,
+        }
+    }
+}
+
+impl std::fmt::Display for Max {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::U32 => "u32::MAX",
+            Self::U16 => "u16::MAX",
+        };
+        f.write_str(s)
     }
 }
 
@@ -705,6 +745,7 @@ mod tests {
 
     const SLACK: MaxDegree = MaxDegree::default_slack();
     const TOO_BIG: usize = 5_000_000_000;
+    const TOO_BIG_16: usize = 70_000;
 
     /// Utility to help check error messages.
     macro_rules! check_msg {
@@ -770,7 +811,7 @@ mod tests {
         assert_eq!(config.alpha(), defaults::ALPHA);
         assert_eq!(config.prune_kind(), prune_kind);
         assert_eq!(
-            config.max_occlusion_size_u32(),
+            config.max_occlusion_size_u16(),
             defaults::MAX_OCCLUSION_SIZE
         );
         assert_eq!(
@@ -927,6 +968,12 @@ mod tests {
                 .unwrap();
 
             assert_eq!(config.max_occlusion_size().get(), i);
+
+            let x: usize = config.max_occlusion_size_u32().get().try_into().unwrap();
+            assert_eq!(x, i);
+
+            let x: usize = config.max_occlusion_size_u16().get().into();
+            assert_eq!(x, i);
         }
 
         let msg = Builder::new_with(10, SLACK, 10, prune_kind, f(0))
@@ -939,14 +986,14 @@ mod tests {
             "parameter \"max_occlusion_size\" invalid because it cannot be zero",
         );
 
-        let msg = Builder::new_with(10, SLACK, 10, prune_kind, f(TOO_BIG))
+        let msg = Builder::new_with(10, SLACK, 10, prune_kind, f(TOO_BIG_16))
             .build()
             .unwrap_err()
             .to_string();
 
         check_msg!(
             msg,
-            "parameter \"max_occlusion_size\" invalid because its value (5000000000) exceeds u32::MAX",
+            "parameter \"max_occlusion_size\" invalid because its value (70000) exceeds u16::MAX",
         );
     }
 

--- a/diskann/src/graph/config/mod.rs
+++ b/diskann/src/graph/config/mod.rs
@@ -211,7 +211,7 @@ pub struct Config {
     /// Whether to attempt graph saturation after all prunes.
     saturate_after_prune: bool,
 
-    /// Experiemntal fields.
+    /// Experimental fields.
     experimental_insert_retry: Option<experimental::InsertRetry>,
 }
 

--- a/diskann/src/graph/index.rs
+++ b/diskann/src/graph/index.rs
@@ -2666,15 +2666,16 @@ where
             "this has an upper bound set by `diskann::graph::Config` and should not exceed `u16::MAX`"
         );
 
-        if context.pool.is_empty() {
-            return;
-        }
-
         let prune::Context {
             pool,
             states,
             neighbors,
         } = context;
+
+        if pool.is_empty() {
+            neighbors.clear();
+            return;
+        }
 
         let alpha = self.config.alpha();
         let degree = self.config.pruned_degree().get();

--- a/diskann/src/graph/index.rs
+++ b/diskann/src/graph/index.rs
@@ -321,9 +321,8 @@ where
                         &mut search_record.visited,
                         self.max_occlusion_size(),
                     ),
-                    occlude_factor: &mut prune_scratch.occlude_factor,
+                    states: &mut prune_scratch.states,
                     neighbors: &mut new_neighbors,
-                    last_checked: &mut prune_scratch.last_checked,
                 };
 
                 let options = prune::Options {
@@ -2603,8 +2602,7 @@ where
 
             let mut context = prune::Context {
                 pool: SortedNeighbors::new(&mut record.visited, self.max_occlusion_size()),
-                occlude_factor: &mut scratch.occlude_factor,
-                last_checked: &mut scratch.last_checked,
+                states: &mut scratch.states,
                 neighbors: &mut scratch.neighbors,
             };
 
@@ -2663,28 +2661,26 @@ where
         C: for<'a, 'b> DistanceFunction<M::ElementRef<'a>, M::ElementRef<'b>, f32>,
         F: Fn(DP::InternalId) -> bool,
     {
+        assert!(
+            context.pool.len() <= u16::MAX.into_usize(),
+            "this has an upper bound set by `diskann::graph::Config` and should not exceed `u16::MAX`"
+        );
+
         if context.pool.is_empty() {
             return;
         }
 
         let prune::Context {
             pool,
-            occlude_factor,
-            neighbors: dst,
-            last_checked,
+            states,
+            neighbors,
         } = context;
-
-        dst.clear();
-        occlude_factor.clear();
 
         let alpha = self.config.alpha();
         let degree = self.config.pruned_degree().get();
 
-        occlude_factor.clear();
-        occlude_factor.resize(pool.len(), 0.0);
-
-        last_checked.clear();
-        last_checked.resize(pool.len(), 0u16);
+        states.clear();
+        states.resize(pool.len(), prune::State::default());
 
         let mut current_alpha = 1.0f32;
         let increment_factor = alpha.min(1.2);
@@ -2707,17 +2703,57 @@ where
             })
             .collect();
 
-        // Loop will also terminate after cur_alpha reaches alpha
-        while dst.len() < degree {
+        // For an alpha value `A`, a candidate `i` is promoted to a neighbor if for all
+        // ```
+        // max{j < i | j is a neighbor}(occlude_factor(i, j))
+        // ```
+        // This process happens with multiple values of `A`.
+        //
+        // We can compute this efficiently using the following rules:
+        //
+        // 1. For a candidate `i`, start scanning `j < i`, computing occlude factors.
+        // 2. If we find an occlude factor greater than `A`, record that `i` has visited
+        //    `j`, stop computing occlude factors, and move on to `i + 1`.
+        // 3. If we reach `j == i - 1` with the maximum occlude factor less than `A`, then
+        //    `i` gets promoted to a neighbor.
+        //
+        // On the implementation side, we use `states` in the following way:
+        //
+        // * `states[n].neighbor` is the **index** in `pool` of the `n`th **neighbor**.
+        //   Note that a "neighbor" is a candidate that passes pruning.
+        //
+        //   Very important: to get the index `j` in the above description, we need to
+        //   check `pool[states[n].neighbor]`.
+        //
+        //   This indexing naturally skips candidates `j` that have not been promoted to
+        //   neighbors.
+        //
+        // * `states[i].occlude_factor` is the maximum occlude factor found for a candidate
+        //   `i`. This gets set to `f32::MAX` when `i` is promoted to a neighbor which
+        //   excludes it from future consideration.
+        //
+        // * `states[i].last_checked` is the highest value of `n` against which the
+        //   occlude factor for `j = pool[states[n].neighbor]` has been checked.
+        //
+        //   The maximum value this should reach is `i`.
+        //
+        // Note that we use `states` for both "candidate" and "neighbor" tracking.
+        let mut found = 0;
+        while found < degree {
             for (i, (neighbor_distance, neighbor)) in cache.iter().enumerate() {
-                if dst.len() >= degree {
+                if found >= degree {
                     break;
                 }
 
-                let factor = &mut occlude_factor[i];
+                // The tracking states for candidate `i`.
+                let prune::State {
+                    mut occlude_factor,
+                    mut last_checked,
+                    ..
+                } = states[i];
 
                 // If the occlusion factor for this neighbor is too high, skip it.
-                if *factor > current_alpha {
+                if occlude_factor > current_alpha {
                     continue;
                 }
 
@@ -2727,39 +2763,28 @@ where
                 let neighbor = match neighbor {
                     Some(n) => n,
                     None => {
-                        *factor = f32::MAX;
+                        debug_assert!(states.get(i).is_some(), "index {i} is out of bounds");
+                        // SAFETY: We've already checked `states[i]`.
+                        unsafe { states.get_unchecked_mut(i) }.occlude_factor = f32::MAX;
                         continue;
                     }
                 };
-
-                // This neighbor has not been exluded.
-                //
-                // To determine whether or not to add it, we must compute its occlusion
-                // factor against all elements in `result` that appear before it in `pool`.
-                //
-                // This computation may be resumed from previous `alpha` values, so we need
-                // to access our scratch data structures.
-                let position = &mut last_checked[i];
-
-                // During computation, we've found an occlusion factor greater than alpha
-                // and wish to abort this neighbor from consideration.
-                let mut skip: bool = false;
 
                 // Increment `position` until we've compared with all current entries in
                 // `result`.
                 //
                 // When the list is empty, the loop is skipped allowing the first undeleted
                 // element to be added.
-                while *position as usize != dst.len() {
-                    let result_to_check = *position;
-                    // Increment the position pointer.
-                    *position += 1;
-
-                    let result_position = dst[result_to_check as usize].into_usize();
+                while last_checked as usize != found {
+                    let result_position = states[last_checked as usize].neighbor.into_usize();
+                    last_checked += 1;
 
                     // If the position of this result in `pool` is greater than or equal
                     // the current working position, then skip this candidate.
                     if result_position >= i {
+                        debug_assert!(states.get(i).is_some(), "index {i} is out of bounds");
+                        // SAFETY: We've already checked `states[i]`.
+                        unsafe { states.get_unchecked_mut(i) }.last_checked = last_checked;
                         continue;
                     }
 
@@ -2773,43 +2798,36 @@ where
                     };
 
                     // Update occlude factor
-                    *factor = self.config.prune_kind().update_occlude_factor(
+                    occlude_factor = self.config.prune_kind().update_occlude_factor(
                         *neighbor_distance,
                         distance,
-                        *factor,
+                        occlude_factor,
                         current_alpha,
                     );
 
                     // Check if the most recent update to the occlusion factor removes this
                     // neighbor from consideration.
-                    if *factor > current_alpha {
-                        // Don't add this neighbor.
-                        skip = true;
+                    if occlude_factor > current_alpha {
                         break;
                     }
                 }
 
-                // N.B.: We can get here straight from the self-neighbor check when the
-                // neighbor and the data at `location` have the same encoding.
-                //
-                // SO, we use short-circuiting logic to avoid checking the occlusion factor
-                // twice, though that might not really save much.
-                if skip || *factor > current_alpha {
+                debug_assert!(states.get(i).is_some(), "index {i} is out of bounds");
+                // SAFETY: We've already checked `states[i]`.
+                let state = unsafe { states.get_unchecked_mut(i) };
+
+                state.last_checked = last_checked;
+                if occlude_factor > current_alpha {
+                    state.occlude_factor = occlude_factor;
                     continue;
                 }
 
                 // This neighbor has passed all the requirements of being a candidate.
-                *factor = f32::MAX;
+                state.occlude_factor = f32::MAX;
 
                 // This conversion should always succeed.
-                #[expect(
-                    clippy::expect_used,
-                    reason = "`i` cannot exceed `u16::MAX` so conversion should succeed"
-                )]
-                dst.push(
-                    i.try_into_vector_id()
-                        .expect("argument should not exceed u16::MAX"),
-                );
+                states[found].neighbor = i as u16;
+                found += 1;
             }
 
             // Exit if we completed the final iteration.
@@ -2820,21 +2838,25 @@ where
             current_alpha = (current_alpha * increment_factor).min(alpha);
         }
 
-        // Cleanup `result` by undoing the local indirection.
-        dst.remap_trusted(|r| *r = pool[r.into_usize()].id);
-        debug_assert!(dst.len() <= degree, "max degree bound violated");
+        let mut guard = neighbors.resize(found);
+        std::iter::zip(guard.iter_mut(), states.iter()).for_each(|(d, s)| {
+            *d = pool[s.neighbor.into_usize()].id;
+        });
+        guard.finish(found);
+
+        debug_assert!(neighbors.len() <= degree, "max degree bound violated");
 
         // Post processing saturation if enabled.
         if options.force_saturate || (self.config.saturate_after_prune() && alpha > 1.0f32) {
             for neighbor in context.pool.iter() {
-                if dst.len() >= degree {
+                if neighbors.len() >= degree {
                     break;
                 }
 
                 if !exclude(neighbor.id) {
                     // `AdjacencyList` filters out duplicates. No need to explicitly
                     // check.
-                    dst.push(neighbor.id);
+                    neighbors.push(neighbor.id);
                 }
             }
         }

--- a/diskann/src/graph/internal/prune.rs
+++ b/diskann/src/graph/internal/prune.rs
@@ -80,7 +80,7 @@ where
 
 /// Position-wise state tracking.
 ///
-/// Refer to the inline documentation in [`DiskANNIndex::occlude_factor`] for documentation
+/// Refer to the inline documentation in [`DiskANNIndex::occlude_list`] for documentation
 /// on the use of these fields.
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct State {

--- a/diskann/src/graph/internal/prune.rs
+++ b/diskann/src/graph/internal/prune.rs
@@ -34,8 +34,7 @@ where
     I: VectorId,
 {
     pub(in crate::graph) pool: Vec<Neighbor<I>>,
-    pub(in crate::graph) occlude_factor: Vec<f32>,
-    pub(in crate::graph) last_checked: Vec<u16>,
+    pub(in crate::graph) states: Vec<State>,
     pub(in crate::graph) neighbors: AdjacencyList<I>,
 }
 
@@ -49,9 +48,8 @@ where
     pub(in crate::graph) fn new() -> Self {
         Self {
             pool: Vec::new(),
-            occlude_factor: Vec::new(),
+            states: Vec::new(),
             neighbors: AdjacencyList::new(),
-            last_checked: Vec::new(),
         }
     }
 
@@ -60,9 +58,8 @@ where
     pub(in crate::graph) fn as_context(&mut self, max_candidates: usize) -> Context<'_, I> {
         Context {
             pool: SortedNeighbors::new(&mut self.pool, max_candidates),
-            occlude_factor: &mut self.occlude_factor,
+            states: &mut self.states,
             neighbors: &mut self.neighbors,
-            last_checked: &mut self.last_checked,
         }
     }
 }
@@ -75,12 +72,34 @@ where
 {
     /// Input: The list of candidates to prune.
     pub(in crate::graph) pool: SortedNeighbors<'ctx, I>,
-    /// Scratch: Tracker for occlude factors during prune.
-    pub(in crate::graph) occlude_factor: &'ctx mut Vec<f32>,
-    /// Scratch: Used to help with lazy pruning.
-    pub(in crate::graph) last_checked: &'ctx mut Vec<u16>,
+    /// Scratch: State tracking for prune.
+    pub(in crate::graph) states: &'ctx mut Vec<State>,
     /// Output: The pruned candidates list.
     pub(in crate::graph) neighbors: &'ctx mut AdjacencyList<I>,
+}
+
+/// Position-wise state tracking.
+///
+/// Refer to the inline documentation in [`DiskANNIndex::occlude_factor`] for documentation
+/// on the use of these fields.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct State {
+    /// The occlude factor for the pool item at the corresponding index.
+    pub(in crate::graph) occlude_factor: f32,
+    /// The index of the last checked neighbor.
+    pub(in crate::graph) last_checked: u16,
+    /// The candidate index of this neighbor.
+    pub(in crate::graph) neighbor: u16,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            occlude_factor: 0.0f32,
+            last_checked: 0,
+            neighbor: 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Error)]

--- a/diskann/src/graph/internal/prune.rs
+++ b/diskann/src/graph/internal/prune.rs
@@ -82,7 +82,7 @@ where
 ///
 /// Refer to the inline documentation in [`DiskANNIndex::occlude_factor`] for documentation
 /// on the use of these fields.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct State {
     /// The occlude factor for the pool item at the corresponding index.
     pub(in crate::graph) occlude_factor: f32,
@@ -90,16 +90,6 @@ pub(crate) struct State {
     pub(in crate::graph) last_checked: u16,
     /// The candidate index of this neighbor.
     pub(in crate::graph) neighbor: u16,
-}
-
-impl Default for State {
-    fn default() -> Self {
-        Self {
-            occlude_factor: 0.0f32,
-            last_checked: 0,
-            neighbor: 0,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, Error)]


### PR DESCRIPTION
Pruning did kind of a sneaky trick of reusing the output neighbor buffer as temporary scratch space for indices during prune. While this worked, it relied on `usize` variables being convertible to `VectorId`, which is kind of dubious because (1) we are moving away from `VectorId`s being convertible to primitive values and (2) it doesn't really provide a good guarantee on **when** the conversion will succeed or not.

This PR fixes that by using a dedicated scratch to store these indices.

While I originally introduced a third `Vec` in `prune::{Scratch, Context}`, I realized that all the auxiliary variables could be collapsed into a single `State`. Note that we get the extra 2-bytes for `neighbor` basically for free because even without it, padding would bring the size of `State` to 8 bytes.

Also, this fixes a potential bug where the max occlusion size could be set larger than `u16::MAX` and thus silently truncate via `_ as u16` by enforcing a `u16::MAX` bound in `diskann::graph::Config`. This far exceeds any practical value anyone should be setting for this value so is unlikely to result in any breakage.