### PR TITLE
benchmark: add experimental diverse graph search integration

### DIFF
--- a/diskann-benchmark-core/Cargo.toml
+++ b/diskann-benchmark-core/Cargo.toml
@@ -25,6 +25,9 @@ default = []
 # BigANN Runbook support requires parsing a YAML file.
 bigann = ["dep:serde_yaml"]
 
+# Diversity-aware search wrappers (experimental).
+experimental_diversity_search = ["diskann/experimental_diversity_search"]
+
 [lints]
 workspace = true
 

--- a/diskann-benchmark-core/Cargo.toml
+++ b/diskann-benchmark-core/Cargo.toml
@@ -25,9 +25,6 @@ default = []
 # BigANN Runbook support requires parsing a YAML file.
 bigann = ["dep:serde_yaml"]
 
-# Diversity-aware search wrappers (experimental).
-experimental_diversity_search = ["diskann/experimental_diversity_search"]
-
 [lints]
 workspace = true
 

--- a/diskann-benchmark-core/src/search/graph/diverse.rs
+++ b/diskann-benchmark-core/src/search/graph/diverse.rs
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+//! A built-in helper for benchmarking diversity-aware K-nearest neighbors search.
+
+use std::sync::Arc;
+
+use diskann::{
+    ANNResult,
+    graph::{self, glue},
+    neighbor::AttributeValueProvider,
+    provider,
+};
+use diskann_utils::{future::AsyncFriendly, views::Matrix};
+
+use crate::search::{self, graph::Strategy, graph::knn::Metrics};
+
+/// A built-in helper for benchmarking diversity-aware search via
+/// [`graph::search::Diverse`].
+///
+/// This mirrors [`super::KNN`] but runs each query through a
+/// [`graph::search::Diverse`] wrapper constructed from the shared
+/// [`AttributeValueProvider`] and diversity parameters stored on this struct. The
+/// [`Search::Parameters`] remain the base [`graph::search::Knn`] parameters so that the
+/// same benchmark driving code (search list sweeps, recall computation, aggregation) can be
+/// reused unchanged.
+///
+/// # Type Parameters
+///
+/// - `DP`: The data provider type.
+/// - `T`: The query element type.
+/// - `S`: The search strategy type.
+/// - `P`: The attribute value provider used to derive diversity attributes.
+#[derive(Debug)]
+pub struct DiverseKNN<DP, T, S, P>
+where
+    DP: provider::DataProvider,
+    P: AttributeValueProvider,
+{
+    index: Arc<graph::DiskANNIndex<DP>>,
+    queries: Arc<Matrix<T>>,
+    strategy: Strategy<S>,
+    attribute_provider: Arc<P>,
+    diverse_attribute_id: usize,
+    diverse_results_k: usize,
+}
+
+impl<DP, T, S, P> DiverseKNN<DP, T, S, P>
+where
+    DP: provider::DataProvider,
+    P: AttributeValueProvider,
+{
+    /// Construct a new [`DiverseKNN`] searcher.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the number of elements in `strategy` is not compatible with
+    /// the number of rows in `queries`.
+    pub fn new(
+        index: Arc<graph::DiskANNIndex<DP>>,
+        queries: Arc<Matrix<T>>,
+        strategy: Strategy<S>,
+        attribute_provider: Arc<P>,
+        diverse_attribute_id: usize,
+        diverse_results_k: usize,
+    ) -> anyhow::Result<Arc<Self>> {
+        strategy.length_compatible(queries.nrows())?;
+
+        Ok(Arc::new(Self {
+            index,
+            queries,
+            strategy,
+            attribute_provider,
+            diverse_attribute_id,
+            diverse_results_k,
+        }))
+    }
+
+    /// Access the index.
+    pub fn index(&self) -> &Arc<graph::DiskANNIndex<DP>> {
+        &self.index
+    }
+}
+
+impl<DP, T, S, P> search::Search for DiverseKNN<DP, T, S, P>
+where
+    DP: provider::DataProvider<Context: Default, ExternalId: search::Id>,
+    S: for<'a> glue::DefaultSearchStrategy<
+            'a,
+            DP,
+            &'a [T],
+            DP::ExternalId,
+            SearchAccessor: glue::SearchAccessor,
+        > + Clone
+        + AsyncFriendly,
+    P: AttributeValueProvider<Id = DP::InternalId> + AsyncFriendly,
+    graph::search::Diverse<P>:
+        for<'a> graph::Search<'a, DP, S, &'a [T], Output = graph::index::SearchStats>,
+    T: AsyncFriendly + Clone,
+{
+    type Id = DP::ExternalId;
+    type Parameters = graph::search::Knn;
+    type Output = Metrics;
+
+    fn num_queries(&self) -> usize {
+        self.queries.nrows()
+    }
+
+    fn id_count(&self, parameters: &Self::Parameters) -> search::IdCount {
+        search::IdCount::Fixed(parameters.k_value())
+    }
+
+    async fn search<O>(
+        &self,
+        parameters: &Self::Parameters,
+        buffer: &mut O,
+        index: usize,
+    ) -> ANNResult<Self::Output>
+    where
+        O: graph::SearchOutputBuffer<DP::ExternalId> + Send,
+    {
+        let context = DP::Context::default();
+        let strategy = self.strategy.get(index)?;
+
+        let diverse_params = graph::DiverseSearchParams::new(
+            self.diverse_attribute_id,
+            self.diverse_results_k,
+            self.attribute_provider.clone(),
+        );
+        let diverse_search = graph::search::Diverse::new(*parameters, diverse_params);
+
+        let stats = self
+            .index
+            .search(
+                diverse_search,
+                strategy,
+                &context,
+                self.queries.row(index),
+                buffer,
+            )
+            .await?;
+
+        Ok(Metrics {
+            comparisons: stats.cmps,
+            hops: stats.hops,
+        })
+    }
+}

--- a/diskann-benchmark-core/src/search/graph/mod.rs
+++ b/diskann-benchmark-core/src/search/graph/mod.rs
@@ -10,12 +10,18 @@ pub mod range;
 
 pub mod strategy;
 
