### PR TITLE
Fix quantizer detection in train_quantizer() and set_element()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-garnet"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "bytemuck",
  "crossbeam",

--- a/diskann-garnet/Cargo.toml
+++ b/diskann-garnet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diskann-garnet"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2024"
 authors.workspace = true
 license.workspace = true

--- a/diskann-garnet/diskann-garnet.nuspec
+++ b/diskann-garnet/diskann-garnet.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>diskann-garnet</id>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <readme>docs/README.md</readme>
     <authors>Microsoft</authors>
     <projectUrl>https://github.com/microsoft/DiskANN</projectUrl>

--- a/diskann-garnet/src/provider.rs
+++ b/diskann-garnet/src/provider.rs
@@ -369,7 +369,14 @@ impl<T: VectorRepr> GarnetProvider<T> {
         };
 
         let quantizer = match &self.quantizer {
-            Some(q) => q,
+            Some(q) => {
+                if !q.is_trained() {
+                    q
+                } else {
+                    // Quantizer already trained, bail.
+                    return false;
+                }
+            }
             None => return false,
         };
 
@@ -719,6 +726,7 @@ impl<T: VectorRepr> SetElement<&[T]> for GarnetProvider<T> {
         // Set quantization readiness
         if let Some(quantizer) = &self.quantizer
             && !internal_id.should_quantize()
+            && !quantizer.is_trained()
             && self.fsm.total_used() > quantizer.required_vectors()
         {
             context.set_quantizer_ready();

--- a/diskann-garnet/src/quantization.rs
+++ b/diskann-garnet/src/quantization.rs
@@ -42,6 +42,8 @@ pub(crate) trait GarnetQuantizer: Send + Sync {
     fn required_vectors(&self) -> usize;
     /// Returns the size of a quantized vector
     fn bytes(&self) -> usize;
+    /// Return whether the quantizer is trained.
+    fn is_trained(&self) -> bool;
     /// Train the quantizer.
     /// Each row of the matrix will be a vector.
     /// Returns a lock guard for purposes of synchronization; after the guard is released, the
@@ -91,6 +93,10 @@ impl GarnetQuantizer for Spherical1Bit {
 
     fn bytes(&self) -> usize {
         Data::<1, GlobalAllocator>::canonical_bytes(self.dim)
+    }
+
+    fn is_trained(&self) -> bool {
+        self.inner.read().unwrap().is_some()
     }
 
     fn train(
@@ -229,6 +235,10 @@ impl GarnetQuantizer for MinMax8Bit {
 
     fn bytes(&self) -> usize {
         minmax::Data::<8>::canonical_bytes(self.inner.dim())
+    }
+
+    fn is_trained(&self) -> bool {
+        true
     }
 
     fn train(&self, _metric: Metric, _data: MatrixView<f32>) -> Result<(), GarnetQuantizerError> {


### PR DESCRIPTION
Some Garnet side testing revealed that there were two small bugs that caused training to erroneously re-trigger. The first is that the check that the quantizer is already trained was wrong. It only checked `quantizer.is_some()` in the provider, but that is always true if quantization is intended. A check on the inner quantizer object is required, so `is_trained()` was added and checked to prevent erroneous retraining. The same check was needed in `set_element` to prevent retriggering calls to `build_quant_table()` if the quantizer is already trained.

The Garnet side tests confirm this fix worked.
