### PR TITLE
Add Rust function to expose crate version

### DIFF
--- a/diskann/src/lib.rs
+++ b/diskann/src/lib.rs
@@ -19,5 +19,10 @@ pub mod graph;
 // Top level exports.
 pub use error::ann_error::{ANNError, ANNErrorKind, ANNResult};
 
+/// Returns the version of the DiskANN crate.
+pub fn version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
 #[cfg(test)]
 mod test;

--- a/diskann/src/test/mod.rs
+++ b/diskann/src/test/mod.rs
@@ -19,3 +19,9 @@ macro_rules! assert_message_contains {
 }
 
 pub(crate) use assert_message_contains;
+
+#[test]
+fn version_works() {
+    let version = super::version();
+    assert!(!version.is_empty(), "version should not be empty");
+}


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- ~[ ] Does this PR add any new dependencies?~
- ~[ ] Does this PR modify any existing APIs?~
- [x] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?

#### What does this implement/fix? Briefly explain your changes.
It would be beneficial to add a diskann::version() function that returns the crate's version string at runtime.
This functionality is useful for applications that need to log/provide dependency versions.
