### PR TITLE
Simplify `expand_beam_accept_only` pre-filter predicate

### DIFF
--- a/diskann/src/graph/ext/labeled.rs
+++ b/diskann/src/graph/ext/labeled.rs
@@ -198,7 +198,7 @@ where
     ) -> ANNResult<()>
     where
         Itr: Iterator<Item = Self::Id> + Send,
-        P: glue::HybridPredicate<Accept<Self::Id>> + Send + Sync,
+        P: glue::Predicate<Self::Id> + glue::PredicateMut<Accept<Self::Id>> + Send + Sync,
         F: FnMut(Accept<Self::Id>, f32) + Send,
     {
         self.inner
@@ -271,13 +271,11 @@ where
 
 impl<P, I> glue::Predicate<I> for EvalFiltered<'_, P, I>
 where
-    P: glue::Predicate<Accept<I>>,
+    P: glue::Predicate<I>,
     I: VectorId,
 {
     fn eval(&self, item: &I) -> bool {
-        // NOTE: Swapping the order here is legal as is passing `Accept` before evaluating
-        // `is_match`. This is because `self.inner.eval` does not modify state.
-        self.inner.eval(&Accept::new(*item)) && self.labels.is_match(*item)
+        self.inner.eval(item) && self.labels.is_match(*item)
     }
 }
 
@@ -295,7 +293,7 @@ where
 
 impl<P, I> glue::HybridPredicate<I> for EvalFiltered<'_, P, I>
 where
-    P: glue::HybridPredicate<Accept<I>>,
+    P: glue::Predicate<I> + glue::PredicateMut<Accept<I>>,
     I: VectorId,
 {
 }

--- a/diskann/src/graph/glue.rs
+++ b/diskann/src/graph/glue.rs
@@ -454,10 +454,10 @@ pub trait FilteredAccessor: HasId + Send + Sync {
     /// Constructing `Accept::new(raw_id)` and passing it to `pred.eval_mut` without
     /// having first classified `raw_id` violates this contract.
     ///
-    /// Because `pred.eval` is required to be side-effect-free (see [`Predicate`]),
-    /// implementors are free to call `pred.eval` on any ID — including those that have
-    /// not yet been classified — to cheaply pre-filter before paying the cost of
-    /// classification.
+    /// The [`Predicate`] bound takes unclassified IDs and is side-effect-free, so it can
+    /// pre-filter IDs before paying the cost of classification. As with [`HybridPredicate`],
+    /// implementors can assume that [`Predicate`] and [`PredicateMut`] "get along" with
+    /// respect to `eval(id)` and `eval_mut(Accept::new(id))`.
     ///
     /// See also: [`SearchAccessor::expand_beam`], [`Self::expand_beam_filtered`].
     fn expand_beam_accept_only<Itr, P, F>(
@@ -468,7 +468,7 @@ pub trait FilteredAccessor: HasId + Send + Sync {
     ) -> impl std::future::Future<Output = ANNResult<()>> + Send
     where
         Itr: Iterator<Item = Self::Id> + Send,
-        P: HybridPredicate<Accept<Self::Id>> + Send + Sync,
+        P: Predicate<Self::Id> + PredicateMut<Accept<Self::Id>> + Send + Sync,
         F: FnMut(Accept<Self::Id>, f32) + Send;
 
     //////////////////////
@@ -539,15 +539,6 @@ where
     }
 }
 
-impl<T> Predicate<Accept<T>> for NotInMut<'_, T>
-where
-    T: Eq + std::hash::Hash,
-{
-    fn eval(&self, item: &Accept<T>) -> bool {
-        self.eval(item.get())
-    }
-}
-
 impl<T> PredicateMut<T> for NotInMut<'_, T>
 where
     T: Clone + Eq + std::hash::Hash,
@@ -568,7 +559,6 @@ where
 
 /// The interfaces `contains` and `insert` agree with each other.
 impl<T> HybridPredicate<T> for NotInMut<'_, T> where T: Clone + Eq + std::hash::Hash {}
-impl<T> HybridPredicate<Accept<T>> for NotInMut<'_, T> where T: Clone + Eq + std::hash::Hash {}
 
 /// A search strategy for query objects of type `T`.
 ///


### PR DESCRIPTION
#1141 introduced the `FilteredAccessor` trait with two `expand_beam` style methods. This split existed because evaluation of the `HybridPredicate` differed subtly between the "all" and "accept only" paths, but this difference was sufficient to completely tank recall in multi-hop filtered search if rejected IDs were passed to the `PredicateMut`. The two-method solution made this harder, but at the cost of needing to create a new `Accept` type to pass to `Predicate` even before a decision had been made, which is confusing.

I think this cleans up that confusion by changing the bound on `expand_beam_accept_only` from
```rust
P: HybridPredicate<Accept<Self::Id>>
```
to
```rust
P: Predicate<Self::Id> + PredicateMut<Accept<Self::Id>>
```
This makes it clear that raw, unclassified IDs can be used for the non-mutating evaluation while only accepted IDs can be passed to `eval_mut`. The docs have been updated to reflect that the rules of `HybridPredicate` also apply to this pair of traits.