### PR TITLE
fix(bftree): validate record sizes at construction 

### DIFF
--- a/diskann-benchmark/src/inputs/bftree.rs
+++ b/diskann-benchmark/src/inputs/bftree.rs
@@ -192,7 +192,8 @@ fn bftree_parameters_from(
 ) -> BfTreeProviderParameters {
     BfTreeProviderParameters {
         max_points: num_points,
-        max_degree: build.exact_max_degree() as u32,
+        max_degree: build.max_degree(),
+        graph_slack_factor: build.graph_slack_factor(),
         num_start_points: NonZero::new(build.start_point_strategy().count()).unwrap(),
         dim,
         metric: build.distance().into(),
@@ -227,9 +228,6 @@ impl BfTreeFullPrecisionBuild {
     }
 
     pub(crate) fn try_as_config(&self) -> anyhow::Result<config::Builder> {
-        // Delegate to IndexBuild's try_as_config which uses the default
-        // MaxDegree::Value(exact_max_degree) with 1.3x slack. The bf_tree
-        // neighbor pages are sized to exact_max_degree to accommodate this.
         self.build.try_as_config()
     }
 
@@ -330,8 +328,6 @@ impl BfTreeDynamicRun {
     }
 
     pub(crate) fn try_as_config(&self) -> anyhow::Result<config::Builder> {
-        // Delegate to IndexBuild's try_as_config which uses the default
-        // MaxDegree::Value(exact_max_degree) with 1.3x slack.
         self.build.try_as_config()
     }
 

--- a/diskann-benchmark/src/inputs/bftree.rs
+++ b/diskann-benchmark/src/inputs/bftree.rs
@@ -190,10 +190,10 @@ fn bftree_parameters_from(
     neighbor_store_config: &Option<BfTreeStoreConfig>,
     quant_store_config: &Option<BfTreeStoreConfig>,
 ) -> BfTreeProviderParameters {
+    let physical_max_degree = (build.max_degree() as f32 * build.graph_slack_factor()) as u32;
     BfTreeProviderParameters {
         max_points: num_points,
-        max_degree: build.max_degree(),
-        graph_slack_factor: build.graph_slack_factor(),
+        max_degree: physical_max_degree,
         num_start_points: NonZero::new(build.start_point_strategy().count()).unwrap(),
         dim,
         metric: build.distance().into(),

--- a/diskann-benchmark/src/inputs/graph_index.rs
+++ b/diskann-benchmark/src/inputs/graph_index.rs
@@ -691,6 +691,16 @@ impl IndexBuild {
         (self.max_degree as f32 * 1.3) as usize
     }
 
+    #[cfg(feature = "bftree")]
+    pub(crate) fn max_degree(&self) -> u32 {
+        self.max_degree as u32
+    }
+
+    #[cfg(feature = "bftree")]
+    pub(crate) fn graph_slack_factor(&self) -> f32 {
+        1.3
+    }
+
     pub(crate) fn try_as_config(&self) -> anyhow::Result<config::Builder> {
         let metric: diskann_vector::distance::Metric = self.distance.into();
         let exact_max_degree = self.exact_max_degree();

--- a/diskann-bftree/src/lib.rs
+++ b/diskann-bftree/src/lib.rs
@@ -24,7 +24,7 @@ pub use bf_tree::Config;
 
 use diskann::{
     error::{RankedError, TransientError},
-    ANNError,
+    ANNError, ANNResult,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -93,6 +93,26 @@ impl TransientError<ANNError> for VectorUnavailable {
 }
 
 pub type AccessError = RankedError<VectorUnavailable, ANNError>;
+
+/// Validate that a bf-tree config's `cb_max_record_size` is large enough for the given
+/// key + value pair. Used by provider constructors to fail early on misconfiguration.
+pub(crate) fn validate_record_size(
+    provider_name: &str,
+    config: &bf_tree::Config,
+    key_size: usize,
+    value_size: usize,
+) -> ANNResult<()> {
+    let required = key_size + value_size;
+    let configured_max = config.get_cb_max_record_size();
+    if required > configured_max {
+        return Err(ANNError::log_index_error(format!(
+            "{provider_name}: cb_max_record_size ({configured_max}) is too small; \
+             a record requires {required} bytes ({key_size}-byte key + {value_size}-byte value); \
+             increase cb_max_record_size to at least {required}"
+        )));
+    }
+    Ok(())
+}
 
 /// Metrics recorded by [`DefaultContext`](diskann::provider::DefaultContext).
 #[derive(Debug, Clone)]

--- a/diskann-bftree/src/neighbors.rs
+++ b/diskann-bftree/src/neighbors.rs
@@ -34,6 +34,10 @@ impl<I: VectorId> HasId for NeighborProvider<I> {
 impl<I: VectorId> NeighborProvider<I> {
     /// Create a new instance based on bf-tree Config directly
     pub fn new_with_config(max_degree: u32, config: Config) -> ANNResult<Self> {
+        let key_size = std::mem::size_of::<u32>();
+        let value_size = (max_degree as usize + 1) * std::mem::size_of::<u32>();
+        crate::validate_record_size("neighbor_provider", &config, key_size, value_size)?;
+
         let adj_list_index = BfTree::with_config(config, None).map_err(ConfigError)?;
 
         Self::new(max_degree, adj_list_index)

--- a/diskann-bftree/src/provider.rs
+++ b/diskann-bftree/src/provider.rs
@@ -106,7 +106,6 @@ use diskann_providers::storage::{LoadWith, SaveWith, StorageReadProvider, Storag
 ///     dim: 4,
 ///     metric: Metric::L2,
 ///     max_degree: 32,
-///     graph_slack_factor: 1.3,
 ///     vector_provider_config: Config::default(),
 ///     quant_vector_provider_config: Config::default(),
 ///     neighbor_list_provider_config: Config::default(),
@@ -161,7 +160,6 @@ use diskann_providers::storage::{LoadWith, SaveWith, StorageReadProvider, Storag
 ///     dim: 4,
 ///     metric: Metric::L2,
 ///     max_degree: 32,
-///     graph_slack_factor: 1.3,
 ///     vector_provider_config: Config::default(),
 ///     quant_vector_provider_config: Config::default(),
 ///     neighbor_list_provider_config: Config::default(),
@@ -215,14 +213,10 @@ pub struct BfTreeProviderParameters {
     // The metric to use for distance computations
     pub metric: Metric,
 
-    // The logical maximum degree (target neighbor count per vertex).
-    // The physical neighbor list capacity is computed internally as
-    // `(max_degree * graph_slack_factor) as u32`.
+    // The physical maximum degree (maximum neighbor list capacity per vertex).
+    // Callers are responsible for applying any slack factor externally before
+    // passing this value.
     pub max_degree: u32,
-
-    // Slack factor applied to `max_degree` to determine the physical neighbor
-    // list capacity. Matches the graph construction convention (default: 1.3).
-    pub graph_slack_factor: f32,
 
     // bf-tree config for vector provider.
     // bf-tree requires a minimum circular buffer size relative to leaf_page_size:
@@ -265,8 +259,6 @@ where
         Self: StartPoint<T>,
         TQ: CreateQuantProvider<Target = Q>,
     {
-        let physical_max_degree = (params.max_degree as f32 * params.graph_slack_factor) as u32;
-
         Ok(Self {
             quant_vectors: quant_precursor.create(params.quant_vector_provider_config)?,
             full_vectors: VectorProvider::new_with_config(
@@ -276,7 +268,7 @@ where
                 params.vector_provider_config,
             )?,
             neighbor_provider: NeighborProvider::new_with_config(
-                physical_max_degree,
+                params.max_degree,
                 params.neighbor_list_provider_config,
             )?,
             metric: params.metric,
@@ -2005,7 +1997,8 @@ mod tests {
     fn create_quant_index() -> Arc<DiskANNIndex<BfTreeProvider<f32, QuantVectorProvider>>> {
         let start_point = Matrix::new(Init(|| 0.0f32), 1, 5);
         let dim = 5;
-        let max_degree = 6;
+        let logical_max_degree = 6;
+        let physical_max_degree = (logical_max_degree as f32 * 1.3) as u32;
         let metric = Metric::L2;
 
         let provider = BfTreeProvider::new(
@@ -2014,8 +2007,7 @@ mod tests {
                 num_start_points: NonZeroUsize::new(1).unwrap(),
                 dim,
                 metric,
-                max_degree,
-                graph_slack_factor: 1.3,
+                max_degree: physical_max_degree,
                 vector_provider_config: Config::default(),
                 quant_vector_provider_config: Config::default(),
                 neighbor_list_provider_config: Config::default(),
@@ -2026,10 +2018,9 @@ mod tests {
         )
         .unwrap();
 
-        let physical_max_degree = (max_degree as f32 * 1.3) as usize;
         let index_config = graph::config::Builder::new_with(
-            max_degree as usize,
-            graph::config::MaxDegree::new(physical_max_degree),
+            logical_max_degree as usize,
+            graph::config::MaxDegree::new(physical_max_degree as usize),
             10,
             metric.into(),
             |_| {},
@@ -2177,7 +2168,8 @@ mod tests {
 
     fn create_full_precision_index() -> Arc<DiskANNIndex<BfTreeProvider<f32, NoStore>>> {
         let start_point = Matrix::new(Init(|| 0.0f32), 1, 5);
-        let max_degree = 6;
+        let logical_max_degree = 6;
+        let physical_max_degree = (logical_max_degree as f32 * 1.3) as u32;
         let metric = Metric::L2;
 
         let provider = BfTreeProvider::new(
@@ -2186,8 +2178,7 @@ mod tests {
                 num_start_points: NonZeroUsize::new(1).unwrap(),
                 dim: 5,
                 metric,
-                max_degree,
-                graph_slack_factor: 1.3,
+                max_degree: physical_max_degree,
                 vector_provider_config: Config::default(),
                 quant_vector_provider_config: Config::default(),
                 neighbor_list_provider_config: Config::default(),
@@ -2198,10 +2189,9 @@ mod tests {
         )
         .unwrap();
 
-        let physical_max_degree = (max_degree as f32 * 1.3) as usize;
         let index_config = graph::config::Builder::new_with(
-            max_degree as usize,
-            graph::config::MaxDegree::new(physical_max_degree),
+            logical_max_degree as usize,
+            graph::config::MaxDegree::new(physical_max_degree as usize),
             10,
             metric.into(),
             |_| {},
@@ -2324,7 +2314,6 @@ mod tests {
                 dim,
                 metric: Metric::L2,
                 max_degree: 64,
-                graph_slack_factor: 1.3,
                 vector_provider_config: Config::default(),
                 quant_vector_provider_config: Config::default(),
                 neighbor_list_provider_config: Config::default(),
@@ -2411,7 +2400,6 @@ mod tests {
                 dim,
                 metric: Metric::L2,
                 max_degree: 64,
-                graph_slack_factor: 1.3,
                 vector_provider_config: Config::default(),
                 quant_vector_provider_config: Config::default(),
                 neighbor_list_provider_config: Config::default(),
@@ -2529,7 +2517,6 @@ mod tests {
             dim,
             metric: Metric::L2,
             max_degree,
-            graph_slack_factor: 1.3,
             vector_provider_config: vector_config.clone(),
             quant_vector_provider_config: Config::default(),
             neighbor_list_provider_config: neighbor_config.clone(),
@@ -2658,7 +2645,6 @@ mod tests {
             dim,
             metric: Metric::L2,
             max_degree,
-            graph_slack_factor: 1.3,
             vector_provider_config: vector_config.clone(),
             quant_vector_provider_config: quant_config.clone(),
             neighbor_list_provider_config: neighbor_config.clone(),
@@ -2788,7 +2774,6 @@ mod tests {
                 dim,
                 metric: Metric::L2,
                 max_degree,
-                graph_slack_factor: 1.3,
                 vector_provider_config: Config::default(),
                 quant_vector_provider_config: Config::default(),
                 neighbor_list_provider_config: Config::default(),
@@ -2896,7 +2881,6 @@ mod tests {
                 dim,
                 metric: Metric::L2,
                 max_degree,
-                graph_slack_factor: 1.3,
                 vector_provider_config: Config::default(),
                 quant_vector_provider_config: Config::default(),
                 neighbor_list_provider_config: Config::default(),

--- a/diskann-bftree/src/provider.rs
+++ b/diskann-bftree/src/provider.rs
@@ -235,6 +235,71 @@ pub struct BfTreeProviderParameters {
     pub graph_params: Option<GraphParams>,
 }
 
+impl BfTreeProviderParameters {
+    /// Validate that the bf-tree configurations are compatible with the configured
+    /// dimensions and degree.
+    ///
+    /// Each bf-tree record must fit within `cb_max_record_size`. This check catches
+    /// misconfiguration early (at provider construction) rather than silently dropping
+    /// inserts at runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `vector_provider_config` or `neighbor_list_provider_config`
+    /// has a `cb_max_record_size` too small for the configured dimensions.
+    pub fn validate<T: VectorRepr>(&self) -> ANNResult<()> {
+        Self::check_record_size(
+            "vector_provider_config",
+            &self.vector_provider_config,
+            std::mem::size_of::<usize>(),
+            self.dim * std::mem::size_of::<T>(),
+        )?;
+
+        // Neighbor key is sizeof(u32), value is (max_degree + 1) * sizeof(u32)
+        let neighbor_key_size = std::mem::size_of::<u32>();
+        let neighbor_value_size = (self.max_degree as usize + 1) * std::mem::size_of::<u32>();
+        Self::check_record_size(
+            "neighbor_list_provider_config",
+            &self.neighbor_list_provider_config,
+            neighbor_key_size,
+            neighbor_value_size,
+        )?;
+
+        Ok(())
+    }
+
+    /// Validate the quant vector provider config against a known quantized dimension.
+    ///
+    /// This must be called after the quantizer is constructed, since the compressed
+    /// vector size is only known at that point.
+    pub fn validate_quant(&self, quant_bytes: usize) -> ANNResult<()> {
+        Self::check_record_size(
+            "quant_vector_provider_config",
+            &self.quant_vector_provider_config,
+            std::mem::size_of::<usize>(),
+            quant_bytes,
+        )
+    }
+
+    fn check_record_size(
+        config_name: &str,
+        config: &Config,
+        key_size: usize,
+        value_size: usize,
+    ) -> ANNResult<()> {
+        let required = key_size + value_size;
+        let configured_max = config.get_cb_max_record_size();
+        if required > configured_max {
+            return Err(ANNError::log_index_error(format!(
+                "{config_name}: cb_max_record_size ({configured_max}) is too small; \
+                 a record requires {required} bytes ({key_size}-byte key + {value_size}-byte value); \
+                 increase cb_max_record_size to at least {required}"
+            )));
+        }
+        Ok(())
+    }
+}
+
 impl<T, Q> BfTreeProvider<T, Q>
 where
     T: VectorRepr,
@@ -257,6 +322,8 @@ where
         Self: StartPoint<T>,
         TQ: CreateQuantProvider<Target = Q>,
     {
+        params.validate::<T>()?;
+
         Ok(Self {
             quant_vectors: quant_precursor.create(params.quant_vector_provider_config)?,
             full_vectors: VectorProvider::new_with_config(
@@ -2971,5 +3038,77 @@ mod tests {
             loaded.status_by_internal_id(ctx, 0).await.unwrap(),
             ElementStatus::Valid
         );
+    }
+
+    #[test]
+    fn test_validate_rejects_undersized_vector_config() {
+        let params = BfTreeProviderParameters {
+            max_points: 100,
+            num_start_points: NonZeroUsize::new(1).unwrap(),
+            dim: 1536, // 1536 * 4 = 6144 bytes + 8-byte key = 6152 bytes needed
+            metric: Metric::L2,
+            max_degree: 8,
+            vector_provider_config: Config::default(), // cb_max_record_size = 1952
+            quant_vector_provider_config: Config::default(),
+            neighbor_list_provider_config: Config::default(),
+            graph_params: None,
+        };
+        let result = params.validate::<f32>();
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("vector_provider_config"),
+            "should name the failing config; got: {err}"
+        );
+        assert!(
+            err.contains("6152"),
+            "should state the required size; got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_rejects_undersized_neighbor_config() {
+        // max_degree=500 → value = (500+1)*4 = 2004 bytes + 4-byte key = 2008 bytes
+        let mut neighbor_config = Config::default(); // cb_max_record_size = 1952
+                                                     // Vector config is fine (dim=4, so 4*4+8=24 bytes)
+        let mut vector_config = Config::default();
+        vector_config.cb_max_record_size(4096);
+        neighbor_config.cb_max_record_size(1952);
+
+        let params = BfTreeProviderParameters {
+            max_points: 100,
+            num_start_points: NonZeroUsize::new(1).unwrap(),
+            dim: 4,
+            metric: Metric::L2,
+            max_degree: 500,
+            vector_provider_config: vector_config,
+            quant_vector_provider_config: Config::default(),
+            neighbor_list_provider_config: neighbor_config,
+            graph_params: None,
+        };
+        let result = params.validate::<f32>();
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("neighbor_list_provider_config"),
+            "should name the failing config; got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_validate_accepts_valid_config() {
+        let mut config = Config::default();
+        config.cb_max_record_size(8192);
+
+        let params = BfTreeProviderParameters {
+            max_points: 100,
+            num_start_points: NonZeroUsize::new(1).unwrap(),
+            dim: 128,
+            metric: Metric::L2,
+            max_degree: 64,
+            vector_provider_config: config.clone(),
+            quant_vector_provider_config: config.clone(),
+            neighbor_list_provider_config: config,
+            graph_params: None,
+        };
+        params.validate::<f32>().unwrap();
     }
 }

--- a/diskann-bftree/src/provider.rs
+++ b/diskann-bftree/src/provider.rs
@@ -106,6 +106,7 @@ use diskann_providers::storage::{LoadWith, SaveWith, StorageReadProvider, Storag
 ///     dim: 4,
 ///     metric: Metric::L2,
 ///     max_degree: 32,
+///     graph_slack_factor: 1.3,
 ///     vector_provider_config: Config::default(),
 ///     quant_vector_provider_config: Config::default(),
 ///     neighbor_list_provider_config: Config::default(),
@@ -160,6 +161,7 @@ use diskann_providers::storage::{LoadWith, SaveWith, StorageReadProvider, Storag
 ///     dim: 4,
 ///     metric: Metric::L2,
 ///     max_degree: 32,
+///     graph_slack_factor: 1.3,
 ///     vector_provider_config: Config::default(),
 ///     quant_vector_provider_config: Config::default(),
 ///     neighbor_list_provider_config: Config::default(),
@@ -213,8 +215,14 @@ pub struct BfTreeProviderParameters {
     // The metric to use for distance computations
     pub metric: Metric,
 
-    // The maximum number of neighbors to store for each vector
+    // The logical maximum degree (target neighbor count per vertex).
+    // The physical neighbor list capacity is computed internally as
+    // `(max_degree * graph_slack_factor) as u32`.
     pub max_degree: u32,
+
+    // Slack factor applied to `max_degree` to determine the physical neighbor
+    // list capacity. Matches the graph construction convention (default: 1.3).
+    pub graph_slack_factor: f32,
 
     // bf-tree config for vector provider.
     // bf-tree requires a minimum circular buffer size relative to leaf_page_size:
@@ -257,6 +265,8 @@ where
         Self: StartPoint<T>,
         TQ: CreateQuantProvider<Target = Q>,
     {
+        let physical_max_degree = (params.max_degree as f32 * params.graph_slack_factor) as u32;
+
         Ok(Self {
             quant_vectors: quant_precursor.create(params.quant_vector_provider_config)?,
             full_vectors: VectorProvider::new_with_config(
@@ -266,7 +276,7 @@ where
                 params.vector_provider_config,
             )?,
             neighbor_provider: NeighborProvider::new_with_config(
-                params.max_degree,
+                physical_max_degree,
                 params.neighbor_list_provider_config,
             )?,
             metric: params.metric,
@@ -1995,7 +2005,7 @@ mod tests {
     fn create_quant_index() -> Arc<DiskANNIndex<BfTreeProvider<f32, QuantVectorProvider>>> {
         let start_point = Matrix::new(Init(|| 0.0f32), 1, 5);
         let dim = 5;
-        let max_degree = 8;
+        let max_degree = 6;
         let metric = Metric::L2;
 
         let provider = BfTreeProvider::new(
@@ -2005,6 +2015,7 @@ mod tests {
                 dim,
                 metric,
                 max_degree,
+                graph_slack_factor: 1.3,
                 vector_provider_config: Config::default(),
                 quant_vector_provider_config: Config::default(),
                 neighbor_list_provider_config: Config::default(),
@@ -2015,9 +2026,10 @@ mod tests {
         )
         .unwrap();
 
+        let physical_max_degree = (max_degree as f32 * 1.3) as usize;
         let index_config = graph::config::Builder::new_with(
-            4,
-            graph::config::MaxDegree::new(max_degree as usize),
+            max_degree as usize,
+            graph::config::MaxDegree::new(physical_max_degree),
             10,
             metric.into(),
             |_| {},
@@ -2165,7 +2177,7 @@ mod tests {
 
     fn create_full_precision_index() -> Arc<DiskANNIndex<BfTreeProvider<f32, NoStore>>> {
         let start_point = Matrix::new(Init(|| 0.0f32), 1, 5);
-        let max_degree = 8;
+        let max_degree = 6;
         let metric = Metric::L2;
 
         let provider = BfTreeProvider::new(
@@ -2175,6 +2187,7 @@ mod tests {
                 dim: 5,
                 metric,
                 max_degree,
+                graph_slack_factor: 1.3,
                 vector_provider_config: Config::default(),
                 quant_vector_provider_config: Config::default(),
                 neighbor_list_provider_config: Config::default(),
@@ -2185,9 +2198,10 @@ mod tests {
         )
         .unwrap();
 
+        let physical_max_degree = (max_degree as f32 * 1.3) as usize;
         let index_config = graph::config::Builder::new_with(
-            4,
-            graph::config::MaxDegree::new(max_degree as usize),
+            max_degree as usize,
+            graph::config::MaxDegree::new(physical_max_degree),
             10,
             metric.into(),
             |_| {},
@@ -2310,6 +2324,7 @@ mod tests {
                 dim,
                 metric: Metric::L2,
                 max_degree: 64,
+                graph_slack_factor: 1.3,
                 vector_provider_config: Config::default(),
                 quant_vector_provider_config: Config::default(),
                 neighbor_list_provider_config: Config::default(),
@@ -2396,6 +2411,7 @@ mod tests {
                 dim,
                 metric: Metric::L2,
                 max_degree: 64,
+                graph_slack_factor: 1.3,
                 vector_provider_config: Config::default(),
                 quant_vector_provider_config: Config::default(),
                 neighbor_list_provider_config: Config::default(),
@@ -2513,6 +2529,7 @@ mod tests {
             dim,
             metric: Metric::L2,
             max_degree,
+            graph_slack_factor: 1.3,
             vector_provider_config: vector_config.clone(),
             quant_vector_provider_config: Config::default(),
             neighbor_list_provider_config: neighbor_config.clone(),
@@ -2641,6 +2658,7 @@ mod tests {
             dim,
             metric: Metric::L2,
             max_degree,
+            graph_slack_factor: 1.3,
             vector_provider_config: vector_config.clone(),
             quant_vector_provider_config: quant_config.clone(),
             neighbor_list_provider_config: neighbor_config.clone(),
@@ -2770,6 +2788,7 @@ mod tests {
                 dim,
                 metric: Metric::L2,
                 max_degree,
+                graph_slack_factor: 1.3,
                 vector_provider_config: Config::default(),
                 quant_vector_provider_config: Config::default(),
                 neighbor_list_provider_config: Config::default(),
@@ -2877,6 +2896,7 @@ mod tests {
                 dim,
                 metric: Metric::L2,
                 max_degree,
+                graph_slack_factor: 1.3,
                 vector_provider_config: Config::default(),
                 quant_vector_provider_config: Config::default(),
                 neighbor_list_provider_config: Config::default(),

--- a/diskann-bftree/src/provider.rs
+++ b/diskann-bftree/src/provider.rs
@@ -235,58 +235,6 @@ pub struct BfTreeProviderParameters {
     pub graph_params: Option<GraphParams>,
 }
 
-impl BfTreeProviderParameters {
-    /// Validate that the bf-tree configurations are compatible with the configured
-    /// dimensions and degree.
-    ///
-    /// Each bf-tree record must fit within `cb_max_record_size`. This check catches
-    /// misconfiguration early (at provider construction) rather than silently dropping
-    /// inserts at runtime.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if `vector_provider_config` or `neighbor_list_provider_config`
-    /// has a `cb_max_record_size` too small for the configured dimensions.
-    pub fn validate<T: VectorRepr>(&self) -> ANNResult<()> {
-        Self::check_record_size(
-            "vector_provider_config",
-            &self.vector_provider_config,
-            std::mem::size_of::<usize>(),
-            self.dim * std::mem::size_of::<T>(),
-        )?;
-
-        // Neighbor key is sizeof(u32), value is (max_degree + 1) * sizeof(u32)
-        let neighbor_key_size = std::mem::size_of::<u32>();
-        let neighbor_value_size = (self.max_degree as usize + 1) * std::mem::size_of::<u32>();
-        Self::check_record_size(
-            "neighbor_list_provider_config",
-            &self.neighbor_list_provider_config,
-            neighbor_key_size,
-            neighbor_value_size,
-        )?;
-
-        Ok(())
-    }
-
-    fn check_record_size(
-        config_name: &str,
-        config: &Config,
-        key_size: usize,
-        value_size: usize,
-    ) -> ANNResult<()> {
-        let required = key_size + value_size;
-        let configured_max = config.get_cb_max_record_size();
-        if required > configured_max {
-            return Err(ANNError::log_index_error(format!(
-                "{config_name}: cb_max_record_size ({configured_max}) is too small; \
-                 a record requires {required} bytes ({key_size}-byte key + {value_size}-byte value); \
-                 increase cb_max_record_size to at least {required}"
-            )));
-        }
-        Ok(())
-    }
-}
-
 impl<T, Q> BfTreeProvider<T, Q>
 where
     T: VectorRepr,
@@ -309,8 +257,6 @@ where
         Self: StartPoint<T>,
         TQ: CreateQuantProvider<Target = Q>,
     {
-        params.validate::<T>()?;
-
         Ok(Self {
             quant_vectors: quant_precursor.create(params.quant_vector_provider_config)?,
             full_vectors: VectorProvider::new_with_config(
@@ -545,17 +491,6 @@ impl CreateQuantProvider for NoStore {
 impl CreateQuantProvider for Poly<dyn Quantizer> {
     type Target = QuantVectorProvider;
     fn create(self, bf_tree_config: Config) -> ANNResult<Self::Target> {
-        let key_size = std::mem::size_of::<usize>();
-        let value_size = self.bytes();
-        let required = key_size + value_size;
-        let configured_max = bf_tree_config.get_cb_max_record_size();
-        if required > configured_max {
-            return Err(ANNError::log_index_error(format!(
-                "quant_vector_provider_config: cb_max_record_size ({configured_max}) is too small; \
-                 a record requires {required} bytes ({key_size}-byte key + {value_size}-byte value); \
-                 increase cb_max_record_size to at least {required}"
-            )));
-        }
         QuantVectorProvider::new_with_config(self, bf_tree_config)
     }
 }
@@ -2046,7 +1981,9 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use crate::neighbors::NeighborProvider;
     use crate::quant::create_test_quantizer;
+    use crate::vectors::VectorProvider;
     use diskann::{
         graph::DiskANNIndex,
         graph::{self, search::Knn},
@@ -3040,21 +2977,16 @@ mod tests {
 
     #[test]
     fn test_validate_rejects_undersized_vector_config() {
-        let params = BfTreeProviderParameters {
-            max_points: 100,
-            num_start_points: NonZeroUsize::new(1).unwrap(),
-            dim: 1536, // 1536 * 4 = 6144 bytes + 8-byte key = 6152 bytes needed
-            metric: Metric::L2,
-            max_degree: 8,
-            vector_provider_config: Config::default(), // cb_max_record_size = 1952
-            quant_vector_provider_config: Config::default(),
-            neighbor_list_provider_config: Config::default(),
-            graph_params: None,
-        };
-        let result = params.validate::<f32>();
-        let err = result.unwrap_err().to_string();
+        // 1536 * 4 = 6144 bytes + 8-byte key = 6152 bytes needed
+        let result = VectorProvider::<f32>::new_with_config(
+            100,
+            1536,
+            1,
+            Config::default(), // cb_max_record_size = 1952
+        );
+        let err = result.err().expect("should fail").to_string();
         assert!(
-            err.contains("vector_provider_config"),
+            err.contains("vector_provider"),
             "should name the failing config; got: {err}"
         );
         assert!(
@@ -3066,47 +2998,26 @@ mod tests {
     #[test]
     fn test_validate_rejects_undersized_neighbor_config() {
         // max_degree=500 → value = (500+1)*4 = 2004 bytes + 4-byte key = 2008 bytes
-        let mut neighbor_config = Config::default(); // cb_max_record_size = 1952
-                                                     // Vector config is fine (dim=4, so 4*4+8=24 bytes)
-        let mut vector_config = Config::default();
-        vector_config.cb_max_record_size(4096);
+        let mut neighbor_config = Config::default();
         neighbor_config.cb_max_record_size(1952);
 
-        let params = BfTreeProviderParameters {
-            max_points: 100,
-            num_start_points: NonZeroUsize::new(1).unwrap(),
-            dim: 4,
-            metric: Metric::L2,
-            max_degree: 500,
-            vector_provider_config: vector_config,
-            quant_vector_provider_config: Config::default(),
-            neighbor_list_provider_config: neighbor_config,
-            graph_params: None,
-        };
-        let result = params.validate::<f32>();
-        let err = result.unwrap_err().to_string();
+        let result = NeighborProvider::<u32>::new_with_config(500, neighbor_config);
+        let err = result.err().expect("should fail").to_string();
         assert!(
-            err.contains("neighbor_list_provider_config"),
+            err.contains("neighbor_provider"),
             "should name the failing config; got: {err}"
         );
     }
 
     #[test]
     fn test_validate_accepts_valid_config() {
-        let mut config = Config::default();
-        config.cb_max_record_size(8192);
-
-        let params = BfTreeProviderParameters {
-            max_points: 100,
-            num_start_points: NonZeroUsize::new(1).unwrap(),
-            dim: 128,
-            metric: Metric::L2,
-            max_degree: 64,
-            vector_provider_config: config.clone(),
-            quant_vector_provider_config: config.clone(),
-            neighbor_list_provider_config: config,
-            graph_params: None,
-        };
-        params.validate::<f32>().unwrap();
+        // dim=128, f32 → key=8 + value=512 = 520 bytes, fits default 1952
+        if let Err(e) = VectorProvider::<f32>::new_with_config(100, 128, 1, Config::default()) {
+            panic!("VectorProvider should succeed: {e}");
+        }
+        // max_degree=64 → key=4 + value=(64+1)*4 = 264 bytes, fits default 1952
+        if let Err(e) = NeighborProvider::<u32>::new_with_config(64, Config::default()) {
+            panic!("NeighborProvider should succeed: {e}");
+        }
     }
 }

--- a/diskann-bftree/src/provider.rs
+++ b/diskann-bftree/src/provider.rs
@@ -268,19 +268,6 @@ impl BfTreeProviderParameters {
         Ok(())
     }
 
-    /// Validate the quant vector provider config against a known quantized dimension.
-    ///
-    /// This must be called after the quantizer is constructed, since the compressed
-    /// vector size is only known at that point.
-    pub fn validate_quant(&self, quant_bytes: usize) -> ANNResult<()> {
-        Self::check_record_size(
-            "quant_vector_provider_config",
-            &self.quant_vector_provider_config,
-            std::mem::size_of::<usize>(),
-            quant_bytes,
-        )
-    }
-
     fn check_record_size(
         config_name: &str,
         config: &Config,
@@ -558,6 +545,17 @@ impl CreateQuantProvider for NoStore {
 impl CreateQuantProvider for Poly<dyn Quantizer> {
     type Target = QuantVectorProvider;
     fn create(self, bf_tree_config: Config) -> ANNResult<Self::Target> {
+        let key_size = std::mem::size_of::<usize>();
+        let value_size = self.bytes();
+        let required = key_size + value_size;
+        let configured_max = bf_tree_config.get_cb_max_record_size();
+        if required > configured_max {
+            return Err(ANNError::log_index_error(format!(
+                "quant_vector_provider_config: cb_max_record_size ({configured_max}) is too small; \
+                 a record requires {required} bytes ({key_size}-byte key + {value_size}-byte value); \
+                 increase cb_max_record_size to at least {required}"
+            )));
+        }
         QuantVectorProvider::new_with_config(self, bf_tree_config)
     }
 }

--- a/diskann-bftree/src/quant.rs
+++ b/diskann-bftree/src/quant.rs
@@ -38,6 +38,13 @@ pub struct QuantVectorProvider {
 
 impl QuantVectorProvider {
     pub fn new_with_config(quantizer: Poly<dyn Quantizer>, config: Config) -> ANNResult<Self> {
+        crate::validate_record_size(
+            "quant_vector_provider",
+            &config,
+            std::mem::size_of::<usize>(),
+            quantizer.bytes(),
+        )?;
+
         let quant_vector_index = BfTree::with_config(config, None).map_err(ConfigError)?;
 
         Ok(Self {

--- a/diskann-bftree/src/vectors.rs
+++ b/diskann-bftree/src/vectors.rs
@@ -33,6 +33,13 @@ impl<T: VectorRepr> VectorProvider<T> {
         num_start_points: usize,
         config: Config,
     ) -> ANNResult<Self> {
+        crate::validate_record_size(
+            "vector_provider",
+            &config,
+            std::mem::size_of::<usize>(),
+            dim * std::mem::size_of::<T>(),
+        )?;
+
         let vector_index = BfTree::with_config(config, None).map_err(ConfigError)?;
 
         Ok(Self {


### PR DESCRIPTION
Problem

BfTree::insert returns a LeafInsertResult indicating success or failure, but all three sub-providers (vectors, neighbors, quant) were discarding it unconditionally. When a record exceeds cb_max_record_size, the insert silently fails and later surfaces as a misleading "vector not found" error during search.

This is the root cause of #1159 (https://github.com/microsoft/DiskANN/issues/1159): the default cb_max_record_size (1952 bytes) is too small for 1536D f32 vectors (8-byte key + 6144-byte value = 6152 bytes), but the failure was swallowed at insert time.

Solution

Early validation at provider construction:

BfTreeProviderParameters::validate::<T>() checks that cb_max_record_size is large enough for both the vector and neighbor stores before any BfTree is created. For the quant store, validation is performed inside the Poly<dyn Quantizer> impl of CreateQuantProvider::create, where quantizer.bytes() is known — no separate call needed.

Defense in depth at every insert site:

All insert() calls in vectors.rs, neighbors.rs, and quant.rs now match on LeafInsertResult::InvalidKV and propagate a clear ANNError. This catches cases where validation is bypassed (e.g., loading from a snapshot with a changed config).

Error message example:

 vector_provider_config: cb_max_record_size (1952) is too small;
 a record requires 6152 bytes (8-byte key + 6144-byte value);
 increase cb_max_record_size to at least 6152

Fixes #1159. Supersedes #1164 

Testing

 - test_validate_rejects_undersized_vector_config — 1536D f32 + default config
 - test_validate_rejects_undersized_neighbor_config — max_degree=500 exceeding default
 - test_validate_accepts_valid_config — properly sized config passes
