### PR TITLE
Properly feature-gate `diskann-benchmark`

### DIFF
--- a/diskann-benchmark/src/disk_index/mod.rs
+++ b/diskann-benchmark/src/disk_index/mod.rs
@@ -17,14 +17,15 @@ cfg_if::cfg_if! {
             benchmarks::register_benchmarks(registry)
         }
     } else {
-        crate::utils::stub_impl!(
-            "disk-index",
-            inputs::disk::DiskIndexOperation
-        );
-
         /// Register a stub that guides users to enable the `disk-index` feature.
         pub(crate) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()> {
-            imp::register("disk-index", registry)
+            registry.register_partially_gated::<crate::inputs::disk::DiskIndexOperation>(
+                "disk-index",
+                diskann_benchmark_runner::Features::new("disk-index"),
+                "Disk index build and search",
+            )?;
+
+            Ok(())
         }
     }
 }

--- a/diskann-benchmark/src/exhaustive/minmax.rs
+++ b/diskann-benchmark/src/exhaustive/minmax.rs
@@ -7,8 +7,6 @@ use diskann_benchmark_runner::Registry;
 
 const NAME: &str = "minmax-exhaustive-search";
 
-crate::utils::stub_impl!("minmax-quantization", inputs::exhaustive::MinMax);
-
 // MinMax - requires feature "minmax-quantization"
 #[cfg(feature = "minmax-quantization")]
 pub(super) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()> {
@@ -23,7 +21,13 @@ pub(super) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()>
 // Stub implementation
 #[cfg(not(feature = "minmax-quantization"))]
 pub(super) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()> {
-    imp::register(NAME, registry)
+    registry.register_partially_gated::<crate::inputs::exhaustive::MinMax>(
+        NAME,
+        diskann_benchmark_runner::Features::new("minmax-quantization"),
+        "MinMax quantization exhaustive search",
+    )?;
+
+    Ok(())
 }
 
 /////////////

--- a/diskann-benchmark/src/exhaustive/product.rs
+++ b/diskann-benchmark/src/exhaustive/product.rs
@@ -7,14 +7,16 @@ use diskann_benchmark_runner::Registry;
 
 const NAME: &str = "product-exhaustive-search";
 
-crate::utils::stub_impl!("product-quantization", inputs::exhaustive::Product);
-
 pub(super) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()> {
     #[cfg(feature = "product-quantization")]
     registry.register(NAME, imp::ProductQ)?;
 
     #[cfg(not(feature = "product-quantization"))]
-    imp::register(NAME, registry)?;
+    registry.register_partially_gated::<crate::inputs::exhaustive::Product>(
+        NAME,
+        diskann_benchmark_runner::Features::new("product-quantization"),
+        "Product quantization exhaustive search",
+    )?;
 
     Ok(())
 }

--- a/diskann-benchmark/src/exhaustive/spherical.rs
+++ b/diskann-benchmark/src/exhaustive/spherical.rs
@@ -7,8 +7,6 @@ use diskann_benchmark_runner::Registry;
 
 const NAME: &str = "spherical-exhaustive-search";
 
-crate::utils::stub_impl!("spherical-quantization", inputs::exhaustive::Spherical);
-
 // Spherical - requires feature "spherical-quantization"
 #[cfg(feature = "spherical-quantization")]
 pub(super) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()> {
@@ -23,7 +21,13 @@ pub(super) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()>
 // Stub implementation
 #[cfg(not(feature = "spherical-quantization"))]
 pub(super) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()> {
-    imp::register(NAME, registry)
+    registry.register_partially_gated::<crate::inputs::exhaustive::Spherical>(
+        NAME,
+        diskann_benchmark_runner::Features::new("spherical-quantization"),
+        "Spherical quantization (RabitQ) exhaustive search",
+    )?;
+
+    Ok(())
 }
 
 ////////////////

--- a/diskann-benchmark/src/index/bftree/mod.rs
+++ b/diskann-benchmark/src/index/bftree/mod.rs
@@ -15,15 +15,28 @@
 //! - `graph-index-build-bftree-spherical-quantization` — static spherical (1/2/4-bit)
 //! - `graph-index-stream-bftree-spherical-quantization` — streaming spherical (1/2/4-bit)
 
-use crate::index::search::plugins::Topk;
 use diskann_benchmark_runner::Registry;
 
+#[cfg(feature = "bftree")]
+use crate::index::search::plugins::Topk;
+
+// Avoid `cfg_if` as `rustfmt` doesn't reliably format through `cfg_if`.
+#[cfg(feature = "bftree")]
 mod full_precision;
+
+#[cfg(feature = "bftree")]
 mod full_precision_streaming;
+
+#[cfg(feature = "bftree")]
 mod spherical;
+
+#[cfg(feature = "bftree")]
 mod spherical_streaming;
+
+#[cfg(feature = "bftree")]
 mod streaming_utils;
 
+#[cfg(feature = "bftree")]
 pub(crate) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()> {
     registry.register(
         "graph-index-bftree-full-precision-f32",
@@ -43,6 +56,39 @@ pub(crate) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()>
     registry.register(
         "graph-index-stream-bftree-spherical-quantization",
         spherical_streaming::StreamingSpherical::new(),
+    )?;
+
+    Ok(())
+}
+
+#[cfg(not(feature = "bftree"))]
+pub(crate) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()> {
+    registry.register_gated(
+        "graph-index-build-bftree-full-precision",
+        "graph-index-bftree-full-precision",
+        diskann_benchmark_runner::Features::new("bftree"),
+        "BFTree powered graph index build and search",
+    )?;
+
+    registry.register_gated(
+        "graph-index-stream-bftree-full-precision",
+        "graph-index-bftree-stream-full-precision",
+        diskann_benchmark_runner::Features::new("bftree"),
+        "BFTree powered graph index streaming",
+    )?;
+
+    registry.register_gated(
+        "graph-index-build-bftree-spherical-quantization",
+        "graph-index-bftree-spherical-quantization",
+        diskann_benchmark_runner::Features::new("bftree"),
+        "BFTree powered graph index build and search with spherical (RabitQ) quantization",
+    )?;
+
+    registry.register_gated(
+        "graph-index-stream-bftree-spherical-quantization",
+        "graph-index-stream-bftree-spherical-quantization",
+        diskann_benchmark_runner::Features::new("bftree"),
+        "BFTree powered graph index streaming with spherical (RabitQ) quantizatiohn",
     )?;
 
     Ok(())

--- a/diskann-benchmark/src/index/bftree/mod.rs
+++ b/diskann-benchmark/src/index/bftree/mod.rs
@@ -88,7 +88,7 @@ pub(crate) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()>
         "graph-index-stream-bftree-spherical-quantization",
         "graph-index-stream-bftree-spherical-quantization",
         diskann_benchmark_runner::Features::new("bftree"),
-        "BFTree powered graph index streaming with spherical (RabitQ) quantizatiohn",
+        "BFTree powered graph index streaming with spherical (RabitQ) quantization",
     )?;
 
     Ok(())

--- a/diskann-benchmark/src/index/inmem/product.rs
+++ b/diskann-benchmark/src/index/inmem/product.rs
@@ -5,12 +5,6 @@
 
 use diskann_benchmark_runner::Registry;
 
-// Create a stub-module if the "spherical-quantization" feature is disabled.
-crate::utils::stub_impl!(
-    "product-quantization",
-    inputs::graph_index::IndexPQOperation
-);
-
 pub(crate) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()> {
     #[cfg(feature = "product-quantization")]
     {
@@ -33,9 +27,12 @@ pub(crate) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()>
         )?;
     }
 
-    // Stub implementation
     #[cfg(not(feature = "product-quantization"))]
-    imp::register("graph-index-pq", registry)?;
+    registry.register_partially_gated::<crate::inputs::graph_index::IndexPQOperation>(
+        "graph-index-pq",
+        diskann_benchmark_runner::Features::new("product-quantization"),
+        "PQ based graph index build and search",
+    )?;
 
     Ok(())
 }

--- a/diskann-benchmark/src/index/inmem/scalar.rs
+++ b/diskann-benchmark/src/index/inmem/scalar.rs
@@ -5,9 +5,6 @@
 
 use diskann_benchmark_runner::Registry;
 
-// Create a stub-module if the "scalar-quantization" feature is disabled.
-crate::utils::stub_impl!("scalar-quantization", inputs::graph_index::IndexSQOperation);
-
 pub(crate) fn register_benchmarks(benchmarks: &mut Registry) -> anyhow::Result<()> {
     #[cfg(feature = "scalar-quantization")]
     {
@@ -44,9 +41,12 @@ pub(crate) fn register_benchmarks(benchmarks: &mut Registry) -> anyhow::Result<(
         )?;
     }
 
-    // Stub implementation
     #[cfg(not(feature = "scalar-quantization"))]
-    imp::register("graph-index-sq", benchmarks)?;
+    benchmarks.register_partially_gated::<crate::inputs::graph_index::IndexSQOperation>(
+        "graph-index-sq",
+        diskann_benchmark_runner::Features::new("scalar-quantization"),
+        "Scalar-quantized graph index build and search",
+    )?;
 
     Ok(())
 }

--- a/diskann-benchmark/src/index/inmem/spherical.rs
+++ b/diskann-benchmark/src/index/inmem/spherical.rs
@@ -5,12 +5,6 @@
 
 use diskann_benchmark_runner::Registry;
 
-// Create a stub-module if the "spherical-quantization" feature is disabled.
-crate::utils::stub_impl!(
-    "spherical-quantization",
-    inputs::graph_index::SphericalQuantBuild
-);
-
 pub(crate) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()> {
     const NAME: &str = "graph-index-spherical-quantization";
 
@@ -52,9 +46,12 @@ pub(crate) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()>
         )?;
     }
 
-    // Stub implementation
     #[cfg(not(feature = "spherical-quantization"))]
-    imp::register(NAME, registry)?;
+    registry.register_partially_gated::<crate::inputs::graph_index::SphericalQuantBuild>(
+        NAME,
+        diskann_benchmark_runner::Features::new("spherical-quantization"),
+        "Spherical quantized (RabitQ) graph build and search",
+    )?;
 
     Ok(())
 }

