### PR TITLE
Bump version to 0.54.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "diskann"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -683,7 +683,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-core"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "anyhow",
  "diskann",
@@ -700,7 +700,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-runner"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -714,7 +714,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-simd"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "anyhow",
  "diskann-benchmark-runner",
@@ -731,7 +731,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-bftree"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "bf-tree",
  "bytemuck",
@@ -753,7 +753,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-disk"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -808,7 +808,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-label-filter"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -831,7 +831,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-linalg"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "approx",
  "cfg-if",
@@ -845,7 +845,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-platform"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "io-uring",
  "libc",
@@ -855,7 +855,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-providers"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "approx",
  "arc-swap",
@@ -893,7 +893,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-quantization"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -914,7 +914,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-tools"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -947,7 +947,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-utils"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -963,7 +963,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-vector"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "approx",
  "bytemuck",
@@ -978,7 +978,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-wide"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ default-members = [
 resolver = "3"
 
 [workspace.package]
-version = "0.53.0"      # Obeying semver
+version = "0.54.0"      # Obeying semver
 description = "DiskANN3 is a composable library for bringing scalable, accurate and cost-effective vector indexing to multiple databases."
 authors = ["Microsoft"]
 repository = "https://github.com/microsoft/DiskANN"
@@ -49,23 +49,23 @@ undocumented_unsafe_blocks = "warn"
 
 [workspace.dependencies]
 # Base And Numerics
-diskann-wide = { path = "diskann-wide", version = "0.53.0" }
-diskann-vector = { path = "diskann-vector", version = "0.53.0" }
-diskann-linalg = { path = "diskann-linalg", version = "0.53.0" }
-diskann-utils = { path = "diskann-utils", default-features = false, version = "0.53.0" }
-diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.53.0" }
-diskann-platform = { path = "diskann-platform", version = "0.53.0" }
+diskann-wide = { path = "diskann-wide", version = "0.54.0" }
+diskann-vector = { path = "diskann-vector", version = "0.54.0" }
+diskann-linalg = { path = "diskann-linalg", version = "0.54.0" }
+diskann-utils = { path = "diskann-utils", default-features = false, version = "0.54.0" }
+diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.54.0" }
+diskann-platform = { path = "diskann-platform", version = "0.54.0" }
 # Algorithm
-diskann = { path = "diskann", version = "0.53.0" }
+diskann = { path = "diskann", version = "0.54.0" }
 # Providers
-diskann-providers = { path = "diskann-providers", default-features = false, version = "0.53.0" }
-diskann-disk = { path = "diskann-disk", version = "0.53.0" }
-diskann-label-filter = { path = "diskann-label-filter", version = "0.53.0" }
+diskann-providers = { path = "diskann-providers", default-features = false, version = "0.54.0" }
+diskann-disk = { path = "diskann-disk", version = "0.54.0" }
+diskann-label-filter = { path = "diskann-label-filter", version = "0.54.0" }
 # Infra
-diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.53.0" }
-diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.53.0" }
-diskann-tools = { path = "diskann-tools", version = "0.53.0" }
-diskann-bftree = {path = "diskann-bftree", version = "0.53.0" }
+diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.54.0" }
+diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.54.0" }
+diskann-tools = { path = "diskann-tools", version = "0.54.0" }
+diskann-bftree = {path = "diskann-bftree", version = "0.54.0" }
 
 # External dependencies (shared versions)
 anyhow = "1.0.98"


### PR DESCRIPTION
## Breaking changes since 0.53.0

### Graph search: `DataProvider` contract collapsed into `SearchAccessor` (#1067)
`Accessor`, `BuildQueryComputer`, `ExpandBeam`, `SearchExt`, and `AsNeighbor`/`NeighborAccessor` are merged into a single `SearchAccessor` trait. The indexing layer no longer has a notion of element types.
- **Upgrade:** Implement `SearchAccessor` instead of the removed traits; use `SearchAccessor::expand_beam` for search. `SearchStrategy`/`InsertStrategy`/`DefaultSearchStrategy`/`DefaultPostProcessor` now carry a lifetime, and the query is passed into `search_accessor` (accessors may now borrow the query). `SearchPostProcess` no longer takes a `QueryComputer` (only requires `HasId`). The blanket `workingset::Fill` impl for `workingset::Map` was removed — implement `Fill` yourself, or use the new synchronous `Map::fill` helper.

