### PR TITLE
Fix floating-point precision loss in benchmark recall calculation (#1171)

### DIFF
--- a/diskann-benchmark-core/src/recall.rs
+++ b/diskann-benchmark-core/src/recall.rs
@@ -3,7 +3,10 @@
  * Licensed under the MIT license.
  */
 
-use std::{collections::HashSet, hash::Hash};
+use std::{
+    collections::{BTreeMap, HashSet},
+    hash::Hash,
+};
 
 use diskann_utils::{
     strided::StridedView,
@@ -196,8 +199,22 @@ where
         }
     }
 
-    // The actual recall computation for groundtruth
-    let mut recall_values: Vec<f64> = Vec::new();
+    // The actual recall computation for groundtruth.
+    //
+    // To avoid floating-point accumulation error we do not sum per-query `f64`
+    // ratios. Each ratio `r / this_recall_k` is generally not exactly
+    // representable (e.g. `99.0 / 100.0`), and summing thousands of them
+    // compounds the rounding, producing values like `0.9999899999999999` where
+    // the exact answer is `0.99999`. Instead we accumulate integer hit counts,
+    // grouped by their (per-row) denominator `this_recall_k`, and divide once
+    // per distinct denominator at the end. This is algebraically identical to
+    // the mean of per-query recalls, but exact whenever all scored rows share a
+    // denominator (the common fixed-size-groundtruth case).
+    //
+    // A `BTreeMap` (rather than `HashMap`) keeps the final summation order
+    // deterministic across runs, so the reported recall is bit-reproducible.
+    let mut hits_by_k: BTreeMap<usize, u64> = BTreeMap::new();
+    let mut num_scored_queries: usize = 0;
     let mut this_groundtruth = HashSet::new();
     let mut this_results = HashSet::new();
 
@@ -244,17 +261,26 @@ where
             .count()
             .min(this_recall_k);
 
-        let recall = (r as f64) / (this_recall_k as f64);
-
-        recall_values.push(recall);
+        *hits_by_k.entry(this_recall_k).or_insert(0) += r as u64;
+        num_scored_queries += 1;
     }
 