--- a/diskann-benchmark/src/index/mod.rs
+++ b/diskann-benchmark/src/index/mod.rs
@@ -13,13 +13,10 @@ mod benchmarks;
 mod inmem;
 mod result;
 
-#[cfg(feature = "bftree")]
 mod bftree;
 
 pub(crate) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()> {
     benchmarks::register_benchmarks(registry)?;
-
-    #[cfg(feature = "bftree")]
     bftree::register_benchmarks(registry)?;
 
     Ok(())

--- a/diskann-benchmark/src/main.rs
+++ b/diskann-benchmark/src/main.rs
@@ -513,7 +513,7 @@ mod tests {
         println!("err = {:?}", err);
 
         let output = String::from_utf8(output.into_inner()).unwrap();
-        assert!(output.contains("\"minmax-quantization\" feature"));
+        assert!(output.contains("feature \"minmax-quantization\""));
         println!("output = {}", output);
 
         // The output file should not have been created because we failed the test.
@@ -580,7 +580,7 @@ mod tests {
         println!("err = {:?}", err);
 
         let output = String::from_utf8(output.into_inner()).unwrap();
-        assert!(output.contains("\"scalar-quantization\" feature"));
+        assert!(output.contains("feature \"scalar-quantization\""));
         println!("output = {}", output);
 
         // The output file should not have been created because we failed the test.
@@ -651,7 +651,7 @@ mod tests {
 
         let output = String::from_utf8(output.into_inner()).unwrap();
         println!("output = {}", output);
-        assert!(output.contains("\"spherical-quantization\" feature"));
+        assert!(output.contains("feature \"spherical-quantization\""));
 
         // The output file should not have been created because we failed the test.
         assert!(!output_path.exists());
@@ -913,7 +913,7 @@ mod tests {
         println!("err = {:?}", err);
 
         let output = String::from_utf8(output.into_inner()).unwrap();
-        assert!(output.contains("\"product-quantization\" feature"));
+        assert!(output.contains("feature \"product-quantization\""));
         println!("output = {}", output);
 
         // The output file should not have been created because we failed the test.
@@ -977,7 +977,7 @@ mod tests {
         println!("err = {:?}", err);
 
         let output = String::from_utf8(output.into_inner()).unwrap();
-        assert!(output.contains("\"multi-vector\" feature"));
+        assert!(output.contains("feature \"multi-vector\""));
         println!("output = {}", output);
 
         // The output file should not have been created because we failed the test.

--- a/diskann-benchmark/src/multi_vector/mod.rs
+++ b/diskann-benchmark/src/multi_vector/mod.rs
@@ -32,7 +32,7 @@ cfg_if::cfg_if! {
     } else {
         pub(super) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()> {
             registry.register_partially_gated::<crate::inputs::multi_vector::MultiVectorOp>(
-                "multi-vector",
+                "multi-vector-op",
                 diskann_benchmark_runner::Features::new("multi-vector"),
                 "Multi-vector distance function benchmarks",
             )?;

--- a/diskann-benchmark/src/multi_vector/mod.rs
+++ b/diskann-benchmark/src/multi_vector/mod.rs
@@ -30,10 +30,14 @@ cfg_if::cfg_if! {
             kernels::register(registry)
         }
     } else {
-        crate::utils::stub_impl!("multi-vector", inputs::multi_vector::MultiVectorOp);
-
         pub(super) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()> {
-            imp::register("multi-vector-op", registry)
+            registry.register_partially_gated::<crate::inputs::multi_vector::MultiVectorOp>(
+                "multi-vector",
+                diskann_benchmark_runner::Features::new("multi-vector"),
+                "Multi-vector distance function benchmarks",
+            )?;
+
+            Ok(())
         }
     }
 }

--- a/diskann-benchmark/src/utils/mod.rs
+++ b/diskann-benchmark/src/utils/mod.rs
@@ -102,61 +102,6 @@ where
     }
 }
 
-/// Backend implementations are gated behind additive features to reduce compilation time
-/// when only a subset of benchmarks are needed.
-///
-/// However, when benchmarks are feature gated, we want to provide a useful diagnostic when
-/// users try to run a benchmark targeting the blocked out method.
-///
-/// To do this, we use stub implementations that use "dispatch matching" to match the same
-/// `CentralDispatch` enum as the base benchmark, but return an error that describes
-/// feature required to enable the backend benchmark.
-macro_rules! stub_impl {
-    ($feature:literal, $input:path $(,)?) => {
-        #[cfg(not(feature = $feature))]
-        mod imp {
-            use diskann_benchmark_runner::{output::Output, Benchmark, Checkpoint, Registry};
-
-            use crate::inputs;
-
-            pub(super) fn register(name: &str, registry: &mut Registry) -> anyhow::Result<()> {
-                Ok(registry.register(name, Stub)?)
-            }
-
-            /// An empty placeholder to provide a hint for the necessary feature.
-            pub(super) struct Stub;
-
-            impl Benchmark for Stub {
-                type Input = $input;
-                type Output = serde_json::Value;
-
-                fn try_match(
-                    &self,
-                    _input: &$input,
-                    context: &diskann_benchmark_runner::benchmark::MatchContext,
-                ) -> diskann_benchmark_runner::benchmark::Score {
-                    context.fail(0, &concat!("Requires the \"", $feature, "\" feature"))
-                }
-
-                fn description(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                    writeln!(f, "{}", concat!("Requires the \"", $feature, "\" feature"))
-                }
-
-                fn run(
-                    &self,
-                    _input: &$input,
-                    _checkpoint: Checkpoint<'_>,
-                    _output: &mut dyn Output,
-                ) -> anyhow::Result<serde_json::Value> {
-                    panic!("this function should not be called!");
-                }
-            }
-        }
-    };
-}
-
-pub(crate) use stub_impl;
-
 /////////////////
 // SmallBanner //
 /////////////////


### PR DESCRIPTION
This is a follow-up to #1242 to move `diskann-benchmark` to the new feature gated feature.

A summary of the updated error messages is shown below:

# When trying to load `bf-tree` inputs

**Command**
```
cargo run --package diskann-benchmark -- \
    run \
    --input-file ./diskann-benchmark/example/graph-index-bftree-stream.json \
    --output-file temp.json
```
**Before**
```
Error: while processing input 1 of 1

Caused by:
    Unrecognized input tag: "graph-index-stream-bftree-full-precision"
```
**After**
```
Error: while processing input 1 of 1

Caused by:
    use of the "graph-index-stream-bftree-full-precision" input is gated behind the feature "bftree"
```

# When trying to run a gated benchmark
**Command**
```
cargo run --package diskann-benchmark -- \
    run \
    --input-file ./diskann-benchmark/example/graph-index-spherical-quantization.json \
    --output-file temp.json
```
**Before**
```
...
Closest matches:

    1. "graph-index-spherical-quantization":
        - Requires the "spherical-quantization" feature

    2. "spherical-exhaustive-search":
        - expected tag "exhaustive-spherical-quantization" - instead got "graph-index-build-spherical-quantization"

    3. "minmax-exhaustive-search":
        - expected tag "exhaustive-minmax-quantization" - instead got "graph-index-build-spherical-quantization"


Error: could not find a benchmark for all inputs
```
**After**
```
No active benchmarks are registered for tag "graph-index-build-spherical-quantization"

Found 1 gated benchmark matching this input:

    * "graph-index-spherical-quantization" (requires the feature "spherical-quantization")

Error: could not find a benchmark for all inputs
```

# Input Discovery
When running `cargo run --package diskann-benchmark -- inputs --all`, the following is now displayed
```
Available input kinds are listed below:
    disk-index
    exhaustive-minmax-quantization
    exhaustive-product-quantization
    exhaustive-spherical-quantization
    flat-search
    graph-index-build
    graph-index-build-pq
    graph-index-build-spherical-quantization
    graph-index-build-sq
    graph-index-dynamic-run
    metadata-index-build
    multi-vector-op
    graph-index-build-bftree-full-precision (requires the feature "bftree")
    graph-index-build-bftree-spherical-quantization (requires the feature "bftree")
    graph-index-stream-bftree-full-precision (requires the feature "bftree")
    graph-index-stream-bftree-spherical-quantization (requires the feature "bftree")
```