### Insert/prune: consolidated into `PruneAccessor` (#1138, follow-up to #1067)
Removed `DelegateNeighbor`, `AsNeighbor`, `AsNeighborMut`, `HasElementRef`, `BuildDistanceComputer`, `workingset::Fill`, and `workingset::AsWorkingSet`, folded into a single `PruneAccessor` trait.
- **Upgrade:** Implement `PruneAccessor` (provides `neighbors()` for neighbor delegation and `fill()` returning both a `View` and the distance computer). Note `neighbors()` now borrows `&mut self`.

### `VectorId`: removed scalar conversion traits/bounds (#1145, #1133)
Dropped `VectorIdTryFrom`, `TryIntoVectorId`, methods `vector_id_try_from`/`try_into_vector_id`, helpers `vecid_from_u32`/`vecid_from_usize`, and `IdConversionError`/`ErrorToVectorId`. Internal IDs no longer need to convert to/from `usize`.
- **Upgrade:** Where `usize` conversion is still required (e.g. roaring-treemap keys in `diskann-label-filter`), add an explicit `IntoUsize` bound (now required on `RoaringAttributeStore`, `InlineBetaStrategy`, `QueryBitmapEvaluator`/`BitmapFilter`). `DiskANNIndex::prune_range` now takes `impl IntoIterator<Item = DP::InternalId> + Send` instead of `Range<DP::InternalId>` — construct the iterator for your ID type at the call site. `SimpleNeighborProviderAsync` and `bftree::VectorProvider` are no longer generic over the ID type (fixed to `u32`).

### `DiskIndexReader`: dropped vestigial `VectorType` generic (#1161)
- **Upgrade:** Replace `DiskIndexReader::<T>::new(...)` with `DiskIndexReader::new(...)`.

### Filtered search renames (#1149)
`MultihopSearch` → `MultihopFilterSearch`; benchmark config phases `MultiHopSearchPhase`/`InlineSearchPhase` → `MultihopFilterSearchPhase`/`InlineFilterSearchPhase`.
- **Upgrade:** Update references to the new names.

### `diskann-garnet` FFI: BIN/Q8 quantizers, bumped to 2.0.0 (#1050)
Vectors are now stored as `Poly<[u8], AlignOfEight>`; a type-erased `GarnetQuantizer` trait replaces index/provider type parameterization. New FFI: `insert()` returns a success/training-ready flag, plus `build_quant_table()` and `backfill_quant_vectors()` for caller-driven async training/backfill. Accessor renamed to `DynamicAccessor`; the FSM is now lockable and gained `visit_used()`.
- **Upgrade:** Garnet consumers must adopt the new 2.0.0 FFI surface (handle the new `insert()` return flag and drive `build_quant_table`/`backfill_quant_vectors`).



## Notable fixes & features (non-breaking)

- **Concurrency:** Fixed an ID double-minting race during concurrent insert/delete; delete now removes mapping/attributes before marking the ID free (#1146). Fixed garnet handling of missing quant vectors during `delete()` (#1130).
- **Quantization:** Fixed quantizer detection in `train_quantizer()` / `set_element()` (#1140).
- **Filtered search:** Added inline filtered search with adaptive `L` (#1131), per the filtered-search RFC (#1128).
- **bftree:** Fixed a bug writing the length to the neighbor list (#1150).
- **Benchmarks/infra:** Multi-vector MaxSim benchmark with BYOTE factory (#1027); `bf_tree` benchmark infrastructure (#1106); spherical exhaustive benchmark threadpool fix (#1148); right-sized `tiled_reduce` tile buffer (#1123).
- `BufferedDistance` accepts `UnalignedSlice`: added a `PreprocessedDistanceFunction<UnalignedSlice<'_, T>>` impl for `BufferedDistance` (#1113).