### PR TITLE
Consolidate insert into `PruneAccessor`

### DIFF
--- a/diskann-benchmark-core/src/build/graph/multi.rs
+++ b/diskann-benchmark-core/src/build/graph/multi.rs
@@ -182,7 +182,7 @@ mod tests {
         .unwrap();
 
         // Ensure that the index is correctly populated.
-        let accessor = index.provider().neighbors();
+        let mut accessor = index.provider().neighbors();
         let mut v = diskann::graph::AdjacencyList::new();
 
         for i in 0..data.nrows() {

--- a/diskann-benchmark-core/src/build/graph/single.rs
+++ b/diskann-benchmark-core/src/build/graph/single.rs
@@ -149,7 +149,7 @@ mod tests {
         .unwrap();
 
         // Ensure that the index is correctly populated.
-        let accessor = index.provider().neighbors();
+        let mut accessor = index.provider().neighbors();
         let mut v = diskann::graph::AdjacencyList::new();
 
         for i in 0..data.nrows() {

--- a/diskann-benchmark-core/src/streaming/graph/drop_deleted.rs
+++ b/diskann-benchmark-core/src/streaming/graph/drop_deleted.rs
@@ -10,7 +10,7 @@ use diskann::{ANNResult, graph, provider};
 use crate::build::{Build, ids::ToIdSized};
 
 /// A [`Build`] stage that invokes
-/// [`drop_deleted_neighbors`](diskann::graph::DiskANNIndex::drop_deleted_neighbors)    
+/// [`drop_deleted_neighbors`](diskann::graph::DiskANNIndex::drop_deleted_neighbors)
 /// on a collection of points.
 ///
 /// The collection of points is determined by an implementation of [`ToIdSized`].
@@ -54,7 +54,7 @@ where
 impl<DP> Build for DropDeleted<DP>
 where
     DP: provider::DataProvider<Context: Default> + provider::Delete + provider::DefaultAccessor,
-    for<'a> <DP as provider::DefaultAccessor>::Accessor<'a>: provider::AsNeighborMut,
+    for<'a> <DP as provider::DefaultAccessor>::Accessor<'a>: provider::NeighborAccessorMut,
 {
     type Output = ();
 
@@ -121,7 +121,7 @@ mod tests {
         )
         .unwrap();
 
-        let accessor = index.provider().neighbors();
+        let mut accessor = index.provider().neighbors();
         let mut v = diskann::graph::AdjacencyList::new();
 
         // `drop_deleted` short-circuits already deleted entries. So we should only check

--- a/diskann-bftree/src/provider.rs
+++ b/diskann-bftree/src/provider.rs
@@ -1024,10 +1024,10 @@ where
     where
         Self: 'a;
 
-    fn fill<'a, Itr>(
-        &'a mut self,
+    fn fill<Itr>(
+        &mut self,
         itr: Itr,
-    ) -> impl SendFuture<ANNResult<(Self::View<'a>, Self::Distance<'a>)>>
+    ) -> impl SendFuture<ANNResult<(Self::View<'_>, Self::Distance<'_>)>>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
     {
@@ -1122,10 +1122,10 @@ where
     where
         Self: 'a;
 
-    fn fill<'a, Itr>(
-        &'a mut self,
+    fn fill<Itr>(
+        &mut self,
         itr: Itr,
-    ) -> impl SendFuture<ANNResult<(Self::View<'a>, Self::Distance<'a>)>>
+    ) -> impl SendFuture<ANNResult<(Self::View<'_>, Self::Distance<'_>)>>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
     {

--- a/diskann-bftree/src/provider.rs
+++ b/diskann-bftree/src/provider.rs
@@ -27,14 +27,13 @@ use diskann::{
             MultiInsertStrategy, PruneStrategy, SearchStrategy,
         },
         strategy::{FullPrecision, Quantized},
-        workingset::{self, map},
+        workingset::map,
         AdjacencyList, SearchOutputBuffer,
     },
     neighbor::Neighbor,
     provider::{
-        BuildDistanceComputer, DataProvider, DefaultContext, DelegateNeighbor, Delete,
-        ElementStatus, HasElementRef, HasId, NeighborAccessor, NeighborAccessorMut, NoopGuard,
-        SetElement,
+        DataProvider, DefaultContext, Delete, ElementStatus, HasId, NeighborAccessor,
+        NeighborAccessorMut, NoopGuard, SetElement,
     },
     utils::{IntoUsize, VectorRepr},
     ANNError, ANNResult,
@@ -568,46 +567,37 @@ where
     type Id = u32;
 }
 
-impl<'a, T, Q> DelegateNeighbor<'a> for BfTreeProvider<T, Q>
-where
-    T: VectorRepr,
-    Q: AsyncFriendly,
-{
-    type Delegate = &'a NeighborProvider<u32>;
-
-    fn delegate_neighbor(&'a mut self) -> Self::Delegate {
-        self.neighbors()
-    }
-}
-
 impl NeighborAccessor for &NeighborProvider<u32> {
     fn get_neighbors(
-        self,
+        &mut self,
         id: Self::Id,
         neighbors: &mut AdjacencyList<Self::Id>,
-    ) -> impl Future<Output = ANNResult<Self>> + Send {
-        std::future::ready(self.get_neighbors(id, neighbors).map(|_| self))
+    ) -> impl Future<Output = ANNResult<()>> + Send {
+        std::future::ready(<NeighborProvider<u32>>::get_neighbors(self, id, neighbors))
     }
 }
 
 impl NeighborAccessorMut for &NeighborProvider<u32> {
     fn set_neighbors(
-        self,
+        &mut self,
         vector_id: u32,
         neighbors: &[u32],
-    ) -> impl Future<Output = ANNResult<Self>> + Send {
-        std::future::ready(self.set_neighbors(vector_id, neighbors).map(|_| self))
+    ) -> impl Future<Output = ANNResult<()>> + Send {
+        std::future::ready(<NeighborProvider<u32>>::set_neighbors(
+            self, vector_id, neighbors,
+        ))
     }
 
     fn append_vector(
-        self,
+        &mut self,
         vector_id: u32,
         new_neighbor_ids: &[u32],
-    ) -> impl Future<Output = ANNResult<Self>> + Send {
-        std::future::ready(
-            self.append_vector(vector_id, new_neighbor_ids)
-                .map(|_| self),
-        )
+    ) -> impl Future<Output = ANNResult<()>> + Send {
+        std::future::ready(<NeighborProvider<u32>>::append_vector(
+            self,
+            vector_id,
+            new_neighbor_ids,
+        ))
     }
 }
 
@@ -979,17 +969,15 @@ where
 // FullPruneAccessor //
 ///////////////////////
 
-/// A pruning accessor for full-precision vectors in the `BfTreeProvider`.
-///
-/// Unlike [`FullAccessor`], this type does not require a query — it implements
-/// [`HasElementRef`], [`BuildDistanceComputer`], and [`Fill`](workingset::Fill) for use
-/// during graph pruning.
+/// A [`glue::PruneAccessor`] for full-precision vectors in the `BfTreeProvider`.
 pub struct FullPruneAccessor<'a, T, Q>
 where
     T: VectorRepr,
     Q: AsyncFriendly,
 {
     provider: &'a BfTreeProvider<T, Q>,
+    set: map::Map<u32, Box<[T]>, map::Ref<[T]>>,
+    distance: T::Distance,
 }
 
 impl<'a, T, Q> FullPruneAccessor<'a, T, Q>
@@ -997,8 +985,15 @@ where
     T: VectorRepr,
     Q: AsyncFriendly,
 {
-    fn new(provider: &'a BfTreeProvider<T, Q>) -> Self {
-        Self { provider }
+    fn new(
+        provider: &'a BfTreeProvider<T, Q>,
+        set: map::Map<u32, Box<[T]>, map::Ref<[T]>>,
+    ) -> Self {
+        Self {
+            provider,
+            set,
+            distance: T::distance(provider.metric, Some(provider.full_vectors.dim())),
+        }
     }
 }
 
@@ -1010,70 +1005,35 @@ where
     type Id = u32;
 }
 
-impl<T, Q> HasElementRef for FullPruneAccessor<'_, T, Q>
+impl<T, Q> glue::PruneAccessor for FullPruneAccessor<'_, T, Q>
 where
     T: VectorRepr,
     Q: AsyncFriendly,
 {
     type ElementRef<'a> = &'a [T];
-}
-
-impl<'a, T, Q> DelegateNeighbor<'a> for FullPruneAccessor<'_, T, Q>
-where
-    T: VectorRepr,
-    Q: AsyncFriendly,
-{
-    type Delegate = &'a NeighborProvider<u32>;
-
-    fn delegate_neighbor(&'a mut self) -> Self::Delegate {
-        self.provider.neighbors()
-    }
-}
-
-impl<T, Q> BuildDistanceComputer for FullPruneAccessor<'_, T, Q>
-where
-    T: VectorRepr,
-    Q: AsyncFriendly,
-{
-    type DistanceComputerError = Infallible;
-    type DistanceComputer = T::Distance;
-
-    fn build_distance_computer(
-        &self,
-    ) -> Result<Self::DistanceComputer, Self::DistanceComputerError> {
-        Ok(T::distance(
-            self.provider.metric,
-            Some(self.provider.full_vectors.dim()),
-        ))
-    }
-}
-
-type WorkingSet<T> = map::Map<u32, Box<[T]>, map::Ref<[T]>>;
-type WorkingSetView<'a, T> = map::View<'a, u32, Box<[T]>, map::Ref<[T]>>;
-
-impl<T, Q> workingset::Fill<WorkingSet<T>> for FullPruneAccessor<'_, T, Q>
-where
-    T: VectorRepr,
-    Q: AsyncFriendly,
-{
-    type Error = ANNError;
     type View<'a>
-        = WorkingSetView<'a, T>
+        = map::View<'a, u32, Box<[T]>, map::Ref<[T]>>
+    where
+        Self: 'a;
+    type Distance<'a>
+        = &'a T::Distance
+    where
+        Self: 'a;
+    type Neighbors<'a>
+        = &'a NeighborProvider<u32>
     where
         Self: 'a;
 
     fn fill<'a, Itr>(
         &'a mut self,
-        working_set: &'a mut WorkingSet<T>,
         itr: Itr,
-    ) -> impl SendFuture<Result<Self::View<'a>, Self::Error>>
+    ) -> impl SendFuture<ANNResult<(Self::View<'a>, Self::Distance<'a>)>>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
-        Self: 'a,
     {
         let mut buf: Option<Box<[T]>> = None;
 
-        let view = working_set.fill(itr, |i: u32| -> ANNResult<_> {
+        let view = self.set.fill(itr, |i: u32| -> ANNResult<_> {
             let mut b = match buf.take() {
                 Some(b) => b,
                 None => std::iter::repeat_n(T::default(), self.provider.dim()).collect(),
@@ -1093,7 +1053,12 @@ where
             }
         });
 
-        std::future::ready(view)
+        let result = view.map(|v| (v, &self.distance));
+        std::future::ready(result)
+    }
+
+    fn neighbors(&mut self) -> Self::Neighbors<'_> {
+        self.provider.neighbors()
     }
 }
 
@@ -1101,24 +1066,34 @@ where
 // QuantPruneAccessor //
 ////////////////////////
 
-/// A pruning accessor for quantized vectors in the `BfTreeProvider`.
-///
-/// Unlike [`QuantAccessor`], this type does not require a query — it implements
-/// [`HasElementRef`], [`BuildDistanceComputer`], and [`Fill`](workingset::Fill) for use
-/// during graph pruning.
+/// A [`glue::PruneAccessor`] for quantized vectors in the `BfTreeProvider`.
 pub struct QuantPruneAccessor<'a, T>
 where
     T: VectorRepr,
 {
     provider: &'a BfTreeProvider<T, QuantVectorProvider>,
+    set: map::Map<u32, Owned>,
+    distance: UnwrapErr<spherical_iface::DistanceComputer, spherical_iface::DistanceError>,
 }
 
 impl<'a, T> QuantPruneAccessor<'a, T>
 where
     T: VectorRepr,
 {
-    fn new(provider: &'a BfTreeProvider<T, QuantVectorProvider>) -> Self {
-        Self { provider }
+    fn new(
+        provider: &'a BfTreeProvider<T, QuantVectorProvider>,
+        capacity: usize,
+    ) -> ANNResult<Self> {
+        let distance = provider
+            .quant_vectors
+            .distance_computer()
+            .map(UnwrapErr::new)?;
+        let set = map::Builder::new(map::Capacity::Default).build(capacity);
+        Ok(Self {
+            provider,
+            set,
+            distance,
+        })
     }
 }
 
@@ -1129,83 +1104,35 @@ where
     type Id = u32;
 }
 
-impl<T> HasElementRef for QuantPruneAccessor<'_, T>
+impl<T> glue::PruneAccessor for QuantPruneAccessor<'_, T>
 where
     T: VectorRepr,
 {
     type ElementRef<'a> = Opaque<'a>;
-}
-
-impl<'a, T> DelegateNeighbor<'a> for QuantPruneAccessor<'_, T>
-where
-    T: VectorRepr,
-{
-    type Delegate = &'a NeighborProvider<u32>;
-    fn delegate_neighbor(&'a mut self) -> Self::Delegate {
-        self.provider.neighbors()
-    }
-}
-
-/// An owned quantized vector that reborrows to [`Opaque`].
-///
-/// Unlike inmem providers (which hand back zero-copy references into a contiguous backing
-/// array), bf_tree copies vector data out of the tree on every access. The
-/// [`workingset::View`] trait requires `get` to return something that implements
-/// `Reborrow<'short, Target = Opaque<'short>>`, so we need an owned type that bridges
-/// bf_tree's copy-out model with the working set's reborrow expectation.
-pub struct Owned(Box<[u8]>);
-
-impl<'short> diskann_utils::Reborrow<'short> for Owned {
-    type Target = Opaque<'short>;
-    fn reborrow(&'short self) -> Self::Target {
-        Opaque::new(&self.0)
-    }
-}
-
-type QuantWorkingSet = map::Map<u32, Owned>;
-type QuantWorkingSetView<'a> = map::View<'a, u32, Owned>;
-
-impl<T> BuildDistanceComputer for QuantPruneAccessor<'_, T>
-where
-    T: VectorRepr,
-{
-    type DistanceComputerError = ANNError;
-    type DistanceComputer =
-        UnwrapErr<spherical_iface::DistanceComputer, spherical_iface::DistanceError>;
-
-    fn build_distance_computer(
-        &self,
-    ) -> Result<Self::DistanceComputer, Self::DistanceComputerError> {
-        self.provider
-            .quant_vectors
-            .distance_computer()
-            .map(UnwrapErr::new)
-    }
-}
-
-impl<T> workingset::Fill<QuantWorkingSet> for QuantPruneAccessor<'_, T>
-where
-    T: VectorRepr,
-{
-    type Error = ANNError;
     type View<'a>
-        = QuantWorkingSetView<'a>
+        = map::View<'a, u32, Owned>
+    where
+        Self: 'a;
+    type Distance<'a>
+        = &'a UnwrapErr<spherical_iface::DistanceComputer, spherical_iface::DistanceError>
+    where
+        Self: 'a;
+    type Neighbors<'a>
+        = &'a NeighborProvider<u32>
     where
         Self: 'a;
 
     fn fill<'a, Itr>(
         &'a mut self,
-        working_set: &'a mut QuantWorkingSet,
         itr: Itr,
-    ) -> impl SendFuture<Result<Self::View<'a>, Self::Error>>
+    ) -> impl SendFuture<ANNResult<(Self::View<'a>, Self::Distance<'a>)>>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
-        Self: 'a,
     {
         let mut buf: Option<Box<[u8]>> = None;
         let bytes = self.provider.quant_vectors.quantizer.bytes();
 
-        let view = working_set.fill(itr, |i: u32| -> ANNResult<_> {
+        let view = self.set.fill(itr, |i: u32| -> ANNResult<_> {
             let mut b = match buf.take() {
                 Some(b) => b,
                 None => std::iter::repeat_n(0, bytes).collect(),
@@ -1225,7 +1152,28 @@ where
             }
         });
 
-        std::future::ready(view)
+        let result = view.map(|v| (v, &self.distance));
+        std::future::ready(result)
+    }
+
+    fn neighbors(&mut self) -> Self::Neighbors<'_> {
+        self.provider.neighbors()
+    }
+}
+
+/// An owned quantized vector that reborrows to [`Opaque`].
+///
+/// Unlike inmem providers (which hand back zero-copy references into a contiguous backing
+/// array), bf_tree copies vector data out of the tree on every access. The
+/// [`workingset::View`] trait requires `get` to return something that implements
+/// `Reborrow<'short, Target = Opaque<'short>>`, so we need an owned type that bridges
+/// bf_tree's copy-out model with the working set's reborrow expectation.
+pub struct Owned(Box<[u8]>);
+
+impl<'short> diskann_utils::Reborrow<'short> for Owned {
+    type Target = Opaque<'short>;
+    fn reborrow(&'short self) -> Self::Target {
+        Opaque::new(&self.0)
     }
 }
 
@@ -1268,8 +1216,6 @@ where
     T: VectorRepr,
     Q: AsyncFriendly,
 {
-    type WorkingSet = WorkingSet<T>;
-    type DistanceComputer<'a> = T::Distance;
     type PruneAccessor<'a> = FullPruneAccessor<'a, T, Q>;
     type PruneAccessorError = diskann::error::Infallible;
 
@@ -1277,12 +1223,10 @@ where
         &'a self,
         provider: &'a BfTreeProvider<T, Q>,
         _context: &'a DefaultContext,
+        capacity: usize,
     ) -> Result<Self::PruneAccessor<'a>, Self::PruneAccessorError> {
-        Ok(FullPruneAccessor::new(provider))
-    }
-
-    fn create_working_set(&self, capacity: usize) -> Self::WorkingSet {
-        map::Builder::new(map::Capacity::Default).build(capacity)
+        let set = map::Builder::new(map::Capacity::Default).build(capacity);
+        Ok(FullPruneAccessor::new(provider, set))
     }
 }
 
@@ -1304,8 +1248,8 @@ where
     B: for<'a> Batch<Element<'a> = &'a [T]> + Debug,
 {
     type Seed = map::Builder<u32, map::Ref<[T]>>;
-    type WorkingSet = WorkingSet<T>;
     type FinishError = diskann::error::Infallible;
+    type PruneStrategy = Self;
     type InsertStrategy = Self;
 
     fn insert_strategy(&self) -> Self::InsertStrategy {
@@ -1325,6 +1269,17 @@ where
         let overlay = map::Overlay::from_batch(batch.clone(), ids);
         let builder = map::Builder::new(map::Capacity::Default).with_overlay(overlay);
         std::future::ready(Ok(builder))
+    }
+
+    fn seeded_prune_accessor<'a>(
+        &'a self,
+        provider: &'a BfTreeProvider<T, Q>,
+        _context: &'a DefaultContext,
+        seed: &'a Self::Seed,
+        capacity: usize,
+    ) -> ANNResult<FullPruneAccessor<'a, T, Q>> {
+        let set = seed.clone().build(capacity);
+        Ok(FullPruneAccessor::new(provider, set))
     }
 }
 
@@ -1411,16 +1366,11 @@ impl<T, B> MultiInsertStrategy<BfTreeProvider<T, QuantVectorProvider>, B> for Qu
 where
     T: VectorRepr,
     B: glue::Batch,
-    Self: for<'a> InsertStrategy<
-        'a,
-        BfTreeProvider<T, QuantVectorProvider>,
-        B::Element<'a>,
-        PruneStrategy = Self,
-    >,
+    B: for<'a> Batch<Element<'a> = &'a [T]> + Debug,
 {
-    type Seed = map::Builder<u32, map::Reborrowed<Owned>>;
-    type WorkingSet = QuantWorkingSet;
+    type Seed = ();
     type FinishError = diskann::error::Infallible;
+    type PruneStrategy = Self;
     type InsertStrategy = Self;
 
     fn insert_strategy(&self) -> Self::InsertStrategy {
@@ -1437,8 +1387,17 @@ where
     where
         Itr: ExactSizeIterator<Item = u32> + Send,
     {
-        let builder = map::Builder::new(map::Capacity::Default);
-        std::future::ready(Ok(builder))
+        std::future::ready(Ok(()))
+    }
+
+    fn seeded_prune_accessor<'a>(
+        &'a self,
+        provider: &'a BfTreeProvider<T, QuantVectorProvider>,
+        _context: &'a DefaultContext,
+        _seed: &'a (),
+        capacity: usize,
+    ) -> ANNResult<QuantPruneAccessor<'a, T>> {
+        QuantPruneAccessor::new(provider, capacity)
     }
 }
 
@@ -1487,22 +1446,16 @@ impl<T> PruneStrategy<BfTreeProvider<T, QuantVectorProvider>> for Quantized
 where
     T: VectorRepr,
 {
-    type WorkingSet = QuantWorkingSet;
-    type DistanceComputer<'a> =
-        UnwrapErr<spherical_iface::DistanceComputer, spherical_iface::DistanceError>;
     type PruneAccessor<'a> = QuantPruneAccessor<'a, T>;
-    type PruneAccessorError = diskann::error::Infallible;
+    type PruneAccessorError = ANNError;
 
     fn prune_accessor<'a>(
         &'a self,
         provider: &'a BfTreeProvider<T, QuantVectorProvider>,
         _context: &'a DefaultContext,
+        capacity: usize,
     ) -> Result<Self::PruneAccessor<'a>, Self::PruneAccessorError> {
-        Ok(QuantPruneAccessor::new(provider))
-    }
-
-    fn create_working_set(&self, capacity: usize) -> Self::WorkingSet {
-        map::Builder::new(map::Capacity::Default).build(capacity)
+        QuantPruneAccessor::new(provider, capacity)
     }
 }
 

--- a/diskann-garnet/src/provider.rs
+++ b/diskann-garnet/src/provider.rs
@@ -17,8 +17,8 @@ use diskann::{
     },
     neighbor::Neighbor,
     provider::{
-        BuildDistanceComputer, DataProvider, DelegateNeighbor, Delete, ElementStatus,
-        HasElementRef, HasId, NeighborAccessor, NeighborAccessorMut, NoopGuard, SetElement,
+        DataProvider, Delete, ElementStatus, HasId, NeighborAccessor, NeighborAccessorMut,
+        NoopGuard, SetElement,
     },
     utils::VectorRepr,
 };
@@ -1193,6 +1193,8 @@ where
     quantized: bool,
     id_buffer: PooledRef<'a, AdjList>,
     filtered_ids: PooledRef<'a, Vec<u32>>,
+    distance: GarnetDistanceComputer,
+    set: workingset::Map<u32, Box<[u8]>>,
 }
 
 impl<'a, T> PruneAccessor<'a, T>
@@ -1203,7 +1205,17 @@ where
         provider: &'a GarnetProvider<T>,
         context: &'a Context,
         quantized: bool,
-    ) -> Self {
+        capacity: usize,
+    ) -> Result<Self, GarnetProviderError> {
+        let distance = if quantized && let Some(quantizer) = provider.quantizer() {
+            quantizer.distance_computer()?
+        } else {
+            GarnetDistanceComputer::new(FullPrecisionDistance::<T>(T::distance(
+                provider.metric_type,
+                Some(provider.dim),
+            )))
+        };
+
         let id_buffer = provider
             .id_buffer_pool
             .get_ref(Undef::new(provider.max_degree + 1));
@@ -1213,13 +1225,23 @@ where
             .filtered_ids_pool
             .get_ref(Undef::new(MAX_OCCLUSION_SIZE.get() as usize * 2));
 
-        Self {
+        // Using `Capacity::Default` means that the constructed working set will act as a
+        // cache and persist up to `capacity` items across uses of the working set.
+        //
+        // This reuse is limited to a single collection of backedges for an insert or multi-insert.
+        let set = workingset::map::Builder::new(workingset::map::Capacity::Default).build(capacity);
+
+        let this = Self {
             provider,
             context,
             quantized,
             id_buffer,
             filtered_ids,
-        }
+            distance,
+            set,
+        };
+
+        Ok(this)
     }
 }
 
@@ -1230,38 +1252,79 @@ where
     type Id = u32;
 }
 
-impl<T> HasElementRef for PruneAccessor<'_, T>
+impl<T> glue::PruneAccessor for PruneAccessor<'_, T>
 where
     T: VectorRepr,
 {
     type ElementRef<'a> = &'a [u8];
-}
+    type View<'a>
+        = workingset::map::View<'a, u32, Box<[u8]>>
+    where
+        Self: 'a;
+    type Distance<'a>
+        = &'a GarnetDistanceComputer
+    where
+        Self: 'a;
+    type Neighbors<'a>
+        = DelegateNeighborAccessor<'a, T>
+    where
+        Self: 'a;
 
