### PR TITLE
Package `WithApproximateNorm` with `SampleableForStart`.

### DIFF
--- a/diskann-benchmark/src/index/benchmarks.rs
+++ b/diskann-benchmark/src/index/benchmarks.rs
@@ -30,7 +30,6 @@ use diskann_providers::{
 };
 use diskann_utils::{
     future::AsyncFriendly,
-    sampling::WithApproximateNorm,
     views::{Matrix, MatrixView},
 };
 use half::f16;
@@ -171,10 +170,7 @@ where
 
 impl<T> Benchmark for FullPrecision<T>
 where
-    T: VectorRepr
-        + diskann_utils::sampling::WithApproximateNorm
-        + diskann::graph::SampleableForStart
-        + AsDataType,
+    T: VectorRepr + diskann::graph::SampleableForStart + AsDataType,
 {
     type Input = IndexOperation;
     type Output = BuildResult;
@@ -298,10 +294,7 @@ impl<T> DynamicFullPrecision<T> {
 
 impl<T> Benchmark for DynamicFullPrecision<T>
 where
-    T: VectorRepr
-        + diskann_utils::sampling::WithApproximateNorm
-        + diskann::graph::SampleableForStart
-        + AsDataType,
+    T: VectorRepr + diskann::graph::SampleableForStart + AsDataType,
 {
     type Input = DynamicIndexRun;
     type Output = Vec<managed::Stats<StreamStats>>;
@@ -778,7 +771,7 @@ fn full_precision_streaming<T>(
     max_points: usize,
 ) -> anyhow::Result<bigann::WithData<T, u32, Managed<T, StreamStats>>>
 where
-    T: bytemuck::Pod + VectorRepr + WithApproximateNorm + SampleableForStart,
+    T: bytemuck::Pod + VectorRepr + SampleableForStart,
 {
     let topk = input.search_phase.as_topk()?;
 

--- a/diskann-benchmark/src/index/bftree/full_precision.rs
+++ b/diskann-benchmark/src/index/bftree/full_precision.rs
@@ -19,7 +19,6 @@ use diskann_providers::{
     model::graph::provider::async_::common::FullPrecision,
     storage::{FileStorageProvider, SaveWith},
 };
-use diskann_utils::sampling::WithApproximateNorm;
 
 use crate::{
     index::{
@@ -69,7 +68,7 @@ where
 
 impl<T> Benchmark for BfTreeFullPrecision<T>
 where
-    T: VectorRepr + AsDataType + SampleableForStart + WithApproximateNorm + 'static,
+    T: VectorRepr + AsDataType + SampleableForStart + 'static,
 {
     type Input = BfTreeFullPrecisionBuild;
     type Output = BuildResult;

--- a/diskann-benchmark/src/index/bftree/full_precision_streaming.rs
+++ b/diskann-benchmark/src/index/bftree/full_precision_streaming.rs
@@ -20,10 +20,7 @@ use diskann_providers::{
     model::graph::provider::async_::common::FullPrecision,
     storage::{FileStorageProvider, SaveWith},
 };
-use diskann_utils::{
-    sampling::WithApproximateNorm,
-    views::{Matrix, MatrixView},
-};
+use diskann_utils::views::{Matrix, MatrixView};
 
 use crate::{
     index::{
@@ -161,7 +158,7 @@ impl<T> StreamingFullPrecision<T> {
 
 impl<T> Benchmark for StreamingFullPrecision<T>
 where
-    T: VectorRepr + WithApproximateNorm + SampleableForStart + AsDataType + bytemuck::Pod,
+    T: VectorRepr + SampleableForStart + AsDataType + bytemuck::Pod,
 {
     type Input = BfTreeDynamicRun;
     type Output = Vec<managed::Stats<StreamStats>>;
@@ -236,7 +233,7 @@ fn bftree_streaming<T>(
     BfTreeFPIndex<T>,
 )>
 where
-    T: bytemuck::Pod + VectorRepr + WithApproximateNorm + SampleableForStart,
+    T: bytemuck::Pod + VectorRepr + SampleableForStart,
 {
     let topk = match &input.search_phase() {
         SearchPhase::Topk(topk) => topk,

--- a/diskann-benchmark/src/index/build.rs
+++ b/diskann-benchmark/src/index/build.rs
@@ -41,9 +41,7 @@ pub(crate) fn set_start_points<DP, T>(
 ) -> ANNResult<()>
 where
     DP: SetStartPoints<[T]>,
-    T: diskann::graph::SampleableForStart
-        + diskann_utils::sampling::WithApproximateNorm
-        + AsyncFriendly,
+    T: diskann::graph::SampleableForStart + AsyncFriendly,
 {
     let start_points = start_strategy
         .compute(data)

--- a/diskann-benchmark/src/index/inmem/product.rs
+++ b/diskann-benchmark/src/index/inmem/product.rs
@@ -124,10 +124,7 @@ mod imp {
 
     impl<T> Benchmark for ProductQuantized<T>
     where
-        T: VectorRepr
-            + diskann_utils::sampling::WithApproximateNorm
-            + diskann::graph::SampleableForStart
-            + AsDataType,
+        T: VectorRepr + diskann::graph::SampleableForStart + AsDataType,
     {
         type Input = IndexPQOperation;
         type Output = QuantBuildResult;

--- a/diskann/src/graph/start_point.rs
+++ b/diskann/src/graph/start_point.rs
@@ -44,6 +44,7 @@ pub trait SampleableForStart:
     diskann_utils::sampling::medoid::ComputeMedoid
     + diskann_utils::sampling::latin_hypercube::SampleLatinHyperCube
     + diskann_utils::sampling::random::RoundFromf32
+    + diskann_utils::sampling::WithApproximateNorm
 {
 }
 
@@ -51,6 +52,7 @@ impl<T> SampleableForStart for T where
     T: diskann_utils::sampling::medoid::ComputeMedoid
         + diskann_utils::sampling::latin_hypercube::SampleLatinHyperCube
         + diskann_utils::sampling::random::RoundFromf32
+        + diskann_utils::sampling::WithApproximateNorm
 {
 }
 
@@ -80,7 +82,7 @@ impl StartPointStrategy {
 
     pub fn compute<T>(&self, train_data: MatrixView<'_, T>) -> Result<Matrix<T>, StartPointError>
     where
-        T: Copy + SampleableForStart + diskann_utils::sampling::WithApproximateNorm,
+        T: Copy + SampleableForStart,
     {
         match self {
             StartPointStrategy::RandomSamples { nsamples, seed } => {


### PR DESCRIPTION
Add `WithApproximateNorm` as a super-trait for `SampleableForStart`.

This is clearly required as `StartPointStrategy::compute` needs this bound.