+#[cfg(feature = "experimental_diversity_search")]
+pub mod diverse;
+
 pub use inline::InlineFilterSearch;
 pub use knn::KNN;
 pub use multihop::MultiHop;
 pub use range::Range;
 
 pub use strategy::Strategy;
+
+#[cfg(feature = "experimental_diversity_search")]
+pub use diverse::DiverseKNN;
 
 ////////////////
 // Test Utils //

--- a/diskann-benchmark-core/src/search/graph/mod.rs
+++ b/diskann-benchmark-core/src/search/graph/mod.rs
@@ -10,7 +10,6 @@ pub mod range;
 
 pub mod strategy;
 
-#[cfg(feature = "experimental_diversity_search")]
 pub mod diverse;
 
 pub use inline::InlineFilterSearch;
@@ -20,7 +19,6 @@ pub use range::Range;
 
 pub use strategy::Strategy;
 
-#[cfg(feature = "experimental_diversity_search")]
 pub use diverse::DiverseKNN;
 
 ////////////////

--- a/diskann-benchmark/Cargo.toml
+++ b/diskann-benchmark/Cargo.toml
@@ -67,6 +67,13 @@ minmax-quantization = []
 # Enable multi-vector MaxSim distance benchmarks
 multi-vector = []
 
+# Enable experimental diversity-aware search benchmarks
+experimental_diversity_search = [
+    "diskann/experimental_diversity_search",
+    "diskann-providers/experimental_diversity_search",
+    "diskann-benchmark-core/experimental_diversity_search",
+]
+
 # Enable bftree backend
 bftree = ["dep:diskann-bftree"]
 

--- a/diskann-benchmark/Cargo.toml
+++ b/diskann-benchmark/Cargo.toml
@@ -67,13 +67,6 @@ minmax-quantization = []
 # Enable multi-vector MaxSim distance benchmarks
 multi-vector = []
 
-# Enable experimental diversity-aware search benchmarks
-experimental_diversity_search = [
-    "diskann/experimental_diversity_search",
-    "diskann-providers/experimental_diversity_search",
-    "diskann-benchmark-core/experimental_diversity_search",
-]
-
 # Enable bftree backend
 bftree = ["dep:diskann-bftree"]
 

