### PR TITLE
Add direct deserialization methods to `Impl`.

### DIFF
--- a/diskann-quantization/src/spherical/iface.rs
+++ b/diskann-quantization/src/spherical/iface.rs
@@ -1175,6 +1175,7 @@ impl<const NBITS: usize, A: Allocator> Impl<NBITS, A> {
         }
     }
 
+    #[cfg(feature = "flatbuffers")]
     fn try_deserialize_from(
         proto: fb::spherical::SphericalQuantizer<'_>,
         alloc: A,

--- a/diskann-quantization/src/spherical/iface.rs
+++ b/diskann-quantization/src/spherical/iface.rs
@@ -1152,10 +1152,7 @@ impl<const NBITS: usize, A: Allocator> Impl<NBITS, A> {
     /// Attempt to deserialize an `spherical::Quantizer` flatbuffer into [`Impl`].
     #[cfg(feature = "flatbuffers")]
     #[cfg_attr(docsrs, doc(cfg(feature = "flatbuffers")))]
-    pub fn try_deserialize(
-        data: &[u8],
-        alloc: A,
-    ) -> Result<Self, DeserializationError>
+    pub fn try_deserialize(data: &[u8], alloc: A) -> Result<Self, DeserializationError>
     where
         Self: Constructible<A>,
     {
@@ -1174,13 +1171,14 @@ impl<const NBITS: usize, A: Allocator> Impl<NBITS, A> {
         if nbits as usize == NBITS {
             Self::try_deserialize_from(proto, alloc)
         } else {
+            println!("here with {}", nbits);
             Err(DeserializationError::UnsupportedBitWidth(nbits))
         }
     }
 
     fn try_deserialize_from(
         proto: fb::spherical::SphericalQuantizer<'_>,
-        alloc: A
+        alloc: A,
     ) -> Result<Self, DeserializationError>
     where
         Self: Constructible<A>,
@@ -2055,7 +2053,7 @@ where
                 return Err(err.into());
             }
             Err(CompoundError::Constructor(err)) => {
-                return Err(err.into());
+                return Err(err);
             }
         };
         Ok(poly!({ Quantizer<O> }, imp))
@@ -2616,20 +2614,15 @@ mod tests {
         use super::*;
         use crate::alloc::{BumpAllocator, GlobalAllocator};
 
-        #[inline(never)]
-        fn test_plan_serialization(
+        fn test_deserialization_inner(
             quantizer: &dyn Quantizer,
+            deserialized: &dyn Quantizer,
             nbits: usize,
-            dataset: MatrixView<f32>,
+            dataset: MatrixView<'_, f32>,
         ) {
-            // Run bit-width agnostic tests.
-            assert_eq!(quantizer.full_dim(), dataset.ncols());
             let scoped_global = ScopedAllocator::global();
 
-            let serialized = quantizer.serialize(GlobalAllocator).unwrap();
-            let deserialized =
-                try_deserialize::<GlobalAllocator, _>(&serialized, GlobalAllocator).unwrap();
-
+            assert_eq!(quantizer.nbits(), nbits);
             assert_eq!(deserialized.nbits(), nbits);
             assert_eq!(deserialized.bytes(), quantizer.bytes());
             assert_eq!(deserialized.dim(), quantizer.dim());
@@ -2740,6 +2733,84 @@ mod tests {
                         }
                     }
                 }
+            }
+        }
+
+        #[inline(never)]
+        fn test_plan_serialization(
+            quantizer: &dyn Quantizer,
+            nbits: usize,
+            dataset: MatrixView<f32>,
+        ) {
+            let global = GlobalAllocator;
+
+            // Run bit-width agnostic tests.
+            assert_eq!(quantizer.full_dim(), dataset.ncols());
+
+            let serialized = quantizer.serialize(global).unwrap();
+            let deserialized = try_deserialize::<GlobalAllocator, _>(&serialized, global).unwrap();
+
+            test_deserialization_inner(quantizer, &*deserialized, nbits, dataset);
+
+            // Go through the direct deserialization interface.
+            match nbits {
+                1 => {
+                    test_deserialization_inner(
+                        quantizer,
+                        &Impl::<1, _>::try_deserialize(&serialized, global).unwrap(),
+                        nbits,
+                        dataset,
+                    );
+
+                    // Verify that we can't reload with a different bit-width.
+                    assert!(matches!(
+                        Impl::<2, _>::try_deserialize(&serialized, global),
+                        Err(DeserializationError::UnsupportedBitWidth(1)),
+                    ));
+                }
+                2 => {
+                    test_deserialization_inner(
+                        quantizer,
+                        &Impl::<2, _>::try_deserialize(&serialized, global).unwrap(),
+                        nbits,
+                        dataset,
+                    );
+
+                    // Verify that we can't reload with a different bit-width.
+                    assert!(matches!(
+                        Impl::<1, _>::try_deserialize(&serialized, global),
+                        Err(DeserializationError::UnsupportedBitWidth(2)),
+                    ));
+                }
+                4 => {
+                    test_deserialization_inner(
+                        quantizer,
+                        &Impl::<4, _>::try_deserialize(&serialized, global).unwrap(),
+                        nbits,
+                        dataset,
+                    );
+
+                    // Verify that we can't reload with a different bit-width.
+                    assert!(matches!(
+                        Impl::<8, _>::try_deserialize(&serialized, global),
+                        Err(DeserializationError::UnsupportedBitWidth(4)),
+                    ));
+                }
+                8 => {
+                    test_deserialization_inner(
+                        quantizer,
+                        &Impl::<8, _>::try_deserialize(&serialized, global).unwrap(),
+                        nbits,
+                        dataset,
+                    );
+
+                    // Verify that we can't reload with a different bit-width.
+                    assert!(matches!(
+                        Impl::<4, _>::try_deserialize(&serialized, global),
+                        Err(DeserializationError::UnsupportedBitWidth(8)),
+                    ));
+                }
+                _ => panic!("bit width {} is not supported", nbits),
             }
         }
 

