### PR TITLE
Add `Clone` to `Runbook`.

### DIFF
--- a/diskann-benchmark-core/src/streaming/executors/bigann/runbook.rs
+++ b/diskann-benchmark-core/src/streaming/executors/bigann/runbook.rs
@@ -19,7 +19,7 @@ use super::{parsing, validate};
 ///
 /// If using this struct as a [`streaming::Executor`], consider using the
 /// [`super::WithData`] adaptor to provide dataset and query matrices.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct RunBook {
     // The individual runbook stages.
     stages: Vec<Stage>,
@@ -470,6 +470,8 @@ mod tests {
     // Runbook //
     //---------//
 
+    fn _assert_is_clone<T: Clone>(_x: &T) {}
+
     struct MockStream {
         stages: Vec<Stage>,
         current_stage: usize,
@@ -661,6 +663,7 @@ test_dataset:
         // Load the runbook
         let mut groundtruth_finder = ScanDirectory::new(temp_dir.path()).unwrap();
         let runbook = RunBook::load(&yaml_path, "test_dataset", &mut groundtruth_finder).unwrap();
+        _assert_is_clone(&runbook);
 
         // Verify the runbook was loaded correctly
         assert_eq!(runbook.len(), 8);


### PR DESCRIPTION
When working on #1206, I ran into a situation where I parsed and stored the runbook during input validation rather than deferring until the benchmark is actually run.

Making it cloneable allows reuse of such a pre-parsed runbook.