### PR TITLE
Concurrency hardening for BfTree parallel workloads

### DIFF
--- a/diskann-bftree/src/lib.rs
+++ b/diskann-bftree/src/lib.rs
@@ -14,6 +14,8 @@ pub mod provider;
 pub mod quant;
 pub mod vectors;
 
+mod locks;
+
 // Accessors
 pub use provider::{
     AsVectorDtype, BfTreePaths, BfTreeProvider, BfTreeProviderParameters, CreateQuantProvider,

--- a/diskann-bftree/src/locks.rs
+++ b/diskann-bftree/src/locks.rs
@@ -47,14 +47,6 @@ impl StripedLocks {
     }
 
     #[inline]
-    pub(crate) fn read(&self, id: usize) -> std::sync::RwLockReadGuard<'_, ()> {
-        let stripe = self.stripe_index(id);
-        self.stripes[stripe]
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-    }
-
-    #[inline]
     pub(crate) fn write(&self, id: usize) -> std::sync::RwLockWriteGuard<'_, ()> {
         let stripe = self.stripe_index(id);
         self.stripes[stripe]

--- a/diskann-bftree/src/locks.rs
+++ b/diskann-bftree/src/locks.rs
@@ -5,7 +5,7 @@
 
 //! Striped lock table for per-vertex synchronization.
 
-use std::sync::RwLock;
+use std::sync::Mutex;
 
 /// A fixed-size table of striped locks for per-vertex synchronization.
 ///
@@ -17,7 +17,7 @@ use std::sync::RwLock;
 /// rounded to the next power of two, minimum 64). This keeps allocation lightweight
 /// in debug/test while still making false contention negligible for real workloads.
 pub(crate) struct StripedLocks {
-    stripes: Box<[RwLock<()>]>,
+    stripes: Box<[Mutex<()>]>,
     hash_shift: u32,
 }
 
@@ -34,7 +34,7 @@ impl StripedLocks {
 
         Self {
             stripes: (0..count)
-                .map(|_| RwLock::new(()))
+                .map(|_| Mutex::new(()))
                 .collect::<Vec<_>>()
                 .into_boxed_slice(),
             hash_shift,
@@ -47,10 +47,10 @@ impl StripedLocks {
     }
 
     #[inline]
-    pub(crate) fn write(&self, id: usize) -> std::sync::RwLockWriteGuard<'_, ()> {
+    pub(crate) fn lock(&self, id: usize) -> std::sync::MutexGuard<'_, ()> {
         let stripe = self.stripe_index(id);
         self.stripes[stripe]
-            .write()
+            .lock()
             .unwrap_or_else(|e| e.into_inner())
     }
 }

--- a/diskann-bftree/src/locks.rs
+++ b/diskann-bftree/src/locks.rs
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+//! Striped lock table for per-vertex synchronization.
+
+use std::sync::RwLock;
+
+/// A fixed-size table of striped locks for per-vertex synchronization.
+///
+/// Vertex IDs are mapped to lock stripes via a multiply-shift hash. This provides
+/// constant memory overhead regardless of dataset size, at the cost of
+/// occasional false contention between vertices that map to the same stripe.
+///
+/// The stripe count is derived from available hardware parallelism (4× cores,
+/// rounded to the next power of two, minimum 64). This keeps allocation lightweight
+/// in debug/test while still making false contention negligible for real workloads.
+pub(crate) struct StripedLocks {
+    stripes: Box<[RwLock<()>]>,
+    hash_shift: u32,
+}
+
+impl StripedLocks {
+    // Fibonacci hashing constant for 64-bit: floor(2^64 / phi)
+    const HASH_MULTIPLIER: u64 = 0x9E3779B97F4A7C15;
+
+    pub(crate) fn new() -> Self {
+        let cpus = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(8);
+        let count = (cpus * 4).next_power_of_two().max(64);
+        let hash_shift = 64 - count.trailing_zeros();
+
+        Self {
+            stripes: (0..count)
+                .map(|_| RwLock::new(()))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+            hash_shift,
+        }
+    }
+
+    #[inline]
+    fn stripe_index(&self, id: usize) -> usize {
+        ((id as u64).wrapping_mul(Self::HASH_MULTIPLIER) >> self.hash_shift) as usize
+    }
+
+    #[inline]
+    pub(crate) fn read(&self, id: usize) -> std::sync::RwLockReadGuard<'_, ()> {
+        let stripe = self.stripe_index(id);
+        self.stripes[stripe]
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[inline]
+    pub(crate) fn write(&self, id: usize) -> std::sync::RwLockWriteGuard<'_, ()> {
+        let stripe = self.stripe_index(id);
+        self.stripes[stripe]
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+}

--- a/diskann-bftree/src/neighbors.rs
+++ b/diskann-bftree/src/neighbors.rs
@@ -6,6 +6,7 @@
 //! Bf-Tree neighbor list provider.
 
 use std::marker::PhantomData;
+use std::sync::RwLock;
 
 use bf_tree::{BfTree, Config};
 use bytemuck::{cast_slice, cast_slice_mut};
