### PR TITLE
Remove vestigial VectorType parameter from DiskIndexReader

### DIFF
--- a/diskann-benchmark/src/backend/disk_index/search.rs
+++ b/diskann-benchmark/src/backend/disk_index/search.rs
@@ -206,7 +206,7 @@ where
     let pq_data_path = get_compressed_pq_file(&index_load.load_path);
     let disk_index_path = get_disk_index_file(&index_load.load_path);
 
-    let index_reader = DiskIndexReader::<T>::new(pivot_path, pq_data_path, &FileStorageProvider)?;
+    let index_reader = DiskIndexReader::new(pivot_path, pq_data_path, &FileStorageProvider)?;
 
     let caching_strategy = if let Some(num_nodes) = search_params.num_nodes_to_cache {
         CachingStrategy::StaticCacheWithBfsNodes(num_nodes)

--- a/diskann-disk/src/build/builder/core.rs
+++ b/diskann-disk/src/build/builder/core.rs
@@ -1040,7 +1040,7 @@ pub(crate) mod disk_index_builder_tests {
         let pq_compressed_path = get_compressed_pq_file(&params.index_path_prefix);
         let index_file_path = get_disk_index_file(&params.index_path_prefix);
 
-        let index_reader = DiskIndexReader::<G::VectorDataType>::new(
+        let index_reader = DiskIndexReader::new(
             pq_pivot_path,
             pq_compressed_path,
             storage_provider.as_ref(),

--- a/diskann-disk/src/build/builder/core.rs
+++ b/diskann-disk/src/build/builder/core.rs
@@ -1040,11 +1040,8 @@ pub(crate) mod disk_index_builder_tests {
         let pq_compressed_path = get_compressed_pq_file(&params.index_path_prefix);
         let index_file_path = get_disk_index_file(&params.index_path_prefix);
 
-        let index_reader = DiskIndexReader::new(
-            pq_pivot_path,
-            pq_compressed_path,
-            storage_provider.as_ref(),
-        )?;
+        let index_reader =
+            DiskIndexReader::new(pq_pivot_path, pq_compressed_path, storage_provider.as_ref())?;
 
         let vertex_provider_factory = DiskVertexProviderFactory::new(
             VirtualAlignedReaderFactory::new(index_file_path, Arc::clone(storage_provider)),

--- a/diskann-disk/src/search/provider/disk_provider.rs
+++ b/diskann-disk/src/search/provider/disk_provider.rs
@@ -153,7 +153,7 @@ where
         let num_points = ctx.num_points;
 
         let index_path_prefix = ctx.quant_load_context.metadata.prefix();
-        let index_reader = DiskIndexReader::<<Data as GraphDataType>::VectorDataType>::new(
+        let index_reader = DiskIndexReader::new(
             get_pq_pivot_file(index_path_prefix),
             get_compressed_pq_file(index_path_prefix),
             provider,
@@ -174,7 +174,7 @@ where
     Data: GraphDataType<VectorIdType = u32>,
 {
     fn new(
-        disk_index_reader: &DiskIndexReader<Data::VectorDataType>,
+        disk_index_reader: &DiskIndexReader,
         graph_header: GraphHeader,
         metric: Metric,
         num_points: usize,
@@ -692,7 +692,7 @@ where
     pub fn new(
         num_threads: usize,
         search_io_limit: usize,
-        disk_index_reader: &DiskIndexReader<Data::VectorDataType>,
+        disk_index_reader: &DiskIndexReader,
         vertex_provider_factory: ProviderFactory,
         metric: Metric,
         runtime: Option<Runtime>,
@@ -1209,7 +1209,7 @@ mod disk_provider_tests {
             .build()
             .unwrap();
 
-        let disk_index_reader = DiskIndexReader::<Data::VectorDataType>::new(
+        let disk_index_reader = DiskIndexReader::new(
             params.pq_pivot_file_path.to_string(),
             params.pq_compressed_file_path.to_string(),
             storage_provider.as_ref(),

--- a/diskann-disk/src/storage/disk_index_reader.rs
+++ b/diskann-disk/src/storage/disk_index_reader.rs
@@ -2,7 +2,7 @@
  * Copyright (c) Microsoft Corporation.
  * Licensed under the MIT license.
  */
-use std::{marker::PhantomData, sync::Arc};
+use std::sync::Arc;
 
 use diskann::ANNResult;
 use diskann_providers::storage::StorageReadProvider;
@@ -15,15 +15,13 @@ use tracing::info;
 /// It includes the PQ data, pivot table, and the warmup query data.
 /// The Storage acts as a provider to read the data from storage system.
 /// The storage provider should be provided as a generic type and be specified by the caller when it initializes the DiskIndexSearcher.
-pub struct DiskIndexReader<VectorType> {
-    phantom: PhantomData<VectorType>,
-
+pub struct DiskIndexReader {
     pq_data: Arc<PQData>,
 
     num_points: usize,
 }
 
-impl<VectorType> DiskIndexReader<VectorType> {
+impl DiskIndexReader {
     /// Create DiskIndexReader instance
     pub fn new<Storage: StorageReadProvider>(
         pq_pivot_path: String,
@@ -53,7 +51,6 @@ impl<VectorType> DiskIndexReader<VectorType> {
         );
 
         Ok(DiskIndexReader {
-            phantom: PhantomData,
             pq_data: Arc::<PQData>::new(PQData::new(pq_pivot_table, pq_compressed_data)?),
             num_points: metadata.npoints(),
         })
@@ -81,7 +78,7 @@ mod disk_index_storage_test {
     fn load_pivot_test() {
         let pivot_file_prefix: &str = "/sift/siftsmall_learn";
         let storage_provider = VirtualStorageProvider::new_overlay(test_data_root());
-        let storage = DiskIndexReader::<f32>::new::<VirtualStorageProvider<OverlayFS>>(
+        let storage = DiskIndexReader::new::<VirtualStorageProvider<OverlayFS>>(
             pivot_file_prefix.to_string() + "_pq_pivots.bin",
             pivot_file_prefix.to_string() + "_pq_compressed.bin",
             &storage_provider,
@@ -98,7 +95,7 @@ mod disk_index_storage_test {
     fn load_pivot_file_not_exist_test() {
         let pivot_file_prefix: &str = "/sift/siftsmall_learn_file_not_exist";
         let storage_provider = VirtualStorageProvider::new_overlay(test_data_root());
-        let err = match DiskIndexReader::<f32>::new::<VirtualStorageProvider<OverlayFS>>(
+        let err = match DiskIndexReader::new::<VirtualStorageProvider<OverlayFS>>(
             pivot_file_prefix.to_string() + "_pq_pivots.bin",
             pivot_file_prefix.to_string() + "_pq_compressed.bin",
             &storage_provider,
@@ -114,7 +111,7 @@ mod disk_index_storage_test {
     fn test_get_num_points() {
         let pivot_file_prefix: &str = "/sift/siftsmall_learn";
         let storage_provider = VirtualStorageProvider::new_overlay(test_data_root());
-        let storage = DiskIndexReader::<f32>::new::<VirtualStorageProvider<OverlayFS>>(
+        let storage = DiskIndexReader::new::<VirtualStorageProvider<OverlayFS>>(
             pivot_file_prefix.to_string() + "_pq_pivots.bin",
             pivot_file_prefix.to_string() + "_pq_compressed.bin",
             &storage_provider,

--- a/diskann-tools/src/utils/range_search_disk_index.rs
+++ b/diskann-tools/src/utils/range_search_disk_index.rs
@@ -74,7 +74,7 @@ where
         );
     }
 
-    let index_reader = DiskIndexReader::<<Data as GraphDataType>::VectorDataType>::new(
+    let index_reader = DiskIndexReader::new(
         format!("{}_pq_pivots.bin", index_path_prefix),
         format!("{}_pq_compressed.bin", index_path_prefix),
         &storage_provider,

--- a/diskann-tools/src/utils/search_disk_index.rs
+++ b/diskann-tools/src/utils/search_disk_index.rs
@@ -133,7 +133,7 @@ where
         );
     }
 
-    let index_reader = DiskIndexReader::<<Data as GraphDataType>::VectorDataType>::new(
+    let index_reader = DiskIndexReader::new(
         get_pq_pivot_file(parameters.index_path_prefix),
         get_compressed_pq_file(parameters.index_path_prefix),
         storage_provider,


### PR DESCRIPTION
The generic was only held as PhantomData and never constrained any field or method. The struct stores Arc<PQData> and num_points, both vector-type-agnostic, and the real genericity (the Storage provider) lives on `new`. Dropping it removes a type argument every call site had to thread through without need.