-impl<T: VectorRepr> BuildDistanceComputer for PruneAccessor<'_, T> {
-    type DistanceComputer = GarnetDistanceComputer;
-    type DistanceComputerError = GarnetProviderError;
+    async fn fill<'a, Itr>(
+        &'a mut self,
+        itr: Itr,
+    ) -> ANNResult<(Self::View<'a>, Self::Distance<'a>)>
+    where
+        Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
+    {
+        // Evict items from the working set to make room if needed.
+        self.set.prepare(itr.clone());
 
-    fn build_distance_computer(
-        &self,
-    ) -> Result<Self::DistanceComputer, Self::DistanceComputerError> {
-        if self.quantized
-            && let Some(quantizer) = self.provider.quantizer()
-        {
-            Ok(quantizer.distance_computer()?)
-        } else {
-            Ok(GarnetDistanceComputer::new(FullPrecisionDistance::<T>(
-                T::distance(self.provider.metric_type, Some(self.provider.dim)),
-            )))
+        self.filtered_ids.clear();
+        for id in itr {
+            if id == 0 {
+                if self.quantized
+                    && let Entry::Vacant(e) = self.set.entry(id)
+                {
+                    if let Some(guard) = self.provider.start_point_quant_cache.get(&id) {
+                        e.insert((&**guard).into());
+                    } else {
+                        return Err(GarnetProviderError::StartPoint.into());
+                    }
+                } else if let Entry::Vacant(e) = self.set.entry(id) {
+                    if let Some(guard) = self.provider.start_point_cache.get(&id) {
+                        e.insert((&**guard).into());
+                    } else {
+                        return Err(GarnetProviderError::StartPoint.into());
+                    }
+                } else {
+                    continue;
+                };
+            } else if !self.set.contains_key(&id) {
+                self.filtered_ids.push(4);
+                self.filtered_ids.push(id);
+            }
         }
-    }
-}
 
-impl<'a, T> DelegateNeighbor<'a> for PruneAccessor<'_, T>
-where
-    T: VectorRepr,
-{
-    type Delegate = DelegateNeighborAccessor<'a, T>;
-    fn delegate_neighbor(&'a mut self) -> Self::Delegate {
+        let ctx = if self.quantized {
+            self.context.term(Term::Quantized)
+        } else {
+            self.context.term(Term::Vector)
+        };
+
+        if !self.filtered_ids.is_empty() {
+            self.provider
+                .callbacks
+                .read_multi_lpiid(&ctx, &self.filtered_ids, |id, v| {
+                    self.set
+                        .insert(self.filtered_ids[id as usize * 2 + 1], v.into());
+                });
+        }
+
+        Ok((self.set.view(), &self.distance))
+    }
+
+    fn neighbors(&mut self) -> Self::Neighbors<'_> {
         DelegateNeighborAccessor {
             provider: self.provider,
             context: self.context,
@@ -1285,12 +1348,12 @@ impl<T: VectorRepr> HasId for DelegateNeighborAccessor<'_, T> {
 
 impl<T: VectorRepr> NeighborAccessor for DelegateNeighborAccessor<'_, T> {
     fn get_neighbors(
-        self,
+        &mut self,
         id: Self::Id,
         neighbors: &mut AdjacencyList<Self::Id>,
-    ) -> impl Future<Output = ANNResult<Self>> + Send {
+    ) -> impl Future<Output = ANNResult<()>> + Send {
         let result = if self.provider.get_neighbors(self.context, id, neighbors) {
-            Ok(self)
+            Ok(())
         } else {
             Err(ANNError::from(GarnetProviderError::Garnet(
                 GarnetError::Read,
@@ -1303,122 +1366,28 @@ impl<T: VectorRepr> NeighborAccessor for DelegateNeighborAccessor<'_, T> {
 
 impl<T: VectorRepr> NeighborAccessorMut for DelegateNeighborAccessor<'_, T> {
     fn set_neighbors(
-        self,
+        &mut self,
         id: Self::Id,
         neighbors: &[Self::Id],
-    ) -> impl Future<Output = ANNResult<Self>> + Send {
-        let result = match self
+    ) -> impl Future<Output = ANNResult<()>> + Send {
+        let result = self
             .provider
             .set_neighbors(self.context, id, neighbors, self.scratch)
-        {
-            Ok(()) => Ok(self),
-            Err(err) => Err(ANNError::from(err)),
-        };
+            .map_err(ANNError::from);
 
         std::future::ready(result)
     }
 
     fn append_vector(
-        self,
+        &mut self,
         id: Self::Id,
         neighbors: &[Self::Id],
-    ) -> impl Future<Output = ANNResult<Self>> + Send {
-        let result = match self.provider.append_vector(self.context, id, neighbors) {
-            Ok(()) => Ok(self),
-            Err(err) => Err(ANNError::from(err)),
-        };
-
+    ) -> impl Future<Output = ANNResult<()>> + Send {
+        let result = self
+            .provider
+            .append_vector(self.context, id, neighbors)
+            .map_err(ANNError::from);
         std::future::ready(result)
-    }
-}
-
-pub(crate) struct WorkingSet {
-    map: workingset::Map<u32, Box<[u8]>>,
-    contains_unquantized: bool,
-}
-
-impl WorkingSet {
-    pub(crate) fn new(capacity_type: workingset::map::Capacity, capacity: usize) -> Self {
-        Self {
-            map: workingset::map::Builder::new(capacity_type).build(capacity),
-            contains_unquantized: false,
-        }
-    }
-}
-
-type WorkingSetView<'a> = workingset::map::View<'a, u32, Box<[u8]>>;
-
-impl<T: VectorRepr> workingset::Fill<WorkingSet> for PruneAccessor<'_, T> {
-    type Error = GarnetProviderError;
-
-    type View<'a>
-        = WorkingSetView<'a>
-    where
-        Self: 'a;
-
-    async fn fill<'a, Itr>(
-        &'a mut self,
-        set: &'a mut WorkingSet,
-        itr: Itr,
-    ) -> Result<Self::View<'a>, Self::Error>
-    where
-        Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
-        Self: 'a,
-    {
-        if !self.quantized {
-            // Mark this working set as having full vectors if we're not quantizing yet
-            set.contains_unquantized = true;
-        } else if set.contains_unquantized {
-            // Working set is polluted by full vectors, it must be cleared
-            set.map.clear();
-            set.contains_unquantized = false;
-        }
-
-        // Evict items from the working set to make room if needed.
-        set.map.prepare(itr.clone());
-
-        self.filtered_ids.clear();
-        for id in itr {
-            if id == 0 {
-                if self.quantized
-                    && let Entry::Vacant(e) = set.map.entry(id)
-                {
-                    if let Some(guard) = self.provider.start_point_quant_cache.get(&id) {
-                        e.insert((&**guard).into());
-                    } else {
-                        return Err(GarnetProviderError::StartPoint);
-                    }
-                } else if let Entry::Vacant(e) = set.map.entry(id) {
-                    if let Some(guard) = self.provider.start_point_cache.get(&id) {
-                        e.insert((&**guard).into());
-                    } else {
-                        return Err(GarnetProviderError::StartPoint);
-                    }
-                } else {
-                    continue;
-                };
-            } else if !set.map.contains_key(&id) {
-                self.filtered_ids.push(4);
-                self.filtered_ids.push(id);
-            }
-        }
-
-        let ctx = if self.quantized {
-            self.context.term(Term::Quantized)
-        } else {
-            self.context.term(Term::Vector)
-        };
-
-        if !self.filtered_ids.is_empty() {
-            self.provider
-                .callbacks
-                .read_multi_lpiid(&ctx, &self.filtered_ids, |id, v| {
-                    set.map
-                        .insert(self.filtered_ids[id as usize * 2 + 1], v.into());
-                });
-        }
-
-        Ok(set.map.view())
     }
 }
 
@@ -1452,24 +1421,15 @@ impl<'a, T: VectorRepr> DefaultPostProcessor<'a, GarnetProvider<T>, &'a [T], Gar
 impl<T: VectorRepr> PruneStrategy<GarnetProvider<T>> for DynamicQuantization {
     type PruneAccessor<'a> = PruneAccessor<'a, T>;
     type PruneAccessorError = GarnetProviderError;
-    type DistanceComputer<'a> = GarnetDistanceComputer;
-    type WorkingSet = WorkingSet;
 
     fn prune_accessor<'a>(
         &'a self,
         provider: &'a GarnetProvider<T>,
         context: &'a <GarnetProvider<T> as DataProvider>::Context,
+        capacity: usize,
     ) -> Result<Self::PruneAccessor<'a>, Self::PruneAccessorError> {
         let quantized = provider.is_quantized();
-        Ok(PruneAccessor::new(provider, context, quantized))
-    }
-
-    fn create_working_set(&self, capacity: usize) -> Self::WorkingSet {
-        // Using `Capacity::Default` means that the constructed working set will act as a
-        // cache and persist up to `capacity` items across uses of the working set.
-        //
-        // This reuse is limited to a single collection of backedges for an insert or multi-insert.
-        WorkingSet::new(workingset::map::Capacity::Default, capacity)
+        PruneAccessor::new(provider, context, quantized, capacity)
     }
 }
 

--- a/diskann-garnet/src/provider.rs
+++ b/diskann-garnet/src/provider.rs
@@ -1270,10 +1270,7 @@ where
     where
         Self: 'a;
 
-    async fn fill<'a, Itr>(
-        &'a mut self,
-        itr: Itr,
-    ) -> ANNResult<(Self::View<'a>, Self::Distance<'a>)>
+    async fn fill<Itr>(&mut self, itr: Itr) -> ANNResult<(Self::View<'_>, Self::Distance<'_>)>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
     {

--- a/diskann-providers/src/index/diskann_async.rs
+++ b/diskann-providers/src/index/diskann_async.rs
@@ -173,8 +173,8 @@ pub(crate) mod tests {
         },
         neighbor::Neighbor,
         provider::{
-            AsNeighbor, AsNeighborMut, DataProvider, DefaultContext, Delete, ExecutionContext,
-            Guard, NeighborAccessor, NeighborAccessorMut, SetElement,
+            DataProvider, DefaultContext, Delete, ExecutionContext, Guard, NeighborAccessor,
+            NeighborAccessorMut, SetElement,
         },
         utils::{IntoUsize, ONE},
     };
@@ -265,7 +265,7 @@ pub(crate) mod tests {
 
     pub(crate) async fn populate_graph<NA>(accessor: &mut NA, source: &[AdjacencyList<u32>])
     where
-        NA: AsNeighborMut<Id = u32>,
+        NA: NeighborAccessorMut<Id = u32>,
     {
         for (i, v) in source.iter().enumerate() {
             accessor.set_neighbors(i as u32, v).await.unwrap();
@@ -2133,7 +2133,7 @@ pub(crate) mod tests {
 
     async fn check_graph_for_self_loops_or_duplicates<NA, Itr>(accessor: &mut NA, itr: Itr)
     where
-        NA: AsNeighbor<Id = u32>,
+        NA: NeighborAccessor<Id = u32>,
         Itr: Iterator<Item = u32>,
     {
         for id in itr {

--- a/diskann-providers/src/index/mod.rs
+++ b/diskann-providers/src/index/mod.rs
@@ -5,4 +5,4 @@
 
 pub mod diskann_async;
 
-pub mod wrapped_async;
+// pub mod wrapped_async;

--- a/diskann-providers/src/index/mod.rs
+++ b/diskann-providers/src/index/mod.rs
@@ -5,4 +5,4 @@
 
 pub mod diskann_async;
 
-// pub mod wrapped_async;
+pub mod wrapped_async;

--- a/diskann-providers/src/index/wrapped_async.rs
+++ b/diskann-providers/src/index/wrapped_async.rs
@@ -17,7 +17,7 @@ use diskann::{
         search_output_buffer,
     },
     neighbor::Neighbor,
-    provider::{AsNeighbor, AsNeighborMut, DataProvider, Delete, SetElement},
+    provider::{DataProvider, Delete, NeighborAccessor, NeighborAccessorMut, SetElement},
     utils::ONE,
 };
 use diskann_utils::Reborrow;
@@ -233,7 +233,7 @@ where
     ) -> ANNResult<bool>
     where
         DP: Delete,
-        NA: AsNeighbor<Id = DP::InternalId>,
+        NA: NeighborAccessor<Id = DP::InternalId>,
     {
         self.handle.block_on(
             self.inner
@@ -243,7 +243,7 @@ where
 
     pub fn drop_adj_list<NA>(&self, accessor: &mut NA, vector_id: DP::InternalId) -> ANNResult<()>
     where
-        NA: AsNeighborMut<Id = DP::InternalId>,
+        NA: NeighborAccessorMut<Id = DP::InternalId>,
     {
         self.handle
             .block_on(self.inner.drop_adj_list(accessor, vector_id))
@@ -258,7 +258,7 @@ where
     ) -> ANNResult<PartitionedNeighbors<DP::InternalId>>
     where
         DP: Delete,
-        NA: AsNeighbor<Id = DP::InternalId>,
+        NA: NeighborAccessor<Id = DP::InternalId>,
     {
         self.handle.block_on(
             self.inner
@@ -296,7 +296,7 @@ where
     ) -> ANNResult<ConsolidateKind>
     where
         DP: Delete,
-        NA: AsNeighborMut<Id = DP::InternalId>,
+        NA: NeighborAccessorMut<Id = DP::InternalId>,
     {
         self.handle.block_on(self.inner.drop_deleted_neighbors(
             context,
@@ -415,7 +415,7 @@ where
         accessor: &mut NA,
     ) -> ANNResult<usize>
     where
-        NA: AsNeighbor<Id = DP::InternalId>,
+        NA: NeighborAccessor<Id = DP::InternalId>,
     {
         self.handle
             .block_on(self.inner.count_reachable_nodes(start_points, accessor))
@@ -424,7 +424,7 @@ where
     pub fn get_degree_stats<NA, Itr>(&self, accessor: &mut NA, itr: Itr) -> ANNResult<DegreeStats>
     where
         Itr: IntoIterator<Item = DP::InternalId, IntoIter: Send> + Send,
-        NA: AsNeighbor<Id = DP::InternalId>,
+        NA: NeighborAccessor<Id = DP::InternalId>,
     {
         self.handle
             .block_on(self.inner.get_degree_stats(accessor, itr))

--- a/diskann-providers/src/model/graph/provider/async_/common.rs
+++ b/diskann-providers/src/model/graph/provider/async_/common.rs
@@ -212,14 +212,6 @@ pub enum PrefetchCacheLineLevel {
 // Common data structure and traits for async providers //
 //////////////////////////////////////////////////////////
 
-/// A ZST for [`MultiInsertStrategy::seed`](diskann::graph::glue::MultiInsertStrategy::Seed)
-/// indicating no use of the input batch.
-///
-/// Inmem providers typically don't use a working set at all, instead passing through accesses
-/// directly to the underlying provider. As such, no seeding is needed.
-#[derive(Debug, Clone, Copy)]
-pub struct Unseeded;
-
 /// A helper trait to set element in the Async index.
 pub trait SetElementHelper<T> {
     /// Set an element in the index.

--- a/diskann-providers/src/model/graph/provider/async_/distances.rs
+++ b/diskann-providers/src/model/graph/provider/async_/distances.rs
@@ -66,100 +66,11 @@ pub mod pq {
 
     use std::sync::Arc;
 
-    use diskann::{
-        graph::workingset::{self, map},
-        utils::VectorRepr,
-    };
-    use diskann_utils::{Reborrow, future::AsyncFriendly};
+    use diskann::utils::VectorRepr;
+    use diskann_utils::Reborrow;
     use diskann_vector::DistanceFunction;
 
     use crate::model::pq::{self, FixedChunkPQTable};
-
-    type InnerMap<F, Q> = workingset::Map<u32, Hybrid<Vec<F>, Vec<Q>>, Projection<F, Q>>;
-
-    /// Projects owned `Hybrid<Vec<F>, Vec<Q>>` values stored in a [`workingset::Map`] into
-    /// borrowed `Hybrid<&[F], &[Q]>` views for distance computation.
-    pub struct Projection<F, Q> {
-        _marker: std::marker::PhantomData<(F, Q)>,
-    }
-
-    impl<F, Q> map::Projection for Projection<F, Q>
-    where
-        F: AsyncFriendly,
-        Q: AsyncFriendly,
-    {
-        type Element<'a> = Hybrid<&'a [F], &'a [Q]>;
-        type ElementRef<'a> = Hybrid<&'a [F], &'a [Q]>;
-    }
-
-    impl<F, Q> map::Project<Projection<F, Q>> for Hybrid<Vec<F>, Vec<Q>>
-    where
-        F: AsyncFriendly,
-        Q: AsyncFriendly,
-    {
-        fn project(&self) -> Hybrid<&[F], &[Q]> {
-            self.reborrow()
-        }
-    }
-
-    /// Newtype around [`workingset::Map`] for hybrid PQ pruning state.
-    ///
-    /// This wrapper exists to avoid the blanket [`workingset::Fill`] implementation on
-    /// raw `Map`, allowing the hybrid accessor to provide a custom `Fill` that selectively
-    /// fetches full-precision vectors for the closest candidates and PQ codes for the rest.
-    pub struct HybridMap<F, Q>(InnerMap<F, Q>)
-    where
-        F: AsyncFriendly,
-        Q: AsyncFriendly;
-
-    /// The [`workingset::View`] for [`HybridMap`].
-    pub type View<'a, F, Q> = map::View<'a, u32, Hybrid<Vec<F>, Vec<Q>>, Projection<F, Q>>;
-
-    /// The [`workingset::AsWorkingSet`] for [`HybridMap`].
-    pub type Overlay<F, Q> = map::Overlay<u32, Projection<F, Q>>;
-
-    impl<F, Q> HybridMap<F, Q>
-    where
-        F: AsyncFriendly,
-        Q: AsyncFriendly,
-    {
-        /// Create a new `HybridMap` with the given capacity and no overlay.
-        pub fn with_capacity(capacity: usize) -> Self {
-            Self(map::Builder::new(map::Capacity::Default).build(capacity))
-        }
-
-        /// Create a new `HybridMap` with the given capacity and a batch overlay.
-        pub fn with_capacity_and(
-            capacity: usize,
-            overlay: map::Overlay<u32, Projection<F, Q>>,
-        ) -> Self {
-            Self(
-                map::Builder::new(map::Capacity::Default)
-                    .with_overlay(overlay)
-                    .build(capacity),
-            )
-        }
-
-        /// Borrow the underlying map.
-        pub fn get(&self) -> &InnerMap<F, Q> {
-            &self.0
-        }
-
-        /// Mutably borrow the underlying map.
-        pub fn get_mut(&mut self) -> &mut InnerMap<F, Q> {
-            &mut self.0
-        }
-    }
-
-    impl<F, Q> workingset::AsWorkingSet<HybridMap<F, Q>> for map::Overlay<u32, Projection<F, Q>>
-    where
-        F: AsyncFriendly,
-        Q: AsyncFriendly,
-    {
-        fn as_working_set(&self, capacity: usize) -> HybridMap<F, Q> {
-            HybridMap::with_capacity_and(capacity, self.clone())
-        }
-    }
 
     /// An element that is either a full-precision vector or a PQ-compressed code.
     ///

--- a/diskann-providers/src/model/graph/provider/async_/inmem/full_precision.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/full_precision.rs
@@ -140,10 +140,7 @@ where
     where
         Self: 'a;
 
-    async fn fill<'a, Itr>(
-        &'a mut self,
-        _itr: Itr,
-    ) -> ANNResult<(Self::View<'a>, Self::Distance<'a>)>
+    async fn fill<Itr>(&mut self, _itr: Itr) -> ANNResult<(Self::View<'_>, Self::Distance<'_>)>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
     {

--- a/diskann-providers/src/model/graph/provider/async_/inmem/full_precision.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/full_precision.rs
@@ -8,7 +8,7 @@ use std::{fmt::Debug, future::Future};
 use diskann::default_post_processor;
 use diskann::{
     ANNError, ANNResult,
-    error::Infallible,
+    error::IntoANNResult,
     graph::{
         AdjacencyList, SearchOutputBuffer,
         glue::{
@@ -18,10 +18,7 @@ use diskann::{
         workingset,
     },
     neighbor::Neighbor,
-    provider::{
-        DefaultContext, ExecutionContext,
-        HasId,
-    },
+    provider::{DefaultContext, ExecutionContext, HasId},
     utils::{IntoUsize, VectorRepr},
 };
 
@@ -34,7 +31,7 @@ use crate::model::graph::provider::async_::{
         CreateVectorStore, FullPrecision, NoDeletes, NoStore, Panics, PrefetchCacheLineLevel,
         SetElementHelper,
     },
-    inmem::{DefaultProvider, PassThrough},
+    inmem::DefaultProvider,
     postprocess::{AsDeletionCheck, DeletionCheck, RemoveDeletedIdsAndCopy},
 };
 
@@ -106,14 +103,13 @@ where
 // PruneAccessor //
 ///////////////////
 
-#[derive(Clone, Copy)]
 pub struct PruneAccessor<'a, T>
 where
     T: VectorRepr,
 {
-    metric: Metric,
     store: &'a FastMemoryVectorProviderAsync<T>,
     neighbors: &'a SimpleNeighborProviderAsync<u32>,
+    distance: <T as VectorRepr>::Distance,
 }
 
 impl<T> HasId for PruneAccessor<'_, T>
@@ -123,64 +119,44 @@ where
     type Id = u32;
 }
 
-impl<T> HasElementRef for PruneAccessor<'_, T>
+impl<T> glue::PruneAccessor for PruneAccessor<'_, T>
 where
     T: VectorRepr,
 {
     type ElementRef<'a> = &'a [T];
-}
-
-impl<'a, T> DelegateNeighbor<'a> for PruneAccessor<'_, T>
-where
-    T: VectorRepr,
-{
-    type Delegate = &'a SimpleNeighborProviderAsync<u32>;
-
-    fn delegate_neighbor(&'a mut self) -> Self::Delegate {
-        self.neighbors
-    }
-}
-
-impl<T> BuildDistanceComputer for PruneAccessor<'_, T>
-where
-    T: VectorRepr,
-{
-    type DistanceComputerError = Panics;
-    type DistanceComputer = T::Distance;
-
-    fn build_distance_computer(
-        &self,
-    ) -> Result<Self::DistanceComputer, Self::DistanceComputerError> {
-        Ok(T::distance(self.metric, Some(self.store.dim())))
-    }
-}
-
-impl<T> workingset::Fill<PassThrough> for PruneAccessor<'_, T>
-where
-    T: VectorRepr,
-{
-    type Error = Infallible;
 
     type View<'a>
-        = PruneAccessor<'a, T>
+        = &'a Self
+    where
+        Self: 'a;
+
+    type Distance<'a>
+        = &'a <T as VectorRepr>::Distance
+    where
+        Self: 'a;
+
+    type Neighbors<'a>
+        = &'a SimpleNeighborProviderAsync<u32>
     where
         Self: 'a;
 
     async fn fill<'a, Itr>(
         &'a mut self,
-        _state: &'a mut PassThrough,
         _itr: Itr,
-    ) -> Result<Self::View<'a>, Self::Error>
+    ) -> ANNResult<(Self::View<'a>, Self::Distance<'a>)>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
-        Self: 'a,
     {
-        Ok(*self)
+        Ok((self, &self.distance))
+    }
+
+    fn neighbors(&mut self) -> Self::Neighbors<'_> {
+        self.neighbors
     }
 }
 
 // Pass-through view.
-impl<T> workingset::View<u32> for PruneAccessor<'_, T>
+impl<T> workingset::View<u32> for &PruneAccessor<'_, T>
 where
     T: VectorRepr,
 {
@@ -473,26 +449,21 @@ where
     D: AsyncFriendly,
     Ctx: ExecutionContext,
 {
-    type DistanceComputer<'a> = T::Distance;
     type PruneAccessor<'a> = PruneAccessor<'a, T>;
     type PruneAccessorError = diskann::error::Infallible;
-    type WorkingSet = PassThrough;
 
     fn prune_accessor<'a>(
         &'a self,
         provider: &'a FullPrecisionProvider<T, Q, D, Ctx>,
         _context: &'a Ctx,
+        _capacity: usize,
     ) -> Result<Self::PruneAccessor<'a>, Self::PruneAccessorError> {
         let accessor = PruneAccessor {
-            metric: provider.metric,
             store: &provider.base_vectors,
             neighbors: provider.neighbors(),
+            distance: T::distance(provider.metric, Some(provider.base_vectors.dim())),
         };
         Ok(accessor)
-    }
-
-    fn create_working_set(&self, _capacity: usize) -> Self::WorkingSet {
-        PassThrough
     }
 }
 
@@ -525,9 +496,9 @@ where
             PruneStrategy = Self,
         >,
 {
-    type Seed = PassThrough;
-    type WorkingSet = PassThrough;
+    type Seed = ();
     type FinishError = diskann::error::Infallible;
+    type PruneStrategy = Self;
     type InsertStrategy = Self;
 
     fn insert_strategy(&self) -> Self::InsertStrategy {
@@ -544,7 +515,18 @@ where
     where
         Itr: ExactSizeIterator<Item = u32> + Send,
     {
-        std::future::ready(Ok(PassThrough))
+        std::future::ready(Ok(()))
+    }
+
+    fn seeded_prune_accessor<'a>(
+        &'a self,
+        provider: &'a FullPrecisionProvider<T, Q, D, Ctx>,
+        context: &'a Ctx,
+        _seed: &'a (),
+        capacity: usize,
+    ) -> ANNResult<PruneAccessor<'a, T>> {
+        self.prune_accessor(provider, context, capacity)
+            .into_ann_result()
     }
 }
 

--- a/diskann-providers/src/model/graph/provider/async_/inmem/full_precision.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/full_precision.rs
@@ -19,7 +19,7 @@ use diskann::{
     },
     neighbor::Neighbor,
     provider::{
-        BuildDistanceComputer, DefaultContext, DelegateNeighbor, ExecutionContext, HasElementRef,
+        DefaultContext, ExecutionContext,
         HasId,
     },
     utils::{IntoUsize, VectorRepr},

--- a/diskann-providers/src/model/graph/provider/async_/inmem/mod.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/mod.rs
@@ -5,22 +5,8 @@
 
 //! Native (DiskANN built-in) data providers and strategies for async index build and search.
 
-use diskann::graph::workingset;
-
 mod provider;
 pub use provider::{DefaultProvider, DefaultProviderParameters, SetStartPoints};
-
-/// The in-mem providers pass through prune elements straight back to their underlying
-/// providers. This is the working-set precursor and is a ZST because ... it doesn't need to
-/// do anything!
-#[derive(Debug, Clone, Copy)]
-pub struct PassThrough;
-
-impl workingset::AsWorkingSet<Self> for PassThrough {
-    fn as_working_set(&self, _capacity: usize) -> Self {
-        *self
-    }
-}
 
 // Extensions
 mod scalar;

--- a/diskann-providers/src/model/graph/provider/async_/inmem/product.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/product.rs
@@ -17,7 +17,7 @@ use diskann::{
         },
         workingset,
     },
-    provider::{BuildDistanceComputer, DelegateNeighbor, ExecutionContext, HasElementRef, HasId},
+    provider::{ExecutionContext, HasId},
     utils::{IntoUsize, VectorRepr},
 };
 use diskann_utils::future::AsyncFriendly;

--- a/diskann-providers/src/model/graph/provider/async_/inmem/product.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/product.rs
@@ -28,13 +28,11 @@ use crate::model::{
         FastMemoryQuantVectorProviderAsync, FastMemoryVectorProviderAsync,
         SimpleNeighborProviderAsync,
         common::{
-            CreateVectorStore, Hybrid, NoStore, Panics, Quantized, SetElementHelper, Unseeded,
-            VectorStore,
+            CreateVectorStore, Hybrid, NoStore, Panics, Quantized, SetElementHelper, VectorStore,
         },
         distances,
         inmem::{
-            DefaultProvider, FullPrecisionProvider, FullPrecisionStore, GetFullPrecision,
-            PassThrough, Rerank,
+            DefaultProvider, FullPrecisionProvider, FullPrecisionStore, GetFullPrecision, Rerank,
         },
         postprocess::{AsDeletionCheck, DeletionCheck, RemoveDeletedIdsAndCopy},
     },
@@ -84,60 +82,51 @@ where
 // PruneAccessor //
 ///////////////////
 
-#[derive(Clone, Copy)]
 pub struct PruneAccessor<'a> {
     provider: &'a FastMemoryQuantVectorProviderAsync,
     neighbors: &'a SimpleNeighborProviderAsync<u32>,
+    distance: pq::distance::DistanceComputer<Arc<FixedChunkPQTable>>,
 }
 
 impl HasId for PruneAccessor<'_> {
     type Id = u32;
 }
 
-impl HasElementRef for PruneAccessor<'_> {
+impl glue::PruneAccessor for PruneAccessor<'_> {
     type ElementRef<'a> = &'a [u8];
-}
 
-impl<'a> DelegateNeighbor<'a> for PruneAccessor<'_> {
-    type Delegate = &'a SimpleNeighborProviderAsync<u32>;
-    fn delegate_neighbor(&'a mut self) -> Self::Delegate {
-        self.neighbors
-    }
-}
-
-impl BuildDistanceComputer for PruneAccessor<'_> {
-    type DistanceComputerError = ANNError;
-    type DistanceComputer = pq::distance::DistanceComputer<Arc<FixedChunkPQTable>>;
-
-    fn build_distance_computer(
-        &self,
-    ) -> Result<Self::DistanceComputer, Self::DistanceComputerError> {
-        Ok(self.provider.distance_computer())
-    }
-}
-
-impl workingset::Fill<PassThrough> for PruneAccessor<'_> {
-    type Error = std::convert::Infallible;
     type View<'a>
-        = Self
+        = &'a Self
+    where
+        Self: 'a;
+
+    type Distance<'a>
+        = &'a pq::distance::DistanceComputer<Arc<FixedChunkPQTable>>
+    where
+        Self: 'a;
+
+    type Neighbors<'a>
+        = &'a SimpleNeighborProviderAsync<u32>
     where
         Self: 'a;
 
     async fn fill<'a, Itr>(
         &'a mut self,
-        _state: &'a mut PassThrough,
         _itr: Itr,
-    ) -> Result<Self::View<'a>, Self::Error>
+    ) -> ANNResult<(Self::View<'a>, Self::Distance<'a>)>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
-        Self: 'a,
     {
-        Ok(*self)
+        Ok((self, &self.distance))
+    }
+
+    fn neighbors(&mut self) -> Self::Neighbors<'_> {
+        self.neighbors
     }
 }
 
 // Pass-through view — reads PQ codes directly from the provider.