--- a/diskann-benchmark/example/async-diverse-search.json
+++ b/diskann-benchmark/example/async-diverse-search.json
@@ -1,0 +1,49 @@
+{
+  "search_directories": [
+    "test_data/disk_index_search"
+  ],
+  "jobs": [
+    {
+      "type": "graph-index-build",
+      "content": {
+        "source": {
+          "index-source": "Build",
+          "data_type": "float32",
+          "data": "disk_index_siftsmall_learn_256pts_data.fbin",
+          "distance": "squared_l2",
+          "max_degree": 32,
+          "l_build": 50,
+          "alpha": 1.2,
+          "backedge_ratio": 1.0,
+          "num_threads": 1,
+          "start_point_strategy": "medoid",
+          "num_insert_attempts": 1,
+          "saturate_inserts": false
+        },
+        "search_phase": {
+          "search-type": "topk-diverse-search",
+          "queries": "disk_index_sample_query_10pts.fbin",
+          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "attributes": "disk_index_siftsmall_learn_256pts_attributes.txt",
+          "reps": 5,
+          "num_threads": [
+            1
+          ],
+          "diverse_attribute_id": 0,
+          "diverse_results_k": 1,
+          "runs": [
+            {
+              "search_n": 20,
+              "search_l": [
+                20,
+                30,
+                40
+              ],
+              "recall_k": 10
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/diskann-benchmark/src/disk_index/search.rs
+++ b/diskann-benchmark/src/disk_index/search.rs
@@ -4,7 +4,12 @@
  */
 
 use rayon::prelude::*;
-use std::{collections::HashSet, fmt, sync::atomic::AtomicBool, time::Instant};
+use std::{
+    collections::HashSet,
+    fmt,
+    sync::{atomic::AtomicBool, Arc},
+    time::Instant,
+};
 
 use opentelemetry::{global, trace::Span, trace::Tracer};
 use opentelemetry_sdk::trace::SdkTracerProvider;
@@ -37,7 +42,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     disk_index::json_spancollector::JsonSpanCollector,
     inputs::disk::{DiskIndexLoad, DiskSearchPhase},
-    utils::{datafiles, SimilarityMeasure},
+    utils::{attributes::FileAttributeProvider, datafiles, SimilarityMeasure},
 };
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -236,6 +241,14 @@ where
 
     logger.log_checkpoint("index_loaded");
 
+    // Load the attribute provider for diversity-aware search, if configured.
+    let diverse_attribute_provider = match &search_params.attributes {
+        Some(attributes_file) => Some(Arc::new(FileAttributeProvider::load(attributes_file)?)),
+        None => None,
+    };
+    let diverse_results_k = search_params.diverse_results_k;
+    let diverse_attribute_id = search_params.diverse_attribute_id;
+
     let pool = create_thread_pool(search_params.num_threads)?;
     let mut search_results_per_l = Vec::with_capacity(search_params.search_list.len());
     let has_any_search_failed = AtomicBool::new(false);
@@ -271,20 +284,31 @@ where
                 // Construct the SearchMode from the JSON-driven
                 // `adaptive_l` is now encapsulated in `DiskSearchMode`, so the
                 // benchmark only supplies the per-query filter and post-processor.
-                let has_filter = search_params.vector_filters_file.is_some();
-                let mode: SearchMode<'_> = search_params.search_mode.search_mode(
-                    has_filter,
-                    vf,
-                    search_params.post_processor.as_ref(),
-                );
+                let mode: SearchMode<'_> = match diverse_attribute_provider.as_ref() {
+                    Some(provider) => SearchMode::diverse_attribute(
+                        provider.clone(),
+                        diverse_attribute_id,
+                        diverse_results_k.unwrap_or(search_params.recall_at as usize),
+                    ),
+                    None => {
+                        let has_filter = search_params.vector_filters_file.is_some();
+                        search_params.search_mode.search_mode(
+                            has_filter,
+                            vf,
+                            search_params.post_processor.as_ref(),
+                        )
+                    }
+                };
 
-                match searcher.search(
+                let search_outcome = searcher.search(
                     q,
                     search_params.recall_at,
                     l,
                     Some(search_params.beam_width),
                     mode,
-                ) {
+                );
+
+                match search_outcome {
                     Ok(search_result) => {
                         *stats = search_result.stats.query_statistics;
                         let base_count = (search_result.stats.result_count as usize)

--- a/diskann-benchmark/src/index/benchmarks.rs
+++ b/diskann-benchmark/src/index/benchmarks.rs
@@ -78,7 +78,6 @@ pub(crate) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()>
         .search(plugins::TopkMultihopFilter)
         .search(plugins::TopkInlineFilter)
         .search(plugins::DeterminantDiversity);
-    #[cfg(feature = "experimental_diversity_search")]
     let full_precision_f32 = full_precision_f32.search(plugins::DiverseSearch);
     registry.register("graph-index-full-precision-f32", full_precision_f32)?;
 
@@ -484,7 +483,6 @@ impl search::Plugin<FullPrecisionProvider<f32>, SearchPhase, Strategy<common::Fu
     }
 }
 
-#[cfg(feature = "experimental_diversity_search")]
 impl search::Plugin<FullPrecisionProvider<f32>, SearchPhase, Strategy<common::FullPrecision>>
     for plugins::DiverseSearch
 {

--- a/diskann-benchmark/src/index/benchmarks.rs
+++ b/diskann-benchmark/src/index/benchmarks.rs
@@ -71,16 +71,16 @@ pub(crate) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()>
     // care.
 
     // Full Precision
-    registry.register(
-        "graph-index-full-precision-f32",
-        FullPrecision::<f32>::new()
-            .search(plugins::Topk)
-            .search(plugins::Range)
-            .search(plugins::TopkBetaFilter)
-            .search(plugins::TopkMultihopFilter)
-            .search(plugins::TopkInlineFilter)
-            .search(plugins::DeterminantDiversity),
-    )?;
+    let full_precision_f32 = FullPrecision::<f32>::new()
+        .search(plugins::Topk)
+        .search(plugins::Range)
+        .search(plugins::TopkBetaFilter)
+        .search(plugins::TopkMultihopFilter)
+        .search(plugins::TopkInlineFilter)
+        .search(plugins::DeterminantDiversity);
+    #[cfg(feature = "experimental_diversity_search")]
+    let full_precision_f32 = full_precision_f32.search(plugins::DiverseSearch);
+    registry.register("graph-index-full-precision-f32", full_precision_f32)?;
 
     registry.register(
         "graph-index-full-precision-f16",
@@ -475,6 +475,54 @@ impl search::Plugin<FullPrecisionProvider<f32>, SearchPhase, Strategy<common::Fu
             queries,
             benchmark_core::search::graph::Strategy::broadcast(common::FullPrecision),
             inmem::DeterminantDiversity::new(params),
+        )?;
+
+        let steps = search::knn::SearchSteps::new(phase.reps, &phase.num_threads, &phase.runs);
+        let results = search::knn::run(&knn, &groundtruth, steps)?;
+
+        Ok(AggregatedSearchResults::Topk(results))
+    }
+}
+
+#[cfg(feature = "experimental_diversity_search")]
+impl search::Plugin<FullPrecisionProvider<f32>, SearchPhase, Strategy<common::FullPrecision>>
+    for plugins::DiverseSearch
+{
+    fn is_match(&self, phase: &SearchPhase) -> bool {
+        plugins::DiverseSearch::is_match(phase)
+    }
+
+    fn kind(&self) -> &'static str {
+        plugins::DiverseSearch::as_str()
+    }
+
+    fn run(
+        &self,
+        index: Arc<DiskANNIndex<FullPrecisionProvider<f32>>>,
+        phase: &SearchPhase,
+        _strategy: &Strategy<common::FullPrecision>,
+    ) -> anyhow::Result<AggregatedSearchResults> {
+        let phase = plugins::DiverseSearch::get(phase)?;
+
+        let queries = Arc::new(datafiles::load_dataset::<f32>(datafiles::BinFile(
+            &phase.queries,
+        ))?);
+        let groundtruth = datafiles::load_groundtruth(
+            datafiles::BinFile(&phase.groundtruth),
+            Some(phase.max_k()),
+        )?;
+
+        let attribute_provider = Arc::new(
+            crate::utils::attributes::FileAttributeProvider::load(&phase.attributes)?,
+        );
+
+        let knn = benchmark_core::search::graph::DiverseKNN::new(
+            index,
+            queries,
+            benchmark_core::search::graph::Strategy::broadcast(common::FullPrecision),
+            attribute_provider,
+            phase.diverse_attribute_id,
+            phase.diverse_results_k,
         )?;
 
         let steps = search::knn::SearchSteps::new(phase.reps, &phase.num_threads, &phase.runs);

--- a/diskann-benchmark/src/index/search/knn.rs
+++ b/diskann-benchmark/src/index/search/knn.rs
@@ -171,3 +171,36 @@ where
         Ok(results.into_iter().map(SearchResults::new).collect())
     }
 }
+
+#[cfg(feature = "experimental_diversity_search")]
+impl<DP, T, S, P> Knn<DP::InternalId> for Arc<core_search::graph::DiverseKNN<DP, T, S, P>>
+where
+    DP: diskann::provider::DataProvider,
+    P: diskann::neighbor::AttributeValueProvider,
+    core_search::graph::DiverseKNN<DP, T, S, P>: core_search::Search<
+        Id = DP::InternalId,
+        Parameters = diskann::graph::search::Knn,
+        Output = core_search::graph::knn::Metrics,
+    >,
+{
+    fn search_all(
+        &self,
+        parameters: Vec<core_search::Run<diskann::graph::search::Knn>>,
+        groundtruth: &dyn benchmark_core::recall::Rows<DP::InternalId>,
+        recall_k: usize,
+        recall_n: usize,
+    ) -> anyhow::Result<Vec<SearchResults>> {
+        let results = core_search::search_all(
+            self.clone(),
+            parameters.into_iter(),
+            core_search::graph::knn::Aggregator::new(
+                groundtruth,
+                recall_k,
+                recall_n,
+                GroundTruthMode::Fixed,
+            ),
+        )?;
+
+        Ok(results.into_iter().map(SearchResults::new).collect())
+    }
+}

--- a/diskann-benchmark/src/index/search/knn.rs
+++ b/diskann-benchmark/src/index/search/knn.rs
@@ -172,7 +172,6 @@ where
     }
 }
 
-#[cfg(feature = "experimental_diversity_search")]
 impl<DP, T, S, P> Knn<DP::InternalId> for Arc<core_search::graph::DiverseKNN<DP, T, S, P>>
 where
     DP: diskann::provider::DataProvider,

--- a/diskann-benchmark/src/index/search/plugins.rs
+++ b/diskann-benchmark/src/index/search/plugins.rs
@@ -179,11 +179,9 @@ impl DeterminantDiversity {
 }
 
 /// A search plugin for diversity-aware top-k search.
-#[cfg(feature = "experimental_diversity_search")]
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct DiverseSearch;
 
-#[cfg(feature = "experimental_diversity_search")]
 impl DiverseSearch {
     pub(crate) fn is_match(phase: &SearchPhase) -> bool {
         phase.as_topk_diverse_search().is_ok()

--- a/diskann-benchmark/src/index/search/plugins.rs
+++ b/diskann-benchmark/src/index/search/plugins.rs
@@ -178,6 +178,28 @@ impl DeterminantDiversity {
     }
 }
 
+/// A search plugin for diversity-aware top-k search.
+#[cfg(feature = "experimental_diversity_search")]
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct DiverseSearch;
+
+#[cfg(feature = "experimental_diversity_search")]
+impl DiverseSearch {
+    pub(crate) fn is_match(phase: &SearchPhase) -> bool {
+        phase.as_topk_diverse_search().is_ok()
+    }
+
+    pub(crate) const fn as_str() -> &'static str {
+        "topk-diverse-search"
+    }
+
+    pub(crate) fn get(
+        phase: &SearchPhase,
+    ) -> anyhow::Result<&crate::inputs::graph_index::TopkDiverseSearchPhase> {
+        Ok(phase.as_topk_diverse_search()?)
+    }
+}
+
 /// A search plugin for range search.
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct Range;

--- a/diskann-benchmark/src/inputs/disk.rs
+++ b/diskann-benchmark/src/inputs/disk.rs
@@ -170,6 +170,18 @@ pub(crate) struct DiskSearchPhase {
     pub(crate) num_nodes_to_cache: Option<usize>,
     pub(crate) search_io_limit: Option<usize>,
     pub(crate) post_processor: Option<TopkPostProcessor>,
+    /// Plaintext file with one integer attribute per line; line `N` is vector `N`'s attribute.
+    ///
+    /// When present, the search phase runs attribute-bucket diversity-aware search
+    /// (keeping at most `diverse_results_k` results per distinct attribute value)
+    /// instead of the mode selected by `search_mode`/`post_processor`.
+    pub(crate) attributes: Option<InputFile>,
+    /// The attribute dimension used for diversity (currently only a single attribute is used).
+    #[serde(default)]
+    pub(crate) diverse_attribute_id: usize,
+    /// The maximum number of results to keep per distinct attribute value.
+    #[serde(default)]
+    pub(crate) diverse_results_k: Option<usize>,
 }
 
 /////////
@@ -320,6 +332,18 @@ impl DiskSearchPhase {
                 .context("invalid disk search post processor")?;
         }
 
+        if let Some(attributes) = self.attributes.as_mut() {
+            attributes
+                .resolve(checker)
+                .context("invalid attributes file")?;
+            match self.diverse_results_k {
+                Some(k) if k > 0 => {}
+                _ => anyhow::bail!(
+                    "diverse_results_k must be a positive integer when attributes is set"
+                ),
+            }
+        }
+
         Ok(())
     }
 }
