### PR TITLE
Make `opt-level=1` the default for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
             cargo clippy --locked --package "$crate" \
               --no-default-features \
               --all-targets \
-              --profile ci \
+              --profile test \
               --no-deps \
               --config "$RUST_CONFIG" \
               -- -Dwarnings
@@ -215,7 +215,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Build workspace
-        run: cargo build --workspace --locked --profile ci
+        run: cargo build --workspace --locked --profile test
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
@@ -294,7 +294,7 @@ jobs:
       - name: "SDE Baseline Tests (Nehalem)"
         run: |
           set -euxo pipefail
-          cargo test --locked --profile ci \
+          cargo test --locked \
               --package diskann-wide \
               --package diskann-vector \
               --package diskann-quantization \
@@ -355,7 +355,7 @@ jobs:
       - name: "SDE Tests (AVX-512)"
         run: |
           set -euxo pipefail
-          cargo test --locked --profile ci \
+          cargo test --locked \
             --package diskann-wide \
             --package diskann-vector \
             --package diskann-quantization \
@@ -390,8 +390,8 @@ jobs:
       - name: test workspace with nextest
         run: |
           set -euxo pipefail
-          cargo nextest run --locked --workspace --cargo-profile ci --config "$RUST_CONFIG"
-          cargo test --locked --doc --workspace --profile ci --config "$RUST_CONFIG"
+          cargo nextest run --locked --workspace --config "$RUST_CONFIG"
+          cargo test --locked --doc --workspace --config "$RUST_CONFIG"
 
   test-workspace-features:
     needs: basics
@@ -422,11 +422,10 @@ jobs:
         run: |
           set -euxo pipefail
           cargo nextest run --locked --workspace \
-            --cargo-profile ci \
             --config "$RUST_CONFIG" \
             --features ${{ env.DISKANN_FEATURES }}
 
-          cargo test --locked --doc --workspace --profile ci --config "$RUST_CONFIG"
+          cargo test --locked --doc --workspace --config "$RUST_CONFIG"
 
   coverage:
     needs: basics
@@ -456,7 +455,7 @@ jobs:
 
       - name: Generate code coverage
         run: |
-          cargo llvm-cov nextest --locked --cargo-profile ci \
+          cargo llvm-cov nextest --locked \
             --config "$RUST_CONFIG" \
             --workspace \
             --lcov --output-path lcov.info
@@ -465,7 +464,7 @@ jobs:
         env:
           RUSTFLAGS: "--cfg=miri"
         run: |
-          cargo +nightly llvm-cov nextest --locked --cargo-profile ci \
+          cargo +nightly llvm-cov nextest --locked \
             --package diskann-quantization \
             --lcov --output-path lcov_miri.info
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,8 +80,8 @@ jobs:
       - name: test workspace with nextest
         run: |
           set -euxo pipefail
-          cargo nextest run --locked --workspace --cargo-profile ci --config "$RUST_CONFIG"
-          cargo test --locked --doc --workspace --profile ci --config "$RUST_CONFIG"
+          cargo nextest run --locked --workspace --config "$RUST_CONFIG"
+          cargo test --locked --doc --workspace --config "$RUST_CONFIG"
 
   test-workspace-features:
     needs:
@@ -108,11 +108,10 @@ jobs:
         run: |
           set -euxo pipefail
           cargo nextest run --locked --workspace \
-            --cargo-profile ci \
             --config "$RUST_CONFIG" \
             --features ${{ env.DISKANN_FEATURES }}
 
-          cargo test --locked --doc --workspace --profile ci --config "$RUST_CONFIG"
+          cargo test --locked --doc --workspace --config "$RUST_CONFIG"
 
   miri:
     name: miri-test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,9 +112,13 @@ codegen-units = 1
 debug = true
 split-debuginfo = "packed"
 