-impl workingset::View<u32> for PruneAccessor<'_> {
+impl workingset::View<u32> for &PruneAccessor<'_> {
     type ElementRef<'a> = &'a [u8];
     type Element<'a>
         = &'a [u8]
@@ -155,7 +144,6 @@ impl workingset::View<u32> for PruneAccessor<'_> {
 // HybridPruneAccessor //
 /////////////////////////
 
-#[derive(Clone)]
 pub struct HybridPruneAccessor<'a, T>
 where
     T: VectorRepr,
@@ -163,6 +151,11 @@ where
     full: &'a FastMemoryVectorProviderAsync<T>,
     quant: &'a FastMemoryQuantVectorProviderAsync,
     neighbors: &'a SimpleNeighborProviderAsync<u32>,
+    distance: distances::pq::HybridComputer<T>,
+
+    // During pruning, we make the first `max_fp_vecs_per_prune` are full-precision with
+    // the rest being quantized. This hash set records which IDs should be full-precision.
+    full_precision_ids: hashbrown::HashSet<u32>,
     max_fp_vecs_per_prune: usize,
 }
 
@@ -173,92 +166,43 @@ where
     type Id = u32;
 }
 
-impl<T> HasElementRef for HybridPruneAccessor<'_, T>
+impl<T> glue::PruneAccessor for HybridPruneAccessor<'_, T>
 where
     T: VectorRepr,
 {
     type ElementRef<'a> = distances::pq::Hybrid<&'a [T], &'a [u8]>;
-}
-
-impl<'a, T> DelegateNeighbor<'a> for HybridPruneAccessor<'_, T>
-where
-    T: VectorRepr,
-{
-    type Delegate = &'a SimpleNeighborProviderAsync<u32>;
-    fn delegate_neighbor(&'a mut self) -> Self::Delegate {
-        self.neighbors
-    }
-}
-
-impl<T> BuildDistanceComputer for HybridPruneAccessor<'_, T>
-where
-    T: VectorRepr,
-{
-    type DistanceComputerError = ANNError;
-    type DistanceComputer = distances::pq::HybridComputer<T>;
-
-    fn build_distance_computer(
-        &self,
-    ) -> Result<Self::DistanceComputer, Self::DistanceComputerError> {
-        let metric = self.quant.metric();
-        Ok(distances::pq::HybridComputer::new(
-            self.quant.distance_computer(),
-            T::distance(metric, Some(self.full.dim())),
-        ))
-    }
-}
-
-/// Tracks which IDs should use full-precision vectors during hybrid pruning.
-///
-/// IDs in the set get full-precision distance computations; all others fall back to
-/// quantized vectors.
-pub struct FullPrecisionTracker(hashbrown::HashSet<u32>);
-
-impl workingset::AsWorkingSet<FullPrecisionTracker> for Unseeded {
-    fn as_working_set(&self, capacity: usize) -> FullPrecisionTracker {
-        FullPrecisionTracker(hashbrown::HashSet::with_capacity(capacity))
-    }
-}
-
-// Selective fill — the first `max_fp_vecs_per_prune` candidates receive full-precision
-// vectors; the remainder are accessed through the pass-through `MaybeFullPrecision` view.
-impl<T> workingset::Fill<FullPrecisionTracker> for HybridPruneAccessor<'_, T>
-where
-    T: VectorRepr,
-{
-    type Error = std::convert::Infallible;
     type View<'a>
-        = MaybeFullPrecision<'a, T>
+        = &'a Self
+    where
+        Self: 'a;
+    type Distance<'a>
+        = &'a distances::pq::HybridComputer<T>
+    where
+        Self: 'a;
+    type Neighbors<'a>
+        = &'a SimpleNeighborProviderAsync<u32>
     where
         Self: 'a;
 
     async fn fill<'a, Itr>(
         &'a mut self,
-        state: &'a mut FullPrecisionTracker,
         itr: Itr,
-    ) -> Result<Self::View<'a>, Self::Error>
+    ) -> ANNResult<(Self::View<'a>, Self::Distance<'a>)>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
-        Self: 'a,
     {
-        state.0.clear();
-        state.0.extend(itr.take(self.max_fp_vecs_per_prune));
-        Ok(MaybeFullPrecision {
-            builder: self,
-            full: state,
-        })
+        self.full_precision_ids.clear();
+        self.full_precision_ids
+            .extend(itr.take(self.max_fp_vecs_per_prune));
+        Ok((self, &self.distance))
+    }
+
+    fn neighbors(&mut self) -> Self::Neighbors<'_> {
+        self.neighbors
     }
 }
 
-pub struct MaybeFullPrecision<'a, T>
-where
-    T: VectorRepr,
-{
-    builder: &'a HybridPruneAccessor<'a, T>,
-    full: &'a FullPrecisionTracker,
-}
-
-impl<T> workingset::View<u32> for MaybeFullPrecision<'_, T>
+impl<T> workingset::View<u32> for &HybridPruneAccessor<'_, T>
 where
     T: VectorRepr,
 {
@@ -269,18 +213,14 @@ where
         Self: 'a;
 
     fn get(&self, id: u32) -> Option<Self::Element<'_>> {
-        let element = if self.full.0.contains(&id) {
+        let element = if self.full_precision_ids.contains(&id) {
             // SAFETY: This is unsound. We assume no concurrent writes to this slot, but
             // this invariant is not enforced. See `get_vector_sync` for details.
-            unsafe {
-                distances::pq::Hybrid::Full(self.builder.full.get_vector_sync(id.into_usize()))
-            }
+            unsafe { distances::pq::Hybrid::Full(self.full.get_vector_sync(id.into_usize())) }
         } else {
             // SAFETY: This is unsound. We assume no concurrent writes to this slot, but
             // this invariant is not enforced. See `get_vector_sync` for details.
-            unsafe {
-                distances::pq::Hybrid::Quant(self.builder.quant.get_vector_sync(id.into_usize()))
-            }
+            unsafe { distances::pq::Hybrid::Quant(self.quant.get_vector_sync(id.into_usize())) }
         };
         Some(element)
     }
@@ -465,24 +405,30 @@ where
     D: AsyncFriendly + DeletionCheck,
     Ctx: ExecutionContext,
 {
-    type DistanceComputer<'a> = distances::pq::HybridComputer<T>;
     type PruneAccessor<'a> = HybridPruneAccessor<'a, T>;
     type PruneAccessorError = diskann::error::Infallible;
-    type WorkingSet = FullPrecisionTracker;
-
-    fn create_working_set(&self, capacity: usize) -> Self::WorkingSet {
-        FullPrecisionTracker(hashbrown::HashSet::with_capacity(capacity))
-    }
 
     fn prune_accessor<'a>(
         &'a self,
         provider: &'a FullPrecisionProvider<T, DefaultQuant, D, Ctx>,
         _context: &'a Ctx,
+        capacity: usize,
     ) -> Result<Self::PruneAccessor<'a>, Self::PruneAccessorError> {
+        let full = &provider.base_vectors;
+        let quant = &provider.aux_vectors;
+        let metric = quant.metric();
+
+        let distance = distances::pq::HybridComputer::new(
+            quant.distance_computer(),
+            T::distance(metric, Some(full.dim())),
+        );
+
         let accessor = HybridPruneAccessor {
             full: &provider.base_vectors,
             quant: &provider.aux_vectors,
             neighbors: provider.neighbors(),
+            distance,
+            full_precision_ids: hashbrown::HashSet::with_capacity(capacity),
             max_fp_vecs_per_prune: self.max_fp_vecs_per_prune.unwrap_or(usize::MAX),
         };
         Ok(accessor)
@@ -516,9 +462,9 @@ where
             PruneStrategy = Self,
         >,
 {
-    type Seed = Unseeded;
-    type WorkingSet = FullPrecisionTracker;
+    type Seed = ();
     type FinishError = diskann::error::Infallible;
+    type PruneStrategy = Self;
     type InsertStrategy = Self;
 
     fn insert_strategy(&self) -> Self::InsertStrategy {
@@ -535,7 +481,19 @@ where
     where
         Itr: ExactSizeIterator<Item = u32> + Send,
     {
-        std::future::ready(Ok(Unseeded))
+        std::future::ready(Ok(()))
+    }
+
+    fn seeded_prune_accessor<'a>(
+        &'a self,
+        provider: &'a FullPrecisionProvider<T, DefaultQuant, D, Ctx>,
+        context: &'a Ctx,
+        _seed: &'a (),
+        capacity: usize,
+    ) -> ANNResult<
+        <Self as PruneStrategy<FullPrecisionProvider<T, DefaultQuant, D, Ctx>>>::PruneAccessor<'a>,
+    > {
+        Ok(self.prune_accessor(provider, context, capacity)?)
     }
 }
 
@@ -618,23 +576,19 @@ where
     D: AsyncFriendly + DeletionCheck,
     Ctx: ExecutionContext,
 {
-    type DistanceComputer<'a> = pq::distance::DistanceComputer<Arc<FixedChunkPQTable>>;
     type PruneAccessor<'a> = PruneAccessor<'a>;
     type PruneAccessorError = diskann::error::Infallible;
-    type WorkingSet = PassThrough;
-
-    fn create_working_set(&self, _capacity: usize) -> Self::WorkingSet {
-        PassThrough
-    }
 
     fn prune_accessor<'a>(
         &'a self,
         provider: &'a DefaultProvider<NoStore, DefaultQuant, D, Ctx>,
         _context: &'a Ctx,
+        _capacity: usize,
     ) -> Result<Self::PruneAccessor<'a>, Self::PruneAccessorError> {
         let accessor = PruneAccessor {
             provider: &provider.aux_vectors,
             neighbors: provider.neighbors(),
+            distance: provider.aux_vectors.distance_computer(),
         };
         Ok(accessor)
     }
@@ -666,9 +620,9 @@ where
             PruneStrategy = Self,
         >,
 {
-    type Seed = PassThrough;
-    type WorkingSet = PassThrough;
+    type Seed = ();
     type FinishError = diskann::error::Infallible;
+    type PruneStrategy = Self;
     type InsertStrategy = Self;
 
     fn insert_strategy(&self) -> Self::InsertStrategy {
@@ -685,6 +639,17 @@ where
     where
         Itr: ExactSizeIterator<Item = u32> + Send,
     {
-        std::future::ready(Ok(PassThrough))
+        std::future::ready(Ok(()))
+    }
+
+    fn seeded_prune_accessor<'a>(
+        &'a self,
+        provider: &'a DefaultProvider<NoStore, DefaultQuant, D, Ctx>,
+        context: &'a Ctx,
+        _seed: &'a (),
+        capacity: usize,
+    ) -> ANNResult<PruneAccessor<'a>> {
+        self.prune_accessor(provider, context, capacity)
+            .into_ann_result()
     }
 }

--- a/diskann-providers/src/model/graph/provider/async_/inmem/product.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/product.rs
@@ -110,10 +110,7 @@ impl glue::PruneAccessor for PruneAccessor<'_> {
     where
         Self: 'a;
 
-    async fn fill<'a, Itr>(
-        &'a mut self,
-        _itr: Itr,
-    ) -> ANNResult<(Self::View<'a>, Self::Distance<'a>)>
+    async fn fill<Itr>(&mut self, _itr: Itr) -> ANNResult<(Self::View<'_>, Self::Distance<'_>)>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
     {
@@ -184,10 +181,7 @@ where
     where
         Self: 'a;
 
-    async fn fill<'a, Itr>(
-        &'a mut self,
-        itr: Itr,
-    ) -> ANNResult<(Self::View<'a>, Self::Distance<'a>)>
+    async fn fill<Itr>(&mut self, itr: Itr) -> ANNResult<(Self::View<'_>, Self::Distance<'_>)>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
     {

--- a/diskann-providers/src/model/graph/provider/async_/inmem/provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/provider.rs
@@ -645,24 +645,24 @@ where
 
 impl NeighborAccessor for &SimpleNeighborProviderAsync<u32> {
     async fn get_neighbors(
-        self,
+        &mut self,
         id: Self::Id,
         neighbors: &mut AdjacencyList<Self::Id>,
-    ) -> ANNResult<Self> {
+    ) -> ANNResult<()> {
         self.get_neighbors_sync(id.into_usize(), neighbors)?;
-        Ok(self)
+        Ok(())
     }
 }
 
 impl NeighborAccessorMut for &SimpleNeighborProviderAsync<u32> {
-    async fn set_neighbors(self, id: u32, neighbors: &[u32]) -> ANNResult<Self> {
+    async fn set_neighbors(&mut self, id: u32, neighbors: &[u32]) -> ANNResult<()> {
         self.set_neighbors_sync(id.into_usize(), neighbors)?;
-        Ok(self)
+        Ok(())
     }
 
-    async fn append_vector(self, id: u32, new_neighbor_ids: &[u32]) -> ANNResult<Self> {
+    async fn append_vector(&mut self, id: u32, new_neighbor_ids: &[u32]) -> ANNResult<()> {
         self.append_vector_sync(id.into_usize(), new_neighbor_ids)?;
-        Ok(self)
+        Ok(())
     }
 }
 
@@ -779,7 +779,7 @@ mod tests {
         for i in iter.clone() {
             // set adjacency list to non-empty before release
             provider
-                .neighbor_provider
+                .neighbors()
                 .set_neighbors(i, &[1, 2])
                 .await
                 .unwrap();
@@ -795,7 +795,7 @@ mod tests {
             // check that adjacency list was reset after release
             let mut neighbors = AdjacencyList::new();
             provider
-                .neighbor_provider
+                .neighbors()
                 .get_neighbors(i, &mut neighbors)
                 .await
                 .unwrap();

--- a/diskann-providers/src/model/graph/provider/async_/inmem/scalar.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/scalar.rs
@@ -414,10 +414,7 @@ where
     where
         Self: 'a;
 
-    async fn fill<'a, Itr>(
-        &'a mut self,
-        _itr: Itr,
-    ) -> ANNResult<(Self::View<'a>, Self::Distance<'a>)>
+    async fn fill<Itr>(&mut self, _itr: Itr) -> ANNResult<(Self::View<'_>, Self::Distance<'_>)>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
     {

--- a/diskann-providers/src/model/graph/provider/async_/inmem/scalar.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/scalar.rs
@@ -34,7 +34,7 @@ use diskann_utils::{Reborrow, ReborrowMut, future::AsyncFriendly};
 use diskann_vector::{DistanceFunction, PreprocessedDistanceFunction, distance::Metric};
 use thiserror::Error;
 
-use super::{DefaultProvider, GetFullPrecision, PassThrough, Rerank};
+use super::{DefaultProvider, GetFullPrecision, Rerank};
 use crate::{
     common::IgnoreLockPoison,
     model::graph::provider::async_::{
@@ -367,7 +367,6 @@ where
 // PruneAccessor //
 ///////////////////
 
-#[derive(Clone, Copy)]
 pub struct PruneAccessor<'a, const NBITS: usize> {
     store: &'a SQStore<NBITS>,
     neighbors: &'a SimpleNeighborProviderAsync<u32>,
@@ -383,8 +382,12 @@ where
         store: &'a SQStore<NBITS>,
         neighbors: &'a SimpleNeighborProviderAsync<u32>,
     ) -> ANNResult<Self> {
-        let computer = store.distance_computer()?;
-        Ok(Self { store, neighbors, computer })
+        let distance = store.distance_computer()?;
+        Ok(Self {
+            store,
+            neighbors,
+            distance,
+        })
     }
 }
 
@@ -395,11 +398,21 @@ impl<const NBITS: usize> HasId for PruneAccessor<'_, NBITS> {
 impl<const NBITS: usize> glue::PruneAccessor for PruneAccessor<'_, NBITS>
 where
     Unsigned: Representation<NBITS>,
+    DistanceComputer: for<'a, 'b> DistanceFunction<CVRef<'a, NBITS>, CVRef<'b, NBITS>, f32>,
 {
     type ElementRef<'a> = CVRef<'a, NBITS>;
-    type View<'a> = &'a Self where Self: 'a;
-    type Distance<'a> = &'a DistanceComputer where Self: 'a;
-    type Neighbors<'a> = &'a SimpleNeighborProviderAsync<u32> where Self: 'a;
+    type View<'a>
+        = &'a Self
+    where
+        Self: 'a;
+    type Distance<'a>
+        = &'a DistanceComputer
+    where
+        Self: 'a;
+    type Neighbors<'a>
+        = &'a SimpleNeighborProviderAsync<u32>
+    where
+        Self: 'a;
 
     async fn fill<'a, Itr>(
         &'a mut self,
@@ -407,13 +420,12 @@ where
     ) -> ANNResult<(Self::View<'a>, Self::Distance<'a>)>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
-        Self: 'a,
     {
-        Ok((self, &self.computer))
+        Ok((self, &self.distance))
     }
 
     fn neighbors(&mut self) -> Self::Neighbors<'_> {
-        &self.neighbors
+        self.neighbors
     }
 }
 
@@ -680,7 +692,7 @@ where
         &'a self,
         provider: &'a DefaultProvider<V, SQStore<NBITS>, D, Ctx>,
         _context: &'a Ctx,
-        _capacity: usize
+        _capacity: usize,
     ) -> Result<Self::PruneAccessor<'a>, Self::PruneAccessorError> {
         PruneAccessor::new(&provider.aux_vectors, provider.neighbors())
     }
@@ -713,7 +725,7 @@ where
     D: AsyncFriendly + DeletionCheck,
     Ctx: ExecutionContext,
     B: glue::Batch,
-    Self: PruneStrategy<DefaultProvider<V, SQStore<NBITS>, D, Ctx>, WorkingSet = PassThrough>
+    Self: PruneStrategy<DefaultProvider<V, SQStore<NBITS>, D, Ctx>>
         + for<'a> InsertStrategy<
             'a,
             DefaultProvider<V, SQStore<NBITS>, D, Ctx>,
@@ -721,9 +733,9 @@ where
             PruneStrategy = Self,
         >,
 {
-    type WorkingSet = PassThrough;
-    type Seed = PassThrough;
+    type Seed = ();
     type FinishError = diskann::error::Infallible;
+    type PruneStrategy = Self;
     type InsertStrategy = Self;
 
     fn insert_strategy(&self) -> Self::InsertStrategy {
@@ -740,7 +752,20 @@ where
     where
         Itr: ExactSizeIterator<Item = u32> + Send,
     {
-        std::future::ready(Ok(PassThrough))
+        std::future::ready(Ok(()))
+    }
+
+    fn seeded_prune_accessor<'a>(
+        &'a self,
+        provider: &'a DefaultProvider<V, SQStore<NBITS>, D, Ctx>,
+        context: &'a Ctx,
+        _seed: &'a (),
+        capacity: usize,
+    ) -> ANNResult<
+        <Self as PruneStrategy<DefaultProvider<V, SQStore<NBITS>, D, Ctx>>>::PruneAccessor<'a>,
+    > {
+        self.prune_accessor(provider, context, capacity)
+            .into_ann_result()
     }
 }
 

--- a/diskann-providers/src/model/graph/provider/async_/inmem/scalar.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/scalar.rs
@@ -17,7 +17,7 @@ use diskann::{
         },
         workingset,
     },
-    provider::{BuildDistanceComputer, DelegateNeighbor, ExecutionContext, HasElementRef, HasId},
+    provider::{ExecutionContext, HasId},
     utils::{IntoUsize, VectorRepr},
 };
 use diskann_quantization::{
@@ -371,11 +371,20 @@ where
 pub struct PruneAccessor<'a, const NBITS: usize> {
     store: &'a SQStore<NBITS>,
     neighbors: &'a SimpleNeighborProviderAsync<u32>,
+    distance: DistanceComputer,
 }
 
