### PR TITLE
[diskann-garnet] Improve code coverage

### DIFF
--- a/diskann-garnet/src/ffi_tests.rs
+++ b/diskann-garnet/src/ffi_tests.rs
@@ -7,16 +7,22 @@ mod tests {
     use std::{ffi::c_void, mem, ptr};
 
     use diskann_vector::distance::Metric;
+    use rand::{Rng, seq::SliceRandom};
 
     use crate::{
-        VectorQuantType, card, check_external_id_valid, create_index, drop_index, garnet::Context,
-        insert, remove, search_vector, set_attribute, test_utils::Store,
+        Index, InsertResult, VectorQuantType, backfill_quant_vectors, build_quant_table, card,
+        check_external_id_valid, check_internal_id_valid, create_index, drop_index,
+        garnet::{Context, Term},
+        insert,
+        quantization::{GarnetQuantizer, Spherical1Bit},
+        remove, search_vector, set_attribute,
+        test_utils::Store,
     };
 
     /// Creates an index with default test values and returns (index_ptr, Context).
     /// The caller is responsible for calling drop_index when done.
-    fn create_test_index(store: &Store) -> (*const c_void, Context) {
-        let (index_ptr, ctx) = create_test_index_with_metric(store, Metric::L2 as i32);
+    fn create_test_index(store: &Store, quant_type: VectorQuantType) -> (*const c_void, Context) {
+        let (index_ptr, ctx) = create_test_index_with_metric(store, quant_type, Metric::L2 as i32);
         assert!(
             !index_ptr.is_null(),
             "create_test_index failed to create index"
@@ -26,7 +32,11 @@ mod tests {
 
     /// Creates an index with specified metric type and returns (index_ptr, Context).
     /// The caller is responsible for calling drop_index when done.
-    fn create_test_index_with_metric(store: &Store, metric_type: i32) -> (*const c_void, Context) {
+    fn create_test_index_with_metric(
+        store: &Store,
+        quant_type: VectorQuantType,
+        metric_type: i32,
+    ) -> (*const c_void, Context) {
         store.clear();
 
         let callbacks = store.callbacks();
@@ -34,7 +44,6 @@ mod tests {
 
         let dim: u32 = 2;
         let reduce_dim = 0;
-        let quant_type = VectorQuantType::NoQuant;
         let l_build = 10;
         let max_degree = 20;
 
@@ -60,7 +69,7 @@ mod tests {
     #[test]
     fn basic_create_index() {
         let store = Store;
-        let (index_ptr, ctx) = create_test_index(&store);
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
         assert!(!index_ptr.is_null());
 
         unsafe {
@@ -76,7 +85,8 @@ mod tests {
         let invalid_metrics = [-1, -2, 99, i32::MAX, i32::MIN];
 
         for invalid_metric in invalid_metrics {
-            let (index_ptr, _ctx) = create_test_index_with_metric(&store, invalid_metric);
+            let (index_ptr, _ctx) =
+                create_test_index_with_metric(&store, VectorQuantType::NoQuant, invalid_metric);
             assert!(
                 index_ptr.is_null(),
                 "Expected null for invalid metric_type={}",
@@ -98,7 +108,8 @@ mod tests {
         ];
 
         for valid_metric in valid_metrics {
-            let (index_ptr, ctx) = create_test_index_with_metric(&store, valid_metric);
+            let (index_ptr, ctx) =
+                create_test_index_with_metric(&store, VectorQuantType::NoQuant, valid_metric);
             assert!(
                 !index_ptr.is_null(),
                 "Expected non-null for valid metric_type_raw={}",
@@ -113,7 +124,7 @@ mod tests {
     #[test]
     fn add_check_and_remove_vector() {
         let store = Store;
-        let (index_ptr, ctx) = create_test_index(&store);
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
 
         // Vector id with 4 bytes size
         let garnet_vector_id = 42u32;
@@ -165,7 +176,7 @@ mod tests {
     #[test]
     fn update_vector_attributes() {
         let store = Store;
-        let (index_ptr, ctx) = create_test_index(&store);
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
 
         // Vector id with 4 bytes size
         let garnet_vector_id = 42u32;
@@ -250,7 +261,7 @@ mod tests {
     #[test]
     fn external_id_exists_lifecycle() {
         let store = Store;
-        let (index_ptr, ctx) = create_test_index(&store);
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
 
         // EID 1
         let eid1 = 1u32;
@@ -336,11 +347,80 @@ mod tests {
         }
     }
 
+    #[test]
+    fn internal_id_exists_lifecycle() {
+        let store = Store;
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
+
+        let bad_iid_bytes = [0u8; 5];
+        let exists0 = unsafe {
+            check_internal_id_valid(
+                ctx.get(),
+                index_ptr,
+                bad_iid_bytes.as_ptr(),
+                bad_iid_bytes.len(),
+            )
+        };
+        assert!(!exists0, "Bad ID should not exist");
+
+        let eid = 1u32;
+        let eid_bytes = bytemuck::bytes_of(&eid);
+
+        let vector: [f32; 2] = [1.0, 2.0];
+        let vector_bytes = bytemuck::cast_slice(&vector);
+        let vector_len = 2;
+
+        // First insert will get ID=1
+        let iid = 1u32;
+        let iid_bytes = bytemuck::bytes_of(&iid);
+
+        // Check internal ID does not exist
+        let exists1 = unsafe {
+            check_internal_id_valid(ctx.get(), index_ptr, iid_bytes.as_ptr(), iid_bytes.len())
+        };
+        assert!(!exists1, "ID should not exist initially");
+
+        // Insert vector
+        let insert_result = unsafe {
+            insert(
+                ctx.get(),
+                index_ptr,
+                eid_bytes.as_ptr(),
+                eid_bytes.len(),
+                vector_bytes.as_ptr(),
+                vector_len,
+                ptr::null(),
+                0,
+            )
+        };
+        assert!(insert_result > 0, "Insert should succeed");
+
+        // Check internal id exists
+        let exists2 = unsafe {
+            check_internal_id_valid(ctx.get(), index_ptr, iid_bytes.as_ptr(), iid_bytes.len())
+        };
+        assert!(exists2, "ID should exist after insert");
+
+        // Remove vector
+        let removed = unsafe { remove(ctx.get(), index_ptr, eid_bytes.as_ptr(), eid_bytes.len()) };
+        assert!(removed, "Remove with EID 1 should succeed");
+
+        // Check internal ID does not exist now
+        let exists3 = unsafe {
+            check_internal_id_valid(ctx.get(), index_ptr, iid_bytes.as_ptr(), iid_bytes.len())
+        };
+        assert!(!exists3, "ID should not exist after removal");
+
+        unsafe {
+            drop_index(ctx.get(), index_ptr);
+        }
+    }
+
     /// Using u64 external IDs, insert some vectors and ensure search results are same.
     #[test]
     fn search_with_large_external_ids() {
         let store = Store;
-        let (index_ptr, ctx) = create_test_index(&store);
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
 
         let id1 = 1234u64;
         let v1 = &[1.0f32, 0.0];
@@ -445,13 +525,138 @@ mod tests {
         }
     }
 
+    #[test]
+    fn search_element() {
+        let store = Store;
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
+
+        let id1 = 1234u64;
+        let v1 = &[1.0f32, 0.0];
+        let id2 = 5678u64;
+        let v2 = &[0.0f32, 1.0];
+
+        let id1_bytes = bytemuck::bytes_of(&id1);
+        let id2_bytes = bytemuck::bytes_of(&id2);
+
+        assert!(
+            unsafe {
+                insert(
+                    ctx.get(),
+                    index_ptr,
+                    id1_bytes.as_ptr(),
+                    id1_bytes.len(),
+                    bytemuck::cast_slice::<f32, u8>(v1).as_ptr(),
+                    v1.len(),
+                    b"".as_ptr(),
+                    0,
+                )
+            } > 0
+        );
+
+        assert!(
+            unsafe {
+                insert(
+                    ctx.get(),
+                    index_ptr,
+                    id2_bytes.as_ptr(),
+                    id2_bytes.len(),
+                    bytemuck::cast_slice::<f32, u8>(v2).as_ptr(),
+                    v2.len(),
+                    b"".as_ptr(),
+                    0,
+                )
+            } > 0
+        );
+
+        let mut output_id_buffer = vec![0u8; 2 * (mem::size_of::<u64>() + mem::size_of::<u32>())];
+        let mut output_dists = vec![0f32; 2];
+
+        let count = unsafe {
+            crate::search_element(
+                ctx.get(),
+                index_ptr,
+                id1_bytes.as_ptr(),
+                id1_bytes.len(),
+                2.0,
+                10,
+                ptr::null(),
+                0,
+                0,
+                output_id_buffer.as_mut_ptr(),
+                output_id_buffer.len(),
+                output_dists.as_mut_ptr(),
+                output_dists.len(),
+                ptr::null_mut(),
+            )
+        };
+
+        assert_eq!(count, 2);
+
+        let mut output_ids = vec![];
+        let mut offset = 0;
+        for _ in 0..(count as usize) {
+            let mut id_len = 0u32;
+            bytemuck::bytes_of_mut(&mut id_len)
+                .copy_from_slice(&output_id_buffer[offset..offset + mem::size_of::<u32>()]);
+            offset += mem::size_of::<u32>();
+
+            assert_eq!(id_len, mem::size_of::<u64>() as u32);
+
+            let mut id = 0u64;
+            bytemuck::bytes_of_mut(&mut id)
+                .copy_from_slice(&output_id_buffer[offset..offset + mem::size_of::<u64>()]);
+            offset += mem::size_of::<u64>();
+
+            output_ids.push(id);
+        }
+
+        match (output_ids[0], output_ids[1]) {
+            (1234u64, 5678u64) => {
+                assert_eq!(output_dists[0], 0.0);
+                assert_eq!(output_dists[1], 2.0);
+            }
+            (5678u64, 1234u64) => {
+                assert_eq!(output_dists[0], 2.0);
+                assert_eq!(output_dists[1], 0.0);
+            }
+            _ => {
+                panic!("got unexpected ids {} and {}", output_ids[0], output_ids[1]);
+            }
+        }
+
+        unsafe {
+            drop_index(ctx.get(), index_ptr);
+        }
+    }
+
+    #[test]
+    fn continue_search() {
+        let store = Store;
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
+        let mut output_id_buffer = vec![0u8; 2 * (mem::size_of::<u64>() + mem::size_of::<u32>())];
+        let mut output_dists = vec![0f32; 2];
+        let res = unsafe {
+            crate::continue_search(
+                ctx.get(),
+                index_ptr,
+                ptr::null_mut(),
+                output_id_buffer.as_mut_ptr(),
+                output_id_buffer.len(),
+                output_dists.as_mut_ptr(),
+                output_dists.len(),
+                ptr::null_mut(),
+            )
+        };
+        assert_eq!(res, -1);
+    }
+
     /// Helper to insert a vector with u32 external ID and FP32 data.
     fn insert_f32_vector(
         ctx: &Context,
         index_ptr: *const c_void,
         eid: u32,
         vector: &[f32],
-    ) -> bool {
+    ) -> InsertResult {
         let id_bytes = bytemuck::bytes_of(&eid);
         let vector_bytes = bytemuck::cast_slice(vector);
         unsafe {
@@ -464,7 +669,8 @@ mod tests {
                 vector.len(),
                 b"".as_ptr(),
                 0,
-            ) > 0
+            )
+            .into()
         }
     }
 
@@ -528,12 +734,21 @@ mod tests {
     #[test]
     fn search_without_filter() {
         let store = Store;
-        let (index_ptr, ctx) = create_test_index(&store);
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
 
         unsafe {
-            assert!(insert_f32_vector(&ctx, index_ptr, 10, &[1.0, 0.0]));
-            assert!(insert_f32_vector(&ctx, index_ptr, 20, &[0.0, 1.0]));
-            assert!(insert_f32_vector(&ctx, index_ptr, 30, &[1.0, 1.0]));
+            assert_eq!(
+                insert_f32_vector(&ctx, index_ptr, 10, &[1.0, 0.0]),
+                InsertResult::Success
+            );
+            assert_eq!(
+                insert_f32_vector(&ctx, index_ptr, 20, &[0.0, 1.0]),
+                InsertResult::Success
+            );
+            assert_eq!(
+                insert_f32_vector(&ctx, index_ptr, 30, &[1.0, 1.0]),
+                InsertResult::Success
+            );
 
             let (ids, _dists) = do_search(&ctx, index_ptr, &[1.0, 0.0], 3, None);
             assert!(ids.len() >= 2, "should return at least 2 vectors");
@@ -547,12 +762,21 @@ mod tests {
     #[test]
     fn search_with_bitmap_all_match() {
         let store = Store;
-        let (index_ptr, ctx) = create_test_index(&store);
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
 
         unsafe {
-            assert!(insert_f32_vector(&ctx, index_ptr, 10, &[1.0, 0.0]));
-            assert!(insert_f32_vector(&ctx, index_ptr, 20, &[0.0, 1.0]));
-            assert!(insert_f32_vector(&ctx, index_ptr, 30, &[1.0, 1.0]));
+            assert_eq!(
+                insert_f32_vector(&ctx, index_ptr, 10, &[1.0, 0.0]),
+                InsertResult::Success
+            );
+            assert_eq!(
+                insert_f32_vector(&ctx, index_ptr, 20, &[0.0, 1.0]),
+                InsertResult::Success
+            );
+            assert_eq!(
+                insert_f32_vector(&ctx, index_ptr, 30, &[1.0, 1.0]),
+                InsertResult::Success
+            );
 
             // Bitmap with bits 1,2,3 set (internal IDs for the 3 inserted vectors;
             // internal ID 0 is the start point)
@@ -570,15 +794,24 @@ mod tests {
     #[test]
     fn search_with_bitmap_partial_match() {
         let store = Store;
-        let (index_ptr, ctx) = create_test_index(&store);
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
 
         unsafe {
             // Internal ID 0 -> EID 10, vector [1,0]
-            assert!(insert_f32_vector(&ctx, index_ptr, 10, &[1.0, 0.0]));
+            assert_eq!(
+                insert_f32_vector(&ctx, index_ptr, 10, &[1.0, 0.0]),
+                InsertResult::Success
+            );
             // Internal ID 1 -> EID 20, vector [0,1]
-            assert!(insert_f32_vector(&ctx, index_ptr, 20, &[0.0, 1.0]));
+            assert_eq!(
+                insert_f32_vector(&ctx, index_ptr, 20, &[0.0, 1.0]),
+                InsertResult::Success
+            );
             // Internal ID 2 -> EID 30, vector [1,1]
-            assert!(insert_f32_vector(&ctx, index_ptr, 30, &[1.0, 1.0]));
+            assert_eq!(
+                insert_f32_vector(&ctx, index_ptr, 30, &[1.0, 1.0]),
+                InsertResult::Success
+            );
 
             // Bitmap with only bit 2 set (internal ID 2 = EID 20, second inserted vector)
             let bitmap: [u8; 8] = [0b00000100, 0, 0, 0, 0, 0, 0, 0];
@@ -599,11 +832,17 @@ mod tests {
     #[test]
     fn search_with_null_bitmap_same_as_unfiltered() {
         let store = Store;
-        let (index_ptr, ctx) = create_test_index(&store);
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
 
         unsafe {
-            assert!(insert_f32_vector(&ctx, index_ptr, 10, &[1.0, 0.0]));
-            assert!(insert_f32_vector(&ctx, index_ptr, 20, &[0.0, 1.0]));
+            assert_eq!(
+                insert_f32_vector(&ctx, index_ptr, 10, &[1.0, 0.0]),
+                InsertResult::Success
+            );
+            assert_eq!(
+                insert_f32_vector(&ctx, index_ptr, 20, &[0.0, 1.0]),
+                InsertResult::Success
+            );
 
             // Null bitmap should behave like no filter
             let (ids_null, dists_null) = do_search(&ctx, index_ptr, &[1.0, 0.0], 2, None);
@@ -614,6 +853,109 @@ mod tests {
             assert_eq!(ids_null, ids_empty);
             assert_eq!(dists_null, dists_empty);
 
+            drop_index(ctx.get(), index_ptr);
+        }
+    }
+
+    #[test]
+    fn basic_quant_bootstrap_lifecycle_bin() {
+        let store = Store;
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::Bin);
+        let index = unsafe { &*index_ptr.cast::<Index>() };
+
+        let quantizer = Spherical1Bit::new(2);
+        let required_vectors = quantizer.required_vectors();
+
+        let mut rng = rand::rng();
+
+        // pre-quantization phase
+
+        assert_eq!(index.inner.approximate_count(), 0);
+        for id in 0..required_vectors - 1 {
+            let v = [rng.random(), rng.random()];
+            assert_eq!(
+                insert_f32_vector(&ctx, index_ptr, id as u32, &v),
+                InsertResult::Success
+            );
+        }
+        assert_eq!(
+            index.inner.approximate_count() as usize,
+            required_vectors - 1
+        );
+
+        // transition phase
+
+        let v = [rng.random(), rng.random()];
+        assert_eq!(
+            insert_f32_vector(&ctx, index_ptr, required_vectors as u32 - 1, &v),
+            InsertResult::SuccessStartTraining
+        );
+
+        // signal to train the quantizer
+
+        let res = unsafe { build_quant_table(ctx.get(), index_ptr) };
+        assert!(res, "quantizer training failed");
+
+        // new inserts will be quantized
+
+        let v = [rng.random(), rng.random()];
+        assert_eq!(
+            insert_f32_vector(&ctx, index_ptr, required_vectors as u32, &v),
+            InsertResult::Success
+        );
+
+        // previous insert is unquantized; inserted before training
+        let iid = required_vectors as u32;
+        assert!(
+            store
+                .get(ctx.term(Term::Quantized).get(), bytemuck::bytes_of(&iid))
+                .is_none()
+        );
+
+        // latest insert is quantized
+        let iid = required_vectors as u32 + 1; // +1 to account for the start vector
+        let qv = store
+            .get(ctx.term(Term::Quantized).get(), bytemuck::bytes_of(&iid))
+            .expect("missing quant vector");
+        assert_eq!(qv.len(), quantizer.bytes());
+
+        // backfill quant vectors
+
+        unsafe { backfill_quant_vectors(ctx.get(), index_ptr, 0, 1) };
+
+        // all previous inserts are now quantized
+        for iid in 1..=required_vectors as u32 {
+            let qv = store
+                .get(ctx.term(Term::Quantized).get(), bytemuck::bytes_of(&iid))
+                .expect("missing quant vector");
+            assert_eq!(qv.len(), quantizer.bytes());
+        }
+
+        // do a search
+        let qv = [0.5f32, 0.5];
+        let (ids, _dists) = do_search(&ctx, index_ptr, &qv, 10, None);
+        assert!(!ids.is_empty(), "no results found");
+
+        // delete some vectors
+        let mut to_delete = (0..required_vectors as u32).collect::<Vec<_>>();
+        to_delete.shuffle(&mut rng);
+        for id in to_delete.into_iter().take(100) {
+            assert!(unsafe {
+                remove(
+                    ctx.get(),
+                    index_ptr,
+                    bytemuck::bytes_of(&id).as_ptr(),
+                    mem::size_of::<u32>(),
+                )
+            });
+        }
+
+        // do another search
+        let qv = [0.5f32, 0.5];
+        let (ids, _dists) = do_search(&ctx, index_ptr, &qv, 10, None);
+        assert!(!ids.is_empty(), "no results found");
+
+        unsafe {
             drop_index(ctx.get(), index_ptr);
         }
     }

--- a/diskann-garnet/src/lib.rs
+++ b/diskann-garnet/src/lib.rs
@@ -55,6 +55,7 @@ mod quantization;
 #[cfg(test)]
 mod test_utils;
 
+#[derive(Debug, PartialEq)]
 enum IndexState {
     NoStartPoints,
     SettingStartPoints,
@@ -370,6 +371,7 @@ fn interpret_vector<'a>(
     Some(v)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq)]
 enum InsertResult {
     Fail,
     Success,
@@ -382,6 +384,17 @@ impl From<InsertResult> for u8 {
             InsertResult::Fail => 0,
             InsertResult::Success => 1,
             InsertResult::SuccessStartTraining => 2,
+        }
+    }
+}
+
+#[cfg(test)]
+impl From<u8> for InsertResult {
+    fn from(value: u8) -> Self {
+        match value {
+            1 => InsertResult::Success,
+            2 => InsertResult::SuccessStartTraining,
+            _ => InsertResult::Fail,
         }
     }
 }
@@ -706,7 +719,7 @@ pub unsafe extern "C" fn continue_search(
     _output_distances_len: usize,
     _new_continuation: *mut c_void,
 ) -> i32 {
-    unimplemented!()
+    -1
 }
 
 /// # Safety
@@ -780,4 +793,157 @@ pub unsafe extern "C" fn check_external_id_valid(
     let id = GarnetId::from(id_bytes);
 
     index.inner.external_id_exists(&ctx, &id)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{mem, ptr};
+
+    use diskann::graph::{BufferState, SearchOutputBuffer};
+    use diskann_vector::distance::Metric;
+
+    use crate::{
+        Index, IndexState, PolyCow, SearchResults, VectorQuantType, drop_index, garnet::GarnetId,
+        test_utils::Store,
+    };
+
+    #[test]
+    fn index_state() {
+        assert_eq!(IndexState::from(0), IndexState::NoStartPoints);
+        assert_eq!(IndexState::from(1), IndexState::SettingStartPoints);
+        assert_eq!(IndexState::from(2), IndexState::Ready);
+    }
+
+    #[test]
+    fn search_results() {
+        let mut ids = vec![0u8; 40]; // 20 bytes for 5 IDs; 20 bytes for 5 length prefixes
+        let mut dists = vec![0.0f32; 5];
+        let ids_buffer = ids.as_mut_ptr();
+        let ids_len = ids.len();
+        let dists_buffer = dists.as_mut_ptr();
+        let dists_len = dists.len();
+
+        let mut sr = SearchResults::new(ids_buffer, ids_len, dists_buffer, dists_len);
+
+        assert_eq!(sr.size_hint(), Some(5));
+
+        let test_data = [
+            (GarnetId::from(bytemuck::bytes_of(&1u32)), 1.1f32),
+            (GarnetId::from(bytemuck::bytes_of(&2u32)), 2.1),
+            (GarnetId::from(bytemuck::bytes_of(&3u32)), 3.1),
+            (GarnetId::from(bytemuck::bytes_of(&4u32)), 4.1),
+            (GarnetId::from(bytemuck::bytes_of(&5u32)), 5.1),
+        ];
+
+        assert_eq!(sr.current_len(), 0);
+
+        sr.extend(test_data);
+
+        assert_eq!(sr.current_len(), 5);
+
+        let mut pos = 0usize;
+        for (i, d) in dists.iter().enumerate() {
+            let mut size = 0u32;
+            bytemuck::bytes_of_mut(&mut size).copy_from_slice(&ids[pos..pos + 4]);
+            pos += 4;
+
+            assert_eq!(size, 4);
+
+            let mut id = 0u32;
+            bytemuck::bytes_of_mut(&mut id).copy_from_slice(&ids[pos..pos + 4]);
+            pos += 4;
+
+            assert_eq!(id, i as u32 + 1);
+
+            assert_eq!(*d, i as f32 + 1.1);
+        }
+
+        assert_eq!(
+            sr.push(GarnetId::from(bytemuck::bytes_of(&6u32)), 6.1f32),
+            BufferState::Full
+        );
+    }
+
+    fn check_create_index(quant_type: VectorQuantType) {
+        let store = Store;
+        let index_ptr = unsafe {
+            super::create_index(
+                0,
+                2,
+                0,
+                quant_type,
+                Metric::L2.into(),
+                10,
+                8,
+                store.callbacks().read_callback(),
+                store.callbacks().write_callback(),
+                store.callbacks().delete_callback(),
+                store.callbacks().rmw_callback(),
+            )
+        };
+        assert!(!index_ptr.is_null());
+        let index = unsafe { &*index_ptr.cast::<Index>() };
+        assert_eq!(index.quant_type, quant_type);
+        assert_eq!(index.inner.approximate_count(), 0);
+
+        unsafe {
+            drop_index(0, index_ptr);
+        }
+    }
+
+    #[test]
+    fn create_index() {
+        let store = Store;
+
+        let index_ptr = unsafe {
+            super::create_index(
+                0,
+                2,
+                0,
+                VectorQuantType::Invalid,
+                Metric::L2.into(),
+                10,
+                8,
+                store.callbacks().read_callback(),
+                store.callbacks().write_callback(),
+                store.callbacks().delete_callback(),
+                store.callbacks().rmw_callback(),
+            )
+        };
+        assert!(index_ptr.is_null());
+
+        check_create_index(VectorQuantType::NoQuant);
+        check_create_index(VectorQuantType::Bin);
+        check_create_index(VectorQuantType::Q8);
+        check_create_index(VectorQuantType::XNoQuantU8);
+        check_create_index(VectorQuantType::XBinU8);
+        check_create_index(VectorQuantType::XNoQuantI8);
+        check_create_index(VectorQuantType::XBinI8);
+    }
+
+    #[test]
+    fn interpret_vector() {
+        // f32; correctly aligned
+        let v = vec![0.0f32; 2];
+        let v_ptr = bytemuck::cast_slice::<f32, u8>(&v).as_ptr();
+        let res = super::interpret_vector(VectorQuantType::NoQuant, &v_ptr, v.len());
+        assert!(matches!(res, Some(PolyCow::Borrowed(_))));
+
+        // f32; unaligned
+        let real_v = vec![0.0f32; 2];
+        let mut v = vec![0u8; 2 * mem::size_of::<f32>() + 1];
+        v[1..].copy_from_slice(bytemuck::cast_slice::<f32, u8>(&real_v));
+        let v_ptr = unsafe { v.as_ptr().offset(1) };
+        let res = super::interpret_vector(VectorQuantType::NoQuant, &v_ptr, real_v.len());
+        assert!(matches!(res, Some(PolyCow::Owned(_))));
+
+        // i8
+        let v = vec![0i8; 2];
+        let v_ptr = bytemuck::cast_slice::<i8, u8>(&v).as_ptr();
+        let res = super::interpret_vector(VectorQuantType::XNoQuantI8, &v_ptr, v.len());
+        assert!(matches!(res, Some(PolyCow::Borrowed(_))));
+
+        let res = super::interpret_vector(VectorQuantType::Invalid, &ptr::null() as &*const u8, 0);
+        assert!(res.is_none());
+    }
 }

--- a/diskann-garnet/src/quantization.rs
+++ b/diskann-garnet/src/quantization.rs
@@ -315,3 +315,95 @@ impl DynQueryComputer for MinMax8BitQueryComputer {
         self.0.evaluate_similarity(a)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use diskann_utils::views::Matrix;
+    use diskann_vector::{DistanceFunction, PreprocessedDistanceFunction, distance::Metric};
+
+    use crate::quantization::{GarnetQuantizer, GarnetQuantizerError, MinMax8Bit, Spherical1Bit};
+
+    #[test]
+    fn basic_spherical_1bit() {
+        let quantizer = Spherical1Bit::new(2);
+
+        assert_eq!(quantizer.required_vectors(), 1000);
+        assert_eq!(quantizer.bytes(), 1 + 6);
+        assert!(!quantizer.is_trained());
+
+        let test_v = [0.5f32, 0.5];
+        let mut test_q = vec![0u8; quantizer.bytes()];
+
+        assert!(matches!(
+            quantizer.compress(&test_v, &mut test_q),
+            Err(GarnetQuantizerError::NoQuantizer)
+        ));
+        assert!(matches!(
+            quantizer.distance_computer(),
+            Err(GarnetQuantizerError::NoQuantizer)
+        ));
+        assert!(matches!(
+            quantizer.query_computer(&test_v),
+            Err(GarnetQuantizerError::NoQuantizer)
+        ));
+
+        let mut test_data = Matrix::new(0.0f32, 1000, 2);
+        for i in 0..1000 {
+            test_data
+                .row_mut(i)
+                .copy_from_slice(&[(i + 1) as f32, (i + 1) as f32]);
+        }
+        quantizer.train(Metric::L2, test_data.as_view()).unwrap();
+
+        assert!(quantizer.is_trained());
+
+        quantizer.compress(&test_v, &mut test_q).unwrap();
+        assert!(!test_q.iter().all(|&b| b == 0));
+
+        let dist_comp = quantizer.distance_computer().unwrap();
+        let full_a = [0.0f32, 0.0];
+        let mut quant_a = vec![0u8; quantizer.bytes()];
+        quantizer.compress(&full_a, &mut quant_a).unwrap();
+
+        let d = dist_comp.evaluate_similarity(&quant_a, &test_q);
+        assert_ne!(d, 0.0);
+
+        let query_comp = quantizer.query_computer(&test_v).unwrap();
+        let d = query_comp.evaluate_similarity(&quant_a);
+        assert_ne!(d, 0.0);
+    }
+
+    #[test]
+    fn basic_minmax_8bit() {
+        let quantizer = MinMax8Bit::new(2, Metric::L2).unwrap();
+
+        assert_eq!(quantizer.required_vectors(), 0);
+        assert_eq!(quantizer.bytes(), 22);
+        // MinMax8Bit starts trained
+        assert!(quantizer.is_trained());
+
+        let test_v = [0.5f32, 0.5];
+        let mut test_q = vec![0u8; quantizer.bytes()];
+
+        let mut test_data = Matrix::new(0.0f32, 1, 2);
+        test_data.row_mut(0).copy_from_slice(&[1.0f32, 1.0]);
+
+        // Training is a no-op, but succeeds.
+        quantizer.train(Metric::L2, test_data.as_view()).unwrap();
+
+        quantizer.compress(&test_v, &mut test_q).unwrap();
+        assert!(!test_q.iter().all(|&b| b == 0));
+
+        let dist_comp = quantizer.distance_computer().unwrap();
+        let full_a = [0.0f32, 0.0];
+        let mut quant_a = vec![0u8; quantizer.bytes()];
+        quantizer.compress(&full_a, &mut quant_a).unwrap();
+
+        let d = dist_comp.evaluate_similarity(&quant_a, &test_q);
+        assert_ne!(d, 0.0);
+
+        let query_comp = quantizer.query_computer(&test_v).unwrap();
+        let d = query_comp.evaluate_similarity(&quant_a);
+        assert_ne!(d, 0.0);
+    }
+}


### PR DESCRIPTION
This adds 90% coverage for most of diskann-garnet, including the new quantization code.

Note that it while there is more stuff to test, coverage % will probably not improve much from here without resorting to testing contrived things because much of what is uncovered is actually unused code that is required to satisfy `DataProvider` trait bounds. For example, we only use two hop in-place deletes, but `visited_and_topk` requires `InplaceDeleteStrategy` to implement `get_delete_element()`, so an implemention is provided.