@@ -19,20 +20,71 @@ use diskann::{
 use super::ConfigError;
 use crate::{bftree_insert, TestCallCount};
 
-pub struct NeighborProvider<I: VectorId> {
+pub struct NeighborProvider<I: VectorId + IntoUsize> {
     adjacency_list_index: BfTree,
     dim: usize, // Max number of neighbors in a neighbor list + 1 for the neighbor count
+    locks: StripedLocks,
     #[allow(dead_code)]
     pub(crate) num_get_calls: TestCallCount,
     _phantom: PhantomData<I>,
 }
 
-impl<I: VectorId> HasId for NeighborProvider<I> {
+/// A fixed-size table of striped locks for per-vertex synchronization.
+///
+/// Vertex IDs are mapped to lock stripes via a multiply-shift hash. This provides
+/// constant memory overhead regardless of dataset size, at the cost of
+/// occasional false contention between vertices that map to the same stripe.
+///
+/// The default stripe count (16384) is chosen to keep false sharing negligible
+/// for typical workloads while using only ~128 KB of memory.
+struct StripedLocks {
+    stripes: Box<[RwLock<()>]>,
+}
+
+impl StripedLocks {
+    const DEFAULT_STRIPE_COUNT: usize = 16384;
+    // Fibonacci hashing constant for 64-bit: floor(2^64 / phi)
+    const HASH_MULTIPLIER: u64 = 0x9E3779B97F4A7C15;
+    // Shift to extract the top log2(16384) = 14 bits
+    const HASH_SHIFT: u32 = 64 - 14;
+
+    fn new() -> Self {
+        Self {
+            stripes: (0..Self::DEFAULT_STRIPE_COUNT)
+                .map(|_| RwLock::new(()))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        }
+    }
+
+    #[inline]
+    fn stripe_index(&self, id: usize) -> usize {
+        ((id as u64).wrapping_mul(Self::HASH_MULTIPLIER) >> Self::HASH_SHIFT) as usize
+    }
+
+    #[inline]
+    fn read(&self, id: usize) -> std::sync::RwLockReadGuard<'_, ()> {
+        let stripe = self.stripe_index(id);
+        self.stripes[stripe]
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
+    #[inline]
+    fn write(&self, id: usize) -> std::sync::RwLockWriteGuard<'_, ()> {
+        let stripe = self.stripe_index(id);
+        self.stripes[stripe]
+            .write()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+}
+
+impl<I: VectorId + IntoUsize> HasId for NeighborProvider<I> {
     type Id = I;
 }
 
-impl<I: VectorId> NeighborProvider<I> {
-    /// Create a new instance based on bf-tree Config directly
+impl<I: VectorId + IntoUsize> NeighborProvider<I> {
+    /// Create a new instance based on bf-tree Config directly.
     pub fn new_with_config(max_degree: u32, config: Config) -> ANNResult<Self> {
         let key_size = std::mem::size_of::<u32>();
         let value_size = (max_degree as usize + 1) * std::mem::size_of::<u32>();
@@ -49,6 +101,7 @@ impl<I: VectorId> NeighborProvider<I> {
         Ok(Self {
             adjacency_list_index,
             dim,
+            locks: StripedLocks::new(),
             num_get_calls: TestCallCount::default(),
             _phantom: PhantomData,
         })
@@ -79,13 +132,32 @@ impl<I: VectorId> NeighborProvider<I> {
         Self::new(max_degree, adjacency_list_index)
     }
 
-    /// Retrieve the neighbor list of a vector
-    /// `neighbors` is cleared first upon each invocation
-    /// One data copy is involved which copies the data from bf-tree to `neighbors`
+    /// Retrieve the neighbor list of a vector.
+    ///
+    /// Acquires a read lock on the vertex to ensure consistency with concurrent
+    /// mutations (set/append).
     pub fn get_neighbors(&self, vector_id: I, neighbors: &mut AdjacencyList<I>) -> ANNResult<()> {
         #[cfg(test)]
         self.num_get_calls.increment();
 
+        // Clear the output before any early returns so callers always see
+        // a deterministic empty state on error.
+        neighbors.clear();
+
+        let idx = vector_id.into_usize();
+        let _guard = self.locks.read(idx);
+
+        self.get_neighbors_unlocked(vector_id, neighbors)
+    }
+
+    /// Retrieve the neighbor list without acquiring any lock.
+    ///
+    /// Callers must ensure they already hold the appropriate lock.
+    fn get_neighbors_unlocked(
+        &self,
+        vector_id: I,
+        neighbors: &mut AdjacencyList<I>,
+    ) -> ANNResult<()> {
         // Resize 'neighbors' to hold any full-size neighbor list + I-cell for length
         let mut guard = neighbors.resize(self.dim);
 
@@ -188,6 +260,8 @@ impl<I: VectorId> NeighborProvider<I> {
 
     /// Insert a neighbor list of a vector in bf-tree as a (K, V) pair.
     ///
+    /// Acquires a write lock on the vertex to ensure exclusive access during mutation.
+    ///
     /// The list of neighbors and their length is written into the passed buffer
     /// `buf` before writing the leading `self.dim * std::mem::size_of::<I>()`
     /// bytes of it into the bf-tree.
@@ -203,10 +277,17 @@ impl<I: VectorId> NeighborProvider<I> {
             ));
         };
 
+        let idx = vector_id.into_usize();
+        let _guard = self.locks.write(idx);
+
         self.set_neighbors_internal(vector_id, neighbors, buf)
     }
 
     /// Append unique vectors into a neighbor list.
+    ///
+    /// Acquires a write lock on the vertex for the entire read-modify-write cycle,
+    /// preventing lost updates when multiple threads append to the same vertex
+    /// concurrently.
     ///
     /// The newly appended neighbor list will always be extended to 'dim'
     /// long to avoid frequent mem copy in bf-tree.
@@ -218,9 +299,12 @@ impl<I: VectorId> NeighborProvider<I> {
         new_neighbor_ids: &[I],
         buf: &mut [I],
     ) -> ANNResult<()> {
-        // Retrieve existing neighborlist
+        let idx = vector_id.into_usize();
+        let _guard = self.locks.write(idx);
+
+        // Retrieve existing neighborlist (no lock needed — we hold the write lock)
         let mut neighbor_list = AdjacencyList::with_capacity(self.dim);
-        self.get_neighbors(vector_id, &mut neighbor_list)?;
+        self.get_neighbors_unlocked(vector_id, &mut neighbor_list)?;
 
         // Append the new neighbors
         let mut new_neighbor_added = false;
@@ -240,9 +324,10 @@ impl<I: VectorId> NeighborProvider<I> {
     }
 
     pub fn delete_vector(&self, vector_id: I) -> ANNResult<()> {
-        // Serialize the key, vector_id, into a byte string, &[u8]
-        let key = bytemuck::bytes_of(&vector_id);
+        let idx = vector_id.into_usize();
+        let _guard = self.locks.write(idx);
 
+        let key = bytemuck::bytes_of(&vector_id);
         self.adjacency_list_index.delete(key);
         Ok(())
     }
@@ -257,7 +342,7 @@ impl<I: VectorId> NeighborProvider<I> {
 
 pub struct NeighborAccessor<'a, I>
 where
-    I: VectorId,
+    I: VectorId + IntoUsize,
 {
     provider: &'a NeighborProvider<I>,
     buf: Vec<I>,
@@ -265,7 +350,7 @@ where
 
 impl<'a, I> NeighborAccessor<'a, I>
 where
-    I: VectorId,
+    I: VectorId + IntoUsize,
 {
     pub fn write_neighbors(&mut self, id: I, neighbors: &[I]) -> ANNResult<()> {
         self.provider.set_neighbors(id, neighbors, &mut self.buf)
@@ -277,14 +362,14 @@ where
 
 impl<'a, I> HasId for NeighborAccessor<'a, I>
 where
-    I: VectorId,
+    I: VectorId + IntoUsize,
 {
     type Id = I;
 }
 
 impl<'a, I> provider::NeighborAccessor for NeighborAccessor<'a, I>
 where
-    I: VectorId,
+    I: VectorId + IntoUsize,
 {
     fn get_neighbors(
         &mut self,
@@ -297,7 +382,7 @@ where
 
 impl<'a, I> provider::NeighborAccessorMut for NeighborAccessor<'a, I>
 where
-    I: VectorId,
+    I: VectorId + IntoUsize,
 {
     fn set_neighbors(
         &mut self,
@@ -546,5 +631,215 @@ mod tests {
         while let Some(res) = set.join_next().await {
             res.unwrap();
         }
+    }
+
+    /// Stress test: many threads concurrently append to the SAME vertex.
+    ///
+    /// Without per-vertex locking, this test would non-deterministically lose edges
+    /// due to the TOCTOU race in append_vector's read-modify-write cycle. With the
+    /// per-vertex write lock, every appended edge must be present in the final list.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn test_concurrent_append_no_lost_edges() {
+        let max_degree = 120u32;
+        let bf_tree_config = Config::default();
+        let provider =
+            Arc::new(NeighborProvider::<u32>::new_with_config(max_degree, bf_tree_config).unwrap());
+
+        // Initialize vertex 0 with an empty neighbor list.
+        let mut scratch = provider.scratch();
+        scratch.write_neighbors(0, &[]).unwrap();
+
+        let num_threads = 8;
+        let edges_per_thread = 10;
+        // Each thread appends a unique set of neighbor IDs to vertex 0.
+        // Thread t appends IDs: [t*10+1, t*10+2, ..., t*10+10]
+        let mut set = JoinSet::new();
+        for t in 0..num_threads {
+            let provider_clone = Arc::clone(&provider);
+            set.spawn(async move {
+                let mut scratch = provider_clone.scratch();
+                let base = t * edges_per_thread + 1;
+                for offset in 0..edges_per_thread {
+                    let neighbor_id = base + offset;
+                    scratch.write_append(0, &[neighbor_id]).unwrap();
+                }
+            });
+        }
+
+        while let Some(res) = set.join_next().await {
+            res.unwrap();
+        }
+
+        // Verify ALL edges from all threads are present.
+        let mut result = AdjacencyList::with_capacity(max_degree as usize + 1);
+        provider.get_neighbors(0, &mut result).unwrap();
+
+        let expected_count = (num_threads * edges_per_thread) as usize;
+        assert_eq!(
+            result.len(),
+            expected_count,
+            "Expected {} edges but found {} — edges were lost!",
+            expected_count,
+            result.len()
+        );
+
+        // Verify every expected ID is present.
+        for t in 0..num_threads {
+            let base = t * edges_per_thread + 1;
+            for offset in 0..edges_per_thread {
+                let expected_id = base + offset;
+                assert!(
+                    result.contains(expected_id),
+                    "Missing edge {} from thread {}",
+                    expected_id,
+                    t
+                );
+            }
+        }
+    }
+
+    /// Stress test: concurrent appends to DIFFERENT vertices (no contention).
+    ///
+    /// Validates that the lock table doesn't introduce false sharing or deadlocks
+    /// when independent vertices are mutated in parallel.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn test_concurrent_append_independent_vertices() {
+        let max_degree = 64u32;
+        let num_threads = 8u32;
+        let vertices_per_thread = 50u32;
+        let num_vertices = num_threads * vertices_per_thread; // 400 vertices, no overlap
+        let bf_tree_config = Config::default();
+        let provider =
+            Arc::new(NeighborProvider::<u32>::new_with_config(max_degree, bf_tree_config).unwrap());
+
+        // Initialize all vertices with empty neighbor lists.
+        {
+            let mut scratch = provider.scratch();
+            for v in 0..num_vertices {
+                scratch.write_neighbors(v, &[]).unwrap();
+            }
+        }
+
+        let mut set = JoinSet::new();
+
+        for t in 0..num_threads {
+            let provider_clone = Arc::clone(&provider);
+            set.spawn(async move {
+                let mut scratch = provider_clone.scratch();
+                // Each thread owns a disjoint range of vertices
+                let base_vertex = t * vertices_per_thread;
+                for i in 0..vertices_per_thread {
+                    let vertex = base_vertex + i;
+                    let neighbor_id = t * 1000 + i;
+                    scratch.write_append(vertex, &[neighbor_id]).unwrap();
+                }
+            });
+        }
+
+        while let Some(res) = set.join_next().await {
+            res.unwrap();
+        }
+
+        // Verify total edge count across all vertices matches expectation.
+        let mut total_edges = 0usize;
+        let mut result = AdjacencyList::with_capacity(max_degree as usize + 1);
+        for v in 0..num_vertices {
+            provider.get_neighbors(v, &mut result).unwrap();
+            total_edges += result.len();
+        }
+
+        let expected_total = (num_threads * vertices_per_thread) as usize;
+        assert_eq!(
+            total_edges, expected_total,
+            "Expected {} total edges but found {} — edges were lost or duplicated!",
+            expected_total, total_edges
+        );
+    }
+
+    /// Stress test: mixed concurrent reads and writes on the same vertex.
+    ///
+    /// Writers continuously append while readers verify the neighbor list is
+    /// always in a consistent state (length matches actual content, no torn reads).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn test_concurrent_read_write_consistency() {
+        let max_degree = 120u32;
+        let bf_tree_config = Config::default();
+        let provider =
+            Arc::new(NeighborProvider::<u32>::new_with_config(max_degree, bf_tree_config).unwrap());
+
+        // Initialize vertex 0.
+        let mut scratch = provider.scratch();
+        scratch.write_neighbors(0, &[]).unwrap();
+
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let writers_remaining = Arc::new(std::sync::atomic::AtomicU32::new(4));
+
+        // Spawn writer threads that append edges.
+        let num_writers = 4u32;
+        let edges_per_writer = 20u32;
+        let mut set = JoinSet::new();
+
+        for t in 0..num_writers {
+            let provider_clone = Arc::clone(&provider);
+            let done_clone = Arc::clone(&done);
+            let remaining_clone = Arc::clone(&writers_remaining);
+            set.spawn(async move {
+                let mut scratch = provider_clone.scratch();
+                let base = t * edges_per_writer + 1;
+                for offset in 0..edges_per_writer {
+                    scratch.write_append(0, &[base + offset]).unwrap();
+                    tokio::task::yield_now().await;
+                }
+                // Signal done only when ALL writers have finished.
+                if remaining_clone.fetch_sub(1, std::sync::atomic::Ordering::AcqRel) == 1 {
+                    done_clone.store(true, std::sync::atomic::Ordering::Release);
+                }
+            });
+        }
+
+        // Spawn reader threads that continuously read and validate consistency.
+        let num_readers = 4;
+        for _ in 0..num_readers {
+            let provider_clone = Arc::clone(&provider);
+            let done_clone = Arc::clone(&done);
+            set.spawn(async move {
+                let mut result = AdjacencyList::with_capacity(max_degree as usize + 1);
+                let mut iterations = 0u64;
+                while !done_clone.load(std::sync::atomic::Ordering::Acquire) {
+                    provider_clone.get_neighbors(0, &mut result).unwrap();
+                    // The list must never exceed max_degree
+                    assert!(
+                        result.len() <= max_degree as usize,
+                        "Neighbor list exceeded max_degree"
+                    );
+                    // All IDs in the list must be non-zero (our IDs start at 1)
+                    for &id in result.iter() {
+                        assert!(id > 0, "Found invalid zero ID in neighbor list");
+                    }
+                    iterations += 1;
+                    tokio::task::yield_now().await;
+                }
+                assert!(
+                    iterations > 0,
+                    "Reader never got a chance to run — test is not validating anything"
+                );
+            });
+        }
+
+        while let Some(res) = set.join_next().await {
+            res.unwrap();
+        }
+
+        // Final check: all edges from all writers present.
+        let mut result = AdjacencyList::with_capacity(max_degree as usize + 1);
+        provider.get_neighbors(0, &mut result).unwrap();
+        let expected = (num_writers * edges_per_writer) as usize;
+        assert_eq!(
+            result.len(),
+            expected,
+            "Expected {} edges but found {}",
+            expected,
+            result.len()
+        );
     }
 }

--- a/diskann-bftree/src/neighbors.rs
+++ b/diskann-bftree/src/neighbors.rs
@@ -315,7 +315,6 @@ where
         id: Self::Id,
         neighbors: &mut AdjacencyList<Self::Id>,
     ) -> impl std::future::Future<Output = ANNResult<()>> + Send {
-        let _guard = self.locks.read(id.into_usize());
         std::future::ready(self.provider.get_neighbors(id, neighbors))
     }
 }

--- a/diskann-bftree/src/neighbors.rs
+++ b/diskann-bftree/src/neighbors.rs
@@ -378,6 +378,26 @@ mod tests {
 
     use super::*;
 
+    /// Number of concurrent worker tasks for stress tests, scaled to the host's
+    /// available parallelism with a floor so contention is guaranteed even on
+    /// low-core CI runners. Falls back to the floor if parallelism is unknown.
+    fn stress_thread_count() -> u32 {
+        std::thread::available_parallelism()
+            .map(|n| n.get() as u32)
+            .unwrap_or(8)
+            .max(8)
+    }
+
+    /// Build a `NeighborProvider<u32>` with a default bf-tree config.
+    fn new_provider(max_degree: u32) -> NeighborProvider<u32> {
+        NeighborProvider::<u32>::new_with_config(max_degree, Config::default()).unwrap()
+    }
+
+    /// Build a shared `NeighborProvider<u32>` with a default bf-tree config.
+    fn new_shared_provider(max_degree: u32) -> Arc<NeighborProvider<u32>> {
+        Arc::new(new_provider(max_degree))
+    }
+
     /// Length round-trips through an `I`-sized cell .
     #[test]
     fn len_cell_round_trip() {
@@ -391,9 +411,7 @@ mod tests {
     #[tokio::test]
     async fn test_neighbor_accessors() {
         let locks = Arc::new(StripedLocks::new());
-        let bf_tree_config = Config::default();
-        let neighbor_provider =
-            NeighborProvider::<u32>::new_with_config(6, bf_tree_config).unwrap();
+        let neighbor_provider = new_provider(6);
         let mut scratch = neighbor_provider.scratch(&locks);
 
         // Set the neighbor list of a vector
@@ -443,9 +461,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn test_parallel_tree_traversal() {
         let locks = Arc::new(StripedLocks::new());
-        let bf_tree_config = Config::default();
-        let neighbor_provider =
-            Arc::new(NeighborProvider::<u32>::new_with_config(120, bf_tree_config).unwrap());
+        let neighbor_provider = new_shared_provider(120);
 
         let mut set = JoinSet::new();
         for i in 0..100 {
@@ -513,19 +529,14 @@ mod tests {
     /// Test that max_degree returns the correct value
     #[tokio::test]
     async fn test_max_degree() {
-        let bf_tree_config = Config::default();
-
         // Test with various max_degree values
-        let neighbor_provider =
-            NeighborProvider::<u32>::new_with_config(6, bf_tree_config.clone()).unwrap();
+        let neighbor_provider = new_provider(6);
         assert_eq!(neighbor_provider.max_degree(), 6);
 
-        let neighbor_provider =
-            NeighborProvider::<u32>::new_with_config(120, bf_tree_config.clone()).unwrap();
+        let neighbor_provider = new_provider(120);
         assert_eq!(neighbor_provider.max_degree(), 120);
 
-        let neighbor_provider =
-            NeighborProvider::<u32>::new_with_config(1, bf_tree_config).unwrap();
+        let neighbor_provider = new_provider(1);
         assert_eq!(neighbor_provider.max_degree(), 1);
     }
 
@@ -550,9 +561,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn test_parallel_neighbor_access() {
         let locks = Arc::new(StripedLocks::new());
-        let bf_tree_config = Config::default();
-        let neighbor_provider =
-            Arc::new(NeighborProvider::<u32>::new_with_config(120, bf_tree_config).unwrap());
+        let neighbor_provider = new_shared_provider(120);
 
         let mut set = JoinSet::new();
         for _ in 0..5 {
@@ -585,64 +594,76 @@ mod tests {
     /// Without per-vertex locking, this test would non-deterministically lose edges
     /// due to the TOCTOU race in append_vector's read-modify-write cycle. With the
     /// per-vertex write lock, every appended edge must be present in the final list.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    ///
+    /// Lost-update races are probabilistic, so a single pass may not surface a
+    /// regression. The scenario is therefore repeated over many outer iterations,
+    /// and the writer count scales with the host's available parallelism (with a
+    /// floor) to keep contention meaningful on CI boxes of any core count. The
+    /// `multi_thread` runtime is left unsized so tokio scales its worker pool to
+    /// the number of CPUs.
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_concurrent_append_no_lost_edges() {
-        let locks = Arc::new(StripedLocks::new());
-        let max_degree = 120u32;
-        let bf_tree_config = Config::default();
-        let provider =
-            Arc::new(NeighborProvider::<u32>::new_with_config(max_degree, bf_tree_config).unwrap());
+        let num_threads = stress_thread_count();
+        let edges_per_thread = 20u32;
+        // Size the degree to the workload so every distinct edge can be retained.
+        let max_degree = num_threads * edges_per_thread;
 
-        // Initialize vertex 0 with an empty neighbor list.
-        let mut scratch = provider.scratch(&locks);
-        scratch.write_neighbors(0, &[]).unwrap();
+        // Repeat the whole scenario many times: each iteration is a fresh chance
+        // to interleave threads such that a broken lock would drop an edge.
+        let outer_iterations = 100;
+        for _ in 0..outer_iterations {
+            let locks = Arc::new(StripedLocks::new());
+            let provider = new_shared_provider(max_degree);
 
-        let num_threads = 8;
-        let edges_per_thread = 10;
-        // Each thread appends a unique set of neighbor IDs to vertex 0.
-        // Thread t appends IDs: [t*10+1, t*10+2, ..., t*10+10]
-        let mut set = JoinSet::new();
-        for t in 0..num_threads {
-            let provider_clone = Arc::clone(&provider);
-            let locks = locks.clone();
-            set.spawn(async move {
-                let mut scratch = provider_clone.scratch(&locks);
+            // Initialize vertex 0 with an empty neighbor list.
+            let mut scratch = provider.scratch(&locks);
+            scratch.write_neighbors(0, &[]).unwrap();
+
+            // Each thread appends a unique set of neighbor IDs to vertex 0.
+            // Thread t appends IDs: [t*edges+1, ..., t*edges+edges]
+            let mut set = JoinSet::new();
+            for t in 0..num_threads {
+                let provider_clone = Arc::clone(&provider);
+                let locks = locks.clone();
+                set.spawn(async move {
+                    let mut scratch = provider_clone.scratch(&locks);
+                    let base = t * edges_per_thread + 1;
+                    for offset in 0..edges_per_thread {
+                        let neighbor_id = base + offset;
+                        scratch.write_append(0, &[neighbor_id]).unwrap();
+                    }
+                });
+            }
+
+            while let Some(res) = set.join_next().await {
+                res.unwrap();
+            }
+
+            // Verify ALL edges from all threads are present.
+            let mut result = AdjacencyList::with_capacity(max_degree as usize + 1);
+            provider.get_neighbors(0, &mut result).unwrap();
+
+            let expected_count = (num_threads * edges_per_thread) as usize;
+            assert_eq!(
+                result.len(),
+                expected_count,
+                "Expected {} edges but found {} — edges were lost!",
+                expected_count,
+                result.len()
+            );
+
+            // Verify every expected ID is present.
+            for t in 0..num_threads {
                 let base = t * edges_per_thread + 1;
                 for offset in 0..edges_per_thread {
-                    let neighbor_id = base + offset;
-                    scratch.write_append(0, &[neighbor_id]).unwrap();
+                    let expected_id = base + offset;
+                    assert!(
+                        result.contains(expected_id),
+                        "Missing edge {} from thread {}",
+                        expected_id,
+                        t
+                    );
                 }
-            });
-        }
-
-        while let Some(res) = set.join_next().await {
-            res.unwrap();
-        }
-
-        // Verify ALL edges from all threads are present.
-        let mut result = AdjacencyList::with_capacity(max_degree as usize + 1);
-        provider.get_neighbors(0, &mut result).unwrap();
-
-        let expected_count = (num_threads * edges_per_thread) as usize;
-        assert_eq!(
-            result.len(),
-            expected_count,
-            "Expected {} edges but found {} — edges were lost!",
-            expected_count,
-            result.len()
-        );
-
-        // Verify every expected ID is present.
-        for t in 0..num_threads {
-            let base = t * edges_per_thread + 1;
-            for offset in 0..edges_per_thread {
-                let expected_id = base + offset;
-                assert!(
-                    result.contains(expected_id),
-                    "Missing edge {} from thread {}",
-                    expected_id,
-                    t
-                );
             }
         }
     }
@@ -650,17 +671,17 @@ mod tests {
     /// Stress test: concurrent appends to DIFFERENT vertices (no contention).
     ///
     /// Validates that the lock table doesn't introduce false sharing or deadlocks
-    /// when independent vertices are mutated in parallel.
-    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    /// when independent vertices are mutated in parallel. The writer count scales
+    /// with the host's available parallelism (with a floor), and the `multi_thread`
+    /// runtime is left unsized so tokio scales its worker pool to the CPU count.
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_concurrent_append_independent_vertices() {
         let locks = Arc::new(StripedLocks::new());
         let max_degree = 64u32;
-        let num_threads = 8u32;
+        let num_threads = stress_thread_count();
         let vertices_per_thread = 50u32;
-        let num_vertices = num_threads * vertices_per_thread; // 400 vertices, no overlap
-        let bf_tree_config = Config::default();
-        let provider =
-            Arc::new(NeighborProvider::<u32>::new_with_config(max_degree, bf_tree_config).unwrap());
+        let num_vertices = num_threads * vertices_per_thread; // disjoint ranges, no overlap
+        let provider = new_shared_provider(max_degree);
 
         // Initialize all vertices with empty neighbor lists.
         {
@@ -711,88 +732,105 @@ mod tests {
     ///
     /// Writers continuously append while readers verify the neighbor list is
     /// always in a consistent state (length matches actual content, no torn reads).
-    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    ///
+    /// The read/write phase is repeated over many outer iterations to surface
+    /// torn-read races more reliably, the writer/reader counts scale with the
+    /// host's available parallelism (with a floor), and the `multi_thread`
+    /// runtime is left unsized so tokio scales its worker pool to the CPU count.
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_concurrent_read_write_consistency() {
-        let locks = Arc::new(StripedLocks::new());
-        let max_degree = 120u32;
-        let bf_tree_config = Config::default();
-        let provider =
-            Arc::new(NeighborProvider::<u32>::new_with_config(max_degree, bf_tree_config).unwrap());
-
-        // Initialize vertex 0.
-        let mut scratch = provider.scratch(&locks);
-        scratch.write_neighbors(0, &[]).unwrap();
-
-        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
-        let writers_remaining = Arc::new(std::sync::atomic::AtomicU32::new(4));
-
-        // Spawn writer threads that append edges.
-        let num_writers = 4u32;
+        let parallelism = stress_thread_count();
+        let num_writers = parallelism;
+        let num_readers = parallelism;
         let edges_per_writer = 20u32;
-        let mut set = JoinSet::new();
+        // Size the degree to the workload so every distinct edge can be retained.
+        let max_degree = num_writers * edges_per_writer;
+        // Largest neighbor ID any writer can append (IDs run 1..=num_writers*edges).
+        let max_valid_id = num_writers * edges_per_writer;
 
-        for t in 0..num_writers {
-            let provider_clone = Arc::clone(&provider);
-            let done_clone = Arc::clone(&done);
-            let remaining_clone = Arc::clone(&writers_remaining);
-            let locks = locks.clone();
-            set.spawn(async move {
-                let mut scratch = provider_clone.scratch(&locks);
-                let base = t * edges_per_writer + 1;
-                for offset in 0..edges_per_writer {
-                    scratch.write_append(0, &[base + offset]).unwrap();
-                    tokio::task::yield_now().await;
-                }
-                // Signal done only when ALL writers have finished.
-                if remaining_clone.fetch_sub(1, std::sync::atomic::Ordering::AcqRel) == 1 {
-                    done_clone.store(true, std::sync::atomic::Ordering::Release);
-                }
-            });
-        }
+        let outer_iterations = 100;
+        for _ in 0..outer_iterations {
+            let locks = Arc::new(StripedLocks::new());
+            let provider = new_shared_provider(max_degree);
 
-        // Spawn reader threads that continuously read and validate consistency.
-        let num_readers = 4;
-        for _ in 0..num_readers {
-            let provider_clone = Arc::clone(&provider);
-            let done_clone = Arc::clone(&done);
-            set.spawn(async move {
-                let mut result = AdjacencyList::with_capacity(max_degree as usize + 1);
-                let mut iterations = 0u64;
-                while !done_clone.load(std::sync::atomic::Ordering::Acquire) {
-                    provider_clone.get_neighbors(0, &mut result).unwrap();
-                    // The list must never exceed max_degree
-                    assert!(
-                        result.len() <= max_degree as usize,
-                        "Neighbor list exceeded max_degree"
-                    );
-                    // All IDs in the list must be non-zero (our IDs start at 1)
-                    for &id in result.iter() {
-                        assert!(id > 0, "Found invalid zero ID in neighbor list");
+            // Initialize vertex 0.
+            let mut scratch = provider.scratch(&locks);
+            scratch.write_neighbors(0, &[]).unwrap();
+
+            let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let writers_remaining = Arc::new(std::sync::atomic::AtomicU32::new(num_writers));
+
+            // Spawn writer threads that append edges.
+            let mut set = JoinSet::new();
+
+            for t in 0..num_writers {
+                let provider_clone = Arc::clone(&provider);
+                let done_clone = Arc::clone(&done);
+                let remaining_clone = Arc::clone(&writers_remaining);
+                let locks = locks.clone();
+                set.spawn(async move {
+                    let mut scratch = provider_clone.scratch(&locks);
+                    let base = t * edges_per_writer + 1;
+                    for offset in 0..edges_per_writer {
+                        scratch.write_append(0, &[base + offset]).unwrap();
+                        tokio::task::yield_now().await;
                     }
-                    iterations += 1;
-                    tokio::task::yield_now().await;
-                }
-                assert!(
-                    iterations > 0,
-                    "Reader never got a chance to run — test is not validating anything"
-                );
-            });
-        }
+                    // Signal done only when ALL writers have finished.
+                    if remaining_clone.fetch_sub(1, std::sync::atomic::Ordering::AcqRel) == 1 {
+                        done_clone.store(true, std::sync::atomic::Ordering::Release);
+                    }
+                });
+            }
 
-        while let Some(res) = set.join_next().await {
-            res.unwrap();
-        }
+            // Spawn reader threads that continuously read and validate consistency.
+            for _ in 0..num_readers {
+                let provider_clone = Arc::clone(&provider);
+                let done_clone = Arc::clone(&done);
+                set.spawn(async move {
+                    let mut result = AdjacencyList::with_capacity(max_degree as usize + 1);
+                    let mut iterations = 0u64;
+                    while !done_clone.load(std::sync::atomic::Ordering::Acquire) {
+                        provider_clone.get_neighbors(0, &mut result).unwrap();
+                        // The list must never exceed max_degree
+                        assert!(
+                            result.len() <= max_degree as usize,
+                            "Neighbor list exceeded max_degree"
+                        );
+                        // Every ID must be a real appended edge: non-zero and within
+                        // the range any writer could have produced. Anything else
+                        // signals a torn or garbage read.
+                        for &id in result.iter() {
+                            assert!(id > 0, "Found invalid zero ID in neighbor list");
+                            assert!(
+                                id <= max_valid_id,
+                                "Found out-of-bounds ID {id} (max valid is {max_valid_id})"
+                            );
+                        }
+                        iterations += 1;
+                        tokio::task::yield_now().await;
+                    }
+                    assert!(
+                        iterations > 0,
+                        "Reader never got a chance to run — test is not validating anything"
+                    );
+                });
+            }
 
-        // Final check: all edges from all writers present.
-        let mut result = AdjacencyList::with_capacity(max_degree as usize + 1);
-        provider.get_neighbors(0, &mut result).unwrap();
-        let expected = (num_writers * edges_per_writer) as usize;
-        assert_eq!(
-            result.len(),
-            expected,
-            "Expected {} edges but found {}",
-            expected,
-            result.len()
-        );
+            while let Some(res) = set.join_next().await {
+                res.unwrap();
+            }
+
+            // Final check: all edges from all writers present.
+            let mut result = AdjacencyList::with_capacity(max_degree as usize + 1);
+            provider.get_neighbors(0, &mut result).unwrap();
+            let expected = (num_writers * edges_per_writer) as usize;
+            assert_eq!(
+                result.len(),
+                expected,
+                "Expected {} edges but found {}",
+                expected,
+                result.len()
+            );
+        }
     }
 }

--- a/diskann-bftree/src/neighbors.rs
+++ b/diskann-bftree/src/neighbors.rs
@@ -6,7 +6,7 @@
 //! Bf-Tree neighbor list provider.
 
 use std::marker::PhantomData;
-use std::sync::RwLock;
+use std::sync::Arc;
 
 use bf_tree::{BfTree, Config};
 use bytemuck::{cast_slice, cast_slice_mut};
@@ -18,65 +18,15 @@ use diskann::{
 };
 
 use super::ConfigError;
+use crate::locks::StripedLocks;
 use crate::{bftree_insert, TestCallCount};
 
 pub struct NeighborProvider<I: VectorId + IntoUsize> {
     adjacency_list_index: BfTree,
     dim: usize, // Max number of neighbors in a neighbor list + 1 for the neighbor count
-    locks: StripedLocks,
     #[allow(dead_code)]
     pub(crate) num_get_calls: TestCallCount,
     _phantom: PhantomData<I>,
-}
-
-/// A fixed-size table of striped locks for per-vertex synchronization.
-///
-/// Vertex IDs are mapped to lock stripes via a multiply-shift hash. This provides
-/// constant memory overhead regardless of dataset size, at the cost of
-/// occasional false contention between vertices that map to the same stripe.
-///
-/// The default stripe count (16384) is chosen to keep false sharing negligible
-/// for typical workloads while using only ~128 KB of memory.
-struct StripedLocks {
-    stripes: Box<[RwLock<()>]>,
-}
-
-impl StripedLocks {
-    const DEFAULT_STRIPE_COUNT: usize = 16384;
-    // Fibonacci hashing constant for 64-bit: floor(2^64 / phi)
-    const HASH_MULTIPLIER: u64 = 0x9E3779B97F4A7C15;
-    // Shift to extract the top log2(16384) = 14 bits
-    const HASH_SHIFT: u32 = 64 - 14;
-
-    fn new() -> Self {
-        Self {
-            stripes: (0..Self::DEFAULT_STRIPE_COUNT)
-                .map(|_| RwLock::new(()))
-                .collect::<Vec<_>>()
-                .into_boxed_slice(),
-        }
-    }
-
-    #[inline]
-    fn stripe_index(&self, id: usize) -> usize {
-        ((id as u64).wrapping_mul(Self::HASH_MULTIPLIER) >> Self::HASH_SHIFT) as usize
-    }
-
-    #[inline]
-    fn read(&self, id: usize) -> std::sync::RwLockReadGuard<'_, ()> {
-        let stripe = self.stripe_index(id);
-        self.stripes[stripe]
-            .read()
-            .unwrap_or_else(|e| e.into_inner())
-    }
-
-    #[inline]
-    fn write(&self, id: usize) -> std::sync::RwLockWriteGuard<'_, ()> {
-        let stripe = self.stripe_index(id);
-        self.stripes[stripe]
-            .write()
-            .unwrap_or_else(|e| e.into_inner())
-    }
 }
 
 impl<I: VectorId + IntoUsize> HasId for NeighborProvider<I> {
@@ -101,7 +51,6 @@ impl<I: VectorId + IntoUsize> NeighborProvider<I> {
         Ok(Self {
             adjacency_list_index,
             dim,
-            locks: StripedLocks::new(),
             num_get_calls: TestCallCount::default(),
             _phantom: PhantomData,
         })
@@ -134,8 +83,7 @@ impl<I: VectorId + IntoUsize> NeighborProvider<I> {
 
     /// Retrieve the neighbor list of a vector.
     ///
-    /// Acquires a read lock on the vertex to ensure consistency with concurrent
-    /// mutations (set/append).
+    /// Does not acquire any lock. Callers must ensure appropriate synchronization.
     pub fn get_neighbors(&self, vector_id: I, neighbors: &mut AdjacencyList<I>) -> ANNResult<()> {
         #[cfg(test)]
         self.num_get_calls.increment();
@@ -143,9 +91,6 @@ impl<I: VectorId + IntoUsize> NeighborProvider<I> {
         // Clear the output before any early returns so callers always see
         // a deterministic empty state on error.
         neighbors.clear();
-
-        let idx = vector_id.into_usize();
-        let _guard = self.locks.read(idx);
 
         self.get_neighbors_unlocked(vector_id, neighbors)
     }
@@ -260,7 +205,7 @@ impl<I: VectorId + IntoUsize> NeighborProvider<I> {
 
     /// Insert a neighbor list of a vector in bf-tree as a (K, V) pair.
     ///
-    /// Acquires a write lock on the vertex to ensure exclusive access during mutation.
+    /// Does not acquire any lock. Callers must ensure appropriate synchronization.
     ///
     /// The list of neighbors and their length is written into the passed buffer
     /// `buf` before writing the leading `self.dim * std::mem::size_of::<I>()`
@@ -277,17 +222,13 @@ impl<I: VectorId + IntoUsize> NeighborProvider<I> {
             ));
         };
 
-        let idx = vector_id.into_usize();
-        let _guard = self.locks.write(idx);
-
         self.set_neighbors_internal(vector_id, neighbors, buf)
     }
 
     /// Append unique vectors into a neighbor list.
     ///
-    /// Acquires a write lock on the vertex for the entire read-modify-write cycle,
-    /// preventing lost updates when multiple threads append to the same vertex
-    /// concurrently.
+    /// Does not acquire any lock. Callers must ensure appropriate synchronization
+    /// for the entire read-modify-write cycle.
     ///
     /// The newly appended neighbor list will always be extended to 'dim'
     /// long to avoid frequent mem copy in bf-tree.
@@ -299,10 +240,7 @@ impl<I: VectorId + IntoUsize> NeighborProvider<I> {
         new_neighbor_ids: &[I],
         buf: &mut [I],
     ) -> ANNResult<()> {
-        let idx = vector_id.into_usize();
-        let _guard = self.locks.write(idx);
-
-        // Retrieve existing neighborlist (no lock needed — we hold the write lock)
+        // Retrieve existing neighborlist
         let mut neighbor_list = AdjacencyList::with_capacity(self.dim);
         self.get_neighbors_unlocked(vector_id, &mut neighbor_list)?;
 
@@ -324,17 +262,15 @@ impl<I: VectorId + IntoUsize> NeighborProvider<I> {
     }
 
     pub fn delete_vector(&self, vector_id: I) -> ANNResult<()> {
-        let idx = vector_id.into_usize();
-        let _guard = self.locks.write(idx);
-
         let key = bytemuck::bytes_of(&vector_id);
         self.adjacency_list_index.delete(key);
         Ok(())
     }
 
-    pub(crate) fn scratch(&self) -> NeighborAccessor<'_, I> {
+    pub(crate) fn scratch<'a>(&'a self, locks: Arc<StripedLocks>) -> NeighborAccessor<'a, I> {
         NeighborAccessor {
             provider: self,
+            locks,
             buf: vec![I::zeroed(); self.dim],
         }
     }
@@ -345,6 +281,7 @@ where
     I: VectorId + IntoUsize,
 {
     provider: &'a NeighborProvider<I>,
+    locks: Arc<StripedLocks>,
     buf: Vec<I>,
 }
 
@@ -353,9 +290,11 @@ where
     I: VectorId + IntoUsize,
 {
     pub fn write_neighbors(&mut self, id: I, neighbors: &[I]) -> ANNResult<()> {
+        let _guard = self.locks.write(id.into_usize());
         self.provider.set_neighbors(id, neighbors, &mut self.buf)
     }
     pub fn write_append(&mut self, id: I, neighbors: &[I]) -> ANNResult<()> {
+        let _guard = self.locks.write(id.into_usize());
         self.provider.append_vector(id, neighbors, &mut self.buf)
     }
 }
@@ -376,6 +315,7 @@ where
         id: Self::Id,
         neighbors: &mut AdjacencyList<Self::Id>,
     ) -> impl std::future::Future<Output = ANNResult<()>> + Send {
+        let _guard = self.locks.read(id.into_usize());
         std::future::ready(self.provider.get_neighbors(id, neighbors))
     }
 }
@@ -389,6 +329,7 @@ where
         id: Self::Id,
         neighbors: &[Self::Id],
     ) -> impl std::future::Future<Output = ANNResult<()>> + Send {
+        let _guard = self.locks.write(id.into_usize());
         std::future::ready(self.provider.set_neighbors(id, neighbors, &mut self.buf))
     }
     fn append_vector(
@@ -396,6 +337,7 @@ where
         id: Self::Id,
         neighbors: &[Self::Id],
     ) -> impl std::future::Future<Output = ANNResult<()>> + Send {
+        let _guard = self.locks.write(id.into_usize());
         std::future::ready(self.provider.append_vector(id, neighbors, &mut self.buf))
     }
 }
@@ -450,10 +392,11 @@ mod tests {
     /// Test corner cases of appending to neighbor list
     #[tokio::test]
     async fn test_neighbor_accessors() {
+        let locks = Arc::new(StripedLocks::new());
         let bf_tree_config = Config::default();
         let neighbor_provider =
             NeighborProvider::<u32>::new_with_config(6, bf_tree_config).unwrap();
-        let mut scratch = neighbor_provider.scratch();
+        let mut scratch = neighbor_provider.scratch(locks.clone());
 
         // Set the neighbor list of a vector
         let adj_list = vec![1, 2, 3];
@@ -501,6 +444,7 @@ mod tests {
     /// by invoking the async accessors of the neighbor list provider
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn test_parallel_tree_traversal() {
+        let locks = Arc::new(StripedLocks::new());
         let bf_tree_config = Config::default();
         let neighbor_provider =
             Arc::new(NeighborProvider::<u32>::new_with_config(120, bf_tree_config).unwrap());
@@ -509,8 +453,9 @@ mod tests {
         for i in 0..100 {
             let neighbor_list = vec![i as u32, (i + 1) as u32, (i + 2) as u32];
             let neighbor_provider_clone = Arc::clone(&neighbor_provider);
+            let locks = locks.clone();
             set.spawn(async move {
-                let mut scratch = neighbor_provider_clone.scratch();
+                let mut scratch = neighbor_provider_clone.scratch(locks.clone());
                 scratch.write_neighbors(i as u32, &neighbor_list).unwrap();
             });
         }
@@ -533,6 +478,7 @@ mod tests {
     /// Test that cpr_snapshot can be called without errors
     #[tokio::test]
     async fn test_snapshot() {
+        let locks = Arc::new(StripedLocks::new());
         // Use a temporary directory that gets cleaned up when dropped
         let temp_dir = tempfile::tempdir().unwrap();
         let snapshot_path = temp_dir.path().join("test_neighbor_snapshot.bftree");
@@ -544,7 +490,7 @@ mod tests {
 
         let neighbor_provider =
             NeighborProvider::<u32>::new_with_config(6, bf_tree_config).unwrap();
-        let mut scratch = neighbor_provider.scratch();
+        let mut scratch = neighbor_provider.scratch(locks.clone());
 
         // Set some neighbor lists
         scratch.write_neighbors(1, &[2, 3, 4]).unwrap();
@@ -588,13 +534,14 @@ mod tests {
     /// Test new_from_bftree constructor
     #[tokio::test]
     async fn test_new_from_bftree() {
+        let locks = Arc::new(StripedLocks::new());
         let bftree = BfTree::with_config(Config::default(), None).expect("Failed to create BfTree");
         let neighbor_provider = NeighborProvider::<u32>::new_from_bftree(10, bftree).unwrap();
 
         assert_eq!(neighbor_provider.max_degree(), 10);
 
         // Verify the provider is functional
-        let mut scratch = neighbor_provider.scratch();
+        let mut scratch = neighbor_provider.scratch(locks.clone());
         scratch.write_neighbors(1, &[2, 3]).unwrap();
         let mut result = AdjacencyList::with_capacity(11);
         neighbor_provider.get_neighbors(1, &mut result).unwrap();
@@ -604,6 +551,7 @@ mod tests {
     /// Test other methods and edge cases of the vector provider and synchronization mechanism of Bf-Tree
     #[tokio::test(flavor = "multi_thread", worker_threads = 5)]
     async fn test_parallel_neighbor_access() {
+        let locks = Arc::new(StripedLocks::new());
         let bf_tree_config = Config::default();
         let neighbor_provider =
             Arc::new(NeighborProvider::<u32>::new_with_config(120, bf_tree_config).unwrap());
@@ -611,8 +559,9 @@ mod tests {
         let mut set = JoinSet::new();
         for _ in 0..5 {
             let neighbor_provider_clone = Arc::clone(&neighbor_provider);
+            let locks = locks.clone();
             set.spawn(async move {
-                let mut scratch = neighbor_provider_clone.scratch();
+                let mut scratch = neighbor_provider_clone.scratch(locks.clone());
                 for i in 0..5 {
                     scratch.write_neighbors(i as u32, &[1, 2, 3, 4, 5]).unwrap();
                 }
@@ -640,13 +589,14 @@ mod tests {
     /// per-vertex write lock, every appended edge must be present in the final list.
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_concurrent_append_no_lost_edges() {
+        let locks = Arc::new(StripedLocks::new());
         let max_degree = 120u32;
         let bf_tree_config = Config::default();
         let provider =
             Arc::new(NeighborProvider::<u32>::new_with_config(max_degree, bf_tree_config).unwrap());
 
         // Initialize vertex 0 with an empty neighbor list.
-        let mut scratch = provider.scratch();
+        let mut scratch = provider.scratch(locks.clone());
         scratch.write_neighbors(0, &[]).unwrap();
 
         let num_threads = 8;
@@ -656,8 +606,9 @@ mod tests {
         let mut set = JoinSet::new();
         for t in 0..num_threads {
             let provider_clone = Arc::clone(&provider);
+            let locks = locks.clone();
             set.spawn(async move {
-                let mut scratch = provider_clone.scratch();
+                let mut scratch = provider_clone.scratch(locks.clone());
                 let base = t * edges_per_thread + 1;
                 for offset in 0..edges_per_thread {
                     let neighbor_id = base + offset;
@@ -704,6 +655,7 @@ mod tests {
     /// when independent vertices are mutated in parallel.
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_concurrent_append_independent_vertices() {
+        let locks = Arc::new(StripedLocks::new());
         let max_degree = 64u32;
         let num_threads = 8u32;
         let vertices_per_thread = 50u32;
@@ -714,7 +666,7 @@ mod tests {
 
         // Initialize all vertices with empty neighbor lists.
         {
-            let mut scratch = provider.scratch();
+            let mut scratch = provider.scratch(locks.clone());
             for v in 0..num_vertices {
                 scratch.write_neighbors(v, &[]).unwrap();
             }
@@ -724,8 +676,9 @@ mod tests {
 
         for t in 0..num_threads {
             let provider_clone = Arc::clone(&provider);
+            let locks = locks.clone();
             set.spawn(async move {
-                let mut scratch = provider_clone.scratch();
+                let mut scratch = provider_clone.scratch(locks.clone());
                 // Each thread owns a disjoint range of vertices
                 let base_vertex = t * vertices_per_thread;
                 for i in 0..vertices_per_thread {
@@ -762,13 +715,14 @@ mod tests {
     /// always in a consistent state (length matches actual content, no torn reads).
     #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
     async fn test_concurrent_read_write_consistency() {
+        let locks = Arc::new(StripedLocks::new());
         let max_degree = 120u32;
         let bf_tree_config = Config::default();
         let provider =
             Arc::new(NeighborProvider::<u32>::new_with_config(max_degree, bf_tree_config).unwrap());
 
         // Initialize vertex 0.
-        let mut scratch = provider.scratch();
+        let mut scratch = provider.scratch(locks.clone());
         scratch.write_neighbors(0, &[]).unwrap();
 
         let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -783,8 +737,9 @@ mod tests {
             let provider_clone = Arc::clone(&provider);
             let done_clone = Arc::clone(&done);
             let remaining_clone = Arc::clone(&writers_remaining);
+            let locks = locks.clone();
             set.spawn(async move {
-                let mut scratch = provider_clone.scratch();
+                let mut scratch = provider_clone.scratch(locks.clone());
                 let base = t * edges_per_writer + 1;
                 for offset in 0..edges_per_writer {
                     scratch.write_append(0, &[base + offset]).unwrap();

--- a/diskann-bftree/src/neighbors.rs
+++ b/diskann-bftree/src/neighbors.rs
@@ -6,7 +6,6 @@
 //! Bf-Tree neighbor list provider.
 
 use std::marker::PhantomData;
-use std::sync::Arc;
 
 use bf_tree::{BfTree, Config};
 use bytemuck::{cast_slice, cast_slice_mut};
@@ -267,7 +266,7 @@ impl<I: VectorId + IntoUsize> NeighborProvider<I> {
         Ok(())
     }
 
-    pub(crate) fn scratch<'a>(&'a self, locks: Arc<StripedLocks>) -> NeighborAccessor<'a, I> {
+    pub(crate) fn scratch<'a>(&'a self, locks: &'a StripedLocks) -> NeighborAccessor<'a, I> {
         NeighborAccessor {
             provider: self,
             locks,
@@ -281,7 +280,7 @@ where
     I: VectorId + IntoUsize,
 {
     provider: &'a NeighborProvider<I>,
-    locks: Arc<StripedLocks>,
+    locks: &'a StripedLocks,
     buf: Vec<I>,
 }
 
@@ -395,7 +394,7 @@ mod tests {
         let bf_tree_config = Config::default();
         let neighbor_provider =
             NeighborProvider::<u32>::new_with_config(6, bf_tree_config).unwrap();
-        let mut scratch = neighbor_provider.scratch(locks.clone());
+        let mut scratch = neighbor_provider.scratch(&locks);
 
         // Set the neighbor list of a vector
         let adj_list = vec![1, 2, 3];
@@ -454,7 +453,7 @@ mod tests {
             let neighbor_provider_clone = Arc::clone(&neighbor_provider);
             let locks = locks.clone();
             set.spawn(async move {
-                let mut scratch = neighbor_provider_clone.scratch(locks.clone());
+                let mut scratch = neighbor_provider_clone.scratch(&locks);
                 scratch.write_neighbors(i as u32, &neighbor_list).unwrap();
             });
         }
@@ -489,7 +488,7 @@ mod tests {
 
         let neighbor_provider =
             NeighborProvider::<u32>::new_with_config(6, bf_tree_config).unwrap();
-        let mut scratch = neighbor_provider.scratch(locks.clone());
+        let mut scratch = neighbor_provider.scratch(&locks);
 
         // Set some neighbor lists
         scratch.write_neighbors(1, &[2, 3, 4]).unwrap();
@@ -540,7 +539,7 @@ mod tests {
         assert_eq!(neighbor_provider.max_degree(), 10);
 
         // Verify the provider is functional
-        let mut scratch = neighbor_provider.scratch(locks.clone());
+        let mut scratch = neighbor_provider.scratch(&locks);
         scratch.write_neighbors(1, &[2, 3]).unwrap();
         let mut result = AdjacencyList::with_capacity(11);
         neighbor_provider.get_neighbors(1, &mut result).unwrap();
@@ -560,7 +559,7 @@ mod tests {
             let neighbor_provider_clone = Arc::clone(&neighbor_provider);
             let locks = locks.clone();
             set.spawn(async move {
-                let mut scratch = neighbor_provider_clone.scratch(locks.clone());
+                let mut scratch = neighbor_provider_clone.scratch(&locks);
                 for i in 0..5 {
                     scratch.write_neighbors(i as u32, &[1, 2, 3, 4, 5]).unwrap();
                 }
@@ -595,7 +594,7 @@ mod tests {
             Arc::new(NeighborProvider::<u32>::new_with_config(max_degree, bf_tree_config).unwrap());
 
         // Initialize vertex 0 with an empty neighbor list.
-        let mut scratch = provider.scratch(locks.clone());
+        let mut scratch = provider.scratch(&locks);
         scratch.write_neighbors(0, &[]).unwrap();
 
         let num_threads = 8;
@@ -607,7 +606,7 @@ mod tests {
             let provider_clone = Arc::clone(&provider);
             let locks = locks.clone();
             set.spawn(async move {
-                let mut scratch = provider_clone.scratch(locks.clone());
+                let mut scratch = provider_clone.scratch(&locks);
                 let base = t * edges_per_thread + 1;
                 for offset in 0..edges_per_thread {
                     let neighbor_id = base + offset;
@@ -665,7 +664,7 @@ mod tests {
 
         // Initialize all vertices with empty neighbor lists.
         {
-            let mut scratch = provider.scratch(locks.clone());
+            let mut scratch = provider.scratch(&locks);
             for v in 0..num_vertices {
                 scratch.write_neighbors(v, &[]).unwrap();
             }
@@ -677,7 +676,7 @@ mod tests {
             let provider_clone = Arc::clone(&provider);
             let locks = locks.clone();
             set.spawn(async move {
-                let mut scratch = provider_clone.scratch(locks.clone());
+                let mut scratch = provider_clone.scratch(&locks);
                 // Each thread owns a disjoint range of vertices
                 let base_vertex = t * vertices_per_thread;
                 for i in 0..vertices_per_thread {
@@ -721,7 +720,7 @@ mod tests {
             Arc::new(NeighborProvider::<u32>::new_with_config(max_degree, bf_tree_config).unwrap());
 
         // Initialize vertex 0.
-        let mut scratch = provider.scratch(locks.clone());
+        let mut scratch = provider.scratch(&locks);
         scratch.write_neighbors(0, &[]).unwrap();
 
         let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
@@ -738,7 +737,7 @@ mod tests {
             let remaining_clone = Arc::clone(&writers_remaining);
             let locks = locks.clone();
             set.spawn(async move {
-                let mut scratch = provider_clone.scratch(locks.clone());
+                let mut scratch = provider_clone.scratch(&locks);
                 let base = t * edges_per_writer + 1;
                 for offset in 0..edges_per_writer {
                     scratch.write_append(0, &[base + offset]).unwrap();

--- a/diskann-bftree/src/neighbors.rs
+++ b/diskann-bftree/src/neighbors.rs
@@ -290,11 +290,11 @@ where
     I: VectorId + IntoUsize,
 {
     pub fn write_neighbors(&mut self, id: I, neighbors: &[I]) -> ANNResult<()> {
-        let _guard = self.locks.write(id.into_usize());
+        let _guard = self.locks.lock(id.into_usize());
         self.provider.set_neighbors(id, neighbors, &mut self.buf)
     }
     pub fn write_append(&mut self, id: I, neighbors: &[I]) -> ANNResult<()> {
-        let _guard = self.locks.write(id.into_usize());
+        let _guard = self.locks.lock(id.into_usize());
         self.provider.append_vector(id, neighbors, &mut self.buf)
     }
 }
@@ -328,7 +328,7 @@ where
         id: Self::Id,
         neighbors: &[Self::Id],
     ) -> impl std::future::Future<Output = ANNResult<()>> + Send {
-        let _guard = self.locks.write(id.into_usize());
+        let _guard = self.locks.lock(id.into_usize());
         std::future::ready(self.provider.set_neighbors(id, neighbors, &mut self.buf))
     }
     fn append_vector(
@@ -336,7 +336,7 @@ where
         id: Self::Id,
         neighbors: &[Self::Id],
     ) -> impl std::future::Future<Output = ANNResult<()>> + Send {
-        let _guard = self.locks.write(id.into_usize());
+        let _guard = self.locks.lock(id.into_usize());
         std::future::ready(self.provider.append_vector(id, neighbors, &mut self.buf))
     }
 }

--- a/diskann-bftree/src/neighbors.rs
+++ b/diskann-bftree/src/neighbors.rs
@@ -789,7 +789,13 @@ mod tests {
                 set.spawn(async move {
                     let mut result = AdjacencyList::with_capacity(max_degree as usize + 1);
                     let mut iterations = 0u64;
-                    while !done_clone.load(std::sync::atomic::Ordering::Acquire) {
+                    // Validate at least once before observing `done`. A reader that is
+                    // first scheduled only after every writer has already finished would
+                    // otherwise see `done == true` immediately, read nothing, and trip the
+                    // liveness assertion below — a scheduling artifact, not a real defect.
+                    // Reading the fully-written state is still a valid, consistent
+                    // observation, so the invariants hold regardless of timing.
+                    loop {
                         provider_clone.get_neighbors(0, &mut result).unwrap();
                         // The list must never exceed max_degree
                         assert!(
@@ -807,6 +813,9 @@ mod tests {
                             );
                         }
                         iterations += 1;
+                        if done_clone.load(std::sync::atomic::Ordering::Acquire) {
+                            break;
+                        }
                         tokio::task::yield_now().await;
                     }
                     assert!(

--- a/diskann-bftree/src/provider.rs
+++ b/diskann-bftree/src/provider.rs
@@ -9,7 +9,6 @@ use std::{
     io::{Read, Write},
     num::NonZeroUsize,
     str::FromStr,
-    sync::Arc,
 };
 
 use diskann_quantization::{
@@ -206,7 +205,7 @@ where
     pub(crate) use_snapshot: bool,
     // Striped locks for per-vertex synchronization across all stores.
     //
-    pub(crate) locks: Arc<StripedLocks>,
+    pub(crate) locks: StripedLocks,
 }
 
 #[derive(Debug, Clone)]
@@ -299,7 +298,7 @@ where
             metric: params.metric,
             graph_params: params.graph_params,
             use_snapshot: params.use_snapshot,
-            locks: Arc::new(StripedLocks::new()),
+            locks: StripedLocks::new(),
         })
     }
 
@@ -343,7 +342,7 @@ where
             // an uninitialized neighbor list in functions `consolidate_deletes` and
             // `consolidate_simple` and getting an error. This is a stop-gap solution
             // until BF-tree API is improved to handle `exists` queries.
-            let mut scratch = provider.neighbor_provider.scratch(provider.locks.clone());
+            let mut scratch = provider.neighbor_provider.scratch(&provider.locks);
             for i in 0..params.max_points {
                 let vector_id = i as u32;
                 scratch.write_neighbors(vector_id, &[])?;
@@ -731,7 +730,7 @@ where
             )));
         }
 
-        let mut scratch = self.neighbor_provider.scratch(self.locks.clone());
+        let mut scratch = self.neighbor_provider.scratch(&self.locks);
         for (id, v) in std::iter::zip(start_point_ids, start_points.row_iter()) {
             // Set the full-precision vector
             self.full_vectors.set_vector_sync(id.into_usize(), v)?;
@@ -762,7 +761,7 @@ where
             )));
         }
 
-        let mut scratch = self.neighbor_provider.scratch(self.locks.clone());
+        let mut scratch = self.neighbor_provider.scratch(&self.locks);
         for (id, v) in std::iter::zip(start_point_ids, start_points.row_iter()) {
             // Set the full-precision vector
             self.full_vectors.set_vector_sync(id.into_usize(), v)?;
@@ -1016,7 +1015,7 @@ where
     ) -> Self {
         Self {
             provider,
-            neighbors: provider.neighbor_provider.scratch(provider.locks.clone()),
+            neighbors: provider.neighbor_provider.scratch(&provider.locks),
             set,
             distance: T::distance(provider.metric, Some(provider.full_vectors.dim())),
         }
@@ -1121,7 +1120,7 @@ where
         let set = map::Builder::new(map::Capacity::Default).build(capacity);
         Ok(Self {
             provider,
-            neighbors: provider.neighbor_provider.scratch(provider.locks.clone()),
+            neighbors: provider.neighbor_provider.scratch(&provider.locks),
             set,
             distance,
         })
@@ -1819,7 +1818,7 @@ where
             metric,
             graph_params: saved_params.graph_params,
             use_snapshot: saved_params.use_snapshot,
-            locks: Arc::new(StripedLocks::new()),
+            locks: StripedLocks::new(),
         })
     }
 }
@@ -1981,7 +1980,7 @@ where
             metric,
             graph_params: saved_params.graph_params,
             use_snapshot: saved_params.use_snapshot,
-            locks: Arc::new(StripedLocks::new()),
+            locks: StripedLocks::new(),
         })
     }
 }
@@ -2434,7 +2433,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut scratch = provider.neighbor_provider.scratch(provider.locks.clone());
+        let mut scratch = provider.neighbor_provider.scratch(&provider.locks);
 
         // Insert new vectors without neighbors and empty neighbor list is
         // expected for each newly inserted vector
@@ -2567,7 +2566,7 @@ mod tests {
         }
 
         // Populate provider with neighbor lists
-        let mut scratch = provider.neighbor_provider.scratch(provider.locks.clone());
+        let mut scratch = provider.neighbor_provider.scratch(&provider.locks);
         for i in 0..num_points as u32 {
             let neighbors: Vec<u32> = (0..std::cmp::min(i, max_degree))
                 .map(|j| (i + j) % num_points as u32)
@@ -2701,7 +2700,7 @@ mod tests {
         }
 
         // Populate provider with neighbor lists
-        let mut scratch = provider.neighbor_provider.scratch(provider.locks.clone());
+        let mut scratch = provider.neighbor_provider.scratch(&provider.locks);
         for i in 0..num_points as u32 {
             let neighbors: Vec<u32> = (0..std::cmp::min(i, max_degree))
                 .map(|j| (i + j) % num_points as u32)
@@ -2829,7 +2828,7 @@ mod tests {
                 .await
                 .unwrap();
         }
-        let mut scratch = provider.neighbor_provider.scratch(provider.locks.clone());
+        let mut scratch = provider.neighbor_provider.scratch(&provider.locks);
         for i in 0..num_points as u32 {
             let neighbors: Vec<u32> = (0..std::cmp::min(i, max_degree))
                 .map(|j| (i + j) % num_points as u32)
@@ -2943,7 +2942,7 @@ mod tests {
                 .await
                 .unwrap();
         }
-        let mut scratch = provider.neighbor_provider.scratch(provider.locks.clone());
+        let mut scratch = provider.neighbor_provider.scratch(&provider.locks);
         for i in 0..num_points as u32 {
             let neighbors: Vec<u32> = (0..std::cmp::min(i, max_degree))
                 .map(|j| (i + j) % num_points as u32)

--- a/diskann-bftree/src/provider.rs
+++ b/diskann-bftree/src/provider.rs
@@ -205,6 +205,22 @@ where
     pub(crate) use_snapshot: bool,
     // Striped locks for per-vertex synchronization across all stores.
     //
+    // # Locking protocol
+    //
+    // Each mutating operation (`set_element`, `delete`, `write_neighbors`,
+    // `set_neighbors`, `append_vector`) acquires exactly **one** stripe lock
+    // for the target vertex ID, performs its work, and drops the guard at
+    // scope exit. No operation acquires a second lock while holding the first,
+    // so **deadlock is structurally impossible** — there is no ordering
+    // concern.
+    //
+    // Reads (`get_neighbors`, `get_vector`) do **not** acquire the stripe
+    // lock. They rely on bf-tree's internal thread safety for reads. A reader
+    // may therefore observe a partially-updated neighbor list (e.g.,
+    // mid-append), but bf-tree guarantees the read will not crash or return
+    // corrupt memory. The DiskANN search algorithm tolerates stale neighbor
+    // reads — it is approximate by design, and momentary inconsistency
+    // affects quality briefly rather than correctness.
     pub(crate) locks: StripedLocks,
 }
 

--- a/diskann-bftree/src/provider.rs
+++ b/diskann-bftree/src/provider.rs
@@ -471,7 +471,7 @@ where
         gid: &Self::ExternalId,
     ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send {
         let id = *gid;
-        let _guard = self.locks.write(id as usize);
+        let _guard = self.locks.lock(id as usize);
         // Only delete vector data here. Neighbor adjacency cleanup (zeroing the
         // deleted vertex's edge list and patching neighbors-of-neighbors) is
         // handled by `DiskANNIndex::inplace_delete` → `drop_adj_list`.
@@ -639,7 +639,7 @@ where
         id: &u32,
         element: &[T],
     ) -> impl Future<Output = Result<Self::Guard, Self::SetError>> + Send {
-        let _guard = self.locks.write(id.into_usize());
+        let _guard = self.locks.lock(id.into_usize());
 
         // First, write to the authoritative full-precision store.
         if let Err(err) = self.full_vectors.set_vector_sync(id.into_usize(), element) {
@@ -675,7 +675,7 @@ where
         id: &u32,
         element: &[T],
     ) -> impl Future<Output = Result<Self::Guard, Self::SetError>> + Send {
-        let _guard = self.locks.write(id.into_usize());
+        let _guard = self.locks.lock(id.into_usize());
 
         if let Err(err) = self.full_vectors.set_vector_sync(id.into_usize(), element) {
             return std::future::ready(Err(err));

--- a/diskann-bftree/src/provider.rs
+++ b/diskann-bftree/src/provider.rs
@@ -416,19 +416,40 @@ where
     }
 }
 
+/// Trait for types that may need cleanup during hard-delete.
+///
+/// `QuantVectorProvider` implements this to delete its quantized embedding.
+/// `NoStore` implements this as a no-op.
+pub(crate) trait DeleteQuant {
+    fn delete_vector(&self, id: usize);
+}
+
+impl DeleteQuant for QuantVectorProvider {
+    fn delete_vector(&self, id: usize) {
+        QuantVectorProvider::delete_vector(self, id);
+    }
+}
+
+impl DeleteQuant for NoStore {
+    fn delete_vector(&self, _id: usize) {}
+}
+
 /// Hard-delete implementation for `BfTreeProvider`.
 ///
 /// This provider performs **hard deletes**: vector data is immediately and irrecoverably erased
-/// from the underlying bf-tree storage when [`Delete::delete`] is called. This has an important
-/// consequence for inplace delete: the [`InplaceDeleteMethod::VisitedAndTopK`] strategy is
-/// **incompatible** with this provider because it requires reading the deleted vector's data
-/// (via [`InplaceDeleteStrategy::get_delete_element`]) *after* the delete has already been
-/// committed. Use [`InplaceDeleteMethod::OneHop`] or [`InplaceDeleteMethod::TwoHopAndOneHop`]
-/// instead, as these strategies only require neighbor topology (which remains accessible).
+/// from the underlying bf-tree storage when [`Delete::delete`] is called. When a quantized
+/// store is present, both the full-precision and quantized entries are removed.
+///
+/// This has an important consequence for inplace delete: the
+/// [`InplaceDeleteMethod::VisitedAndTopK`] strategy is **incompatible** with this provider
+/// because it requires reading the deleted vector's data (via
+/// [`InplaceDeleteStrategy::get_delete_element`]) *after* the delete has already been committed.
+/// Use [`InplaceDeleteMethod::OneHop`] or [`InplaceDeleteMethod::TwoHopAndOneHop`] instead,
+/// as these strategies only require neighbor topology (which remains accessible).
 impl<T, Q> Delete for BfTreeProvider<T, Q>
 where
     T: VectorRepr,
-    Q: AsyncFriendly,
+    Q: AsyncFriendly + DeleteQuant,
 {
     fn release(
         &self,
@@ -444,7 +465,11 @@ where
         gid: &Self::ExternalId,
     ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send {
         let id = *gid;
+        // Only delete vector data here. Neighbor adjacency cleanup (zeroing the
+        // deleted vertex's edge list and patching neighbors-of-neighbors) is
+        // handled by `DiskANNIndex::inplace_delete` → `drop_adj_list`.
         self.full_vectors.delete_vector(id as usize);
+        self.quant_vectors.delete_vector(id as usize);
 
         std::future::ready(Ok(()))
     }
@@ -597,28 +622,30 @@ where
 
     /// Store the provided element in both the full-precision and quant vector stores.
     ///
-    /// The process of storing the element in the quant store will compress the vector
-    ///
+    /// Full-precision is written first as the authoritative store. This ensures that
+    /// if the quant write fails, the worst case is a vector reachable in full-precision
+    /// but not yet in quantized search (benign), rather than a quantized ghost with no
+    /// full-precision backing data.
     fn set_element(
         &self,
         _context: &Self::Context,
         id: &u32,
         element: &[T],
     ) -> impl Future<Output = Result<Self::Guard, Self::SetError>> + Send {
-        // First, try adding to the quant provider.
-        //
-        if let Err(err) = self.quant_vectors.set_vector_sync(id.into_usize(), element) {
-            return std::future::ready(Err(err));
-        }
-
-        // Next, add to the full precision provider.
-        //
+        // First, write to the authoritative full-precision store.
         if let Err(err) = self.full_vectors.set_vector_sync(id.into_usize(), element) {
             return std::future::ready(Err(err));
         }
 
-        // Success
-        //
+        // Then, write the compressed representation to the quant store.
+        if let Err(err) = self.quant_vectors.set_vector_sync(id.into_usize(), element) {
+            debug_assert!(
+                false,
+                "quant write failed after full-precision success: {err}"
+            );
+            return std::future::ready(Err(err));
+        }
+
         std::future::ready(Ok(NoopGuard::new(*id)))
     }
 }

--- a/diskann-bftree/src/provider.rs
+++ b/diskann-bftree/src/provider.rs
@@ -9,6 +9,7 @@ use std::{
     io::{Read, Write},
     num::NonZeroUsize,
     str::FromStr,
+    sync::Arc,
 };
 
 use diskann_quantization::{
@@ -47,6 +48,7 @@ use super::{
     vectors::VectorProvider,
     AccessError, NoStore,
 };
+use crate::locks::StripedLocks;
 use diskann_providers::model::graph::provider::async_::distances::UnwrapErr;
 use diskann_providers::storage::{LoadWith, SaveWith, StorageReadProvider, StorageWriteProvider};
 
@@ -202,6 +204,9 @@ where
 
     // Whether CPR snapshot support is enabled for this provider's trees.
     pub(crate) use_snapshot: bool,
+    // Striped locks for per-vertex synchronization across all stores.
+    //
+    pub(crate) locks: Arc<StripedLocks>,
 }
 
 #[derive(Debug, Clone)]
@@ -294,6 +299,7 @@ where
             metric: params.metric,
             graph_params: params.graph_params,
             use_snapshot: params.use_snapshot,
+            locks: Arc::new(StripedLocks::new()),
         })
     }
 
@@ -337,7 +343,7 @@ where
             // an uninitialized neighbor list in functions `consolidate_deletes` and
             // `consolidate_simple` and getting an error. This is a stop-gap solution
             // until BF-tree API is improved to handle `exists` queries.
-            let mut scratch = provider.neighbor_provider.scratch();
+            let mut scratch = provider.neighbor_provider.scratch(provider.locks.clone());
             for i in 0..params.max_points {
                 let vector_id = i as u32;
                 scratch.write_neighbors(vector_id, &[])?;
@@ -465,6 +471,7 @@ where
         gid: &Self::ExternalId,
     ) -> impl std::future::Future<Output = Result<(), Self::Error>> + Send {
         let id = *gid;
+        let _guard = self.locks.write(id as usize);
         // Only delete vector data here. Neighbor adjacency cleanup (zeroing the
         // deleted vertex's edge list and patching neighbors-of-neighbors) is
         // handled by `DiskANNIndex::inplace_delete` → `drop_adj_list`.
@@ -632,6 +639,8 @@ where
         id: &u32,
         element: &[T],
     ) -> impl Future<Output = Result<Self::Guard, Self::SetError>> + Send {
+        let _guard = self.locks.write(id.into_usize());
+
         // First, write to the authoritative full-precision store.
         if let Err(err) = self.full_vectors.set_vector_sync(id.into_usize(), element) {
             return std::future::ready(Err(err));
@@ -666,14 +675,12 @@ where
         id: &u32,
         element: &[T],
     ) -> impl Future<Output = Result<Self::Guard, Self::SetError>> + Send {
-        // Add to the full precision provider
-        //
+        let _guard = self.locks.write(id.into_usize());
+
         if let Err(err) = self.full_vectors.set_vector_sync(id.into_usize(), element) {
             return std::future::ready(Err(err));
         }
 
-        // Success
-        //
         std::future::ready(Ok(NoopGuard::new(*id)))
     }
 }
@@ -724,7 +731,7 @@ where
             )));
         }
 
-        let mut scratch = self.neighbor_provider.scratch();
+        let mut scratch = self.neighbor_provider.scratch(self.locks.clone());
         for (id, v) in std::iter::zip(start_point_ids, start_points.row_iter()) {
             // Set the full-precision vector
             self.full_vectors.set_vector_sync(id.into_usize(), v)?;
@@ -755,7 +762,7 @@ where
             )));
         }
 
-        let mut scratch = self.neighbor_provider.scratch();
+        let mut scratch = self.neighbor_provider.scratch(self.locks.clone());
         for (id, v) in std::iter::zip(start_point_ids, start_points.row_iter()) {
             // Set the full-precision vector
             self.full_vectors.set_vector_sync(id.into_usize(), v)?;
@@ -1009,7 +1016,7 @@ where
     ) -> Self {
         Self {
             provider,
-            neighbors: provider.neighbor_provider.scratch(),
+            neighbors: provider.neighbor_provider.scratch(provider.locks.clone()),
             set,
             distance: T::distance(provider.metric, Some(provider.full_vectors.dim())),
         }
@@ -1114,7 +1121,7 @@ where
         let set = map::Builder::new(map::Capacity::Default).build(capacity);
         Ok(Self {
             provider,
-            neighbors: provider.neighbor_provider.scratch(),
+            neighbors: provider.neighbor_provider.scratch(provider.locks.clone()),
             set,
             distance,
         })
@@ -1812,6 +1819,7 @@ where
             metric,
             graph_params: saved_params.graph_params,
             use_snapshot: saved_params.use_snapshot,
+            locks: Arc::new(StripedLocks::new()),
         })
     }
 }
@@ -1973,6 +1981,7 @@ where
             metric,
             graph_params: saved_params.graph_params,
             use_snapshot: saved_params.use_snapshot,
+            locks: Arc::new(StripedLocks::new()),
         })
     }
 }
@@ -2425,7 +2434,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut scratch = provider.neighbor_provider.scratch();
+        let mut scratch = provider.neighbor_provider.scratch(provider.locks.clone());
 
         // Insert new vectors without neighbors and empty neighbor list is
         // expected for each newly inserted vector
@@ -2558,7 +2567,7 @@ mod tests {
         }
 
         // Populate provider with neighbor lists
-        let mut scratch = provider.neighbor_provider.scratch();
+        let mut scratch = provider.neighbor_provider.scratch(provider.locks.clone());
         for i in 0..num_points as u32 {
             let neighbors: Vec<u32> = (0..std::cmp::min(i, max_degree))
                 .map(|j| (i + j) % num_points as u32)
@@ -2692,7 +2701,7 @@ mod tests {
         }
 
         // Populate provider with neighbor lists
-        let mut scratch = provider.neighbor_provider.scratch();
+        let mut scratch = provider.neighbor_provider.scratch(provider.locks.clone());
         for i in 0..num_points as u32 {
             let neighbors: Vec<u32> = (0..std::cmp::min(i, max_degree))
                 .map(|j| (i + j) % num_points as u32)
@@ -2820,7 +2829,7 @@ mod tests {
                 .await
                 .unwrap();
         }
-        let mut scratch = provider.neighbor_provider.scratch();
+        let mut scratch = provider.neighbor_provider.scratch(provider.locks.clone());
         for i in 0..num_points as u32 {
             let neighbors: Vec<u32> = (0..std::cmp::min(i, max_degree))
                 .map(|j| (i + j) % num_points as u32)
@@ -2934,7 +2943,7 @@ mod tests {
                 .await
                 .unwrap();
         }
-        let mut scratch = provider.neighbor_provider.scratch();
+        let mut scratch = provider.neighbor_provider.scratch(provider.locks.clone());
         for i in 0..num_points as u32 {
             let neighbors: Vec<u32> = (0..std::cmp::min(i, max_degree))
                 .map(|j| (i + j) % num_points as u32)

--- a/diskann-bftree/src/quant.rs
+++ b/diskann-bftree/src/quant.rs
@@ -77,6 +77,11 @@ impl QuantVectorProvider {
         }
     }
 
+    pub(crate) fn delete_vector(&self, i: usize) {
+        let key = bytemuck::bytes_of(&i);
+        self.quant_vector_index.delete(key);
+    }
+
     /// Return the dimension of the full-precision data associated with this provider
     pub fn full_dim(&self) -> usize {
         self.quantizer.full_dim()


### PR DESCRIPTION
# Problem

`NeighborProvider::append_vector` performs a read-modify-write cycle (read existing neighbors → append → write back) without synchronization. Under concurrent mutation, the last writer wins and silently drops the other's edges. Stress testing shows edge loss under multi-thread contention on a single vertex.

Additionally, the dual-store `set_element` wrote quant before full-precision, meaning if the full-precision write failed after quant succeeded, it would leave a quantized ghost with no backing data. And `delete` did not clean up the quant store entry.

# Solution

## Striped `Mutex` table for per-vertex synchronization

- `StripedLocks`: a fixed-size table of `Mutex<()>` stripes (`diskann-bftree/src/locks.rs`).
- Stripe count is derived from hardware parallelism: `(cpus * 4).next_power_of_two().max(64)` — constant memory regardless of dataset size, suitable for billion-scale workloads.
- Vertex IDs map to stripes via Fibonacci multiply-shift hashing (`floor(2^64 / phi)`), keeping false contention negligible.
- Each mutating op acquires exactly **one** stripe lock for the target vertex, does its work, and drops the guard — no nested locking, so deadlock is structurally impossible.

### Why striped instead of per-vertex locks?

BfTree's value proposition is spilling to disk for datasets exceeding RAM. At 1B vectors, per-vertex locks would consume gigabytes of in-memory locks — defeating the purpose. Striped locks keep memory constant at the cost of rare false contention.

### Reads are lock-free

`get_neighbors` and `get_vector` acquire **no** stripe lock. They rely on bf-tree's internal thread safety and the fact that DiskANN search is approximate by design: a reader may briefly observe a partially-updated neighbor list, which affects recall momentarily rather than correctness. Writers (`set_element`, `delete`, `set_neighbors`/`write_neighbors`, `append_vector`/`write_append`) serialize on the stripe.

## Dual-store write ordering

- Full-precision is now written **first** in `set_element`.
- Failure mode is benign: vector reachable in full-precision but not yet in quantized search (rather than a quantized ghost with no backing data).

## Quant store cleanup on delete

- New `DeleteQuant` trait: real impl for `QuantVectorProvider` (deletes the quant entry), no-op for `NoStore`.
- `delete` now removes both full-precision and quant entries under the stripe lock. Neighbor-topology cleanup remains in the upper `DiskANNIndex` layer (`drop_adj_list`).

# Testing

Three new concurrent stress tests in `diskann-bftree/src/neighbors.rs`:

- `test_concurrent_append_no_lost_edges` — 8 threads × 10 edges to the same vertex; asserts every edge survives.
- `test_concurrent_append_independent_vertices` — 8 threads appending to disjoint vertex ranges; asserts total edge count.
- `test_concurrent_read_write_consistency` — mixed readers + writers on the same vertex; validates no torn reads.