@@ -367,6 +391,9 @@ impl Example for DiskIndexOperation {
             num_nodes_to_cache: None,
             search_io_limit: None,
             post_processor: None,
+            attributes: None,
+            diverse_attribute_id: 0,
+            diverse_results_k: None,
         };
 
         Self {

--- a/diskann-benchmark/src/inputs/graph_index.rs
+++ b/diskann-benchmark/src/inputs/graph_index.rs
@@ -401,6 +401,64 @@ impl Example for TopkDeterminantDiversityPhase {
     }
 }
 
+#[cfg(feature = "experimental_diversity_search")]
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct TopkDiverseSearchPhase {
+    pub(crate) queries: InputFile,
+    pub(crate) groundtruth: InputFile,
+    /// Plaintext file with one integer attribute per line; line `N` is vector `N`'s attribute.
+    pub(crate) attributes: InputFile,
+    pub(crate) reps: NonZeroUsize,
+    pub(crate) num_threads: Vec<NonZeroUsize>,
+    pub(crate) runs: Vec<GraphSearch>,
+    /// The attribute dimension used for diversity (currently only a single attribute is used).
+    #[serde(default)]
+    pub(crate) diverse_attribute_id: usize,
+    /// The maximum number of results to keep per distinct attribute value.
+    pub(crate) diverse_results_k: usize,
+}
+
+#[cfg(feature = "experimental_diversity_search")]
+impl TopkDiverseSearchPhase {
+    pub(crate) fn max_k(&self) -> usize {
+        self.runs.iter().map(|run| run.recall_k).max().unwrap_or(0)
+    }
+
+    pub(crate) fn validate(&mut self, checker: &mut Checker) -> Result<(), anyhow::Error> {
+        if self.diverse_results_k == 0 {
+            return Err(anyhow!("diverse_results_k must be greater than zero"));
+        }
+        self.queries.resolve(checker)?;
+        self.groundtruth.resolve(checker)?;
+        self.attributes.resolve(checker)?;
+        for (i, run) in self.runs.iter_mut().enumerate() {
+            run.validate(checker)
+                .with_context(|| format!("search run {}", i))?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "experimental_diversity_search")]
+impl Example for TopkDiverseSearchPhase {
+    fn example() -> Self {
+        Self {
+            queries: InputFile::new("path/to/queries"),
+            groundtruth: InputFile::new("path/to/groundtruth"),
+            attributes: InputFile::new("path/to/attributes.txt"),
+            reps: NonZeroUsize::new(1).unwrap(),
+            num_threads: vec![NonZeroUsize::new(1).unwrap()],
+            runs: vec![GraphSearch {
+                search_n: 10,
+                search_l: vec![10, 20, 30, 40],
+                recall_k: 10,
+            }],
+            diverse_attribute_id: 0,
+            diverse_results_k: 1,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(tag = "search-type", rename_all = "kebab-case")]
 pub(crate) enum SearchPhase {
@@ -410,6 +468,8 @@ pub(crate) enum SearchPhase {
     TopkMultihopFilter(MultihopFilterSearchPhase),
     TopkInlineFilter(InlineFilterSearchPhase),
     TopkDeterminantDiversity(TopkDeterminantDiversityPhase),
+    #[cfg(feature = "experimental_diversity_search")]
+    TopkDiverseSearch(TopkDiverseSearchPhase),
 }
 
 #[derive(Debug, Error)]
@@ -438,6 +498,8 @@ impl SearchPhase {
             Self::TopkMultihopFilter(_) => SearchPhaseKind::TopkMultihopFilter,
             Self::TopkInlineFilter(_) => SearchPhaseKind::TopkInlineFilter,
             Self::TopkDeterminantDiversity(_) => SearchPhaseKind::TopkDeterminantDiversity,
+            #[cfg(feature = "experimental_diversity_search")]
+            Self::TopkDiverseSearch(_) => SearchPhaseKind::TopkDiverseSearch,
         }
     }
 
@@ -506,6 +568,19 @@ impl SearchPhase {
             )),
         }
     }