-impl<'a, const NBITS: usize> PruneAccessor<'a, NBITS> {
-    fn new(store: &'a SQStore<NBITS>, neighbors: &'a SimpleNeighborProviderAsync<u32>) -> Self {
-        Self { store, neighbors }
+impl<'a, const NBITS: usize> PruneAccessor<'a, NBITS>
+where
+    Unsigned: Representation<NBITS>,
+    DistanceComputer: for<'x, 'y> DistanceFunction<CVRef<'x, NBITS>, CVRef<'y, NBITS>, f32>,
+{
+    fn new(
+        store: &'a SQStore<NBITS>,
+        neighbors: &'a SimpleNeighborProviderAsync<u32>,
+    ) -> ANNResult<Self> {
+        let computer = store.distance_computer()?;
+        Ok(Self { store, neighbors, computer })
     }
 }
 
@@ -383,60 +392,33 @@ impl<const NBITS: usize> HasId for PruneAccessor<'_, NBITS> {
     type Id = u32;
 }
 
-impl<const NBITS: usize> HasElementRef for PruneAccessor<'_, NBITS>
+impl<const NBITS: usize> glue::PruneAccessor for PruneAccessor<'_, NBITS>
 where
     Unsigned: Representation<NBITS>,
 {
     type ElementRef<'a> = CVRef<'a, NBITS>;
-}
-
-impl<'a, const NBITS: usize> DelegateNeighbor<'a> for PruneAccessor<'_, NBITS> {
-    type Delegate = &'a SimpleNeighborProviderAsync<u32>;
-    fn delegate_neighbor(&'a mut self) -> Self::Delegate {
-        self.neighbors
-    }
-}
-
-impl<const NBITS: usize> BuildDistanceComputer for PruneAccessor<'_, NBITS>
-where
-    Unsigned: Representation<NBITS>,
-    DistanceComputer: for<'a, 'b> DistanceFunction<CVRef<'a, NBITS>, CVRef<'b, NBITS>, f32>,
-{
-    type DistanceComputerError = ANNError;
-    type DistanceComputer = DistanceComputer;
-
-    fn build_distance_computer(
-        &self,
-    ) -> Result<Self::DistanceComputer, Self::DistanceComputerError> {
-        Ok(self.store.distance_computer()?)
-    }
-}
-
-impl<const NBITS: usize> workingset::Fill<PassThrough> for PruneAccessor<'_, NBITS>
-where
-    Unsigned: Representation<NBITS>,
-{
-    type Error = std::convert::Infallible;
-    type View<'a>
-        = Self
-    where
-        Self: 'a;
+    type View<'a> = &'a Self where Self: 'a;
+    type Distance<'a> = &'a DistanceComputer where Self: 'a;
+    type Neighbors<'a> = &'a SimpleNeighborProviderAsync<u32> where Self: 'a;
 
     async fn fill<'a, Itr>(
         &'a mut self,
-        _state: &'a mut PassThrough,
         _itr: Itr,
-    ) -> Result<Self::View<'a>, Self::Error>
+    ) -> ANNResult<(Self::View<'a>, Self::Distance<'a>)>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
         Self: 'a,
     {
-        Ok(*self)
+        Ok((self, &self.computer))
+    }
+
+    fn neighbors(&mut self) -> Self::Neighbors<'_> {
+        &self.neighbors
     }
 }
 
 // Pass-through view — reads scalar-quantized vectors directly from the provider.
-impl<const NBITS: usize> workingset::View<u32> for PruneAccessor<'_, NBITS>
+impl<const NBITS: usize> workingset::View<u32> for &PruneAccessor<'_, NBITS>
 where
     Unsigned: Representation<NBITS>,
 {
@@ -691,24 +673,16 @@ where
     Unsigned: Representation<NBITS>,
     DistanceComputer: for<'a, 'b> DistanceFunction<CVRef<'a, NBITS>, CVRef<'b, NBITS>, f32>,
 {
-    type DistanceComputer<'a> = DistanceComputer;
     type PruneAccessor<'a> = PruneAccessor<'a, NBITS>;
-    type PruneAccessorError = diskann::error::Infallible;
-    type WorkingSet = PassThrough;
-
-    fn create_working_set(&self, _capacity: usize) -> Self::WorkingSet {
-        PassThrough
-    }
+    type PruneAccessorError = ANNError;
 
     fn prune_accessor<'a>(
         &'a self,
         provider: &'a DefaultProvider<V, SQStore<NBITS>, D, Ctx>,
         _context: &'a Ctx,
+        _capacity: usize
     ) -> Result<Self::PruneAccessor<'a>, Self::PruneAccessorError> {
-        Ok(PruneAccessor::new(
-            &provider.aux_vectors,
-            provider.neighbors(),
-        ))
+        PruneAccessor::new(&provider.aux_vectors, provider.neighbors())
     }
 }
 

--- a/diskann-providers/src/model/graph/provider/async_/inmem/spherical.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/spherical.rs
@@ -18,7 +18,7 @@ use diskann::{
         },
         workingset,
     },
-    provider::{BuildDistanceComputer, DelegateNeighbor, ExecutionContext, HasElementRef, HasId},
+    provider::{ExecutionContext, HasId},
     utils::{IntoUsize, VectorRepr},
 };
 use diskann_quantization::{

--- a/diskann-providers/src/model/graph/provider/async_/inmem/spherical.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/spherical.rs
@@ -323,10 +323,7 @@ impl glue::PruneAccessor for PruneAccessor<'_> {
     where
         Self: 'a;
 
-    async fn fill<'a, Itr>(
-        &'a mut self,
-        _itr: Itr,
-    ) -> ANNResult<(Self::View<'a>, Self::Distance<'a>)>
+    async fn fill<Itr>(&mut self, _itr: Itr) -> ANNResult<(Self::View<'_>, Self::Distance<'_>)>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
     {

--- a/diskann-providers/src/model/graph/provider/async_/inmem/spherical.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/spherical.rs
@@ -30,7 +30,7 @@ use diskann_utils::future::AsyncFriendly;
 use diskann_vector::{PreprocessedDistanceFunction, distance::Metric};
 use thiserror::Error;
 
-use super::{GetFullPrecision, PassThrough, Rerank};
+use super::{GetFullPrecision, Rerank};
 use crate::{
     common::IgnoreLockPoison,
     model::graph::provider::async_::{
@@ -293,62 +293,53 @@ where
 // PruneAccessor //
 ///////////////////
 
-#[derive(Clone, Copy)]
+type Distance = UnwrapErr<spherical::iface::DistanceComputer, spherical::iface::DistanceError>;
+
 pub struct PruneAccessor<'a> {
     store: &'a SphericalStore,
     neighbors: &'a SimpleNeighborProviderAsync<u32>,
+    distance: Distance,
 }
 
 impl HasId for PruneAccessor<'_> {
     type Id = u32;
 }
 
-impl HasElementRef for PruneAccessor<'_> {
+impl glue::PruneAccessor for PruneAccessor<'_> {
     type ElementRef<'a> = spherical::iface::Opaque<'a>;
-}
 
-impl<'a> DelegateNeighbor<'a> for PruneAccessor<'_> {
-    type Delegate = &'a SimpleNeighborProviderAsync<u32>;
-    fn delegate_neighbor(&'a mut self) -> Self::Delegate {
-        self.neighbors
-    }
-}
-
-impl BuildDistanceComputer for PruneAccessor<'_> {
-    type DistanceComputerError = AllocatorError;
-    type DistanceComputer =
-        UnwrapErr<spherical::iface::DistanceComputer, spherical::iface::DistanceError>;
-
-    fn build_distance_computer(
-        &self,
-    ) -> Result<Self::DistanceComputer, Self::DistanceComputerError> {
-        self.store.distance_computer().map(UnwrapErr::new)
-    }
-}
-
-// Pass-through fill — returns `&Self` which directly accesses the underlying provider.
-impl workingset::Fill<PassThrough> for PruneAccessor<'_> {
-    type Error = std::convert::Infallible;
     type View<'a>
-        = Self
+        = &'a Self
+    where
+        Self: 'a;
+
+    type Distance<'a>
+        = &'a Distance
+    where
+        Self: 'a;
+
+    type Neighbors<'a>
+        = &'a SimpleNeighborProviderAsync<u32>
     where
         Self: 'a;
 
     async fn fill<'a, Itr>(
         &'a mut self,
-        _state: &'a mut PassThrough,
         _itr: Itr,
-    ) -> Result<Self::View<'a>, Self::Error>
+    ) -> ANNResult<(Self::View<'a>, Self::Distance<'a>)>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
-        Self: 'a,
     {
-        Ok(*self)
+        Ok((self, &self.distance))
+    }
+
+    fn neighbors(&mut self) -> Self::Neighbors<'_> {
+        self.neighbors
     }
 }
 
 // Pass-through view — reads spherical vectors directly from the provider.
-impl workingset::View<u32> for PruneAccessor<'_> {
+impl workingset::View<u32> for &PruneAccessor<'_> {
     type ElementRef<'a> = spherical::iface::Opaque<'a>;
     type Element<'a>
         = spherical::iface::Opaque<'a>
@@ -620,24 +611,22 @@ where
     D: AsyncFriendly + DeletionCheck,
     Ctx: ExecutionContext,
 {
-    type DistanceComputer<'a> =
-        UnwrapErr<spherical::iface::DistanceComputer, spherical::iface::DistanceError>;
     type PruneAccessor<'a> = PruneAccessor<'a>;
-    type PruneAccessorError = diskann::error::Infallible;
-    type WorkingSet = PassThrough;
-
-    fn create_working_set(&self, _capacity: usize) -> Self::WorkingSet {
-        PassThrough
-    }
+    type PruneAccessorError = AllocatorError;
 
     fn prune_accessor<'a>(
         &'a self,
         provider: &'a DefaultProvider<V, SphericalStore, D, Ctx>,
         _context: &'a Ctx,
+        _capacity: usize,
     ) -> Result<Self::PruneAccessor<'a>, Self::PruneAccessorError> {
         let accessor = PruneAccessor {
             store: &provider.aux_vectors,
             neighbors: provider.neighbors(),
+            distance: provider
+                .aux_vectors
+                .distance_computer()
+                .map(UnwrapErr::new)?,
         };
         Ok(accessor)
     }
@@ -671,9 +660,9 @@ where
             PruneStrategy = Self,
         >,
 {
-    type Seed = PassThrough;
-    type WorkingSet = PassThrough;
+    type Seed = ();
     type FinishError = diskann::error::Infallible;
+    type PruneStrategy = Self;
     type InsertStrategy = Self;
 
     fn insert_strategy(&self) -> Self::InsertStrategy {
@@ -690,7 +679,17 @@ where
     where
         Itr: ExactSizeIterator<Item = u32> + Send,
     {
-        std::future::ready(Ok(PassThrough))
+        std::future::ready(Ok(()))
+    }
+
+    fn seeded_prune_accessor<'a>(
+        &'a self,
+        provider: &'a DefaultProvider<V, SphericalStore, D, Ctx>,
+        context: &'a Ctx,
+        _seed: &'a (),
+        capacity: usize,
+    ) -> ANNResult<PruneAccessor<'a>> {
+        Ok(self.prune_accessor(provider, context, capacity)?)
     }
 }
 

--- a/diskann-vector/src/traits.rs
+++ b/diskann-vector/src/traits.rs
@@ -23,7 +23,7 @@ pub trait DistanceFunction<Left, Right, To = f32> {
 
 impl<Left, Right, To, T> DistanceFunction<Left, Right, To> for &T
 where
-    T: DistanceFunction<Left, Right, To>
+    T: DistanceFunction<Left, Right, To>,
 {
     fn evaluate_similarity(&self, x: Left, y: Right) -> To {
         <T as DistanceFunction<_, _, _>>::evaluate_similarity(self, x, y)

--- a/diskann-vector/src/traits.rs
+++ b/diskann-vector/src/traits.rs
@@ -21,6 +21,15 @@ pub trait DistanceFunction<Left, Right, To = f32> {
     fn evaluate_similarity(&self, x: Left, y: Right) -> To;
 }
 
+impl<Left, Right, To, T> DistanceFunction<Left, Right, To> for &T
+where
+    T: DistanceFunction<Left, Right, To>
+{
+    fn evaluate_similarity(&self, x: Left, y: Right) -> To {
+        <T as DistanceFunction<_, _, _>>::evaluate_similarity(self, x, y)
+    }
+}
+
 /// A mutable version of [`DistanceFunction`] that allows mutation of `Self`.
 ///
 /// This trait is useful for computing distances where the distance functor holds

--- a/diskann/src/graph/glue.rs
+++ b/diskann/src/graph/glue.rs
@@ -650,10 +650,10 @@ pub trait PruneAccessor: HasId + Send + Sync {
     ///
     /// See: [`Map`](crate::graph::workingset::Map) for a flexible data structure that
     /// can be used to make an implementation.
-    fn fill<'a, Itr>(
-        &'a mut self,
+    fn fill<Itr>(
+        &mut self,
         itr: Itr,
-    ) -> impl SendFuture<ANNResult<(Self::View<'a>, Self::Distance<'a>)>>
+    ) -> impl SendFuture<ANNResult<(Self::View<'_>, Self::Distance<'_>)>>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync;
 }

--- a/diskann/src/graph/glue.rs
+++ b/diskann/src/graph/glue.rs
@@ -26,7 +26,7 @@
 //! 2. Neighbor pruning to compute new adjacency lists.
 //!
 //! Like search, there is a primary trait for extending this behavior: [`PruneAccessor`].
-//! Neighbor manipulation is done via [`PruneAccessor::neighbors`] where-as pruning is
+//! Neighbor manipulation is done via [`PruneAccessor::neighbors`] whereas pruning is
 //! facilitated with [`PruneAccessor::fill`].
 //!
 //! A single [`PruneAccessor`] can be used for multiple rounds of pruning during a single
@@ -634,8 +634,8 @@ pub trait PruneAccessor: HasId + Send + Sync {
     ///
     /// ## Reuse
     ///
-    /// This method may be called multiple times through-out the lifetime of `Self`, providing
-    /// an opportunity to cache previously return results withing `Self`.
+    /// This method may be called multiple times throughout the lifetime of `Self`, providing
+    /// an opportunity to cache previously returned results within `Self`.
     ///
     /// Trade offs include:
     ///
@@ -699,7 +699,7 @@ pub trait PruneStrategy<Provider>: Send + Sync + 'static
 where
     Provider: DataProvider,
 {
-    /// The concrete type of the [`PruenAccessor`] that is used during index construction.
+    /// The concrete type of the [`PruneAccessor`] that is used during index construction.
     type PruneAccessor<'a>: PruneAccessor<Id = Provider::InternalId>;
 
     /// An error that can occur when getting the prune accessor.

--- a/diskann/src/graph/glue.rs
+++ b/diskann/src/graph/glue.rs
@@ -18,6 +18,22 @@
 //! Accessors are constructed via [`SearchStrategy::search_accessor`] and
 //! [`InsertStrategy::insert_search_accessor`] where they are provided with the query.
 //!
+//! # Build
+//!
+//! Index building consists of two main parts:
+//!
+//! 1. Adjacency list manipulation.
+//! 2. Neighbor pruning to compute new adjacency lists.
+//!
+//! Like search, there is a primary trait for extending this behavior: [`PruneAccessor`].
+//! Neighbor manipulation is done via [`PruneAccessor::neighbors`] where-as pruning is
+//! facilitated with [`PruneAccessor::fill`].
+//!
+//! A single [`PruneAccessor`] can be used for multiple rounds of pruning during a single
+//! insert or delete operation. As such, implementations may wish to cache a small number
+//! of vectors internally across calls to [`PruneAccessor::fill`] and are encouraged to use
+//! [`Map`](crate::graph::workingset::Map) for this cache.
+//!
 //! # Strategies
 //!
 //! Strategies provide the "glue" between [`DataProvider`]s and index operations like search,
@@ -68,18 +84,8 @@
 //!
 //!   This accessor is then used for search, followed by pruning.
 //!
-//! * [`PruneStrategy`]: The pruning strategy is largely straightforward, consisting of
-//!   an accessor and a random access [`DistanceFunction`] for performing distance
-//!   calculations on the retrieved elements.
-//!
-//!   One subtle aspect is the use of the [`workingset::Fill`] trait. For clients with
-//!   expensive vector retrieval calls, we wish to only retrieve vector IDs once for pruning.
-//!
-//!   This is done by using a working set to store the elements retrieved by the
-//!   `PruneAccessor`. To give implementers the ability to perform a hybrid prune
-//!   (consisting of a mix of full-precision and quantized vectors), **without** the index
-//!   algorithm being aware of these two levels, the trait [`workingset::Fill`] is used to
-//!   delegate the responsibility of populating this cache to the [`DataProvider`].
+//! * [`PruneStrategy`]: The pruning strategy is simpler a deferred mechanism of constructing
+//!   a [`PruneAccessor`].
 //!
 //! * [`InplaceDeleteStrategy`]: This follows the trend of defining accessors and related
 //!   strategies. One difference for inplace-deletion is that we use an element accessed
@@ -569,48 +575,49 @@ where
 // Insert //
 ////////////
 
+/// The customization point for graph index construction.
+///
+/// Index construction consists of adjacency list manipulation and candidate pruning.
+/// Adjacency list manipulation is facilitated by [`neighbors`](Self::neighbors) and provides
+/// an opportunity for implementations to delegate to a common implementation if needed.
+/// If [`provider::NeighborAccessorMut`] is already implemented, then [`provider::Neighbors`]
+/// can be used to return `&mut Self`.
+///
+/// Pruning rounds happen using a sequence where [`fill`](Self::fill) is called on a
+/// collection of IDs to be pruned. Because a [`PruneAccessor`] may be used for multiple
+/// rounds of pruning, implementations can use [`Map`](crate::graph::workingset::Map) as
+/// a bounded cache of elements to avoid traffic to the backing provider.
 pub trait PruneAccessor: HasId + Send + Sync {
+    /// The type of the neighbor-accessor delegate.
+    type Neighbors<'a>: provider::NeighborAccessorMut<Id = Self::Id>
+    where
+        Self: 'a;
+
+    /// The element type yielded from [`Self::View`].
     type ElementRef<'a>;
 
+    /// The type of the prune-local view over a collection of ids.
     type View<'a>: for<'x> workingset::View<Self::Id, ElementRef<'x> = Self::ElementRef<'x>>
         + Send
         + Sync
     where
         Self: 'a;
 
+    /// The computer used to compute distances between elements.
     type Distance<'a>: for<'x, 'y> DistanceFunction<Self::ElementRef<'x>, Self::ElementRef<'y>, f32>
         + Send
         + Sync
     where
         Self: 'a;
 
-    type Neighbors<'a>: provider::NeighborAccessorMut<Id = Self::Id>
-    where
-        Self: 'a;
+    /// Return a delegate for performing graph manipulation.
+    ///
+    /// If `Self` implements [`NeighborAccessorMut`], then [`provider::Neighbors`] can be
+    /// used to wrap `&mut self`.
+    fn neighbors(&mut self) -> Self::Neighbors<'_>;
 
-    /// Populate a `WorkingSet` with data from an accessor and return a [`View`] over the set.
-    ///
-    /// For each `i` in `itr` - the accessor should make the data behind `i` available, either
-    /// by storing it in `working_set` or through direct storage in the returned [`View`].
-    ///
-    /// The `WorkingSet` type is constructed by either:
-    ///
-    /// * [`PruneStrategy`](crate::graph::glue::PruneStrategy::create_working_set): Direct
-    ///   construction of a working set for use in multiple prunes.
-    ///
-    /// * [`MultiInsertStrategy::Seed`](crate::graph::glue::MultiInsertStrategy::Seed): Indirect
-    ///   creation that uses [`AsWorkingSet`] for the final conversion. This allows the elements
-    ///   in the input batch to [`multi_insert`](crate::graph::DiskANNIndex::multi_insert) to be
-    ///   directly accessible by the `WorkingSet`/[`View`] types.
-    ///
-    /// For many simple use cases, [`Map::fill`] should be sufficient to provide a good
-    /// implementation of [`Fill::fill`].
-    ///
-    /// See Also: [`View`], [`AsWorkingSet`], [`Map`].
-    ///
-    /// Make the data elements for items in `itr` available in the returned [`View`].
-    ///
-    /// Implementations may use `working_set` as scratch and to persist work across multiple calls.
+    /// Make the data elements for items in `itr` available in the returned [`View`] and
+    /// provide a means of computing distance between elements in the view.
     ///
     /// The input `itr` is `Clone` and is expected that the implementation of `Clone` is cheap
     /// and without interior mutability. This allows implementers to perform multiple passes
@@ -624,14 +631,31 @@ pub trait PruneAccessor: HasId + Send + Sync {
     ///
     /// If a ID really needs to be fetched for algorithmic purposes, it will be the first
     /// item yielded from `itr`.
+    ///
+    /// ## Reuse
+    ///
+    /// This method may be called multiple times through-out the lifetime of `Self`, providing
+    /// an opportunity to cache previously return results withing `Self`.
+    ///
+    /// Trade offs include:
+    ///
+    /// * Without any reuse, more backend vector retrievals are made but the returned
+    ///   [`workingset::View`] is more up-to-date.
+    ///
+    /// * With reuse, the consumed memory increases but the total number of vector
+    ///   retrievals will be lower.
+    ///
+    /// Accessors are alive for a relatively small temporal window, so the risk of stale
+    /// entries in the cache causing incorrect graphs is minimal.
+    ///
+    /// See: [`Map`](crate::graph::workingset::Map) for a flexible data structure that
+    /// can be used to make an implementation.
     fn fill<'a, Itr>(
         &'a mut self,
         itr: Itr,
     ) -> impl SendFuture<ANNResult<(Self::View<'a>, Self::Distance<'a>)>>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync;
-
-    fn neighbors(&mut self) -> Self::Neighbors<'_>;
 }
 
 /// A strategy for inserting elements from the data provider.
@@ -675,42 +699,44 @@ pub trait PruneStrategy<Provider>: Send + Sync + 'static
 where
     Provider: DataProvider,
 {
-    /// The concrete type of the accessor that is used to access `Self` during pruning.
-    ///
-    /// The accessor implements [`workingset::Fill`] for the strategy's
-    /// [`WorkingSet`](Self::WorkingSet) type, which controls how elements are fetched and
-    /// cached for distance computations.
+    /// The concrete type of the [`PruenAccessor`] that is used during index construction.
     type PruneAccessor<'a>: PruneAccessor<Id = Provider::InternalId>;
 
     /// An error that can occur when getting the prune accessor.
     type PruneAccessorError: StandardError;
 
-    /// Return the prune accessor.
+    /// Return the [`PruneAccessor`]. Argument `capacity` provides an upper bound on the
+    /// length of the iterator passed to [`PruneAccessor::fill`].
     fn prune_accessor<'a>(
         &'a self,
         provider: &'a Provider,
         context: &'a Provider::Context,
-        size_hint: usize,
+        capacity: usize,
     ) -> Result<Self::PruneAccessor<'a>, Self::PruneAccessorError>;
 }
 
 /// Strategy for bulk insertion via [`multi_insert`](crate::graph::DiskANNIndex::multi_insert).
 ///
-/// This trait delegates to its [`InsertStrategy`] for most selections during insert with
-/// one difference, the [working set](crate::graph::workingset) provided to the insertion
-/// [`PruneStrategy`] is seeded from [`Self::Seed`]. Seeding allows elements of the input
-/// batch `B` to be part of the working set throughout prune, saving on vector retrievals.
+/// Multi-insert bulk-inserts a batch of vectors and provides this batch to
+/// [`MultiInsertStrategy::finish`] to create a seed. This seed is then provided to
+/// multiple calls to [`MultiInsertStrategy::seeded_prune_accessor`] to construct the various
+/// [`PruneAccessors`] needed during build.
+///
+/// This architecture allows implementations to use overlays like
+/// [`Overlay`](crate::graph::workingset::map::Overlay) so accesses to batch elements can
+/// be routed locally rather than all the way back to the underlying provider.
 pub trait MultiInsertStrategy<Provider, B>: Send + Sync + 'static
 where
     Provider: DataProvider,
     B: Batch,
 {
-    /// The working set "seed", potentially containing `B` for faster access.
+    /// The prune-accessor "seed", potentially containing `B` for faster access.
     type Seed: Send + Sync + 'static;
 
     /// Any critical error that occurs during [`finish`](Self::finish).
     type FinishError: Into<ANNError> + std::fmt::Debug + Send + Sync;
 
+    /// The delegated [`PruneStrategy`] used for pruning.
     type PruneStrategy: PruneStrategy<Provider>;
 
     /// The delegated [`InsertStrategy`] for most insertion related decisions.
@@ -735,6 +761,10 @@ where
     where
         Itr: ExactSizeIterator<Item = Provider::InternalId> + Send;
 
+    /// Construct a [`PruneAccessor`] from a seed returned by [`Self::finish`].
+    ///
+    /// Argument `capacity` provides an upper bound on the iterator length for
+    /// [`PruneAccessor::fill`].
     fn seeded_prune_accessor<'a>(
         &'a self,
         provider: &'a Provider,

--- a/diskann/src/graph/glue.rs
+++ b/diskann/src/graph/glue.rs
@@ -91,7 +91,7 @@
 
 use std::{future::Future, sync::Arc};
 
-use diskann_utils::Reborrow;
+use diskann_utils::{Reborrow, future::SendFuture};
 use diskann_vector::DistanceFunction;
 use futures_util::FutureExt;
 
@@ -100,7 +100,7 @@ use crate::{
     error::StandardError,
     graph::{SearchOutputBuffer, workingset},
     neighbor::Neighbor,
-    provider::{AsNeighborMut, BuildDistanceComputer, DataProvider, HasElementRef, HasId},
+    provider::{self, DataProvider, HasId},
 };
 
 /// The main extension point for graph search.
@@ -565,6 +565,75 @@ where
     }
 }
 
+////////////
+// Insert //
+////////////
+
+pub trait PruneAccessor: HasId + Send + Sync {
+    type ElementRef<'a>;
+
+    type View<'a>: for<'x> workingset::View<Self::Id, ElementRef<'x> = Self::ElementRef<'x>>
+        + Send
+        + Sync
+    where
+        Self: 'a;
+
+    type Distance<'a>: for<'x, 'y> DistanceFunction<Self::ElementRef<'x>, Self::ElementRef<'y>, f32>
+        + Send
+        + Sync
+    where
+        Self: 'a;
+
+    type Neighbors<'a>: provider::NeighborAccessorMut<Id = Self::Id>
+    where
+        Self: 'a;
+
+    /// Populate a `WorkingSet` with data from an accessor and return a [`View`] over the set.
+    ///
+    /// For each `i` in `itr` - the accessor should make the data behind `i` available, either
+    /// by storing it in `working_set` or through direct storage in the returned [`View`].
+    ///
+    /// The `WorkingSet` type is constructed by either:
+    ///
+    /// * [`PruneStrategy`](crate::graph::glue::PruneStrategy::create_working_set): Direct
+    ///   construction of a working set for use in multiple prunes.
+    ///
+    /// * [`MultiInsertStrategy::Seed`](crate::graph::glue::MultiInsertStrategy::Seed): Indirect
+    ///   creation that uses [`AsWorkingSet`] for the final conversion. This allows the elements
+    ///   in the input batch to [`multi_insert`](crate::graph::DiskANNIndex::multi_insert) to be
+    ///   directly accessible by the `WorkingSet`/[`View`] types.
+    ///
+    /// For many simple use cases, [`Map::fill`] should be sufficient to provide a good
+    /// implementation of [`Fill::fill`].
+    ///
+    /// See Also: [`View`], [`AsWorkingSet`], [`Map`].
+    ///
+    /// Make the data elements for items in `itr` available in the returned [`View`].
+    ///
+    /// Implementations may use `working_set` as scratch and to persist work across multiple calls.
+    ///
+    /// The input `itr` is `Clone` and is expected that the implementation of `Clone` is cheap
+    /// and without interior mutability. This allows implementers to perform multiple passes
+    /// of `itr` if needed.
+    ///
+    /// ## Missing Entries
+    ///
+    /// While it's a good idea to ensure all items in `itr` are fetched, callers are
+    /// designed to tolerate a small number of missing entries without serious performance
+    /// degradation.
+    ///
+    /// If a ID really needs to be fetched for algorithmic purposes, it will be the first
+    /// item yielded from `itr`.
+    fn fill<'a, Itr>(
+        &'a mut self,
+        itr: Itr,
+    ) -> impl SendFuture<ANNResult<(Self::View<'a>, Self::Distance<'a>)>>
+    where
+        Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync;
+
+    fn neighbors(&mut self) -> Self::Neighbors<'_>;
+}
+
 /// A strategy for inserting elements from the data provider.
 ///
 /// This strategy is used during the greedy search portion of index construction.
@@ -606,53 +675,22 @@ pub trait PruneStrategy<Provider>: Send + Sync + 'static
 where
     Provider: DataProvider,
 {
-    /// The [working set](crate::graph::workingset) used during pruning.
-    ///
-    /// For single insert this is typically an empty [`Map`](super::workingset::Map).
-    /// For multi-insert it may be pre-seeded with batch elements.
-    type WorkingSet: Send + Sync;
-
-    /// The distance computer used during pruning.
-    ///
-    /// We could grab this type from the `PruneAccessor` associated type, but it's
-    /// useful enough that we move it up here.
-    type DistanceComputer<'computer>: for<'a, 'b, 'c, 'd> DistanceFunction<
-            <Self::PruneAccessor<'a> as HasElementRef>::ElementRef<'b>,
-            <Self::PruneAccessor<'c> as HasElementRef>::ElementRef<'d>,
-            f32,
-        > + Send
-        + Sync;
-
     /// The concrete type of the accessor that is used to access `Self` during pruning.
     ///
     /// The accessor implements [`workingset::Fill`] for the strategy's
     /// [`WorkingSet`](Self::WorkingSet) type, which controls how elements are fetched and
     /// cached for distance computations.
-    type PruneAccessor<'a>: HasId<Id = Provider::InternalId>
-        + HasElementRef
-        + BuildDistanceComputer<DistanceComputer = Self::DistanceComputer<'a>>
-        + AsNeighborMut
-        + workingset::Fill<Self::WorkingSet>
-        + Send
-        + Sync;
+    type PruneAccessor<'a>: PruneAccessor<Id = Provider::InternalId>;
 
     /// An error that can occur when getting the prune accessor.
     type PruneAccessorError: StandardError;
-
-    /// Create a fresh working set pre-sized for up to `capacity` elements.
-    ///
-    /// Argument `capacity` is an upper-bound: callers guarantee that no more than
-    /// `capacity` elements will be inserted into the working set during a single
-    /// [fill](workingset::Fill).
-    ///
-    /// Implementations may use this to pre-allocate or panic if exceeded.
-    fn create_working_set(&self, capacity: usize) -> Self::WorkingSet;
 
     /// Return the prune accessor.
     fn prune_accessor<'a>(
         &'a self,
         provider: &'a Provider,
         context: &'a Provider::Context,
+        size_hint: usize,
     ) -> Result<Self::PruneAccessor<'a>, Self::PruneAccessorError>;
 }
 
