### PR TITLE
Don't append a new-line after `Indent`.

### DIFF
--- a/diskann-benchmark-runner/src/app.rs
+++ b/diskann-benchmark-runner/src/app.rs
@@ -228,7 +228,7 @@ impl App {
                         writeln!(output)?;
                     } else {
                         writeln!(output)?;
-                        write!(output, "{}", Indent::new(&description, 8))?;
+                        writeln!(output, "{}", Indent::new(&description, 8))?;
                     }
                 }
             }
@@ -259,7 +259,7 @@ impl App {
                         writeln!(output, "Closest matches:\n")?;
                         for (i, mismatch) in mismatches.into_iter().enumerate() {
                             writeln!(output, "    {}. \"{}\":", i + 1, mismatch.method(),)?;
-                            writeln!(output, "{}", Indent::new(mismatch.reason(), 8),)?;
+                            writeln!(output, "{}\n", Indent::new(mismatch.reason(), 8),)?;
                         }
                         writeln!(output)?;
 

--- a/diskann-benchmark-runner/src/utils/fmt.rs
+++ b/diskann-benchmark-runner/src/utils/fmt.rs
@@ -226,16 +226,14 @@ impl std::fmt::Display for Indent<'_> {
         // newline at the end of the last print, we instead add a newline to line `N-1` when
         // writing out line `N`.
         let mut first = true;
-        self.string
-            .lines()
-            .try_for_each(|ln| {
-                if first {
-                    first = false;
-                    write!(f, "{: >spaces$}{}", "", ln)
-                } else {
-                    write!(f, "\n{: >spaces$}{}", "", ln)
-                }
-            })
+        self.string.lines().try_for_each(|ln| {
+            if first {
+                first = false;
+                write!(f, "{: >spaces$}{}", "", ln)
+            } else {
+                write!(f, "\n{: >spaces$}{}", "", ln)
+            }
+        })
     }
 }
 

--- a/diskann-benchmark-runner/src/utils/fmt.rs
+++ b/diskann-benchmark-runner/src/utils/fmt.rs
@@ -203,7 +203,7 @@ impl std::fmt::Display for Banner<'_> {
 /// use diskann_benchmark_runner::utils::fmt::Indent;
 ///
 /// let indented = Indent::new("hello\nworld", 4).to_string();
-/// assert_eq!(indented, "    hello\n    world\n");
+/// assert_eq!(indented, "    hello\n    world");
 /// ```
 #[derive(Debug, Clone, Copy)]
 pub struct Indent<'a> {
@@ -221,9 +221,21 @@ impl<'a> Indent<'a> {
 impl std::fmt::Display for Indent<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let spaces = self.spaces;
+
+        // We don't know ahead of time how many lines there are. To avoid appending a
+        // newline at the end of the last print, we instead add a newline to line `N-1` when
+        // writing out line `N`.
+        let mut first = true;
         self.string
             .lines()
-            .try_for_each(|ln| writeln!(f, "{: >spaces$}{}", "", ln))
+            .try_for_each(|ln| {
+                if first {
+                    first = false;
+                    write!(f, "{: >spaces$}{}", "", ln)
+                } else {
+                    write!(f, "\n{: >spaces$}{}", "", ln)
+                }
+            })
     }
 }
 
@@ -511,19 +523,19 @@ string,        ,   string
     #[test]
     fn test_indent_single_line() {
         let s = Indent::new("hello", 4).to_string();
-        assert_eq!(s, "    hello\n");
+        assert_eq!(s, "    hello");
     }
 
     #[test]
     fn test_indent_multi_line() {
         let s = Indent::new("hello\nworld\nfoo", 2).to_string();
-        assert_eq!(s, "  hello\n  world\n  foo\n");
+        assert_eq!(s, "  hello\n  world\n  foo");
     }
 
     #[test]
     fn test_indent_zero_spaces() {
         let s = Indent::new("hello\nworld", 0).to_string();
-        assert_eq!(s, "hello\nworld\n");
+        assert_eq!(s, "hello\nworld");
     }
 
     #[test]

--- a/diskann-benchmark-runner/src/utils/fmt.rs
+++ b/diskann-benchmark-runner/src/utils/fmt.rs
@@ -195,7 +195,7 @@ impl std::fmt::Display for Banner<'_> {
 
 /// Indents each line of a string by a fixed number of spaces.
 ///
-/// Each line is prefixed with `spaces` spaces and terminated with a newline.
+/// Each line is prefixed with `spaces` spaces.
 ///
 /// # Examples
 ///


### PR DESCRIPTION
Currently, `Indent` is always appending a newline to its last printed line. However, this can make formatting weird when using `Indent` to render nested blocks. This PR removes the trailing newline.