+
+    #[cfg(feature = "experimental_diversity_search")]
+    pub(crate) fn as_topk_diverse_search(
+        &self,
+    ) -> Result<&TopkDiverseSearchPhase, WrongSearchPhaseKind> {
+        match self {
+            Self::TopkDiverseSearch(phase) => Ok(phase),
+            _ => Err(WrongSearchPhaseKind::new(
+                SearchPhaseKind::TopkDiverseSearch,
+                self.kind(),
+            )),
+        }
+    }
 }
 
 impl SearchPhase {
@@ -517,6 +592,8 @@ impl SearchPhase {
             SearchPhase::TopkMultihopFilter(phase) => phase.validate(checker),
             SearchPhase::TopkInlineFilter(phase) => phase.validate(checker),
             SearchPhase::TopkDeterminantDiversity(phase) => phase.validate(checker),
+            #[cfg(feature = "experimental_diversity_search")]
+            SearchPhase::TopkDiverseSearch(phase) => phase.validate(checker),
         }
     }
 }
@@ -529,6 +606,8 @@ pub(crate) enum SearchPhaseKind {
     TopkMultihopFilter,
     TopkInlineFilter,
     TopkDeterminantDiversity,
+    #[cfg(feature = "experimental_diversity_search")]
+    TopkDiverseSearch,
 }
 
 impl SearchPhaseKind {
@@ -540,6 +619,8 @@ impl SearchPhaseKind {
             Self::TopkMultihopFilter => "topk-multihop-filter",
             Self::TopkInlineFilter => "topk-inline-filter",
             Self::TopkDeterminantDiversity => "topk-determinant-diversity",
+            #[cfg(feature = "experimental_diversity_search")]
+            Self::TopkDiverseSearch => "topk-diverse-search",
         }
     }
 }

--- a/diskann-benchmark/src/inputs/graph_index.rs
+++ b/diskann-benchmark/src/inputs/graph_index.rs
@@ -401,7 +401,6 @@ impl Example for TopkDeterminantDiversityPhase {
     }
 }
 