-[profile.ci]
-inherits = "dev"
+# Much of our code relies on inlining and at least moderate optimizations to run in a
+# reasonable time. Setting `opt-level=1` decreases end-to-end test execution significantly
+# without blowing up compile times.
+#
+# Since `profile.test` inherits from `profile.dev` - debug assertions, overflow checks,
+# and such are still applied.
+#
+# See: https://doc.rust-lang.org/cargo/reference/profiles.html#test
+[profile.test]
 opt-level = 1
-debug = true
-debug-assertions = true
-overflow-checks = true

--- a/agents.md
+++ b/agents.md
@@ -36,7 +36,7 @@ This guide helps coding agents understand how to work efficiently with the DiskA
 The repository uses a Cargo workspace with crates organized into functional tiers. See [`Cargo.toml`](Cargo.toml) for:
 - Workspace members and their dependencies
 - Shared dependency versions
-- Build profiles (release, ci)
+- Build profiles (release, test)
 - Workspace-level lints
 
 ### Crate Organization
@@ -91,9 +91,6 @@ cargo test -p diskann
 
 # Run specific test
 cargo test -p diskann -- --exact test_name
-
-# Run with CI profile (faster)
-cargo test --profile ci
 
 # Run doc tests
 cargo test --doc

--- a/diskann-wide/README.md
+++ b/diskann-wide/README.md
@@ -30,7 +30,7 @@ The steps below assume a Linux environment with SDE installed. On Windows, use
 ```bash
 WIDE_TEST_MIN_ARCH=x86-64-v4 \
 CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="${PATH_TO_SDE} -spr --" \
-  cargo test --profile ci --package diskann-wide
+  cargo test --package diskann-wide
 ```
 
 - `CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER` tells Cargo to run every test
@@ -48,7 +48,7 @@ instructions, run under a Nehalem model:
 ```bash
 RUSTFLAGS="-Ctarget-cpu=x86-64" \
 CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER="${PATH_TO_SDE} -nhm --" \
-  cargo test --profile ci --package diskann-wide
+  cargo test --package diskann-wide
 ```
 
 SDE will abort if any AVX instruction is executed, catching accidental use of
@@ -72,7 +72,7 @@ Then run tests:
 WIDE_TEST_MIN_ARCH=neon \
 CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc \
 CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUNNER="qemu-aarch64 -L /usr/aarch64-linux-gnu" \
-  cargo test --profile ci --package diskann-wide --target aarch64-unknown-linux-gnu
+  cargo test --package diskann-wide --target aarch64-unknown-linux-gnu
 ```
 
 - `-L /usr/aarch64-linux-gnu` sets the sysroot so QEMU can find the AArch64

--- a/diskann-wide/compile-aarch64-on-x86.sh
+++ b/diskann-wide/compile-aarch64-on-x86.sh
@@ -1,4 +1,3 @@
 RUSTFLAGS="-Ctarget-feature=+neon,+dotprod -Clinker=aarch64-linux-gnu-gcc" cargo test \
     --package "$1" \
-    --target aarch64-unknown-linux-gnu \
-    --profile ci
+    --target aarch64-unknown-linux-gnu


### PR DESCRIPTION
Our workspace-wide tests have been pretty useless to run at `opt-level=0` (the default for the [dev](https://doc.rust-lang.org/cargo/reference/profiles.html#dev)/[test](https://doc.rust-lang.org/cargo/reference/profiles.html#test)) for a while now. This was made worse by the addition of larger [testing datasets](https://github.com/microsoft/DiskANN/pull/1199).

To tackle this, the `ci` profile was introduced to build and run our tests at `opt-level=1`.

However, as the workspace continues to grow, `opt-level=1` more and more just needs to be the default. Especially to be compatible with [crater](https://github.com/rust-lang/crater) runs.

This PR drops the `ci` profile and instead changes our `profile.test` to use `opt-level=1` by default. After this PR,
```
cargo nextest run --workspace
```
will use `opt-level=1` and behave like our current
```
cargo nextest run --workspace --cargo-profile ci
```