### PR TITLE
[diskann-garnet] Fix cache coherence on set_neighbors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-garnet"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "bytemuck",
  "crossbeam",

--- a/diskann-garnet/Cargo.toml
+++ b/diskann-garnet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diskann-garnet"
-version = "4.0.0"
+version = "4.0.1"
 edition = "2024"
 authors.workspace = true
 license.workspace = true

--- a/diskann-garnet/diskann-garnet.nuspec
+++ b/diskann-garnet/diskann-garnet.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>diskann-garnet</id>
-    <version>4.0.0</version>
+    <version>4.0.1</version>
     <readme>docs/README.md</readme>
     <authors>Microsoft</authors>
     <projectUrl>https://github.com/microsoft/DiskANN</projectUrl>

--- a/diskann-garnet/src/provider.rs
+++ b/diskann-garnet/src/provider.rs
@@ -728,18 +728,22 @@ impl<T: VectorRepr> GarnetProvider<T> {
         guard[0..neighbors.len()].copy_from_slice(neighbors);
         guard[self.max_degree] = neighbors.len() as u32;
 
-        if !self
-            .callbacks
-            .write_iid(&context.term(Term::Neighbors), iid, &guard)
-        {
-            return Err(GarnetProviderError::Garnet(GarnetError::Write));
+        // NOTE: We use `rmw_iid` here instead of `write_iid` to guarantee cache coherence.
+        if !self.callbacks.rmw_iid(
+            &context.term(Term::Neighbors),
+            iid,
+            (self.max_degree + 1) * mem::size_of::<u32>(),
+            |data: &mut [u32]| {
+                data.copy_from_slice(&guard);
+                if iid == 0 {
+                    self.neighbor_cache.insert(iid, neighbors.to_vec());
+                }
+            },
+        ) {
+            return Err(GarnetError::Write.into());
         }
 
         guard.finish(0);
-
-        if iid == 0 {
-            self.neighbor_cache.insert(iid, neighbors.to_vec());
-        }
 
         Ok(())
     }
@@ -780,7 +784,7 @@ impl<T: VectorRepr> GarnetProvider<T> {
                 }
             },
         ) {
-            return Err(GarnetProviderError::Garnet(GarnetError::Write));
+            return Err(GarnetError::Write.into());
         }
 
         Ok(())


### PR DESCRIPTION
When diagnosing some issues last week I realized that there was a cache coherency problem with `set_neighbors()`. `append_vector()` updates the start point neighbor cache atomically alongside the real neighbor list, but `set_neighbors()` did two writes sequentially which could result in coherency issues.

As far as I'm aware, this did not cause any actual problems, but it was easy enough to make it coherent by using RMW instead in `set_neighbors()`.