-#[cfg(feature = "experimental_diversity_search")]
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct TopkDiverseSearchPhase {
     pub(crate) queries: InputFile,
@@ -418,7 +417,6 @@ pub(crate) struct TopkDiverseSearchPhase {
     pub(crate) diverse_results_k: usize,
 }
 
-#[cfg(feature = "experimental_diversity_search")]
 impl TopkDiverseSearchPhase {
     pub(crate) fn max_k(&self) -> usize {
         self.runs.iter().map(|run| run.recall_k).max().unwrap_or(0)
@@ -439,7 +437,6 @@ impl TopkDiverseSearchPhase {
     }
 }
 
-#[cfg(feature = "experimental_diversity_search")]
 impl Example for TopkDiverseSearchPhase {
     fn example() -> Self {
         Self {
@@ -468,7 +465,6 @@ pub(crate) enum SearchPhase {
     TopkMultihopFilter(MultihopFilterSearchPhase),
     TopkInlineFilter(InlineFilterSearchPhase),
     TopkDeterminantDiversity(TopkDeterminantDiversityPhase),
-    #[cfg(feature = "experimental_diversity_search")]
     TopkDiverseSearch(TopkDiverseSearchPhase),
 }
 
@@ -498,7 +494,6 @@ impl SearchPhase {
             Self::TopkMultihopFilter(_) => SearchPhaseKind::TopkMultihopFilter,
             Self::TopkInlineFilter(_) => SearchPhaseKind::TopkInlineFilter,
             Self::TopkDeterminantDiversity(_) => SearchPhaseKind::TopkDeterminantDiversity,
-            #[cfg(feature = "experimental_diversity_search")]
             Self::TopkDiverseSearch(_) => SearchPhaseKind::TopkDiverseSearch,
         }
     }
@@ -569,7 +564,6 @@ impl SearchPhase {
         }
     }
 
-    #[cfg(feature = "experimental_diversity_search")]
     pub(crate) fn as_topk_diverse_search(
         &self,
     ) -> Result<&TopkDiverseSearchPhase, WrongSearchPhaseKind> {
@@ -592,7 +586,6 @@ impl SearchPhase {
             SearchPhase::TopkMultihopFilter(phase) => phase.validate(checker),
             SearchPhase::TopkInlineFilter(phase) => phase.validate(checker),
             SearchPhase::TopkDeterminantDiversity(phase) => phase.validate(checker),
-            #[cfg(feature = "experimental_diversity_search")]
             SearchPhase::TopkDiverseSearch(phase) => phase.validate(checker),
         }
     }
@@ -606,7 +599,6 @@ pub(crate) enum SearchPhaseKind {
     TopkMultihopFilter,
     TopkInlineFilter,
     TopkDeterminantDiversity,
-    #[cfg(feature = "experimental_diversity_search")]
     TopkDiverseSearch,
 }
 
@@ -619,7 +611,6 @@ impl SearchPhaseKind {
             Self::TopkMultihopFilter => "topk-multihop-filter",
             Self::TopkInlineFilter => "topk-inline-filter",
             Self::TopkDeterminantDiversity => "topk-determinant-diversity",
-            #[cfg(feature = "experimental_diversity_search")]
             Self::TopkDiverseSearch => "topk-diverse-search",
         }
     }

--- a/diskann-benchmark/src/utils/attributes.rs
+++ b/diskann-benchmark/src/utils/attributes.rs
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+//! A file-backed [`AttributeValueProvider`] for diversity-aware benchmarks.
+
+use std::path::Path;
+
+use anyhow::Context;
+use diskann::{neighbor::AttributeValueProvider, provider::HasId};
+
+/// The reserved attribute bucket assigned to graph navigation nodes (frozen start points)
+/// that fall outside the range of loaded per-vector attributes.
+///
+/// Greedy graph search seeds traversal from the index's start points. Those points must
+/// therefore carry an attribute, otherwise the diverse queue would drop them and search
+/// would never expand beyond the entry node. Assigning them a dedicated bucket keeps them
+/// traversable without merging them into any real attribute group.
+const NAVIGATION_BUCKET: u32 = u32::MAX;
+
+/// An attribute value provider backed by a plaintext attribute file.
+///
+/// The file is expected to contain one unsigned integer per line, where the value on the
+/// `N`-th line (0-indexed) is the diversity attribute of the `N`-th vector. This matches the
+/// on-disk layout produced by the labelling tools used elsewhere in the pipeline.
+///
+/// Ids outside the range of loaded attributes (for example the graph's frozen start points)
+/// are mapped to a reserved [`NAVIGATION_BUCKET`] so that greedy search can still traverse
+/// the graph through them.
+#[derive(Debug, Clone)]
+pub(crate) struct FileAttributeProvider {
+    attributes: Vec<u32>,
+}
+
+impl FileAttributeProvider {
+    /// Load attributes from the plaintext file at `path`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be read or if any line fails to parse as a `u32`.
+    pub(crate) fn load(path: &Path) -> anyhow::Result<Self> {
+        let contents = std::fs::read_to_string(path)
+            .with_context(|| format!("while reading attribute file {}", path.display()))?;
+
+        let attributes = contents
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .enumerate()
+            .map(|(line, value)| {
+                value.parse::<u32>().with_context(|| {
+                    format!("invalid attribute value {value:?} on line {}", line + 1)
+                })
+            })
+            .collect::<anyhow::Result<Vec<u32>>>()?;
+
+        Ok(Self { attributes })
+    }
+}
+
+impl HasId for FileAttributeProvider {
+    type Id = u32;
+}
+
+impl AttributeValueProvider for FileAttributeProvider {
+    type Value = u32;
+
+    fn get(&self, id: Self::Id) -> Option<Self::Value> {
+        Some(
+            self.attributes
+                .get(id as usize)
+                .copied()
+                .unwrap_or(NAVIGATION_BUCKET),
+        )
+    }
+}

--- a/diskann-benchmark/src/utils/mod.rs
+++ b/diskann-benchmark/src/utils/mod.rs
@@ -15,7 +15,6 @@ pub(crate) mod recall;
 pub(crate) mod streaming;
 pub(crate) mod tokio;
 
-#[cfg(feature = "experimental_diversity_search")]
 pub(crate) mod attributes;
 
 const DATA_TYPE_MISMATCH: FailureScore = FailureScore(1000);

--- a/diskann-benchmark/src/utils/mod.rs
+++ b/diskann-benchmark/src/utils/mod.rs
@@ -15,6 +15,9 @@ pub(crate) mod recall;
 pub(crate) mod streaming;
 pub(crate) mod tokio;
 
+#[cfg(feature = "experimental_diversity_search")]
+pub(crate) mod attributes;
+
 const DATA_TYPE_MISMATCH: FailureScore = FailureScore(1000);
 
 pub(crate) fn match_data_type<T>(data_type: DataType) -> Result<MatchScore, FailureScore>

--- a/diskann-bftree/Cargo.toml
+++ b/diskann-bftree/Cargo.toml
@@ -35,7 +35,6 @@ tokio = { workspace = true, features = ["full"] }
 
 [features]
 default = []
-experimental_diversity_search = ["diskann/experimental_diversity_search"]
 
 [lints.clippy]
 undocumented_unsafe_blocks = "warn"

--- a/diskann-disk/Cargo.toml
+++ b/diskann-disk/Cargo.toml
@@ -68,10 +68,6 @@ proptest.workspace = true
 default = []
 perf_test = ["dep:opentelemetry"]
 virtual_storage = ["diskann-providers/virtual_storage"]
-experimental_diversity_search = [
-    "diskann/experimental_diversity_search",
-    "diskann-providers/experimental_diversity_search",
-]
 
 [[bench]]
 name = "bench_main"

--- a/diskann-disk/src/search/provider/disk_provider.rs
+++ b/diskann-disk/src/search/provider/disk_provider.rs
@@ -1951,7 +1951,6 @@ mod disk_provider_tests {
         );
     }
 
-    #[cfg(feature = "experimental_diversity_search")]
     #[test]
     fn test_disk_search_diversity_search() {
         use diskann::graph::DiverseSearchParams;

--- a/diskann-disk/src/search/provider/disk_provider.rs
+++ b/diskann-disk/src/search/provider/disk_provider.rs
@@ -1190,6 +1190,31 @@ where
                     &mut result_output_buffer,
                 ))?
             }
