### PR TITLE
[benchmark] Spherical exhaustive benchmark threadpool bug

### DIFF
--- a/diskann-benchmark/src/backend/exhaustive/spherical.rs
+++ b/diskann-benchmark/src/backend/exhaustive/spherical.rs
@@ -116,13 +116,19 @@ mod imp {
             // Compressing
             let start = std::time::Instant::now();
             let store = {
+                let threadpool = rayon::ThreadPoolBuilder::new()
+                    .num_threads(input.compression_threads.get())
+                    .build()?;
+
                 let compression_progress =
                     make_progress_bar("compressing", data.nrows(), output.draw_target())?;
-                let store = Store::new(
-                    data.as_view(),
-                    diskann_quantization::spherical::iface::Impl::<NBITS>::new(quantizer)?,
-                    &compression_progress,
-                )?;
+                let store = threadpool.install(|| {
+                    Store::new(
+                        data.as_view(),
+                        diskann_quantization::spherical::iface::Impl::<NBITS>::new(quantizer)?,
+                        &compression_progress,
+                    )
+                })?;
                 compression_progress.finish();
                 store
             };


### PR DESCRIPTION
The exhaustive spherical backend's compression step called `Store::new(...)` without an `install(...)`, so its internal rayon parallel iteration ran on the global pool instead of the per-run pool sized by `compression_threads`. This silently ignored
the benchmark's thread budget.