-    // Compute the average recall
-    let total: f64 = recall_values.iter().sum();
-    let average = if recall_values.is_empty() {
+    // Compute the average recall as the mean of the per-query recalls. Grouping
+    // by denominator lets each group be reduced with an exact integer numerator,
+    // limiting rounding to at most one division per distinct `this_recall_k`.
+    //
+    // `num_scored_queries` is the *global* count of scored queries, not a
+    // per-denominator count: the mean of per-query recalls divides the grand
+    // total by the number of queries, so each query contributes `1 / N`
+    // regardless of its `this_recall_k`. Concretely,
+    // `(1/N) * sum_i (r_i / k_i) == sum_d (hits_by_k[d] / (d * N))`.
+    let average = if num_scored_queries == 0 {
         0.0
     } else {
-        total / (recall_values.len() as f64)
+        hits_by_k
+            .into_iter()
+            .map(|(k, hits)| (hits as f64) / ((k * num_scored_queries) as f64))
+            .sum()
     };
 
     Ok(RecallMetrics {
@@ -675,6 +701,44 @@ mod tests {
         assert_eq!(recall.average, 0.0);
         assert!(!recall.average.is_nan());
         assert!(!recall.average.is_infinite());
+    }
+
+    // Regression test for the reported "0.9999899999999999" recall (issue #1171).
+    //
+    // With a fixed denominator, the average of the per-query recalls must be
+    // computed without floating-point accumulation error: a perfect run reports
+    // exactly `1.0`, and a run missing exactly 5 of 500_000 neighbours reports
+    // exactly `0.99999` rather than `0.9999899999999999`.
+    #[test]
+    fn test_fixed_denominator_no_precision_loss() {
+        let k = 100usize;
+        let num_queries = 5000usize;
+
+        // Groundtruth: every row is `0..k`.
+        let gt_row: Vec<u32> = (0..k as u32).collect();
+        let groundtruth: Vec<_> = (0..num_queries).map(|_| gt_row.clone()).collect();
+
+        // Perfect results: every query recovers all `k` neighbours.
+        let perfect: Vec<_> = (0..num_queries).map(|_| gt_row.clone()).collect();
+        let recall = knn(&groundtruth, None, &perfect, k, k, GroundTruthMode::Fixed).unwrap();
+        assert_eq!(recall.average, 1.0);
+
+        // Miss exactly one neighbour on 5 queries (5 misses out of 500_000).
+        let mut near_perfect = perfect.clone();
+        for row in near_perfect.iter_mut().take(5) {
+            // Replace the last groundtruth id with a non-matching one.
+            *row.last_mut().unwrap() = u32::MAX;
+        }
+        let recall = knn(
+            &groundtruth,
+            None,
+            &near_perfect,
+            k,
+            k,
+            GroundTruthMode::Fixed,
+        )
+        .unwrap();
+        assert_eq!(recall.average, 0.99999);
     }
 
     #[test]

--- a/diskann-benchmark-core/src/recall.rs
+++ b/diskann-benchmark-core/src/recall.rs
@@ -205,11 +205,13 @@ where
     // ratios. Each ratio `r / this_recall_k` is generally not exactly
     // representable (e.g. `99.0 / 100.0`), and summing thousands of them
     // compounds the rounding, producing values like `0.9999899999999999` where
-    // the exact answer is `0.99999`. Instead we accumulate integer hit counts,
-    // grouped by their (per-row) denominator `this_recall_k`, and divide once
-    // per distinct denominator at the end. This is algebraically identical to
-    // the mean of per-query recalls, but exact whenever all scored rows share a
-    // denominator (the common fixed-size-groundtruth case).
+    // the closest `f64` to the true answer is `0.99999`. Instead we accumulate
+    // integer hit counts, grouped by their (per-row) denominator
+    // `this_recall_k`, and divide once per distinct denominator at the end. This
+    // is algebraically identical to the mean of per-query recalls; the result is
+    // still rounded to `f64`, but whenever all scored rows share a denominator
+    // (the common fixed-size-groundtruth case) the rounding is limited to that
+    // single division rather than accumulating across every query.
     //
     // A `BTreeMap` (rather than `HashMap`) keeps the final summation order
     // deterministic across runs, so the reported recall is bit-reproducible.
@@ -266,7 +268,7 @@ where
     }
 
     // Compute the average recall as the mean of the per-query recalls. Grouping
-    // by denominator lets each group be reduced with an exact integer numerator,
+    // by denominator lets each group be reduced with an integer numerator,
     // limiting rounding to at most one division per distinct `this_recall_k`.
     //
     // `num_scored_queries` is the *global* count of scored queries, not a
@@ -274,12 +276,19 @@ where
     // total by the number of queries, so each query contributes `1 / N`
     // regardless of its `this_recall_k`. Concretely,
     // `(1/N) * sum_i (r_i / k_i) == sum_d (hits_by_k[d] / (d * N))`.
+    //
+    // The denominator is formed as a `u128` product so `k * num_scored_queries`
+    // cannot overflow on very large benchmarks; the single division to `f64` is
+    // the only rounding step.
     let average = if num_scored_queries == 0 {
         0.0
     } else {
         hits_by_k
             .into_iter()
-            .map(|(k, hits)| (hits as f64) / ((k * num_scored_queries) as f64))
+            .map(|(k, hits)| {
+                let denom = (k as u128) * (num_scored_queries as u128);
+                (hits as f64) / (denom as f64)
+            })
             .sum()
     };
 


### PR DESCRIPTION
### Problem

Recently, the newly added `flat scan benchmark` uncovered a small precision issue in recall calculation. `benchmark_core::recall::knn` computes recall as the mean of per-query recalls. It did this by pushing each per-query ratio `r / this_recall_k` into a `Vec<f64>`, then summing and dividing by the query count.

When every query is a clean fraction the sum stays exact, but as soon as some queries have non-terminating binary ratios (e.g. `99/100`, which isn't exactly representable in `f64`), summing such values compounds the rounding.

In the next example, the reported average then lands just off the true value — e.g. the flat-index benchmark shows `0.9999899999999999` where the exact recall is `0.99999` (499,995 matches over 500,000 groundtruth results):
```
cargo run --package diskann-benchmark --release -- run --input-file diskann-benchmark\perf_test_inputs\wikipedia-100K-flat-index.json --output-file ./target/tmp/flat-index-output.json     

######################
# Running Job 1 of 1 #
######################

              Data: target/tmp\wikipedia_cohere/wikipedia_base.bin.crop_nb_100000
         Data Type: float32
          Distance: inner_product
           Queries: target/tmp\wikipedia_cohere/wikipedia_query.bin
       Groundtruth: target/tmp\wikipedia_cohere/wikipedia-100K
                 K: 100
           Threads: 4, 8
              Reps: 1

Loading dataset...
  Loaded 100000 vectors of dimension 768
  Queries: 5000, Groundtruth: 5000x100


  K,   Avg cmps,   QPS - mean(max),             Avg Latency,           p99 Latency,               Recall,   Threads
===================================================================================================================
100,     100000,     123.0 (123.0),   32430.0us (32430.0us),   35711.0us (35711us),   0.9999899999999999,         4
100,     100000,     250.4 (250.4),   31909.2us (31909.2us),   33323.0us (33323us),   0.9999899999999999,         8
```

### Fix

Defer the division: accumulate **integer** hit counts grouped by their denominator `this_recall_k` and divide once per distinct denominator. This is algebraically identical to the mean of per-query recalls but exact whenever all rows share a denominator (the common fixed-groundtruth case), collapsing to a single division. A `BTreeMap` keeps the summation order deterministic so recall is bit-reproducible. Macro-average semantics are unchanged. A regression test asserts a perfect run reports `1.0` and a run missing 5 of 500,000 neighbours reports `0.99999`.

After the fix, recall reports `0.99999` as expected:
```
  K,   Avg cmps,   QPS - mean(max),             Avg Latency,           p99 Latency,    Recall,   Threads
========================================================================================================
100,     100000,     136.4 (136.4),   29235.7us (29235.7us),   35473.0us (35473us),   0.99999,         4
100,     100000,     268.4 (268.4),   29687.9us (29687.9us),   35269.0us (35269us),   0.99999,         8
```

PS. **Why an exact top-k flat scan still shows 5 misses (and can't reach 1.0 here)**: intuitively a brute-force flat scan should match the groundtruth perfectly, but this dataset's groundtruth was generated by an external tool whose distance kernel differs from DiskANN's by a few f32 ULPs (~1e-5). That tiny difference only matters right at the rank-k  cutoff: when two neighbours are equidistant to within f32 precision, the two kernels can disagree on which one lands at position 100 versus 101. In this run that happens for 5 queries (one of them an exact tie), so the flat scan keeps an equally-correct neighbour that the groundtruth places just outside the top 100.
