### PR TITLE
Strengthen diskann-disk build and search test coverage

### DIFF
--- a/diskann-disk/src/build/builder/core.rs
+++ b/diskann-disk/src/build/builder/core.rs
@@ -682,6 +682,7 @@ pub(crate) mod disk_index_builder_tests {
         pub checkpoint_params: Option<CheckpointParams>,
         pub num_threads: usize,
         pub metric: Metric,
+        pub block_size: usize,
     }
 
     impl Default for TestParams {
@@ -700,6 +701,7 @@ pub(crate) mod disk_index_builder_tests {
                 checkpoint_params: None,
                 num_threads: 1,
                 metric: L2,
+                block_size: DEFAULT_DISK_SECTOR_LEN,
             }
         }
     }
@@ -799,7 +801,7 @@ pub(crate) mod disk_index_builder_tests {
                 self.params.data_path.clone(),
                 self.params.index_path_prefix.clone(),
                 self.params.associated_data_path.clone(),
-                DEFAULT_DISK_SECTOR_LEN,
+                self.params.block_size,
             )?;
 
             let mut disk_index = match self.params.checkpoint_params {
@@ -921,6 +923,31 @@ pub(crate) mod disk_index_builder_tests {
         let index_path_prefix = format!("{}_metric_{:?}", INDEX_PATH_PREFIX, metric);
 
         run_one_shot_test(index_path_prefix, |params| TestParams { metric, ..params });
+    }
+
+    /// Forces the multi-sector-per-node layout: with a 512-byte block, a 128-d f32 vector
+    /// (512 B) plus its neighbor list exceeds one sector, so each node spans multiple
+    /// sectors (`node_len > block_size`). The default 4096-byte sector packs these small
+    /// nodes many-per-sector, leaving the crossing path otherwise untested; 512 is one of
+    /// the two block sizes the disk format supports.
+    #[test]
+    fn test_build_multi_sector_per_node() {
+        let params = TestParams {
+            block_size: 512,
+            max_degree: 16,
+            l_build: 64,
+            index_path_prefix: format!("{}_multi_sector", INDEX_PATH_PREFIX),
+            ..TestParams::default()
+        };
+        let fixture = IndexBuildFixture::new(new_vfs(), params).unwrap();
+        fixture.build::<GraphDataF32VectorUnitData>().unwrap();
+        verify_search_result_with_ground_truth::<GraphDataF32VectorUnitData>(
+            &fixture.params,
+            10,
+            32,
+            &fixture.storage_provider,
+        )
+        .unwrap();
     }
 
     #[test]

--- a/diskann-disk/src/search/provider/disk_provider.rs
+++ b/diskann-disk/src/search/provider/disk_provider.rs
@@ -1226,8 +1226,12 @@ mod disk_provider_tests {
         });
     }
 
-    #[test]
-    fn test_disk_search_k10_l20_single_or_multi_thread_128dim() {
+    #[rstest]
+    #[case(CachingStrategy::None)]
+    #[case(CachingStrategy::StaticCacheWithBfsNodes(32))]
+    fn test_disk_search_k10_l20_single_or_multi_thread_128dim(
+        #[case] caching_strategy: CachingStrategy,
+    ) {
         let storage_provider = Arc::new(VirtualStorageProvider::new_overlay(test_data_root()));
 
         let search_engine = create_disk_index_searcher::<GraphDataF32VectorUnitData>(
@@ -1237,6 +1241,7 @@ mod disk_provider_tests {
                 pq_compressed_file_path: TEST_PQ_COMPRESSED_128DIM,
                 index_path: TEST_INDEX_128DIM,
                 index_path_prefix: TEST_INDEX_PREFIX_128DIM,
+                caching_strategy,
                 ..Default::default()
             },
             &storage_provider,
@@ -1353,6 +1358,7 @@ mod disk_provider_tests {
         index_path: &'a str,
         index_path_prefix: &'a str,
         io_limit: usize,
+        caching_strategy: CachingStrategy,
     }
 
     impl Default for CreateDiskIndexSearcherParams<'_> {
@@ -1364,6 +1370,7 @@ mod disk_provider_tests {
                 index_path: "",
                 index_path_prefix: "",
                 io_limit: usize::MAX,
+                caching_strategy: CachingStrategy::None,
             }
         }
     }
@@ -1396,10 +1403,11 @@ mod disk_provider_tests {
             get_disk_index_file(params.index_path_prefix),
             Arc::clone(storage_provider),
         );
-        let caching_strategy = CachingStrategy::None;
-        let vertex_provider_factory =
-            DiskVertexProviderFactory::<Data, _>::new(aligned_reader_factory, caching_strategy)
-                .unwrap();
+        let vertex_provider_factory = DiskVertexProviderFactory::<Data, _>::new(
+            aligned_reader_factory,
+            params.caching_strategy,
+        )
+        .unwrap();
 
         DiskIndexSearcher::<Data, DiskVertexProviderFactory<Data, _>>::new(
             params.max_thread_num,
@@ -2251,6 +2259,7 @@ mod disk_provider_tests {
                 index_path: TEST_INDEX,
                 index_path_prefix: TEST_INDEX_PREFIX,
                 io_limit,
+                ..Default::default()
             },
             &storage_provider,
         );


### PR DESCRIPTION
# Strengthen diskann-disk build and search test coverage

## Why

Two disk-layer paths are covered only by the out-of-tree internal tests, not by `diskann-disk` itself:

- **Multi-sector-per-node layout.** When `node_len > block_size`, a node's data spans multiple sectors on write and is reassembled on read. The public fixture's small nodes always fit one sector, so this path never runs; `test_build_multi_sector_per_node` forces it with a 512-byte block.
- **Search through a BFS static cache.** `CachedDiskVertexProvider` mixes cache and disk reads, remapping candidate indices to the uncached set — a wrong remap silently corrupts results, yet every search test hardcoded `CachingStrategy::None`. `test_disk_search_..._128dim` adds a `StaticCacheWithBfsNodes(32)` case asserting the same ground truth.