+            SearchMode::DiverseAttribute {
+                provider,
+                diverse_attribute_id,
+                diverse_results_k,
+            } => {
+                // Attribute-bucket diversity: keep at most `diverse_results_k`
+                // results per distinct attribute value. The provider is type
+                // erased (see `ErasedAttributeProvider`) so it fits the
+                // non-generic `SearchMode`.
+                let strategy = self.search_strategy(&io_tracker, PostprocessStrategy::AcceptAll);
+                let knn_search = Knn::new(k, l, beam_width)?;
+                let diverse_params = graph::DiverseSearchParams::new(
+                    *diverse_attribute_id,
+                    *diverse_results_k,
+                    Arc::new(provider.clone()),
+                );
+                let diverse = graph::search::Diverse::new(knn_search, diverse_params);
+                self.runtime.block_on(self.index.search(
+                    diverse,
+                    &strategy,
+                    &DefaultContext,
+                    query,
+                    &mut result_output_buffer,
+                ))?
+            }
         };
         query_stats.total_comparisons = stats.cmps;
         query_stats.search_hops = stats.hops;

--- a/diskann-disk/src/search/search_mode.rs
+++ b/diskann-disk/src/search/search_mode.rs
@@ -11,13 +11,42 @@
 
 use diskann::graph::ext::labeled::QueryLabelProvider;
 use diskann::graph::search::AdaptiveL;
+use diskann::neighbor::AttributeValueProvider;
+use diskann::provider::HasId;
 use diskann_providers::model::graph::provider::DeterminantDiversityParams;
+use std::sync::Arc;
 
 /// Owned closure used to filter vector IDs during disk search.
 ///
 /// The `&u32` argument is the disk-side internal/external ID (they coincide
 /// on the disk path by construction).
 pub type SearchPredicate<'a> = Box<dyn Fn(&u32) -> bool + Send + Sync + 'a>;
+
+/// Type-erased attribute provider used by the [`SearchMode::DiverseAttribute`]
+/// variant.
+///
+/// `SearchMode` is a non-generic enum, so the generic
+/// `P: AttributeValueProvider<Id = u32>` required by attribute-bucket diverse
+/// search is erased behind this trait object. The `Value` type is pinned to
+/// `u32`, matching every current provider.
+pub type DynAttributeProvider = dyn AttributeValueProvider<Id = u32, Value = u32>;
+
+/// `Sized` wrapper around [`DynAttributeProvider`] so it can be handed to
+/// `DiverseSearchParams<P>`, which requires `P: Sized`.
+#[derive(Debug, Clone)]
+pub struct ErasedAttributeProvider(pub Arc<DynAttributeProvider>);
+
+impl HasId for ErasedAttributeProvider {
+    type Id = u32;
+}
+
+impl AttributeValueProvider for ErasedAttributeProvider {
+    type Value = u32;
+
+    fn get(&self, id: Self::Id) -> Option<Self::Value> {
+        self.0.get(id)
+    }
+}
 
 /// Top-level disk search mode.
 ///
@@ -50,6 +79,12 @@ pub enum SearchMode<'a> {
     DiverseGraph {
         filter: Option<SearchPredicate<'a>>,
         params: DeterminantDiversityParams,
+    },
+
+    DiverseAttribute {
+        provider: ErasedAttributeProvider,
+        diverse_attribute_id: usize,
+        diverse_results_k: usize,
     },
 }
 
@@ -137,6 +172,21 @@ impl<'a> SearchMode<'a> {
         Self::DiverseGraph {
             filter: Some(Box::new(predicate)),
             params,
+        }
+    }
+
+    /// Attribute-bucket diverse search. Diversifies the top-k so that results
+    /// are spread across distinct attribute buckets (as opposed to
+    /// [`Self::diverse_graph`], which is determinant-based post-processing).
+    pub fn diverse_attribute(
+        provider: Arc<DynAttributeProvider>,
+        diverse_attribute_id: usize,
+        diverse_results_k: usize,
+    ) -> Self {
+        Self::DiverseAttribute {
+            provider: ErasedAttributeProvider(provider),
+            diverse_attribute_id,
+            diverse_results_k,
         }
     }
 }

--- a/diskann-providers/Cargo.toml
+++ b/diskann-providers/Cargo.toml
@@ -73,7 +73,6 @@ targets = [
 default = []
 perf_test = ["dep:opentelemetry"]
 testing = ["dep:tempfile"]
-experimental_diversity_search = ["diskann/experimental_diversity_search"]
 virtual_storage = ["dep:vfs"]
 
 # Some 'cfg's in the source tree will be flagged by `cargo clippy -j 2 --workspace --no-deps --all-targets -- -D warnings`

--- a/diskann-providers/src/index/diskann_async.rs
+++ b/diskann-providers/src/index/diskann_async.rs
@@ -2869,7 +2869,6 @@ pub(crate) mod tests {
         );
     }
 
-    #[cfg(feature = "experimental_diversity_search")]
     #[tokio::test]
     async fn test_inmemory_search_diversity_search() {
         use diskann::neighbor::AttributeValueProvider;

--- a/diskann/Cargo.toml
+++ b/diskann/Cargo.toml
@@ -61,6 +61,3 @@ tracing = ["dep:tracing"]
 
 # Enable testing providers.
 testing = ["dep:dashmap"]
-
-# Enable experimental diversity search
-experimental_diversity_search = []

--- a/diskann/src/graph/misc.rs
+++ b/diskann/src/graph/misc.rs
@@ -32,7 +32,6 @@ pub enum InplaceDeleteMethod {
 }
 
 // Parameters for diverse search
-#[cfg(feature = "experimental_diversity_search")]
 #[derive(Clone, Debug)]
 pub struct DiverseSearchParams<P>
 where
@@ -43,7 +42,6 @@ where
     pub attribute_provider: std::sync::Arc<P>,
 }
 