--- a/diskann-quantization/src/spherical/iface.rs
+++ b/diskann-quantization/src/spherical/iface.rs
@@ -1149,6 +1149,46 @@ impl<const NBITS: usize, A: Allocator> Impl<NBITS, A> {
         .map_err(|e| e.into())
     }
 
+    /// Attempt to deserialize an `spherical::Quantizer` flatbuffer into [`Impl`].
+    #[cfg(feature = "flatbuffers")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "flatbuffers")))]
+    pub fn try_deserialize(
+        data: &[u8],
+        alloc: A,
+    ) -> Result<Self, DeserializationError>
+    where
+        Self: Constructible<A>,
+    {
+        // Check that this is one of the known identifiers.
+        if !fb::spherical::quantizer_buffer_has_identifier(data) {
+            return Err(DeserializationError::InvalidIdentifier);
+        }
+
+        // Match as much as we can without allocating.
+        //
+        // Then, we branch on the number of bits.
+        let root = fb::spherical::root_as_quantizer(data)?;
+        let nbits = root.nbits();
+        let proto = root.quantizer();
+
+        if nbits as usize == NBITS {
+            Self::try_deserialize_from(proto, alloc)
+        } else {
+            Err(DeserializationError::UnsupportedBitWidth(nbits))
+        }
+    }
+
+    fn try_deserialize_from(
+        proto: fb::spherical::SphericalQuantizer<'_>,
+        alloc: A
+    ) -> Result<Self, DeserializationError>
+    where
+        Self: Constructible<A>,
+    {
+        let quantizer = SphericalQuantizer::try_unpack(alloc, proto)?;
+        Ok(Self::new(quantizer)?)
+    }
+
     #[cfg(feature = "flatbuffers")]
     fn serialize<B>(&self, allocator: B) -> Result<Poly<[u8], B>, AllocatorError>
     where
@@ -2007,11 +2047,7 @@ where
         Impl<NBITS, A>: Quantizer<O> + Constructible<A>,
     {
         let imp = match Poly::new_with(
-            #[inline(never)]
-            |alloc| -> Result<_, super::quantizer::DeserializationError> {
-                let quantizer = SphericalQuantizer::try_unpack(alloc, proto)?;
-                Ok(Impl::new(quantizer)?)
-            },
+            |alloc| Impl::<NBITS, A>::try_deserialize_from(proto, alloc),
             alloc,
         ) {
             Ok(imp) => imp,

--- a/diskann-quantization/src/spherical/iface.rs
+++ b/diskann-quantization/src/spherical/iface.rs
@@ -1171,7 +1171,6 @@ impl<const NBITS: usize, A: Allocator> Impl<NBITS, A> {
         if nbits as usize == NBITS {
             Self::try_deserialize_from(proto, alloc)
         } else {
-            println!("here with {}", nbits);
             Err(DeserializationError::UnsupportedBitWidth(nbits))
         }
     }

--- a/diskann-quantization/src/spherical/iface.rs
+++ b/diskann-quantization/src/spherical/iface.rs
@@ -1149,7 +1149,7 @@ impl<const NBITS: usize, A: Allocator> Impl<NBITS, A> {
         .map_err(|e| e.into())
     }
 
-    /// Attempt to deserialize an `spherical::Quantizer` flatbuffer into [`Impl`].
+    /// Attempt to deserialize a FlatBuffer `fb::spherical::Quantizer` (as produced by [`Quantizer::serialize`]) into [`Impl`].
     #[cfg(feature = "flatbuffers")]
     #[cfg_attr(docsrs, doc(cfg(feature = "flatbuffers")))]
     pub fn try_deserialize(data: &[u8], alloc: A) -> Result<Self, DeserializationError>


### PR DESCRIPTION
Add `try_deserialize` methods directly to `spherical::iface::Impl` structs to allow deserialization independently of the `Quantizer` trait object.