@@ -662,27 +700,21 @@ where
 /// one difference, the [working set](crate::graph::workingset) provided to the insertion
 /// [`PruneStrategy`] is seeded from [`Self::Seed`]. Seeding allows elements of the input
 /// batch `B` to be part of the working set throughout prune, saving on vector retrievals.
-pub trait MultiInsertStrategy<Provider, B>: Send + Sync
+pub trait MultiInsertStrategy<Provider, B>: Send + Sync + 'static
 where
     Provider: DataProvider,
     B: Batch,
 {
-    /// The working set for the insertion [`PruneStrategy`].
-    type WorkingSet: Send + Sync + 'static;
-
     /// The working set "seed", potentially containing `B` for faster access.
-    type Seed: workingset::AsWorkingSet<Self::WorkingSet> + Send + Sync + 'static;
+    type Seed: Send + Sync + 'static;
 
     /// Any critical error that occurs during [`finish`](Self::finish).
     type FinishError: Into<ANNError> + std::fmt::Debug + Send + Sync;
 
+    type PruneStrategy: PruneStrategy<Provider>;
+
     /// The delegated [`InsertStrategy`] for most insertion related decisions.
-    type InsertStrategy: for<'a> InsertStrategy<
-            'a,
-            Provider,
-            B::Element<'a>,
-            PruneStrategy: PruneStrategy<Provider, WorkingSet = Self::WorkingSet>,
-        >;
+    type InsertStrategy: for<'a> InsertStrategy<'a, Provider, B::Element<'a>, PruneStrategy = Self::PruneStrategy>;
 
     /// Construct the associated [`InsertStrategy`].
     fn insert_strategy(&self) -> Self::InsertStrategy;
@@ -702,6 +734,14 @@ where
     ) -> impl std::future::Future<Output = Result<Self::Seed, Self::FinishError>> + Send
     where
         Itr: ExactSizeIterator<Item = Provider::InternalId> + Send;
+
+    fn seeded_prune_accessor<'a>(
+        &'a self,
+        provider: &'a Provider,
+        context: &'a Provider::Context,
+        seed: &'a Self::Seed,
+        capacity: usize,
+    ) -> ANNResult<<Self::PruneStrategy as PruneStrategy<Provider>>::PruneAccessor<'a>>;
 }
 
 /// A batch of elements indexed positionally.

--- a/diskann/src/graph/index.rs
+++ b/diskann/src/graph/index.rs
@@ -2401,13 +2401,13 @@ where
     ///
     /// All other fields of `scratch` are clobbered.
     ///
-    /// This works by first retrieving `location` and all ids in `list` into `working_set`
-    /// via [`Fill`] and then computing distances to populate the candidate pool.
+    /// This works by first retrieving `location` and all ids in `list` via
+    /// [`PruneAccessor::fill`] and then computing distances to populate the candidate pool.
     ///
     /// # Errors
     ///
     /// Forwards errors from [`PruneAccessor::fill`]. If `location` was not made available
