### PR TITLE
Make `Specialize` a public type.

### DIFF
--- a/diskann-vector/src/distance/implementations.rs
+++ b/diskann-vector/src/distance/implementations.rs
@@ -50,11 +50,10 @@ macro_rules! architecture_hook {
 /// A utility for specializing distance computations for fixed-length slices.
 ///
 /// When `F` implements [`diskann_wide::arch::Target2`] for [`UnalignedSlice`],
-/// `Specialize<N, F>` will implement [`FTarget2`] for slices of exactly length `N`. This
-/// can lead to must better generated code, especially when `N` is small.
+/// `Specialize<N, F>` will implement [`diskann_wide::arch::FTarget2`] for slices of exactly
+/// length `N`. This can lead to must better generated code, especially when `N` is small.
 ///
 /// Passing slices of length not equal to `N` will panic.
-///
 /// ```
 /// use diskann_vector::{AsUnaligned, distance::{Specialize, SquaredL2}};
 /// use diskann_wide::{ARCH, arch::FTarget2};

--- a/diskann-vector/src/distance/implementations.rs
+++ b/diskann-vector/src/distance/implementations.rs
@@ -48,8 +48,51 @@ macro_rules! architecture_hook {
 }
 
 /// A utility for specializing distance computations for fixed-length slices.
-#[derive(Debug, Clone, Copy)]
-pub(crate) struct Specialize<const N: usize, F>(std::marker::PhantomData<F>);
+///
+/// When `F` implements [`diskann_wide::arch::Target2`] for [`UnalignedSlice`],
+/// `Specialize<N, F>` will implement [`FTarget2`] for slices of exactly length `N`. This
+/// can lead to must better generated code, especially when `N` is small.
+///
+/// Passing slices of length not equal to `N` will panic.
+///
+/// ```
+/// use diskann_vector::{AsUnaligned, distance::{Specialize, SquaredL2}};
+/// use diskann_wide::{ARCH, arch::FTarget2};
+///
+/// let x = [1.0f32, 2.0, 3.0];
+/// let y = [2.0f32, 3.0, 4.0];
+///
+/// let result: f32 = Specialize::<3, SquaredL2>::run(
+///     ARCH,
+///     x.as_unaligned(),
+///     y.as_unaligned(),
+/// );
+///
+/// assert_eq!(result, 3.0);
+/// ```
+#[derive(Debug)]
+pub struct Specialize<const N: usize, F>(std::marker::PhantomData<F>);
+
+impl<const N: usize, F> Specialize<N, F> {
+    /// Create a new [`Specialize`].
+    pub const fn new() -> Self {
+        Self(std::marker::PhantomData)
+    }
+}
+
+impl<const N: usize, F> Default for Specialize<N, F> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const N: usize, F> Clone for Specialize<N, F> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<const N: usize, F> Copy for Specialize<N, F> {}
 
 impl<A, T, L, R, const N: usize, F>
     diskann_wide::arch::FTarget2<A, T, UnalignedSlice<'_, L>, UnalignedSlice<'_, R>>

--- a/diskann-vector/src/distance/mod.rs
+++ b/diskann-vector/src/distance/mod.rs
@@ -9,7 +9,7 @@ pub mod reference;
 pub mod simd;
 
 pub mod implementations;
-pub use implementations::{Cosine, CosineNormalized, FullL2, InnerProduct, SquaredL2};
+pub use implementations::{Cosine, CosineNormalized, FullL2, InnerProduct, Specialize, SquaredL2};
 
 pub mod distance_provider;
 pub use distance_provider::{Distance, DistanceProvider};


### PR DESCRIPTION
The `Specialize` struct is used to codegen distance function implementations for a specific slice size. This is currently used as an implementation detail of `DistanceProvider`.

This PR makes this a public type to allow downstream crates to specialize distances independently of `DistanceProvider`.