-#[cfg(feature = "experimental_diversity_search")]
 impl<P> DiverseSearchParams<P>
 where
     P: crate::neighbor::AttributeValueProvider,

--- a/diskann/src/graph/mod.rs
+++ b/diskann/src/graph/mod.rs
@@ -23,7 +23,6 @@ pub use start_point::{SampleableForStart, StartPointStrategy};
 mod misc;
 pub use misc::{ConsolidateKind, InplaceDeleteMethod};
 
-#[cfg(feature = "experimental_diversity_search")]
 pub use misc::DiverseSearchParams;
 
 pub mod glue;

--- a/diskann/src/graph/search/mod.rs
+++ b/diskann/src/graph/search/mod.rs
@@ -117,9 +117,7 @@ pub use knn_search::{Knn, KnnSearchError, RecordedKnn};
 pub use multihop_filter_search::MultihopFilterSearch;
 pub use range_search::{Range, RangeSearchError};
 
-// Feature-gated diverse search.
-#[cfg(feature = "experimental_diversity_search")]
+// Diverse search.
 mod diverse_search;
 
-#[cfg(feature = "experimental_diversity_search")]
 pub use diverse_search::Diverse;

--- a/diskann/src/neighbor/mod.rs
+++ b/diskann/src/neighbor/mod.rs
@@ -12,9 +12,7 @@ use crate::graph::{SearchOutputBuffer, search_output_buffer};
 mod queue;
 pub use queue::{NeighborPriorityQueue, NeighborPriorityQueueIdType, NeighborQueue};
 
-#[cfg(feature = "experimental_diversity_search")]
 mod diverse_priority_queue;
-#[cfg(feature = "experimental_diversity_search")]
 pub use diverse_priority_queue::{
     Attribute, AttributeValueProvider, DiverseNeighborQueue, VectorIdWithAttribute,
 };

--- a/diskann/src/neighbor/queue.rs
+++ b/diskann/src/neighbor/queue.rs
@@ -421,7 +421,6 @@ impl<I: NeighborPriorityQueueIdType> NeighborPriorityQueue<I> {
     ///
     /// # Arguments
     /// * `f` - A predicate that returns `true` for items to keep
-    #[cfg(feature = "experimental_diversity_search")]
     pub fn retain<F>(&mut self, mut f: F)
     where
         F: FnMut(&Neighbor<I>) -> bool,
@@ -460,7 +459,6 @@ impl<I: NeighborPriorityQueueIdType> NeighborPriorityQueue<I> {
     ///
     /// # Arguments
     /// * `len` - The new length of the queue
-    #[cfg(feature = "experimental_diversity_search")]
     pub fn truncate(&mut self, len: usize) {
         let new_size = len;
         if new_size < self.size {
@@ -1291,7 +1289,6 @@ mod neighbor_priority_queue_test {
     }
 
     #[test]
-    #[cfg(feature = "experimental_diversity_search")]
     fn test_retain() {
         let mut queue = NeighborPriorityQueue::<u32>::new(10);
 
@@ -1327,7 +1324,6 @@ mod neighbor_priority_queue_test {
     }
 
     #[test]
-    #[cfg(feature = "experimental_diversity_search")]
     fn test_retain_empty() {
         let mut queue = NeighborPriorityQueue::<u32>::new(10);
 
@@ -1337,7 +1333,6 @@ mod neighbor_priority_queue_test {
     }
 
     #[test]
-    #[cfg(feature = "experimental_diversity_search")]
     fn test_retain_remove_all() {
         let mut queue = NeighborPriorityQueue::<u32>::new(10);
 
@@ -1353,7 +1348,6 @@ mod neighbor_priority_queue_test {
     }
 
     #[test]
-    #[cfg(feature = "experimental_diversity_search")]
     fn test_retain_remove_none() {
         let mut queue = NeighborPriorityQueue::<u32>::new(10);
 
@@ -1371,7 +1365,6 @@ mod neighbor_priority_queue_test {
     }
 
     #[test]
-    #[cfg(feature = "experimental_diversity_search")]
     fn test_retain_resets_visited_state() {
         let mut queue = NeighborPriorityQueue::<u32>::new(10);
 
@@ -1411,7 +1404,6 @@ mod neighbor_priority_queue_test {
     }
 
     #[test]
-    #[cfg(feature = "experimental_diversity_search")]
     fn test_truncate() {
         let mut queue = NeighborPriorityQueue::<u32>::new(10);
 
@@ -1433,7 +1425,6 @@ mod neighbor_priority_queue_test {
     }
 
     #[test]
-    #[cfg(feature = "experimental_diversity_search")]
     fn test_truncate_larger_size() {
         let mut queue = NeighborPriorityQueue::<u32>::new(10);
 
@@ -1447,7 +1438,6 @@ mod neighbor_priority_queue_test {
     }
 
     #[test]
-    #[cfg(feature = "experimental_diversity_search")]
     fn test_truncate_with_cursor() {
         let mut queue = NeighborPriorityQueue::<u32>::new(10);
 

--- a/test_data/disk_index_search/disk_index_siftsmall_learn_256pts_attributes.txt
+++ b/test_data/disk_index_search/disk_index_siftsmall_learn_256pts_attributes.txt
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d8477e541005d06914517da07ef48b6a7dc56b3494a68eaed7cda6c124ccbe49
+size 768


### PR DESCRIPTION
Adds a feature-gated (experimental_diversity_search) topk-diverse-search benchmark path:
- DiverseKNN search wrapper in diskann-benchmark-core
- FileAttributeProvider loading plaintext per-point attributes
- TopkDiverseSearchPhase input, DiverseSearch plugin, and Knn impl wiring
- Example config and sample attribute test data All additions are gated so default builds are unaffected.