-    /// during [`PruneAccessor::Fill`], [`prune::ListError::FailedVectorRetrieval`] is
+    /// during [`PruneAccessor::fill`], [`prune::ListError::FailedVectorRetrieval`] is
     /// returned to delegate escalation to the caller.
     fn robust_prune_list<A>(
         &self,
@@ -2486,8 +2486,8 @@ where
     ///
     /// # Errors
     ///
-    /// Forwards errors from [`PruneAccessor::fill`]. If `internal_id` cannot be retrieved
-    /// from the, [`prune::ListError::FailedVectorRetrieval`] is returned.
+    /// Forwards errors from [`PruneAccessor::fill`]. If `internal_id` cannot be retrieved,
+    /// [`prune::ListError::FailedVectorRetrieval`] is returned.
     fn robust_prune_with<A, Itr>(
         &self,
         accessor: &mut A,

--- a/diskann/src/graph/index.rs
+++ b/diskann/src/graph/index.rs
@@ -25,8 +25,8 @@ use tokio::task::JoinSet;
 use super::{
     AdjacencyList, Config, ConsolidateKind, InplaceDeleteMethod, Search,
     glue::{
-        self, Batch, InplaceDeleteStrategy, InsertStrategy, MultiInsertStrategy, PruneStrategy,
-        SearchAccessor, SearchPostProcess, SearchStrategy,
+        self, Batch, InplaceDeleteStrategy, InsertStrategy, MultiInsertStrategy, PruneAccessor,
+        PruneStrategy, SearchAccessor, SearchPostProcess, SearchStrategy,
     },
     internal::{BackedgeBuffer, SortedNeighbors, prune},
     search::{
@@ -35,7 +35,7 @@ use super::{
         scratch::{self, PriorityQueueConfiguration, SearchScratch, SearchScratchParams},
     },
     search_output_buffer,
-    workingset::{AsWorkingSet, Fill, View},
+    workingset::View,
 };
 
 use crate::{
@@ -44,8 +44,8 @@ use crate::{
     internal,
     neighbor::{self, Neighbor, NeighborQueue},
     provider::{
-        AsNeighbor, AsNeighborMut, BuildDistanceComputer, DataProvider, Delete, ElementStatus,
-        ExecutionContext, Guard, NeighborAccessor, NeighborAccessorMut, SetElement,
+        DataProvider, Delete, ElementStatus, ExecutionContext, Guard, NeighborAccessor,
+        NeighborAccessorMut, SetElement,
     },
     tracked_debug, tracked_error, tracked_trace,
     utils::{
@@ -284,7 +284,7 @@ where
 
             let prune_strategy = strategy.prune_strategy();
             let mut prune_accessor = prune_strategy
-                .prune_accessor(&self.data_provider, context)
+                .prune_accessor(&self.data_provider, context, self.max_occlusion_size())
                 .into_ann_result()?;
 
             let mut scratch = self.search_scratch(self.l_build(), num_start_ids);
@@ -295,7 +295,6 @@ where
             let insert_retry = self.config.experimental_insert_retry();
             let num_insert_attempts = insert_retry.map_or(1, |v| v.max_retries().get());
 
-            let mut working_set = prune_strategy.create_working_set(self.max_occlusion_size());
             let mut prune_scratch = prune::Scratch::new();
             let mut new_neighbors = AdjacencyList::with_capacity(self.max_degree_with_slack());
 
@@ -324,14 +323,8 @@ where
                     force_saturate: insert_retry.is_some_and(|v| v.should_saturate(attempt)),
                 };
 
-                self.robust_prune(
-                    &mut prune_accessor,
-                    internal_id,
-                    context,
-                    &mut working_set,
-                    options,
-                )
-                .await?;
+                self.robust_prune(&mut prune_accessor, internal_id, context, options)
+                    .await?;
 
                 let should_retry =
                     insert_retry.is_some_and(|v| v.should_retry(attempt, new_neighbors.len()));
@@ -352,6 +345,7 @@ where
 
             // insert out edges
             prune_accessor
+                .neighbors()
                 .set_neighbors(internal_id, &new_neighbors)
                 .await?;
 
@@ -361,12 +355,10 @@ where
             // add edges from `new_neighbors` to `internal_id` and prune if necessary
             for source in new_neighbors.iter().take(num_back_edges) {
                 self.add_edge_and_prune(
-                    &prune_strategy,
-                    context,
+                    &mut prune_accessor,
                     std::slice::from_ref(&internal_id),
                     *source,
                     &mut prune_scratch,
-                    &mut working_set,
                     None,
                 )
                 .await?;
@@ -383,25 +375,20 @@ where
         clippy::too_many_arguments,
         reason = "internal method with tightly coupled params"
     )]
-    fn search_and_prune<S, B, Set>(
+    fn search_and_prune<S, B, A>(
         &self,
         strategy: &S,
         context: &DP::Context,
         batch: &B,
         ids: &[DP::InternalId],
         position: usize,
-        working_set: &mut Set,
+        prune_accessor: &mut A,
         prune_scratch: &mut prune::Scratch<DP::InternalId>,
     ) -> impl SendFuture<ANNResult<PendingEdge<DP::InternalId>>>
     where
-        S: for<'a> InsertStrategy<
-                'a,
-                DP,
-                B::Element<'a>,
-                PruneStrategy: PruneStrategy<DP, WorkingSet = Set>,
-            >,
+        S: for<'a> InsertStrategy<'a, DP, B::Element<'a>>,
         B: Batch,
-        Set: Send + Sync,
+        A: PruneAccessor<Id = DP::InternalId>,
     {
         async move {
             let internal_id = ids[position];
@@ -436,11 +423,7 @@ where
                 .await?;
 
                 // Add other vector id pairs in the mini batch to the candidate pool
-                let prune_strategy = strategy.prune_strategy();
-                let mut prune_accessor = prune_strategy
-                    .prune_accessor(&self.data_provider, context)
-                    .into_ann_result()?;
-
+                //
                 // N.B.: If `candidates == 0`, then `async_tools::around` naturally returns
                 // an empty iterator and `robust_prune_with` will skip the additional
                 // distance computations.
@@ -451,12 +434,11 @@ where
                 };
 
                 self.robust_prune_with(
-                    &mut prune_accessor,
+                    prune_accessor,
                     internal_id,
                     async_tools::around(ids, position, candidates).copied(),
                     &mut search_record,
                     prune_scratch,
-                    working_set,
                     options,
                 )
                 .await
@@ -592,36 +574,40 @@ where
     ///
     /// Returns a pair `(edges, result)`. Whether or not `result` is an error, `edges` will
     /// contain all edges successfully processed by this task.
-    fn search_and_prune_batch<S, B, Set>(
+    fn search_and_prune_batch<S, B>(
         &self,
         strategy: &S,
         context: &DP::Context,
         batch: &B,
         work: &DynamicBalancer<DP::InternalId>,
-        working_set: &mut Set,
+        seed: &S::Seed,
     ) -> impl SendFuture<BatchResult<Vec<PendingEdge<DP::InternalId>>>>
     where
+        S: MultiInsertStrategy<DP, B>,
         B: Batch,
-        S: for<'a> InsertStrategy<
-                'a,
-                DP,
-                B::Element<'a>,
-                PruneStrategy: PruneStrategy<DP, WorkingSet = Set>,
-            >,
-        Set: Send + Sync,
     {
         async move {
             let mut output = Vec::new();
+            let mut accessor = match strategy.seeded_prune_accessor(
+                self.provider(),
+                context,
+                seed,
+                self.max_occlusion_size(),
+            ) {
+                Ok(accessor) => accessor,
+                Err(err) => return Err((output, err)),
+            };
+
             let mut prune_scratch = prune::Scratch::new();
             while let Some((_, position)) = work.next() {
                 match self
                     .search_and_prune(
-                        strategy,
+                        &strategy.insert_strategy(),
                         context,
                         batch,
                         work.all(),
                         position,
-                        working_set,
+                        &mut accessor,
                         &mut prune_scratch,
                     )
                     .await
@@ -667,11 +653,10 @@ where
                 ));
 
             let mut accessor = strategy
-                .prune_accessor(&self.data_provider, context)
+                .prune_accessor(&self.data_provider, context, self.max_occlusion_size())
                 .into_ann_result()?;
 
             let mut prune_scratch = prune::Scratch::new();
-            let mut working_set = strategy.create_working_set(self.max_occlusion_size());
 
             // During bootstrap, we want the graph to be as dense as possible to aid
             // in early navigation.
@@ -686,7 +671,6 @@ where
                 current.source,
                 &candidates,
                 &mut prune_scratch,
-                &mut working_set,
                 options,
             )
             .await
@@ -907,23 +891,26 @@ where
                 .await
                 .into_ann_result()?;
 
+            let seed = Arc::new(seed);
+            let strategy = Arc::new(strategy);
+
             let handles: Vec<_> = (0..num_tasks.get() - 1)
                 .map(|_| {
                     let self_clone = self.clone();
-                    let insert_strategy = strategy.insert_strategy();
+                    let seed_clone = seed.clone();
+                    let strategy_clone = strategy.clone();
                     let context_clone = context.clone();
                     let vectors_clone = vectors.clone();
                     let work_clone = work.clone();
-                    let mut working_set = seed.as_working_set(self.max_occlusion_size());
 
                     let future = async move {
                         self_clone
                             .search_and_prune_batch(
-                                &insert_strategy,
+                                &*strategy_clone,
                                 &context_clone,
                                 &vectors_clone,
                                 &work_clone,
-                                &mut working_set,
+                                &seed_clone,
                             )
                             .await
                     };
@@ -933,13 +920,7 @@ where
 
             // Defer dealing with the `result` until after we have joined the other tasks.
             let mut edges = match self
-                .search_and_prune_batch(
-                    &strategy.insert_strategy(),
-                    context,
-                    &vectors,
-                    &work,
-                    &mut seed.as_working_set(self.max_occlusion_size()),
-                )
+                .search_and_prune_batch(&*strategy, context, &vectors, &work, &seed)
                 .await
             {
                 Ok(v) => v,
@@ -1001,9 +982,11 @@ where
             {
                 let prune_strategy = strategy.insert_strategy().prune_strategy();
                 let accessor = &mut prune_strategy
-                    .prune_accessor(&self.data_provider, context)
+                    .prune_accessor(&self.data_provider, context, 0)
                     .into_ann_result()?;
+
                 accessor
+                    .neighbors()
                     .set_neighbors_bulk(
                         edges
                             .into_iter()
@@ -1017,11 +1000,18 @@ where
                 .map(|i| {
                     let self_clone = self.clone();
                     let context_clone = context.clone();
-                    let strategy_clone = strategy.insert_strategy().prune_strategy();
+                    let strategy_clone = strategy.clone();
                     let backedges_clone = backedges.clone();
-                    let mut working_set = seed.as_working_set(self.max_occlusion_size());
+                    let seed_clone = seed.clone();
 
                     tokio::spawn(context.wrap_spawn(async move {
+                        let mut accessor = strategy_clone.seeded_prune_accessor(
+                            self_clone.provider(),
+                            &context_clone,
+                            &seed_clone,
+                            self_clone.max_occlusion_size(),
+                        )?;
+
                         // Get the range of items to process in this task.
                         let range = async_tools::partition(backedges_clone.len(), num_tasks, i)?;
                         let itr = backedges_clone.iter().skip(range.start).take(range.len());
@@ -1038,12 +1028,10 @@ where
 
                             self_clone
                                 .add_edge_and_prune(
-                                    &strategy_clone,
-                                    &context_clone,
+                                    &mut accessor,
                                     &sorted_buf,
                                     *source,
                                     &mut prune_scratch,
-                                    &mut working_set,
                                     None,
                                 )
                                 .await?;
@@ -1083,7 +1071,7 @@ where
     ) -> impl SendFuture<ANNResult<bool>>
     where
         DP: Delete,
-        NA: AsNeighbor<Id = DP::InternalId>,
+        NA: NeighborAccessor<Id = DP::InternalId>,
     {
         async move {
             let mut neighbors = AdjacencyList::new();
@@ -1105,7 +1093,7 @@ where
 
     pub fn drop_adj_list(
         &self,
-        accessor: &mut impl AsNeighborMut<Id = DP::InternalId>,
+        accessor: &mut impl NeighborAccessorMut<Id = DP::InternalId>,
         vector_id: DP::InternalId,
     ) -> impl SendFuture<ANNResult<()>> {
         accessor
@@ -1127,7 +1115,7 @@ where
         DP: Delete,
         F: FnMut(DP::InternalId) + Send,
         G: FnMut(DP::InternalId) + Send,
-        NA: AsNeighbor<Id = DP::InternalId>,
+        NA: NeighborAccessor<Id = DP::InternalId>,
     {
         async move {
             let mut neighbors = AdjacencyList::new();
@@ -1162,7 +1150,7 @@ where
     ) -> impl SendFuture<ANNResult<PartitionedNeighbors<DP::InternalId>>>
     where
         DP: Delete,
-        NA: AsNeighbor<Id = DP::InternalId>,
+        NA: NeighborAccessor<Id = DP::InternalId>,
     {
         async move {
             let mut undeleted = Vec::new();
@@ -1190,7 +1178,7 @@ where
     ) -> impl SendFuture<ANNResult<Vec<DP::InternalId>>>
     where
         DP: Delete,
-        NA: AsNeighbor<Id = DP::InternalId>,
+        NA: NeighborAccessor<Id = DP::InternalId>,
     {
         async move {
             let mut return_candidates = Vec::new();
@@ -1269,11 +1257,11 @@ where
             // Collect IDs whose adjacency lists need to be updated.
             let prune_strategy = strategy.prune_strategy();
             let mut prune_accessor = prune_strategy
-                .prune_accessor(self.provider(), context)
+                .prune_accessor(self.provider(), context, 0)
                 .into_ann_result()?;
 
             let ids_to_modify = self
-                .return_refs_to_deleted_vertex(&mut prune_accessor, id, &undeleted_ids)
+                .return_refs_to_deleted_vertex(&mut prune_accessor.neighbors(), id, &undeleted_ids)
                 .await?;
 
             undeleted_ids.truncate(k_value);
@@ -1296,7 +1284,7 @@ where
     ) -> impl SendFuture<ANNResult<InplaceDeleteWorkList<DP::InternalId>>>
     where
         DP: Delete,
-        NA: AsNeighbor<Id = DP::InternalId>,
+        NA: NeighborAccessor<Id = DP::InternalId>,
     {
         async move {
             let mut two_hop_nbhs = HashSet::new();
@@ -1359,7 +1347,7 @@ where
     ) -> impl SendFuture<ANNResult<InplaceDeleteWorkList<DP::InternalId>>>
     where
         DP: Delete,
-        NA: AsNeighbor<Id = DP::InternalId>,
+        NA: NeighborAccessor<Id = DP::InternalId>,
     {
         async move {
             let mut undeleted_one_hop_nbhs = Vec::new();
@@ -1509,8 +1497,13 @@ where
                             };
 
                             let mut prune_scratch = prune::Scratch::new();
-                            let mut working_set =
-                                strategy_clone.create_working_set(self_clone.max_occlusion_size());
+                            let mut accessor = strategy_clone
+                                .prune_accessor(
+                                    self_clone.provider(),
+                                    &context_clone,
+                                    self_clone.max_occlusion_size(),
+                                )
+                                .into_ann_result()?;
 
                             match result {
                                 Some(source) => {
@@ -1524,12 +1517,10 @@ where
 
                                     self_clone
                                         .add_edge_and_prune(
-                                            &strategy_clone,
-                                            &context_clone,
+                                            &mut accessor,
                                             &adj_list,
                                             source,
                                             &mut prune_scratch,
-                                            &mut working_set,
                                             Some(&ids_to_delete_clone), // delete any edges to a deleted point as part of add_edge_and_prune
                                         )
                                         .await?;
@@ -1553,11 +1544,12 @@ where
                 // finally, drop each deleted neighbor's edges, this can run sequentially
                 let prune_strategy = strategy.prune_strategy();
                 let mut accessor = prune_strategy
-                    .prune_accessor(&self.data_provider, context)
+                    .prune_accessor(&self.data_provider, context, 0)
                     .into_ann_result()?;
 
                 for vector_id in ids_to_delete.iter() {
-                    self.drop_adj_list(&mut accessor, *vector_id).await?;
+                    self.drop_adj_list(&mut accessor.neighbors(), *vector_id)
+                        .await?;
                 }
             }
 
@@ -1602,27 +1594,25 @@ where
             delete_set.insert(vector_id);
             let prune_strategy = strategy.prune_strategy();
 
-            let mut working_set = prune_strategy.create_working_set(self.max_occlusion_size());
+            let mut accessor = prune_strategy
+                .prune_accessor(self.provider(), context, self.max_occlusion_size())
+                .into_ann_result()?;
+
             let mut prune_scratch = prune::Scratch::new();
 
             for (neighbor, edges) in edges_to_add.iter() {
                 self.add_edge_and_prune(
-                    &prune_strategy,
-                    context,
+                    &mut accessor,
                     edges,
                     *neighbor,
                     &mut prune_scratch,
-                    &mut working_set,
                     Some(&delete_set), // delete the edge to the deleted point as part of add_edge_and_prune
                 )
                 .await?
             }
 
-            let mut accessor = prune_strategy
-                .prune_accessor(&self.data_provider, context)
-                .into_ann_result()?;
-
-            self.drop_adj_list(&mut accessor, vector_id).await?;
+            self.drop_adj_list(&mut accessor.neighbors(), vector_id)
+                .await?;
 
             Ok(())
         }
@@ -1654,7 +1644,7 @@ where
 
             let prune_strategy = strategy.prune_strategy();
             let mut accessor = prune_strategy
-                .prune_accessor(&self.data_provider, context)
+                .prune_accessor(&self.data_provider, context, self.max_occlusion_size())
                 .into_ann_result()?;
 
             let InplaceDeleteWorkList {
@@ -1669,16 +1659,19 @@ where
                         .await?
                 }
                 InplaceDeleteMethod::TwoHopAndOneHop => {
-                    self.get_candidates_using_twohop_and_onehop(context, &mut accessor, vector_id)
-                        .await?
+                    self.get_candidates_using_twohop_and_onehop(
+                        context,
+                        &mut accessor.neighbors(),
+                        vector_id,
+                    )
+                    .await?
                 }
                 InplaceDeleteMethod::OneHop => {
-                    self.get_candidates_using_onehop(context, &mut accessor, vector_id)
+                    self.get_candidates_using_onehop(context, &mut accessor.neighbors(), vector_id)
                         .await?
                 }
             };
 
-            let mut working_set = prune_strategy.create_working_set(self.max_occlusion_size());
             let mut edges_to_add = HashMap::<DP::InternalId, Vec<DP::InternalId>>::new();
 
             // fetch the filtered adjacency list of `p`.
@@ -1686,25 +1679,20 @@ where
                 undeleted: adjacency_list,
                 ..
             } = self
-                .get_undeleted_neighbors(context, &mut accessor, vector_id)
+                .get_undeleted_neighbors(context, &mut accessor.neighbors(), vector_id)
                 .await?;
-
-            let computer = accessor.build_distance_computer().into_ann_result()?;
 
             // This is the total union of elements that we consider for neighbors.
             // It's possible there is some repitition, but implementations of `Fill` should
             // already properly handle that.
-            let view = accessor
-                .fill(
-                    &mut working_set,
+            let (view, computer) = accessor
+                .fill(internal::chain(
                     internal::chain(
-                        internal::chain(
-                            replace_candidates.iter().copied(),
-                            in_neighbors.iter().copied(),
-                        ),
-                        adjacency_list.iter().copied(),
+                        replace_candidates.iter().copied(),
+                        in_neighbors.iter().copied(),
                     ),
-                )
+                    adjacency_list.iter().copied(),
+                ))
                 .await
                 .into_ann_result()?;
 
@@ -1792,7 +1780,7 @@ where
     ) -> impl SendFuture<ANNResult<ConsolidateKind>>
     where
         DP: Delete,
-        NA: AsNeighborMut<Id = DP::InternalId>,
+        NA: NeighborAccessorMut<Id = DP::InternalId>,
     {
         async move {
             let status = self
@@ -1872,12 +1860,12 @@ where
             let mut pool = HashSet::new();
             let mut deleted_neighbors = Vec::new();
             let accessor = &mut strategy
-                .prune_accessor(&self.data_provider, context)
+                .prune_accessor(&self.data_provider, context, self.max_occlusion_size())
                 .into_ann_result()?;
 
             self.on_neighbors(
                 context,
-                accessor,
+                &mut accessor.neighbors(),
                 vector_id,
                 |i| {
                     pool.insert(i);
@@ -1899,7 +1887,7 @@ where
             for id in deleted_neighbors.iter() {
                 self.on_neighbors(
                     context,
-                    accessor,
+                    &mut accessor.neighbors(),
                     *id,
                     |i| {
                         pool.insert(i);
@@ -1919,7 +1907,6 @@ where
                     neighbors
                 } else {
                     let mut prune_scratch = prune::Scratch::new();
-                    let mut working_set = strategy.create_working_set(self.max_occlusion_size());
 
                     // Force saturation is mainly used for the retry insert logic.
                     //
@@ -1934,7 +1921,6 @@ where
                             vector_id,
                             &neighbors,
                             &mut prune_scratch,
-                            &mut working_set,
                             options,
                         )
                         .await
@@ -1954,7 +1940,10 @@ where
                 adj_list
             );
 
-            accessor.set_neighbors(vector_id, &adj_list).await?;
+            accessor
+                .neighbors()
+                .set_neighbors(vector_id, &adj_list)
+                .await?;
             Ok(ConsolidateKind::Complete)
         }
     }
@@ -2192,7 +2181,7 @@ where
         accessor: &mut NA,
     ) -> impl SendFuture<ANNResult<usize>>
     where
-        NA: AsNeighbor<Id = DP::InternalId>,
+        NA: NeighborAccessor<Id = DP::InternalId>,
     {
         async move {
             let mut expanded_nodes = HashSet::<DP::InternalId>::new();
@@ -2223,7 +2212,7 @@ where
     ) -> impl SendFuture<ANNResult<DegreeStats>>
     where
         Itr: IntoIterator<Item = DP::InternalId, IntoIter: Send> + Send,
-        NA: AsNeighbor<Id = DP::InternalId>,
+        NA: NeighborAccessor<Id = DP::InternalId>,
     {
         async move {
             let mut max_degree_usize: usize = 0;
@@ -2289,26 +2278,23 @@ where
     /// We're going through a temporary phase of moving the `Context` into the `Strategy`.
     /// For now - we unfortunately need both.
     #[allow(clippy::too_many_arguments)]
-    pub(crate) fn add_edge_and_prune<'a, S>(
+    pub(crate) fn add_edge_and_prune<'a, A>(
         &'a self,
-        strategy: &'a S,
-        context: &'a DP::Context,
+        accessor: &'a mut A,
         targets: &[DP::InternalId],
         source: DP::InternalId,
         scratch: &mut prune::Scratch<DP::InternalId>,
-        working_set: &mut S::WorkingSet,
         to_remove: Option<&HashSet<DP::InternalId>>,
     ) -> impl SendFuture<ANNResult<()>>
     where
-        S: PruneStrategy<DP>,
+        A: PruneAccessor<Id = DP::InternalId>,
     {
         async move {
-            let mut accessor = strategy
-                .prune_accessor(&self.data_provider, context)
-                .into_ann_result()?;
-
             let mut adj_list = AdjacencyList::with_capacity(self.max_degree_with_slack());
-            accessor.get_neighbors(source, &mut adj_list).await?;
+            accessor
+                .neighbors()
+                .get_neighbors(source, &mut adj_list)
+                .await?;
 
             let mut did_remove = false;
             if let Some(set) = to_remove {
@@ -2333,9 +2319,12 @@ where
                 // No pruning is needed; we can just append.
                 tracked_trace!("Appending back-edge from {} to {:?}.", source, targets,);
                 if did_remove {
-                    accessor.set_neighbors(source, &adj_list).await?;
+                    accessor
+                        .neighbors()
+                        .set_neighbors(source, &adj_list)
+                        .await?;
                 } else if let Some(edges) = adj_list.last(num_new_edges) {
-                    accessor.append_vector(source, edges).await?;
+                    accessor.neighbors().append_vector(source, edges).await?;
                 }
             } else {
                 // During back-edge insertion, we are working with a limited number
@@ -2346,16 +2335,9 @@ where
                     force_saturate: false,
                 };
 
-                self.robust_prune_list(
-                    &mut accessor,
-                    source,
-                    &adj_list,
-                    scratch,
-                    working_set,
-                    options,
-                )
-                .await
-                .escalate("retrieving inserted vector must succeed")?;
+                self.robust_prune_list(accessor, source, &adj_list, scratch, options)
+                    .await
+                    .escalate("retrieving inserted vector must succeed")?;
 
                 tracked_trace!(
                     "Setting new AdjList for vector_id {} to {:?}.",
@@ -2363,7 +2345,10 @@ where
                     scratch.neighbors
                 );
 
-                accessor.set_neighbors(source, &scratch.neighbors).await?;
+                accessor
+                    .neighbors()
+                    .set_neighbors(source, &scratch.neighbors)
+                    .await?;
             }
 
             Ok(())
@@ -2379,17 +2364,15 @@ where
     /// this API are suppressed and any IDs that failed will be skipped during prune.
     ///
     /// Errors due to [`BuildDistanceComputer::build_distance_computer`] are propagated.
-    fn robust_prune<A, Set>(
+    fn robust_prune<A>(
         &self,
         accessor: &mut A,
         location: DP::InternalId,
         mut context: prune::Context<'_, DP::InternalId>,
-        working_set: &mut Set,
         options: prune::Options,
     ) -> impl SendFuture<ANNResult<()>>
     where
-        A: BuildDistanceComputer + Fill<Set, Id = DP::InternalId> + Send + Sync,
-        Set: Send + Sync,
+        A: PruneAccessor<Id = DP::InternalId>,
     {
         async move {
             // Early exit.
@@ -2397,13 +2380,10 @@ where
                 return Ok(());
             }
 
-            let computer = accessor.build_distance_computer().into_ann_result()?;
-
-            let view = accessor
-                .fill(working_set, context.pool.iter().map(|n| n.id))
+            let (view, computer) = accessor
+                .fill(context.pool.iter().map(|n| n.id))
                 .send()
-                .await
-                .into_ann_result()?;
+                .await?;
 
             self.occlude_list::<A::View<'_>, _, _>(
                 &computer,
@@ -2436,18 +2416,16 @@ where
     /// the caller.
     ///
     /// Errors due to [`BuildDistanceComputer::build_distance_computer`] are propagated.
-    fn robust_prune_list<A, Set>(
+    fn robust_prune_list<A>(
         &self,
         accessor: &mut A,
         location: DP::InternalId,
         list: &AdjacencyList<DP::InternalId>,
         scratch: &mut prune::Scratch<DP::InternalId>,
-        working_set: &mut Set,
         options: prune::Options,
     ) -> impl SendFuture<Result<(), prune::ListError<DP::InternalId>>>
     where
-        A: BuildDistanceComputer + Fill<Set, Id = DP::InternalId> + Send + Sync,
-        Set: Send + Sync,
+        A: PruneAccessor<Id = DP::InternalId>,
     {
         async move {
             // Early exit.
@@ -2455,17 +2433,14 @@ where
                 return Ok(());
             }
 
-            let computer = accessor.build_distance_computer().into_ann_result()?;
-
             // Fetch into the working set, including the source location.
-            let view = accessor
-                .fill(
-                    working_set,
-                    internal::chain(std::iter::once(location), list.iter().copied()),
-                )
+            let (view, computer) = accessor
+                .fill(internal::chain(
+                    std::iter::once(location),
+                    list.iter().copied(),
+                ))
                 .send()
-                .await
-                .into_ann_result()?;
+                .await?;
 
             scratch.pool.clear();
             scratch.pool.reserve(list.len());
@@ -2522,38 +2497,29 @@ where
     /// from the working set, [`prune::ListError::FailedVectorRetrieval`] is returned.
     ///
     /// Errors due to [`BuildDistanceComputer::build_distance_computer`] are propagated
-    #[expect(
-        clippy::too_many_arguments,
-        reason = "internal method with tightly coupled params"
-    )]
-    fn robust_prune_with<A, Set, Itr>(
+    fn robust_prune_with<A, Itr>(
         &self,
         accessor: &mut A,
         internal_id: DP::InternalId,
         extras: Itr,
         record: &mut VisitedSearchRecord<DP::InternalId>,
         scratch: &mut prune::Scratch<DP::InternalId>,
-        working_set: &mut Set,
         options: prune::Options,
     ) -> impl SendFuture<Result<(), prune::ListError<DP::InternalId>>>
     where
-        A: BuildDistanceComputer + Fill<Set, Id = DP::InternalId> + Send + Sync,
-        Set: Send + Sync,
+        A: PruneAccessor<Id = DP::InternalId>,
         Itr: ExactSizeIterator<Item = DP::InternalId> + Clone + Send + Sync,
     {
         async move {
-            let computer = accessor.build_distance_computer().into_ann_result()?;
-            let view = accessor
+            let (view, computer) = accessor
                 .fill(
-                    working_set,
                     internal::chain(
                         std::iter::once(internal_id),
                         internal::chain(extras.clone(), record.ids()),
                     )
                     .take(self.max_occlusion_size()),
                 )
-                .await
-                .into_ann_result()?;
+                .await?;
 
             if extras.len() != 0 {
                 let this_vector = view
@@ -2851,17 +2817,18 @@ where
             let end: u64 = range.end.into();
 
             let mut accessor = strategy
-                .prune_accessor(&self.data_provider, context)
+                .prune_accessor(&self.data_provider, context, self.max_occlusion_size())
                 .into_ann_result()?;
-
-            let mut working_set = strategy.create_working_set(self.max_occlusion_size());
 
             let mut neighbors = AdjacencyList::with_capacity(self.max_degree_with_slack());
             let mut prune_scratch = prune::Scratch::<DP::InternalId>::new();
 
             for id in start..end {
                 let id = id.try_into_vector_id()?;
-                accessor.get_neighbors(id, &mut neighbors).await?;
+                accessor
+                    .neighbors()
+                    .get_neighbors(id, &mut neighbors)
+                    .await?;
                 if neighbors.len() <= self.pruned_degree() {
                     continue;
                 }
@@ -2871,18 +2838,14 @@ where
                     force_saturate: false,
                 };
 
-                self.robust_prune_list(
-                    &mut accessor,
-                    id,
-                    &neighbors,
-                    &mut prune_scratch,
-                    &mut working_set,
-                    options,
-                )
-                .await
-                .escalate("prune-range does not support transient errors")?;
+                self.robust_prune_list(&mut accessor, id, &neighbors, &mut prune_scratch, options)
+                    .await
+                    .escalate("prune-range does not support transient errors")?;
 
-                accessor.set_neighbors(id, &prune_scratch.neighbors).await?;
+                accessor
+                    .neighbors()
+                    .set_neighbors(id, &prune_scratch.neighbors)
+                    .await?;
             }
 
             Ok(())

--- a/diskann/src/graph/index.rs
+++ b/diskann/src/graph/index.rs
@@ -2360,10 +2360,7 @@ where
     ///
     /// # Errors
     ///
-    /// Forwards critical errors from [`Fill::fill`]. Transient errors from
-    /// this API are suppressed and any IDs that failed will be skipped during prune.
-    ///
-    /// Errors due to [`BuildDistanceComputer::build_distance_computer`] are propagated.
+    /// Forwards errors from [`PruneAccessor::fill`].
     fn robust_prune<A>(
         &self,
         accessor: &mut A,
@@ -2409,13 +2406,9 @@ where
     ///
     /// # Errors
     ///
-    /// Forwards critical errors from [`Fill::fill`]. Transient errors from
-    /// this API are suppressed and any IDs that failed will be skipped during prune unless
-    /// the vector that was not retrieved was `location`. If this is the case,
-    /// [`prune::ListError::FailedVectorRetrieval`] is returned to delegate escalation to
-    /// the caller.
-    ///
-    /// Errors due to [`BuildDistanceComputer::build_distance_computer`] are propagated.
+    /// Forwards errors from [`PruneAccessor::fill`]. If `location` was not made available
+    /// during [`PruneAccessor::Fill`], [`prune::ListError::FailedVectorRetrieval`] is
+    /// returned to delegate escalation to the caller.
     fn robust_prune_list<A>(
         &self,
         accessor: &mut A,
@@ -2493,10 +2486,8 @@ where
     ///
     /// # Errors
     ///
-    /// Forwards critical errors from [`Fill::fill`]. If `internal_id` cannot be retrieved
-    /// from the working set, [`prune::ListError::FailedVectorRetrieval`] is returned.
-    ///
-    /// Errors due to [`BuildDistanceComputer::build_distance_computer`] are propagated
+    /// Forwards errors from [`PruneAccessor::fill`]. If `internal_id` cannot be retrieved
+    /// from the, [`prune::ListError::FailedVectorRetrieval`] is returned.
     fn robust_prune_with<A, Itr>(
         &self,
         accessor: &mut A,

--- a/diskann/src/graph/test/cases/index.rs
+++ b/diskann/src/graph/test/cases/index.rs
@@ -93,7 +93,7 @@ async fn test_prune_range() {
 
     index.prune_range(&strat, &ctx, 0..4).await.unwrap();
 
-    let accessor = index.provider().neighbors();
+    let mut accessor = index.provider().neighbors();
     let mut list = AdjacencyList::new();
     for node in 0u32..4 {
         accessor.get_neighbors(node, &mut list).await.unwrap();

--- a/diskann/src/graph/test/cases/inplace_delete.rs
+++ b/diskann/src/graph/test/cases/inplace_delete.rs
@@ -116,7 +116,7 @@ async fn delete_node_3_and_validate(method: InplaceDeleteMethod) {
         .await
         .unwrap();
 
-    let neighbors = &index.provider().neighbors();
+    let neighbors = &mut index.provider().neighbors();
     validate_graph_rebuild_for_simple_graph_after_3_delete(neighbors).await;
 }
 
@@ -137,7 +137,7 @@ async fn multi_delete_2_and_3_and_validate(method: InplaceDeleteMethod) {
         .await
         .unwrap();
 
-    let neighbors = &index.provider().neighbors();
+    let neighbors = &mut index.provider().neighbors();
     validate_graph_after_2_and_3_delete(neighbors).await;
 }
 
@@ -176,7 +176,7 @@ async fn multi_inplace_delete_visited_and_topk() {
     .await;
 }
 
-async fn validate_graph_rebuild_for_simple_graph_after_3_delete<N>(neighbors: &N)
+async fn validate_graph_rebuild_for_simple_graph_after_3_delete<N>(neighbors: &mut N)
 where
     N: NeighborAccessor<Id = u32> + Copy,
 {
@@ -222,7 +222,7 @@ where
 ///   2: [3, 4]  — deleted
 ///   3: [2, 4]  — deleted
 ///   4: [0, 1, 2, 3] — edges to 2 and 3 must be removed
-async fn validate_graph_after_2_and_3_delete<N>(neighbors: &N)
+async fn validate_graph_after_2_and_3_delete<N>(neighbors: &mut N)
 where
     N: NeighborAccessor<Id = u32> + Copy,
 {
@@ -277,7 +277,7 @@ async fn delete_isolated_node() {
     let ctx = test_provider::Context::new();
 
     //capture state of neighbors pre-delete (ignoring node 2)
-    let accessor = index.provider().neighbors();
+    let mut accessor = index.provider().neighbors();
     let mut list = AdjacencyList::new();
     let mut before: Vec<Vec<u32>> = Vec::new();
 

--- a/diskann/src/graph/test/provider.rs
+++ b/diskann/src/graph/test/provider.rs
@@ -820,9 +820,6 @@ impl From<AccessedInvalidId> for ANNError {
 
 /// A transient error from the test accessor — the ID exists but the retrieval
 /// temporarily failed. Must be acknowledged or escalated before being dropped.
-///
-/// Amognst other things, this is used to test the transient error handling of the blanket
-/// implementation of [`workingset::Fill`] for [`workingset::Map`].
 #[derive(Debug)]
 pub struct TransientAccessError {
     id: u32,
@@ -1063,22 +1060,7 @@ impl<'a> PruneAccessor<'a> {
             set,
         }
     }
-
-    // fn get(&mut self, id: u32) -> Result<Box<[f32]>, AccessError> {
-    //     let f = |data: &[f32]| -> Result<Box<[f32]>, TransientAccessError> {
-    //         self.transient_ids.check(id)?;
-    //         self.get_vector.increment();
-    //         Ok(data.into())
-    //     };
-
-    //     match self.provider.get(id, f) {
-    //         Ok(Ok(buf)) => Ok(buf),
-    //         Ok(Err(transient)) => Err(AccessError::Transient(transient)),
-    //         Err(invalid) => Err(AccessError::InvalidId(invalid)),
-    //     }
-    // }
 }
-
 
 impl provider::HasId for PruneAccessor<'_> {
     type Id = u32;
@@ -1086,9 +1068,18 @@ impl provider::HasId for PruneAccessor<'_> {
 
 impl glue::PruneAccessor for PruneAccessor<'_> {
     type ElementRef<'a> = &'a [f32];
-    type View<'a> = View<'a> where Self: 'a;
-    type Distance<'a> = <f32 as VectorRepr>::Distance where Self: 'a;
-    type Neighbors<'a> = NeighborAccessor<'a> where Self: 'a;
+    type View<'a>
+        = View<'a>
+    where
+        Self: 'a;
+    type Distance<'a>
+        = <f32 as VectorRepr>::Distance
+    where
+        Self: 'a;
+    type Neighbors<'a>
+        = NeighborAccessor<'a>
+    where
+        Self: 'a;
 
     async fn fill<'a, Itr>(
         &'a mut self,
@@ -1109,7 +1100,7 @@ impl glue::PruneAccessor for PruneAccessor<'_> {
                 Ok(Err(transient)) => {
                     transient.acknowledge("transient failures allowed");
                     Ok(None)
-                },
+                }
                 Err(invalid) => Err(invalid),
             }
         })?;
@@ -1121,31 +1112,6 @@ impl glue::PruneAccessor for PruneAccessor<'_> {
         NeighborAccessor::new(self.provider)
     }
 }
-
-// impl provider::HasElementRef for PruneAccessor<'_> {
-//     type ElementRef<'a> = &'a [f32];
-// }
-//
-// impl<'a> provider::DelegateNeighbor<'a> for PruneAccessor<'_> {
-//     type Delegate = NeighborAccessor<'a>;
-//     fn delegate_neighbor(&'a mut self) -> Self::Delegate {
-//         NeighborAccessor::new(self.provider)
-//     }
-// }
-//
-// impl provider::BuildDistanceComputer for PruneAccessor<'_> {
-//     type DistanceComputerError = Infallible;
-//     type DistanceComputer = <f32 as VectorRepr>::Distance;
-//
-//     fn build_distance_computer(
-//         &self,
-//     ) -> Result<Self::DistanceComputer, Self::DistanceComputerError> {
-//         Ok(f32::distance(
-//             self.provider.distance_metric(),
-//             Some(self.provider.dim()),
-//         ))
-//     }
-// }
 
 //////////////
 // Accessor //

--- a/diskann/src/graph/test/provider.rs
+++ b/diskann/src/graph/test/provider.rs
@@ -1081,10 +1081,7 @@ impl glue::PruneAccessor for PruneAccessor<'_> {
     where
         Self: 'a;
 
-    async fn fill<'a, Itr>(
-        &'a mut self,
-        itr: Itr,
-    ) -> ANNResult<(Self::View<'a>, Self::Distance<'a>)>
+    async fn fill<Itr>(&mut self, itr: Itr) -> ANNResult<(Self::View<'_>, Self::Distance<'_>)>
     where
         Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
     {

--- a/diskann/src/graph/test/provider.rs
+++ b/diskann/src/graph/test/provider.rs
@@ -939,17 +939,16 @@ impl provider::HasId for NeighborAccessor<'_> {
 
 impl provider::NeighborAccessor for NeighborAccessor<'_> {
     async fn get_neighbors(
-        self,
+        &mut self,
         id: Self::Id,
         neighbors: &mut AdjacencyList<Self::Id>,
-    ) -> ANNResult<Self> {
-        self.provider.get_neighbors(id, neighbors)?;
-        Ok(self)
+    ) -> ANNResult<()> {
+        self.provider.get_neighbors(id, neighbors)
     }
 }
 
 impl provider::NeighborAccessorMut for NeighborAccessor<'_> {
-    async fn set_neighbors(self, id: Self::Id, neighbors: &[Self::Id]) -> ANNResult<Self> {
+    async fn set_neighbors(&mut self, id: Self::Id, neighbors: &[Self::Id]) -> ANNResult<()> {
         if neighbors.len() > self.provider.max_degree() {
             return Err(message!(
                 "trying to assign neighbors with length {} when max degree is {}",
@@ -976,14 +975,14 @@ impl provider::NeighborAccessorMut for NeighborAccessor<'_> {
                 if term.neighbors.len() != neighbors.len() {
                     Err(message!("duplicate neighbors detected"))
                 } else {
-                    Ok(self)
+                    Ok(())
                 }
             }
             None => Err(ANNError::opaque(AccessedInvalidId(id))),
         }
     }
 
-    async fn append_vector(self, id: Self::Id, neighbors: &[Self::Id]) -> ANNResult<Self> {
+    async fn append_vector(&mut self, id: Self::Id, neighbors: &[Self::Id]) -> ANNResult<()> {
         match self.provider.terms.get_mut(&id) {
             Some(mut term) => {
                 // Do not allow `append_vector` to exceed the max degree.
@@ -1003,7 +1002,7 @@ impl provider::NeighborAccessorMut for NeighborAccessor<'_> {
                 if added != neighbors.len() {
                     Err(message!("duplicate ids in append-vector"))
                 } else {
-                    Ok(self)
+                    Ok(())
                 }
             }
             None => Err(ANNError::opaque(AccessedInvalidId(id))),
@@ -1043,90 +1042,110 @@ pub struct PruneAccessor<'a> {
     provider: &'a Provider,
     get_vector: LocalCounter<'a>,
     transient_ids: Flaky<'a>,
+    distance: <f32 as VectorRepr>::Distance,
+    set: WorkingSet,
 }
 
+type WorkingSet = workingset::Map<u32, Box<[f32]>, workingset::map::Ref<[f32]>>;
+type View<'a> = workingset::map::View<'a, u32, Box<[f32]>, workingset::map::Ref<[f32]>>;
+
 impl<'a> PruneAccessor<'a> {
-    fn new(provider: &'a Provider, transient_ids: Option<Cow<'a, HashSet<u32>>>) -> Self {
+    fn new(
+        provider: &'a Provider,
+        transient_ids: Option<Cow<'a, HashSet<u32>>>,
+        set: WorkingSet,
+    ) -> Self {
         Self {
             provider,
             get_vector: provider.get_vector.local(),
             transient_ids: Flaky::new(transient_ids),
+            distance: f32::distance(provider.distance_metric(), Some(provider.dim())),
+            set,
         }
     }
 
-    fn get(&mut self, id: u32) -> Result<Box<[f32]>, AccessError> {
-        let f = |data: &[f32]| -> Result<Box<[f32]>, TransientAccessError> {
-            self.transient_ids.check(id)?;
-            self.get_vector.increment();
-            Ok(data.into())
-        };
+    // fn get(&mut self, id: u32) -> Result<Box<[f32]>, AccessError> {
+    //     let f = |data: &[f32]| -> Result<Box<[f32]>, TransientAccessError> {
+    //         self.transient_ids.check(id)?;
+    //         self.get_vector.increment();
+    //         Ok(data.into())
+    //     };
 
-        match self.provider.get(id, f) {
-            Ok(Ok(buf)) => Ok(buf),
-            Ok(Err(transient)) => Err(AccessError::Transient(transient)),
-            Err(invalid) => Err(AccessError::InvalidId(invalid)),
-        }
-    }
+    //     match self.provider.get(id, f) {
+    //         Ok(Ok(buf)) => Ok(buf),
+    //         Ok(Err(transient)) => Err(AccessError::Transient(transient)),
+    //         Err(invalid) => Err(AccessError::InvalidId(invalid)),
+    //     }
+    // }
 }
+
 
 impl provider::HasId for PruneAccessor<'_> {
     type Id = u32;
 }
 
-impl provider::HasElementRef for PruneAccessor<'_> {
+impl glue::PruneAccessor for PruneAccessor<'_> {
     type ElementRef<'a> = &'a [f32];
-}
+    type View<'a> = View<'a> where Self: 'a;
+    type Distance<'a> = <f32 as VectorRepr>::Distance where Self: 'a;
+    type Neighbors<'a> = NeighborAccessor<'a> where Self: 'a;
 
-impl<'a> provider::DelegateNeighbor<'a> for PruneAccessor<'_> {
-    type Delegate = NeighborAccessor<'a>;
-    fn delegate_neighbor(&'a mut self) -> Self::Delegate {
+    async fn fill<'a, Itr>(
+        &'a mut self,
+        itr: Itr,
+    ) -> ANNResult<(Self::View<'a>, Self::Distance<'a>)>
+    where
+        Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
+    {
+        let view = self.set.fill(itr, |i| {
+            let f = |data: &[f32]| -> Result<Box<[f32]>, TransientAccessError> {
+                self.transient_ids.check(i)?;
+                self.get_vector.increment();
+                Ok(data.into())
+            };
+
+            match self.provider.get(i, f) {
+                Ok(Ok(buf)) => Ok(Some(buf)),
+                Ok(Err(transient)) => {
+                    transient.acknowledge("transient failures allowed");
+                    Ok(None)
+                },
+                Err(invalid) => Err(invalid),
+            }
+        })?;
+
+        Ok((view, self.distance))
+    }
+
+    fn neighbors(&mut self) -> Self::Neighbors<'_> {
         NeighborAccessor::new(self.provider)
     }
 }
 
-impl provider::BuildDistanceComputer for PruneAccessor<'_> {
-    type DistanceComputerError = Infallible;
-    type DistanceComputer = <f32 as VectorRepr>::Distance;
-
-    fn build_distance_computer(
-        &self,
-    ) -> Result<Self::DistanceComputer, Self::DistanceComputerError> {
-        Ok(f32::distance(
-            self.provider.distance_metric(),
-            Some(self.provider.dim()),
-        ))
-    }
-}
-
-//------//
-// glue //
-//------//
-
-type WorkingSet = workingset::Map<u32, Box<[f32]>, workingset::map::Ref<[f32]>>;
-type View<'a> = workingset::map::View<'a, u32, Box<[f32]>, workingset::map::Ref<[f32]>>;
-
-impl workingset::Fill<WorkingSet> for PruneAccessor<'_> {
-    type Error = ANNError;
-    type View<'a>
-        = View<'a>
-    where
-        Self: 'a,
-        WorkingSet: 'a;
-
-    async fn fill<'a, Itr>(
-        &'a mut self,
-        set: &'a mut WorkingSet,
-        itr: Itr,
-    ) -> Result<Self::View<'a>, Self::Error>
-    where
-        Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
-        Self: 'a,
-    {
-        set.fill(itr, |i| {
-            self.get(i).allow_transient("transient failures allowed")
-        })
-    }
-}
+// impl provider::HasElementRef for PruneAccessor<'_> {
+//     type ElementRef<'a> = &'a [f32];
+// }
+//
+// impl<'a> provider::DelegateNeighbor<'a> for PruneAccessor<'_> {
+//     type Delegate = NeighborAccessor<'a>;
+//     fn delegate_neighbor(&'a mut self) -> Self::Delegate {
+//         NeighborAccessor::new(self.provider)
+//     }
+// }
+//
+// impl provider::BuildDistanceComputer for PruneAccessor<'_> {
+//     type DistanceComputerError = Infallible;
+//     type DistanceComputer = <f32 as VectorRepr>::Distance;
+//
+//     fn build_distance_computer(
+//         &self,
+//     ) -> Result<Self::DistanceComputer, Self::DistanceComputerError> {
+//         Ok(f32::distance(
+//             self.provider.distance_metric(),
+//             Some(self.provider.dim()),
+//         ))
+//     }
+// }
 
 //////////////
 // Accessor //
@@ -1332,29 +1351,26 @@ impl<'a> glue::DefaultPostProcessor<'a, Provider, &'a [f32]> for Strategy {
 }
 
 impl glue::PruneStrategy<Provider> for Strategy {
-    type WorkingSet = workingset::Map<u32, Box<[f32]>, workingset::map::Ref<[f32]>>;
-    type DistanceComputer<'a> = <f32 as VectorRepr>::Distance;
     type PruneAccessor<'a> = PruneAccessor<'a>;
     type PruneAccessorError = Infallible;
 
-    fn create_working_set(&self, capacity: usize) -> Self::WorkingSet {
+    fn prune_accessor<'a>(
+        &'a self,
+        provider: &'a Provider,
+        _context: &'a Context,
+        capacity: usize,
+    ) -> Result<Self::PruneAccessor<'a>, Self::PruneAccessorError> {
         let cap = if self.working_set_reuse {
             workingset::map::Capacity::Default
         } else {
             workingset::map::Capacity::None
         };
 
-        workingset::map::Builder::new(cap).build(capacity)
-    }
+        let set = workingset::map::Builder::new(cap).build(capacity);
 
-    fn prune_accessor<'a>(
-        &'a self,
-        provider: &'a Provider,
-        _context: &'a Context,
-    ) -> Result<Self::PruneAccessor<'a>, Self::PruneAccessorError> {
         match &self.transient_ids {
-            Some(ids) => Ok(PruneAccessor::new(provider, Some(Cow::Borrowed(ids)))),
-            None => Ok(PruneAccessor::new(provider, None)),
+            Some(ids) => Ok(PruneAccessor::new(provider, Some(Cow::Borrowed(ids)), set)),
+            None => Ok(PruneAccessor::new(provider, None, set)),
         }
     }
 }
@@ -1377,9 +1393,9 @@ impl<'a> glue::InsertStrategy<'a, Provider, &'a [f32]> for Strategy {
 }
 
 impl glue::MultiInsertStrategy<Provider, Matrix<f32>> for Strategy {
-    type WorkingSet = workingset::Map<u32, Box<[f32]>, workingset::map::Ref<[f32]>>;
     type Seed = workingset::map::Builder<u32, workingset::map::Ref<[f32]>>;
     type FinishError = Infallible;
+    type PruneStrategy = Self;
     type InsertStrategy = Self;
 
     fn insert_strategy(&self) -> Self::InsertStrategy {
@@ -1407,6 +1423,19 @@ impl glue::MultiInsertStrategy<Provider, Matrix<f32>> for Strategy {
         std::future::ready(Ok(
             Builder::new(capacity).with_overlay(Overlay::from_batch(batch.clone(), ids))
         ))
+    }
+
+    fn seeded_prune_accessor<'a>(
+        &'a self,
+        provider: &'a Provider,
+        _context: &'a Context,
+        builder: &'a Self::Seed,
+        capacity: usize,
+    ) -> ANNResult<PruneAccessor<'a>> {
+        let set = builder.clone().build(capacity);
+        let transient_ids = self.transient_ids.as_deref().map(Cow::Borrowed);
+
+        Ok(PruneAccessor::new(provider, transient_ids, set))
     }
 }
 
@@ -1843,7 +1872,7 @@ mod tests {
         use provider::{DefaultAccessor, NeighborAccessor};
 
         let provider = create_test_provider();
-        let accessor = provider.default_accessor();
+        let mut accessor = provider.default_accessor();
         let mut v = AdjacencyList::new();
 
         let rt = current_thread_runtime();
@@ -1872,7 +1901,7 @@ mod tests {
         use provider::{DefaultAccessor, NeighborAccessor, NeighborAccessorMut};
 
         let provider = create_test_provider();
-        let accessor = provider.default_accessor();
+        let mut accessor = provider.default_accessor();
         let mut v = AdjacencyList::new();
 
         let rt = current_thread_runtime();
@@ -1950,7 +1979,7 @@ mod tests {
         use provider::{DefaultAccessor, NeighborAccessor, NeighborAccessorMut};
 
         let provider = create_test_provider();
-        let accessor = provider.default_accessor();
+        let mut accessor = provider.default_accessor();
         let mut v = AdjacencyList::new();
 
         let rt = current_thread_runtime();

--- a/diskann/src/graph/workingset/map.rs
+++ b/diskann/src/graph/workingset/map.rs
@@ -786,7 +786,7 @@ where
 /// Builder for [`Map`]-backed working sets.
 ///
 /// Doubles as the `Seed` type for
-/// [`MultiInserStrategy::Seed`](crate::graph::glue::MultiInsertStrategy::Seed): strategies
+/// [`MultiInsertStrategy::Seed`](crate::graph::glue::MultiInsertStrategy::Seed): strategies
 /// return a `Builder` from
 /// [`MultiInsertStrategy::finish`](crate::graph::glue::MultiInsertStrategy::finish),
 /// and later provide it to

--- a/diskann/src/graph/workingset/map.rs
+++ b/diskann/src/graph/workingset/map.rs
@@ -143,13 +143,12 @@ use crate::graph::glue;
 ///
 /// This struct uses [`Builder`] as its constructor.
 ///
-/// Additionally, [working set reuse](super#reuse-in-a-workingset) is optionally supported and
-/// is controlled by the [`Capacity`] enum. See the [module level docs](self#working-set-reuse)
-/// for more details.
+/// Additionally, caching is optionally supported and is controlled by the [`Capacity`] enum.
+/// See the [module level docs](self#working-set-reuse) for more details.
 ///
 /// When working set reuse is enabled, older entries are evicted using an unspecified
-/// algorithm with the guarantee that items of the [`Fill`] iterator that are already present
-/// will not be evicted.
+/// algorithm with the guarantee that items of the [`Map::fill`] iterator that are already
+/// present will not be evicted.
 ///
 /// For zero-copy multi-insert compatibility, an [`Overlay`] should be provided to the [`Builder`].
 #[derive(Debug)]
@@ -231,8 +230,7 @@ where
     /// Prepare the map for the next [`fill`](Self::fill) cycle.
     ///
     /// Pins entries whose keys appear in `itr` and evicts unpinned entries as needed
-    /// to stay within the configured [`Capacity`]. Called automatically by [`fill`](Self::fill);
-    /// only call directly if using [`fill_with`](Self::fill_with).
+    /// to stay within the configured [`Capacity`]. Called automatically by [`fill`](Self::fill).
     ///
     /// Note: When semantically correct, `itr` may not be consumed. Callers must not rely
     /// on `itr` being advanced to completion.
@@ -383,34 +381,6 @@ where
     /// assert_eq!(*view.get(1).unwrap(), 1.0);
     /// assert_eq!(*view.get(2).unwrap(), 2.0);
     /// assert!(view.get(3).is_none());
-    /// ```
-    ///
-    /// # Implementing [`Fill`](super::Fill) with `Map::fill`
-    ///
-    /// The [`Fill`](super::Fill) trait requires implementers to populate a working set
-    /// from an accessor. `Map::fill` is designed to make this straightforward:
-    ///
-    /// ```ignore
-    /// impl workingset::Fill<WorkingSet> for MyAccessor<'_> {
-    ///     type Error = ANNError;
-    ///     type View<'a> = workingset::map::View<'a, u32, Box<[f32]>, Ref<[f32]>>
-    ///     where
-    ///         Self: 'a;
-    ///
-    ///     async fn fill<'a, Itr>(
-    ///         &'a mut self,
-    ///         set: &'a mut WorkingSet,
-    ///         itr: Itr,
-    ///     ) -> Result<Self::View<'a>, Self::Error>
-    ///     where
-    ///         Itr: ExactSizeIterator<Item = u32> + Clone + Send + Sync,
-    ///         Self: 'a,
-    ///     {
-    ///         set.fill(itr, |id| {
-    ///             self.get_vector(id).allow_transient("skipping transient errors")
-    ///         })
-    ///     }
-    /// }
     /// ```
     pub fn fill<Itr, E>(
         &mut self,
@@ -815,9 +785,12 @@ where
 
 /// Builder for [`Map`]-backed working sets.
 ///
-/// Doubles as the `Seed` type for [`AsWorkingSet<Map>`]: strategies return a `Builder`
-/// from [`MultiInsertStrategy::finish`](crate::graph::glue::MultiInsertStrategy::finish),
-/// and the index calls [`as_working_set`](AsWorkingSet::as_working_set) to materialize it.
+/// Doubles as the `Seed` type for
+/// [`MultiInserStrategy::Seed`](crate::graph::glue::MultiInsertStrategy::Seed): strategies
+/// return a `Builder` from
+/// [`MultiInsertStrategy::finish`](crate::graph::glue::MultiInsertStrategy::finish),
+/// and later provide it to
+/// [`MultiInsertStrategy::seeded_prune_accessor`](crate::graph::glue::MultiInsertStrategy::seeded_prune_accessor).
 ///
 /// # Examples
 ///
@@ -912,7 +885,7 @@ impl Capacity {
 /// given precedence.
 ///
 /// If [working set reuse](self#working-set-reuse) is enabled, then all elements within
-/// the [`Map`] are visible, not just those that belong to the most recent [`Fill`].
+/// the [`Map`] are visible, not just those that belong to the most recent fill.
 #[derive(Debug)]
 pub struct View<'a, K, V, P: Projection = Reborrowed<V>> {
     map: &'a Map<K, V, P>,

--- a/diskann/src/graph/workingset/map.rs
+++ b/diskann/src/graph/workingset/map.rs
@@ -134,8 +134,6 @@ use hashbrown::hash_map;
 
 use crate::graph::glue;
 
-use super::AsWorkingSet;
-
 /////////
 // Map //
 /////////
@@ -143,8 +141,7 @@ use super::AsWorkingSet;
 /// Default [working set](super) state backed by a `HashMap` with an optional overlay for
 /// [`multi_insert`](crate::graph::glue::MultiInsertStrategy).
 ///
-/// This struct uses [`Builder`] as its constructor, which implements [`AsWorkingSet`] for
-/// multi-insert compatibility.
+/// This struct uses [`Builder`] as its constructor.
 ///
 /// Additionally, [working set reuse](super#reuse-in-a-workingset) is optionally supported and
 /// is controlled by the [`Capacity`] enum. See the [module level docs](self#working-set-reuse)
@@ -874,15 +871,6 @@ impl<K, P: Projection> Clone for Builder<K, P> {
             overlay: self.overlay.clone(),
             capacity: self.capacity,
         }
-    }
-}
-
-impl<K, V, P> AsWorkingSet<Map<K, V, P>> for Builder<K, P>
-where
-    P: Projection,
-{
-    fn as_working_set(&self, capacity: usize) -> Map<K, V, P> {
-        self.clone().build(capacity)
     }
 }
 
@@ -1845,14 +1833,6 @@ mod tests {
         let ws: TestMap = Builder::new(Capacity::Default).build(32);
         assert!(!ws.contains_key(&1));
         // No overlay.
-        let view = ws.view();
-        assert!(view.get(1).is_none());
-    }
-
-    #[test]
-    fn builder_as_working_set() {
-        let ws: TestMap = Builder::new(Capacity::Default).as_working_set(32);
-        assert!(!ws.contains_key(&1));
         let view = ws.view();
         assert!(view.get(1).is_none());
     }

--- a/diskann/src/graph/workingset/mod.rs
+++ b/diskann/src/graph/workingset/mod.rs
@@ -3,69 +3,7 @@
  * Licensed under the MIT license.
  */
 
-//! The working-set is a core scratch data structure used during pruning.
-//!
-//! # Overview
-//!
-//! This interface consists of two traits for all insert types and one additional trait for
-//! batch operations like [`multi_insert`](crate::graph::DiskANNIndex::multi_insert).
-//! These are summarized below.
-//!
-//! * [`View`] (all inserts): Read-only random access to cached data. Data access should
-//!   be reasonably efficient.
-//!
-//! * [`Fill`] (all inserts): Extension point for fetching data associated with internal IDs
-//!   and producing a [`View`] to access the retrieved data. This trait uses an opaque
-//!   `WorkingSet` that implementations are free to use in any way they see fit.
-//!
-//! * [`AsWorkingSet`] (bulk operations): Deferred creation of a `WorkingSet` to pass to
-//!   [`Fill`]. This allows [`MultiInsertStrategy`](crate::graph::glue::MultiInsertStrategy)
-//!   to seed [`View`]s with elements of the input.
-//!
-//! Traits that produce and otherwise interact with working sets are:
-//!
-//! * [`PruneStrategy`](crate::graph::glue::PruneStrategy): Creates a `WorkingSet` opaque type.
-//! * [`MultiInsertStrategy`](crate::graph::glue::MultiInsertStrategy): Creates an implementation
-//!   of [`AsWorkingSet`] to defer creation of the final `WorkingSet` until needed by worker
-//!   tasks.
-//!
-//! # Implementation Strategies
-//!
-//! The `WorkingSet` type passed to [`Fill`] is opaque. Instead only the returned [`View`]
-//! is accessed directly. This enables the following implementation strategies:
-//!
-//! * Allocate in `WorkingSet`, making `View` a shallow wrapper. This is the most
-//!   straightforward approach. Elements are stored directly in `WorkingSet` and the accessor
-//!   simply populates data.
-//!
-//! * Allocate in `Accessor`: Another approach is to allocate scratch space directly in `Self`
-//!   for the elements in `itr`. This works since [`Fill::View`] borrows from `Self`.
-//!
-//! * Passthrough: If random access is synchronous and fast, then an implementation of
-//!   [`View`] can simply reach through the `Accessor`, use zero-sized types for the
-//!   `WorkingSet`, and avoid allocation entirely.
-//!
-//! Within these, there are multiple strategies as well. For example, if data is known to
-//! be standard slices of standard types, then an implementation of `WorkingSet` can pack
-//! this data contiguously in memory for better memory locality.
-//!
-//! # Reuse in a `WorkingSet`
-//!
-//! Any particular `WorkingSet` can be reused across multiple prunes. It's up to the
-//! implementation to decide whether this reuse can serve as a cache for vectors or not.
-//! The default implementation [`Map`] offers both cached and uncached modes.
-//!
-//! Trade offs include:
-//!
-//! * Without any cross-fill reuse, more vector retrievals are made, but the data in the
-//!   associated [`View`] is up-to-date.
-//!
-//! * With cross-fill reuse, the memory used by the working set increases.
-//!
-//! Working sets are used in the indexing algorithm within fairly tight temporal windows so
-//! the risk of stale entries in the cache causing incorrect graphs is minimal.
-
-use diskann_utils::{Reborrow};
+use diskann_utils::Reborrow;
 
 /////////////
 // Exports //
@@ -78,11 +16,11 @@ pub use map::Map;
 // Traits //
 ////////////
 
-/// Read-only view into a [working set](Fill).
+/// Read-only view into a [`PruneAccessor`].
 ///
 /// Used by `occlude_list` and distance computations.
 ///
-/// See Also: [`Fill`], [`Map`], [`map::View`].
+/// See Also: [`PruneAccessor::fill`], [`Map`], [`map::View`].
 pub trait View<I> {
     /// The reborrowed element with an arbitrarily short lifetime.
     ///
@@ -93,17 +31,14 @@ pub trait View<I> {
     ///
     /// The reborrow bound allows this type to be decoupled from the type provided to
     /// distance computers, and as a proxy for `Copy`.
-    ///
-    /// This does **not** need to be the same as [`crate::provider::Accessor::Element`]
-    /// provided [`Self::ElementRef`] matches the accessor's `ElementRef`.
     type Element<'a>: for<'b> Reborrow<'b, Target = Self::ElementRef<'b>>
     where
         Self: 'a;
 
     /// Retrieve element associated with `id` if available.
     ///
-    /// Users can expect that if `Self` was constructed from [`Fill::fill`], then `id` will
-    /// belong to the iterator argument of that function.
+    /// Users can expect that if `Self` was constructed from [`PruneAccessor::fill`], then
+    /// `id` will belong to the iterator argument of that function.
     ///
     /// Retrieval should be reasonably efficient, but is not called in the hot-loop of prune.
     fn get(&self, id: I) -> Option<Self::Element<'_>>;

--- a/diskann/src/graph/workingset/mod.rs
+++ b/diskann/src/graph/workingset/mod.rs
@@ -65,12 +65,7 @@
 //! Working sets are used in the indexing algorithm within fairly tight temporal windows so
 //! the risk of stale entries in the cache causing incorrect graphs is minimal.
 
-use diskann_utils::{Reborrow, future::SendFuture};
-
-use crate::{
-    ANNError,
-    provider::{HasElementRef, HasId},
-};
+use diskann_utils::{Reborrow};
 
 /////////////
 // Exports //
@@ -82,63 +77,6 @@ pub use map::Map;
 ////////////
 // Traits //
 ////////////
-
-/// Populate a `WorkingSet` with data from an accessor and return a [`View`] over the set.
-///
-/// For each `i` in `itr` - the accessor should make the data behind `i` available, either
-/// by storing it in `working_set` or through direct storage in the returned [`View`].
-///
-/// The `WorkingSet` type is constructed by either:
-///
-/// * [`PruneStrategy`](crate::graph::glue::PruneStrategy::create_working_set): Direct
-///   construction of a working set for use in multiple prunes.
-///
-/// * [`MultiInsertStrategy::Seed`](crate::graph::glue::MultiInsertStrategy::Seed): Indirect
-///   creation that uses [`AsWorkingSet`] for the final conversion. This allows the elements
-///   in the input batch to [`multi_insert`](crate::graph::DiskANNIndex::multi_insert) to be
-///   directly accessible by the `WorkingSet`/[`View`] types.
-///
-/// For many simple use cases, [`Map::fill`] should be sufficient to provide a good
-/// implementation of [`Fill::fill`].
-///
-/// See Also: [`View`], [`AsWorkingSet`], [`Map`].
-pub trait Fill<WorkingSet>: HasElementRef + HasId {
-    /// Any critical error that occurs during [`fill`](Self::fill).
-    ///
-    /// Implementations of `fill` are expected to swallow any non-critical errors.
-    type Error: Into<ANNError> + std::fmt::Debug + Send + Sync;
-
-    /// The post-fill [`View`] used to access the retrieved data.
-    type View<'a>: for<'b> View<Self::Id, ElementRef<'b> = Self::ElementRef<'b>> + Send + Sync
-    where
-        Self: 'a,
-        WorkingSet: 'a;
-
-    /// Make the data elements for items in `itr` available in the returned [`View`].
-    ///
-    /// Implementations may use `working_set` as scratch and to persist work across multiple calls.
-    ///
-    /// The input `itr` is `Clone` and is expected that the implementation of `Clone` is cheap
-    /// and without interior mutability. This allows implementers to perform multiple passes
-    /// of `itr` if needed.
-    ///
-    /// ## Missing Entries
-    ///
-    /// While it's a good idea to ensure all items in `itr` are fetched, callers are
-    /// designed to tolerate a small number of missing entries without serious performance
-    /// degradation.
-    ///
-    /// If a ID really needs to be fetched for algorithmic purposes, it will be the first
-    /// item yielded from `itr`.
-    fn fill<'a, Itr>(
-        &'a mut self,
-        working_set: &'a mut WorkingSet,
-        itr: Itr,
-    ) -> impl SendFuture<Result<Self::View<'a>, Self::Error>>
-    where
-        Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync,
-        Self: 'a;
-}
 
 /// Read-only view into a [working set](Fill).
 ///
@@ -169,16 +107,4 @@ pub trait View<I> {
     ///
     /// Retrieval should be reasonably efficient, but is not called in the hot-loop of prune.
     fn get(&self, id: I) -> Option<Self::Element<'_>>;
-}
-
-/// Use `Self` as a seed for `WorkingSet`.
-///
-/// This is used by [`crate::graph::glue::MultiInsertStrategy::Seed`] to package the data
-/// provided to the input batch in a way that enables zero-copy access for multi-insert
-/// worker threads.
-///
-/// See Also: [`Fill`], [`map::Builder`].
-pub trait AsWorkingSet<WorkingSet> {
-    /// Create a working set capable of holding `capacity` elements.
-    fn as_working_set(&self, capacity: usize) -> WorkingSet;
 }

--- a/diskann/src/graph/workingset/mod.rs
+++ b/diskann/src/graph/workingset/mod.rs
@@ -16,11 +16,12 @@ pub use map::Map;
 // Traits //
 ////////////
 
-/// Read-only view into a [`PruneAccessor`].
+/// Read-only view into a [`PruneAccessor`](crate::graph::glue::PruneAccessor).
 ///
 /// Used by `occlude_list` and distance computations.
 ///
-/// See Also: [`PruneAccessor::fill`], [`Map`], [`map::View`].
+/// See Also: [`PruneAccessor::fill`](crate::graph::glue::PruneAccessor::fill), [`Map`],
+/// [`map::View`].
 pub trait View<I> {
     /// The reborrowed element with an arbitrarily short lifetime.
     ///

--- a/diskann/src/graph/workingset/mod.rs
+++ b/diskann/src/graph/workingset/mod.rs
@@ -42,7 +42,7 @@
 //!   for the elements in `itr`. This works since [`Fill::View`] borrows from `Self`.
 //!
 //! * Passthrough: If random access is synchronous and fast, then an implementation of
-//!   [`View`] can simply go directly to the backing store, use zero-sized types for the
+//!   [`View`] can simply reach through the `Accessor`, use zero-sized types for the
 //!   `WorkingSet`, and avoid allocation entirely.
 //!
 //! Within these, there are multiple strategies as well. For example, if data is known to

--- a/diskann/src/provider.rs
+++ b/diskann/src/provider.rs
@@ -55,40 +55,10 @@
 //!
 //!   The [`HasId`] trait provides a common base-trait for these related concepts, which
 //!   ensures implementers only need to define and constrain it once.
-//!
-//! * [`BuildDistanceComputer`]: A sub-trait of [`HasElementRef`] that allows for
-//!   random-access distance computations on the retrieved elements.
-//!
-//! # Neighbor Delegation
-//!
-//! Graph operations require both data access (distances, elements) and graph
-//! access (neighbor retrieval and mutation). These concerns are typically served
-//! by different backing stores and need not vary together.
-//!
-//! For example, search and pruning use different data accessors (optimized for
-//! query distances vs. pairwise element distances), but both share the same
-//! graph topology.
-//!
-//! Rather than requiring every data accessor to manually forward
-//! [`NeighborAccessor`] methods, the [`DelegateNeighbor`] trait routes neighbor
-//! access to a single shared implementation.
-//!
-//! Data accessor types should implement [`DelegateNeighbor`] to return a
-//! [`NeighborAccessor`]. This automatically provides [`AsNeighbor`] and
-//! [`AsNeighborMut`] (the latter when the delegate implements
-//! [`NeighborAccessorMut`]).
-//!
-//! Algorithms requiring graph access should accept `&mut T` where
-//! `T: AsNeighbor` or `T: AsNeighborMut`, which provides blanket
-//! implementations of [`NeighborAccessor`] and [`NeighborAccessorMut`]
-//! for `&mut T`.
 
 use std::ops::Deref;
 
-use diskann_vector::DistanceFunction;
-use sealed::{BoundTo, Sealed};
-
-use crate::{ANNError, ANNResult, error::ToRanked, graph::AdjacencyList, utils::VectorId};
+use crate::{ANNResult, error::ToRanked, graph::AdjacencyList, utils::VectorId};
 
 //////////////////////
 // ExecutionContext //
@@ -366,45 +336,9 @@ where
     }
 }
 
-///////////////////
-// HasElementRef //
-///////////////////
-
-/// An association between a data accessor and the element it yields.
-pub trait HasElementRef {
-    type ElementRef<'a>;
-}
-
-/////////////////////////////
-// Build Distance Computer //
-/////////////////////////////
-
-/// A trait that provides random-access distance computations over elements
-/// identified by [`HasElementRef`].
-pub trait BuildDistanceComputer: HasElementRef {
-    /// The error type (if any) associated with distance computer construction.
-    ///
-    /// Implementations are encouraged to make distance computer construction infallible.
-    type DistanceComputerError: std::error::Error + Into<ANNError> + Send + Sync + 'static;
-
-    /// The concrete type of the distance computer, which must be applicable to all pairs
-    /// of elements identified by [`HasElementRef::ElementRef`].
-    type DistanceComputer: for<'a, 'b> DistanceFunction<Self::ElementRef<'a>, Self::ElementRef<'b>>
-        + Send
-        + Sync;
-
-    /// Build the random-access distance computer for this accessor.
-    ///
-    /// This method is expected to be relatively cheap to invoke and implementations are
-    /// encouraged to make this method infallible.
-    fn build_distance_computer(
-        &self,
-    ) -> Result<Self::DistanceComputer, Self::DistanceComputerError>;
-}
-
-/////////////////////////
-// Neighbor Delegation //
-/////////////////////////
+///////////////////////
+// Neighbor Accessor //
+///////////////////////
 
 /// An accessor that provides random-access neighbor retrieval from a graph.
 ///
@@ -431,10 +365,10 @@ pub trait NeighborAccessor: HasId + Sized + Send + Sync {
     ///
     /// Implementations are expected to clear `neighbors` prior to populating.
     fn get_neighbors(
-        self,
+        &mut self,
         id: Self::Id,
         neighbors: &mut AdjacencyList<Self::Id>,
-    ) -> impl std::future::Future<Output = ANNResult<Self>> + Send;
+    ) -> impl std::future::Future<Output = ANNResult<()>> + Send;
 }
 
 /// A mutable extension of [`NeighborAccessor`] that enables the underlying graph to be
@@ -445,20 +379,20 @@ pub trait NeighborAccessor: HasId + Sized + Send + Sync {
 pub trait NeighborAccessorMut: NeighborAccessor {
     /// Overwrite the neighbor list for the node associated with `id`.
     fn set_neighbors(
-        self,
+        &mut self,
         id: Self::Id,
         neighbors: &[Self::Id],
-    ) -> impl std::future::Future<Output = ANNResult<Self>> + Send;
+    ) -> impl std::future::Future<Output = ANNResult<()>> + Send;
 
     /// Append all entries in `neighbors` tothe neighbor list currently associated with `id`.
     ///
     /// The behavior when the resulting list exceeds some pre-configured capacity or
     /// contains duplicates is implementation defined.
     fn append_vector(
-        self,
+        &mut self,
         id: Self::Id,
         neighbors: &[Self::Id],
-    ) -> impl std::future::Future<Output = ANNResult<Self>> + Send;
+    ) -> impl std::future::Future<Output = ANNResult<()>> + Send;
 
     /// A potentially optimized bulk implementation of [`Self::set_neighbors`].
     ///
@@ -467,125 +401,21 @@ pub trait NeighborAccessorMut: NeighborAccessor {
     ///
     /// Implementations are allowed to commit entries out of order.
     fn set_neighbors_bulk<I, T>(
-        mut self,
+        &mut self,
         iter: I,
-    ) -> impl std::future::Future<Output = ANNResult<Self>> + Send
+    ) -> impl std::future::Future<Output = ANNResult<()>> + Send
     where
         I: Iterator<Item = (Self::Id, T)> + Send,
         T: Deref<Target = [Self::Id]> + Send,
     {
         async move {
             for (vector_id, neighbors) in iter {
-                self = self.set_neighbors(vector_id, neighbors.deref()).await?;
+                self.set_neighbors(vector_id, neighbors.deref()).await?;
             }
-            Ok(self)
+            Ok(())
         }
     }
 }
-
-/// This implementation allows `&mut T` to be used as a [`NeighborAccessor`] without
-/// requiring manual invocation of [`DelegateNeighbor`].
-impl<T> NeighborAccessor for &mut T
-where
-    T: AsNeighbor,
-{
-    async fn get_neighbors(
-        self,
-        id: Self::Id,
-        neighbors: &mut AdjacencyList<Self::Id>,
-    ) -> ANNResult<Self> {
-        self.delegate_neighbor()
-            .get_neighbors(id, neighbors)
-            .await?;
-        Ok(self)
-    }
-}
-
-/// This implementation allows `&mut T` to be used as a [`NeighborAccessorMut`] without
-/// requiring manual invocation of [`DelegateNeighbor`].
-impl<T> NeighborAccessorMut for &mut T
-where
-    T: AsNeighborMut,
-{
-    async fn set_neighbors(self, id: Self::Id, neighbors: &[Self::Id]) -> ANNResult<Self> {
-        self.delegate_neighbor()
-            .set_neighbors(id, neighbors)
-            .await?;
-        Ok(self)
-    }
-    async fn append_vector(self, id: Self::Id, neighbors: &[Self::Id]) -> ANNResult<Self> {
-        self.delegate_neighbor()
-            .append_vector(id, neighbors)
-            .await?;
-        Ok(self)
-    }
-    async fn set_neighbors_bulk<I, U>(self, iter: I) -> ANNResult<Self>
-    where
-        I: Iterator<Item = (Self::Id, U)> + Send,
-        U: Deref<Target = [Self::Id]> + Send,
-    {
-        self.delegate_neighbor().set_neighbors_bulk(iter).await?;
-        Ok(self)
-    }
-}
-
-/// Accessor may delegate the responsibility of being a [`NeighborAccessor`] to an auxiliary
-/// type by implementing this trait.
-///
-/// If the implementation of a [`NeighborAccessor`]/[`NeighborAccessorMut`] is coupled with
-/// the data accessor itself (meaning that no delegation can take place), then implementations
-/// may do the following. Assume the accessor has type `T`. Then:
-///
-/// 1. Implement [`NeighborAccessor`]/[`NeighborAccessorMut`] for a thin wrapper around
-///    `&[mut] T`.
-///
-/// 2. Implement [`DelegateNeighbor`] to return this wrapper as its delegate.
-///
-/// Implementation code can use this trait through the [`AsNeighbor`] and [`AsNeighborMut`]
-/// convenience traits to ensure proper application of the HRTB requirements.
-///
-/// Additionally, the `&mut T` blanket implementation of [`NeighborAccessor`] and
-/// [`NeighborAccessorMut`] can be used to avoid manually invoking `delegate_neighbor`.
-pub trait DelegateNeighbor<'this, Lifetime: Sealed = BoundTo<&'this Self>>:
-    HasId + Send + Sync
-{
-    /// The type of the delegated [`NeighborAccessor`].
-    type Delegate: NeighborAccessor<Id = Self::Id>;
-
-    /// Construct the delegate.
-    fn delegate_neighbor(&'this mut self) -> Self::Delegate;
-}
-
-impl<'this, T> DelegateNeighbor<'this> for T
-where
-    T: Copy + NeighborAccessor,
-{
-    type Delegate = Self;
-    fn delegate_neighbor(&'this mut self) -> Self::Delegate {
-        *self
-    }
-}
-
-/// A convenience HRTB wrapper for [`DelegateNeighbor`]. Accessors should implement
-/// [`DelegateNeighbor`].
-///
-/// # Note
-///
-/// This trait should never be implemented manually. Instead, this trait is automatically
-/// implemented for a type `T` when it implements [`DelegateNeighbor`].
-pub trait AsNeighbor: for<'a> DelegateNeighbor<'a> {}
-
-/// A convenience HRTB wrapper for [`DelegateNeighbor`]. Accessors should implement
-/// [`DelegateNeighbor`].
-///
-/// # Note
-///
-/// This trait should never be implemented manually. Instead, this trait is automatically
-/// implemented for a type `T` when it implements [`DelegateNeighbor`].
-pub trait AsNeighborMut: for<'a> DelegateNeighbor<'a, Delegate: NeighborAccessorMut> {}
-
-impl<T> AsNeighbor for T where T: for<'a> DelegateNeighbor<'a> {}
-impl<T> AsNeighborMut for T where T: for<'a> DelegateNeighbor<'a, Delegate: NeighborAccessorMut> {}
 
 /// Get a default accessor from a provider.
 ///
@@ -615,17 +445,6 @@ impl std::fmt::Display for DefaultContext {
 }
 
 impl ExecutionContext for DefaultContext {}
-
-//////////
-// Misc //
-//////////
-
-// Constraint for HRBT-style associated types.
-mod sealed {
-    pub trait Sealed: Sized {}
-    pub struct BoundTo<T>(T);
-    impl<T> Sealed for BoundTo<T> {}
-}
 
 ///////////
 // Tests //

--- a/diskann/src/provider.rs
+++ b/diskann/src/provider.rs
@@ -348,7 +348,7 @@ where
 ///
 /// As such, data accessors used in conjunction with graph operations need to additionally
 /// provide an implementation of this trait.
-pub trait NeighborAccessor: HasId + Sized + Send + Sync {
+pub trait NeighborAccessor: HasId + Send + Sync {
     /// Get the neighbors for the node associated with `id`.
     ///
     /// Populate the neighbors into the `neighbors` out parameter.

--- a/diskann/src/provider.rs
+++ b/diskann/src/provider.rs
@@ -50,7 +50,7 @@
 //!   implementations may allow internal IDs to be reused immediately following the deletion
 //!   of the external ID while others may wait for a "release".
 //!
-//! * [`HasId`]: Traits such as [`NeighborAccessor`] and [`DelegateNeighbors`] all need to
+//! * [`HasId`]: Traits such as [`NeighborAccessor`] and [`NeighborAccessorMut`] all need to
 //!   interact with the underlying [`DataProvider`] using an internal ID type.
 //!
 //!   The [`HasId`] trait provides a common base-trait for these related concepts, which
@@ -348,16 +348,6 @@ where
 ///
 /// As such, data accessors used in conjunction with graph operations need to additionally
 /// provide an implementation of this trait.
-///
-/// To avoid repeating implementations for every accessor flavor, the trait
-/// [`DelegateNeighbor`] should be used instead to route the implementation of
-/// [`NeighborAccessor`] to a single type if applicable.
-///
-/// # Note
-///
-/// The `NeighborAccessor` method receive by value. Implementations are strongly encouraged
-/// to be cheap to construct, copy, or clone. This can generally be achieved by implementing
-/// `NeighborAccessor` for `&T`, `&mut T`, or a thing wrapper around such references.
 pub trait NeighborAccessor: HasId + Sized + Send + Sync {
     /// Get the neighbors for the node associated with `id`.
     ///
@@ -373,9 +363,6 @@ pub trait NeighborAccessor: HasId + Sized + Send + Sync {
 
 /// A mutable extension of [`NeighborAccessor`] that enables the underlying graph to be
 /// mutated.
-///
-/// Generally, data accessors should implement [`DelegateNeighbor`] instead of extending this
-/// trait if graph and data access are naturally decoupled.
 pub trait NeighborAccessorMut: NeighborAccessor {
     /// Overwrite the neighbor list for the node associated with `id`.
     fn set_neighbors(
@@ -384,7 +371,7 @@ pub trait NeighborAccessorMut: NeighborAccessor {
         neighbors: &[Self::Id],
     ) -> impl std::future::Future<Output = ANNResult<()>> + Send;
 
-    /// Append all entries in `neighbors` tothe neighbor list currently associated with `id`.
+    /// Append all entries in `neighbors` to the neighbor list currently associated with `id`.
     ///
     /// The behavior when the resulting list exceeds some pre-configured capacity or
     /// contains duplicates is implementation defined.
@@ -414,6 +401,61 @@ pub trait NeighborAccessorMut: NeighborAccessor {
             }
             Ok(())
         }
+    }
+}
+
+/// A small adaptor providing [`NeighborAccessor`] and [`NeighborAccessorMut`] for `&mut T`.
+pub struct Neighbors<'a, T>(pub &'a mut T);
+
+impl<T> HasId for Neighbors<'_, T>
+where
+    T: HasId,
+{
+    type Id = T::Id;
+}
+
+impl<T> NeighborAccessor for Neighbors<'_, T>
+where
+    T: NeighborAccessor,
+{
+    fn get_neighbors(
+        &mut self,
+        id: Self::Id,
+        neighbors: &mut AdjacencyList<Self::Id>,
+    ) -> impl std::future::Future<Output = ANNResult<()>> + Send {
+        self.0.get_neighbors(id, neighbors)
+    }
+}
+
+impl<T> NeighborAccessorMut for Neighbors<'_, T>
+where
+    T: NeighborAccessorMut,
+{
+    fn set_neighbors(
+        &mut self,
+        id: Self::Id,
+        neighbors: &[Self::Id],
+    ) -> impl std::future::Future<Output = ANNResult<()>> + Send {
+        self.0.set_neighbors(id, neighbors)
+    }
+
+    fn append_vector(
+        &mut self,
+        id: Self::Id,
+        neighbors: &[Self::Id],
+    ) -> impl std::future::Future<Output = ANNResult<()>> + Send {
+        self.0.append_vector(id, neighbors)
+    }
+
+    fn set_neighbors_bulk<I, U>(
+        &mut self,
+        iter: I,
+    ) -> impl std::future::Future<Output = ANNResult<()>> + Send
+    where
+        I: Iterator<Item = (Self::Id, U)> + Send,
+        U: Deref<Target = [Self::Id]> + Send,
+    {
+        self.0.set_neighbors_bulk(iter)
     }
 }
 

--- a/rfcs/01067-search-accessor.md
+++ b/rfcs/01067-search-accessor.md
@@ -81,7 +81,6 @@ and `SearchStrategy` to
 pub trait SearchStrategy<'a, Provider, T>: Send + Sync
 where
     Provider: DataProvider,
-
 {
     type SearchAccessor: SearchAccessor<Id = Provider::InternalId>;
     type SearchAccessorError: StandardError;

--- a/rfcs/01067-search-accessor.md
+++ b/rfcs/01067-search-accessor.md
@@ -81,6 +81,7 @@ and `SearchStrategy` to
 pub trait SearchStrategy<'a, Provider, T>: Send + Sync
 where
     Provider: DataProvider,
+
 {
     type SearchAccessor: SearchAccessor<Id = Provider::InternalId>;
     type SearchAccessorError: StandardError;


### PR DESCRIPTION
The insert followup to #1067, consolidating the following traits:
* `diskann::provider::{DelegateNeighbor, AsNeighbor, AsNeighborMut}`: Neighbor accessor delegation in this manner is no longer needed.
* `diskann::provider::{HasElementRef, BuildDistanceComputer}`: Consolidated into `PruneAccessor`.
* `diskann::graph::workingset::{Fill, AsWorkingSet}`: Consolidated into `PruneAccessor`

Into a single `PruneAccessor` trait:
```rust
pub trait PruneAccessor: HasId + Send + Sync {
    type Neighbors<'a>: provider::NeighborAccessorMut<Id = Self::Id>
    where
        Self: 'a;

    type ElementRef<'a>;

    type View<'a>: for<'x> workingset::View<Self::Id, ElementRef<'x> = Self::ElementRef<'x>>
        + Send
        + Sync
    where
        Self: 'a;

    type Distance<'a>: for<'x, 'y> DistanceFunction<Self::ElementRef<'x>, Self::ElementRef<'y>, f32>
        + Send
        + Sync
    where
        Self: 'a;

    /// Replaces neighbor delegation
    fn neighbors(&mut self) -> Self::Neighbors<'_>;

    /// Replaces `workingset::Fill`.
    fn fill<Itr>(
        &mut self,
        itr: Itr,
    ) -> impl SendFuture<ANNResult<(Self::View<'_>, Self::Distance<'_>)>>
    where
        Itr: ExactSizeIterator<Item = Self::Id> + Clone + Send + Sync;
```
For insert/prune, the accessor has two jobs:
1. Neighbor access for manipulating datasets. The new trait uses a `neighbors` method for delegation mainly because it's a pattern we use quite heavily already: implement one `NeighborAccessor` and have all the other accessors use that.
2. Gathering item for pruning and enabling distance computation. This is done via `fill`, which now returns both a `View` and the distance computer. I think this should still remain as a method with a view because it scopes the duration for which pruning is being performed, allowing implementation to acquire locks or otherwise enter some critical region for a duration shorter than the lifetime of the whole accessor.

## Interaction with the Working Set
The working set is used to cache entries across prunes to reduce trips to the backing provider. With this change, the working set and distance computers become part of the accessor, which adds a *little* bloat to the accessors, but simplifies how these objects get along. 

Without an external working-set, `PruneStrategy` becomes much simpler (now it's like `SearchStrategy` with just two associated types and a single method. `MultiInsertStrategy` is slightly changed with `finish` still returning an opaque `Seed` but with the `PruneAccessor` being constructed via `seeded_prune_accessor`. This is the replacement for the `AsWorkingSet` transformation.

## Suggested Review Order
* `diskann/src/graph/glue.rs`: The new `PruneAccessor` trait
* `diskann/src/provider.rs`: Simplification to provider-related traits.
* `diskann/src/graph/workingset/`: Simplification to workingset API.
* `diskann/src/graph/index.rs`: Updated indexing algorithm to take a `PruneAccessor` rather than a strategy + provider + context.
* `diskann-providers/`: Mostly mechanical clean-up.
* `diskann-bftree/`: Mostly mechanical clean-up.
* `diskann-garnet/`: Mostly mechanical, with one simplification. Since the workingset is now part of the accessor, we can no longer run into situations where the working set contains full-precision vectors but the accessor wants quantized vectors, resulting in some simplification.