### PR TITLE
Strip generic from PQ computers.

### DIFF
--- a/diskann-benchmark/src/exhaustive/product.rs
+++ b/diskann-benchmark/src/exhaustive/product.rs
@@ -363,9 +363,7 @@ mod imp {
     }
 
     impl algos::CreateQuantComputer<Store> for Plan {
-        type Computer<'a> = diskann_providers::model::pq::distance::QueryComputer<
-            &'a diskann_providers::model::pq::FixedChunkPQTable,
-        >;
+        type Computer<'a> = diskann_providers::model::pq::distance::QueryComputer<'a>;
 
         fn create_quant_computer<'a>(
             &self,

--- a/diskann-providers/src/model/graph/provider/async_/distances.rs
+++ b/diskann-providers/src/model/graph/provider/async_/distances.rs
@@ -64,13 +64,11 @@ pub mod pq {
     //! vector or a PQ-compressed code. The [`Hybrid`] enum captures this duality, and the
     //! remaining types adapt it to the [`workingset`](diskann::graph::workingset) framework.
 
-    use std::sync::Arc;
-
     use diskann::utils::VectorRepr;
     use diskann_utils::Reborrow;
     use diskann_vector::DistanceFunction;
 
-    use crate::model::pq::{self, FixedChunkPQTable};
+    use crate::model::pq;
 
     /// An element that is either a full-precision vector or a PQ-compressed code.
     ///
@@ -117,28 +115,25 @@ pub mod pq {
     /// When both operands are full-precision, the native distance function is used. When
     /// at least one is quantized, the PQ distance table is used instead. Mixed pairs
     /// (full vs quant) convert the full-precision side to `f32` for the PQ lookup.
-    pub struct HybridComputer<T>
+    pub struct HybridComputer<'a, T>
     where
         T: VectorRepr,
     {
-        quant: pq::distance::DistanceComputer<Arc<FixedChunkPQTable>>,
+        quant: pq::distance::DistanceComputer<'a>,
         full: T::Distance,
     }
 
-    impl<T> HybridComputer<T>
+    impl<'a, T> HybridComputer<'a, T>
     where
         T: VectorRepr,
     {
-        pub fn new(
-            quant: pq::distance::DistanceComputer<Arc<FixedChunkPQTable>>,
-            full: T::Distance,
-        ) -> Self {
+        pub fn new(quant: pq::distance::DistanceComputer<'a>, full: T::Distance) -> Self {
             Self { quant, full }
         }
     }
 
     /// The implementation of `DistanceFunction` for the hybrid computer.
-    impl<T> DistanceFunction<Hybrid<&[T], &[u8]>, Hybrid<&[T], &[u8]>, f32> for HybridComputer<T>
+    impl<T> DistanceFunction<Hybrid<&[T], &[u8]>, Hybrid<&[T], &[u8]>, f32> for HybridComputer<'_, T>
     where
         T: VectorRepr,
     {

--- a/diskann-providers/src/model/graph/provider/async_/experimental/multi_pq_async.rs
+++ b/diskann-providers/src/model/graph/provider/async_/experimental/multi_pq_async.rs
@@ -18,10 +18,9 @@ use crate::model::{
 /// The discriminant type for PQ vector versions.
 type VersionId = u8;
 type VersionedPQVector = multi::VersionedPQVector<VersionId>;
-type TableType = Arc<FixedChunkPQTable>;
-type MultiTable = multi::MultiTable<TableType, VersionId>;
-type QueryComputer = multi::MultiQueryComputer<TableType, VersionId>;
-type DistanceComputer = multi::MultiDistanceComputer<TableType, VersionId>;
+type MultiTable<'a> = multi::MultiTable<'a, VersionId>;
+type QueryComputer<'a> = multi::MultiQueryComputer<'a, VersionId>;
+type DistanceComputer<'a> = multi::MultiDistanceComputer<'a, VersionId>;
 
 /// A provider that has two PQ schemas.
 pub struct TestMultiPQProviderAsync {
@@ -68,14 +67,14 @@ impl TestMultiPQProviderAsync {
         self.table_new.get_num_chunks()
     }
 
-    pub fn multi_table(&self) -> Result<MultiTable, multi::EqualVersionsError> {
+    pub fn multi_table(&self) -> Result<MultiTable<'_>, multi::EqualVersionsError> {
         match &self.table_old {
-            None => Ok(MultiTable::one(self.table_new.clone(), 1)),
-            Some(table_old) => MultiTable::two(self.table_new.clone(), table_old.clone(), 2, 1),
+            None => Ok(MultiTable::one(&self.table_new, 1)),
+            Some(table_old) => MultiTable::two(&self.table_new, table_old, 2, 1),
         }
     }
 
-    pub fn get_query_computer<T>(&self, query: &[T]) -> ANNResult<NoneToInfinity<QueryComputer>>
+    pub fn get_query_computer<T>(&self, query: &[T]) -> ANNResult<NoneToInfinity<QueryComputer<'_>>>
     where
         T: VectorRepr,
     {
@@ -89,7 +88,7 @@ impl TestMultiPQProviderAsync {
         )?))
     }
 
-    pub fn get_distance_computer(&self) -> ANNResult<NoneToInfinity<DistanceComputer>> {
+    pub fn get_distance_computer(&self) -> ANNResult<NoneToInfinity<DistanceComputer<'_>>> {
         let table = self.multi_table().map_err(|err| {
             ANNError::log_index_error(format_args!("Table construction failed with: {}", err))
         })?;

--- a/diskann-providers/src/model/graph/provider/async_/fast_memory_quant_vector_provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/fast_memory_quant_vector_provider.rs
@@ -55,8 +55,8 @@ pub struct FastMemoryQuantVectorProviderAsync {
     vec_pool: Arc<ObjectPool<Vec<f32>>>,
 }
 
-type DistanceComputer = pq::distance::DistanceComputer<Arc<FixedChunkPQTable>>;
-type QueryComputer = pq::distance::QueryComputer<Arc<FixedChunkPQTable>>;
+type DistanceComputer<'a> = pq::distance::DistanceComputer<'a>;
+type QueryComputer<'a> = pq::distance::QueryComputer<'a>;
 
 impl FastMemoryQuantVectorProviderAsync {
     pub fn new(dist_metric: Metric, max_vectors: usize, pq_chunk_table: FixedChunkPQTable) -> Self {
@@ -99,12 +99,12 @@ impl FastMemoryQuantVectorProviderAsync {
     }
 
     /// Create a query computer for the provided query vector.
-    pub fn query_computer<T>(&self, query: &[T]) -> ANNResult<QueryComputer>
+    pub fn query_computer<T>(&self, query: &[T]) -> ANNResult<QueryComputer<'_>>
     where
         T: VectorRepr,
     {
         QueryComputer::new(
-            self.pq_chunk_table.clone(),
+            &self.pq_chunk_table,
             self.metric,
             &T::as_f32(query).into_ann_result()?,
             Some(self.vec_pool.clone()),
@@ -112,8 +112,8 @@ impl FastMemoryQuantVectorProviderAsync {
     }
 
     /// Create a distance computer for the underlying schema.
-    pub fn distance_computer(&self) -> DistanceComputer {
-        DistanceComputer::new(self.pq_chunk_table.clone(), self.metric)
+    pub fn distance_computer(&self) -> DistanceComputer<'_> {
+        DistanceComputer::new(&self.pq_chunk_table, self.metric)
     }
 
     /// Return an "immutable" slice over the PQ data at index `i`.

--- a/diskann-providers/src/model/graph/provider/async_/inmem/product.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/product.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-use std::{future::Future, sync::Arc};
+use std::future::Future;
 
 use diskann::default_post_processor;
 use diskann::{
@@ -85,7 +85,7 @@ where
 pub struct PruneAccessor<'a> {
     provider: &'a FastMemoryQuantVectorProviderAsync,
     neighbors: &'a SimpleNeighborProviderAsync,
-    distance: pq::distance::DistanceComputer<Arc<FixedChunkPQTable>>,
+    distance: pq::distance::DistanceComputer<'a>,
 }
 
 impl HasId for PruneAccessor<'_> {
@@ -101,7 +101,7 @@ impl glue::PruneAccessor for PruneAccessor<'_> {
         Self: 'a;
 
     type Distance<'a>
-        = &'a pq::distance::DistanceComputer<Arc<FixedChunkPQTable>>
+        = &'a pq::distance::DistanceComputer<'a>
     where
         Self: 'a;
 
@@ -148,7 +148,7 @@ where
     full: &'a FastMemoryVectorProviderAsync<T>,
     quant: &'a FastMemoryQuantVectorProviderAsync,
     neighbors: &'a SimpleNeighborProviderAsync,
-    distance: distances::pq::HybridComputer<T>,
+    distance: distances::pq::HybridComputer<'a, T>,
 
     // During pruning, we make the first `max_fp_vecs_per_prune` are full-precision with
     // the rest being quantized. This hash set records which IDs should be full-precision.
@@ -173,7 +173,7 @@ where
     where
         Self: 'a;
     type Distance<'a>
-        = &'a distances::pq::HybridComputer<T>
+        = &'a distances::pq::HybridComputer<'a, T>
     where
         Self: 'a;
     type Neighbors<'a>
@@ -232,7 +232,7 @@ where
 /// * [`BuildQueryComputer`].
 pub struct QuantAccessor<'a, V, D, Ctx> {
     provider: &'a DefaultProvider<V, DefaultQuant, D, Ctx>,
-    computer: pq::distance::QueryComputer<Arc<FixedChunkPQTable>>,
+    computer: pq::distance::QueryComputer<'a>,
 }
 
 impl<'a, V, D, Ctx> QuantAccessor<'a, V, D, Ctx>

--- a/diskann-providers/src/model/graph/provider/async_/memory_quant_vector_provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/memory_quant_vector_provider.rs
@@ -43,8 +43,8 @@ pub struct MemoryQuantVectorProviderAsync {
     vec_pool: Arc<ObjectPool<Vec<f32>>>,
 }
 
-type DistanceComputer = pq::distance::DistanceComputer<Arc<FixedChunkPQTable>>;
-type QueryComputer = pq::distance::QueryComputer<Arc<FixedChunkPQTable>>;
+type DistanceComputer<'a> = pq::distance::DistanceComputer<'a>;
+type QueryComputer<'a> = pq::distance::QueryComputer<'a>;
 
 impl MemoryQuantVectorProviderAsync {
     pub fn new(dist_metric: Metric, max_vectors: usize, pq_chunk_table: FixedChunkPQTable) -> Self {
@@ -85,12 +85,12 @@ impl MemoryQuantVectorProviderAsync {
     }
 
     /// Create a query computer for the provided query vector.
-    pub fn query_computer<T>(&self, query: &[T]) -> ANNResult<QueryComputer>
+    pub fn query_computer<T>(&self, query: &[T]) -> ANNResult<QueryComputer<'_>>
     where
         T: VectorRepr,
     {
         QueryComputer::new(
-            self.pq_chunk_table.clone(),
+            &self.pq_chunk_table,
             self.metric,
             &T::as_f32(query).into_ann_result()?,
             Some(self.vec_pool.clone()),
@@ -98,8 +98,8 @@ impl MemoryQuantVectorProviderAsync {
     }
 
     /// Create a distance computer for the underlying schema.
-    pub fn distance_computer(&self) -> DistanceComputer {
-        DistanceComputer::new(self.pq_chunk_table.clone(), self.metric)
+    pub fn distance_computer(&self) -> DistanceComputer<'_> {
+        DistanceComputer::new(&self.pq_chunk_table, self.metric)
     }
 
     /// Return an immutable, reference counted guard over the data as position `i`.

--- a/diskann-providers/src/model/pq/distance/cosine.rs
+++ b/diskann-providers/src/model/pq/distance/cosine.rs
@@ -3,8 +3,6 @@
  * Licensed under the MIT license.
  */
 
-use std::ops::Deref;
-
 use diskann::ANNResult;
 use diskann_vector::PreprocessedDistanceFunction;
 
@@ -16,29 +14,23 @@ use crate::model::pq::fixed_chunk_pq_table::FixedChunkPQTable;
 
 /// A `PreprocessedDistanceFunction` for Cosine Similarity
 #[derive(Debug)]
-pub struct DirectCosine<T>
-where
-    T: Deref<Target = FixedChunkPQTable>,
-{
+pub struct DirectCosine<'a> {
     /// Pre-converted query
     query: Vec<f32>,
 
     /// The parent table for the pivots and other meta-data regarding the PQ Schema.
-    parent: T,
+    parent: &'a FixedChunkPQTable,
 }
 
-impl<T> DirectCosine<T>
-where
-    T: Deref<Target = FixedChunkPQTable>,
-{
+impl<'a> DirectCosine<'a> {
     /// Caller must ensure `query.len() == parent.get_dim()` (validated by `QueryComputer::new`).
-    pub(crate) fn new(parent: T, query: &[f32]) -> ANNResult<Self> {
+    pub(crate) fn new(parent: &'a FixedChunkPQTable, query: &[f32]) -> ANNResult<Self> {
         let mut object = Self::new_unpopulated(parent);
         object.populate(query)?;
         Ok(object)
     }
 
-    fn new_unpopulated(parent: T) -> Self {
+    fn new_unpopulated(parent: &'a FixedChunkPQTable) -> Self {
         Self {
             query: vec![0.0f32; parent.get_dim()],
             parent,
@@ -71,10 +63,7 @@ where
     }
 }
 
-impl<T> PreprocessedDistanceFunction<&[u8], f32> for DirectCosine<T>
-where
-    T: Deref<Target = FixedChunkPQTable>,
-{
+impl PreprocessedDistanceFunction<&[u8], f32> for DirectCosine<'_> {
     fn evaluate_similarity(&self, changing: &[u8]) -> f32 {
         self.evaluate(changing)
     }

--- a/diskann-providers/src/model/pq/distance/dynamic.rs
+++ b/diskann-providers/src/model/pq/distance/dynamic.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 
 use diskann::{ANNError, ANNResult};
 use diskann_utils::object_pool::ObjectPool;
@@ -15,19 +15,13 @@ use crate::model::pq::fixed_chunk_pq_table::FixedChunkPQTable;
 
 /// A quantized computation that works for multiple distance functions.
 #[derive(Debug)]
-pub enum QueryComputer<T>
-where
-    T: Deref<Target = FixedChunkPQTable>,
-{
-    L2(TableL2<T>),
-    IP(TableIP<T>),
-    Cosine(DirectCosine<T>),
+pub enum QueryComputer<'a> {
+    L2(TableL2<'a>),
+    IP(TableIP<'a>),
+    Cosine(DirectCosine<'a>),
 }
 
-impl<T> QueryComputer<T>
-where
-    T: Deref<Target = FixedChunkPQTable>,
-{
+impl<'a> QueryComputer<'a> {
     /// Create a new query computer implementing the `PreprocessedDistanceFunction` API.
     ///
     /// The returned object will implement the requested distance according to the provided
@@ -68,7 +62,7 @@ where
     /// Even though PQ does not necessarily preserve the norms of compressed vectors, using L2
     /// for Cosine Normalized seems to work well enough in practice to work as a temporary fix.
     pub fn new(
-        table: T,
+        table: &'a FixedChunkPQTable,
         metric: Metric,
         query: &[f32],
         pool: Option<Arc<ObjectPool<Vec<f32>>>>,
@@ -90,10 +84,7 @@ where
     }
 }
 
-impl<T> PreprocessedDistanceFunction<&[u8], f32> for QueryComputer<T>
-where
-    T: Deref<Target = FixedChunkPQTable>,
-{
+impl PreprocessedDistanceFunction<&[u8], f32> for QueryComputer<'_> {
     fn evaluate_similarity(&self, changing: &[u8]) -> f32 {
         match self {
             QueryComputer::L2(f) => PreprocessedDistanceFunction::evaluate_similarity(f, changing),
@@ -152,18 +143,12 @@ impl VTable {
 ///
 /// Internally, a mini v-table is kept to invoke the correct distance function.
 #[derive(Debug)]
-pub struct DistanceComputer<T>
-where
-    T: Deref<Target = FixedChunkPQTable>,
-{
-    table: T,
+pub struct DistanceComputer<'a> {
+    table: &'a FixedChunkPQTable,
     vtable: VTable,
 }
 
-impl<T> DistanceComputer<T>
-where
-    T: Deref<Target = FixedChunkPQTable>,
-{
+impl<'a> DistanceComputer<'a> {
     /// Create a new distance computer implementing the `DistanceFunction` API for
     /// full-precision/quant and quant/quant combinations.
     ///
@@ -177,7 +162,7 @@ where
     /// * `Metric::Cosine`
     /// * `Metric::CosineNormalized`
     ///
-    pub fn new(table: T, distance: Metric) -> Self {
+    pub fn new(table: &'a FixedChunkPQTable, distance: Metric) -> Self {
         Self {
             table,
             vtable: VTable::new(distance),
@@ -188,10 +173,7 @@ where
 const INVALID_PQ_DIMENSION: &str = "invalid PQ dimension";
 
 /// Perform a comparison between a full-precision vector and quantized vector.
-impl<T> DistanceFunction<&[f32], &[u8], f32> for DistanceComputer<T>
-where
-    T: Deref<Target = FixedChunkPQTable>,
-{
+impl DistanceFunction<&[f32], &[u8], f32> for DistanceComputer<'_> {
     #[inline(always)]
     fn evaluate_similarity(&self, fp: &[f32], q: &[u8]) -> f32 {
         assert_eq!(
@@ -207,21 +189,18 @@ where
             "{}",
             INVALID_PQ_DIMENSION
         );
-        (self.vtable.distance_fn)(&self.table, fp, q)
+        (self.vtable.distance_fn)(self.table, fp, q)
     }
 }
 
 /// Perform a comparison between two quantized vectors.
-impl<T> DistanceFunction<&[u8], &[u8], f32> for DistanceComputer<T>
-where
-    T: Deref<Target = FixedChunkPQTable>,
-{
+impl DistanceFunction<&[u8], &[u8], f32> for DistanceComputer<'_> {
     #[inline(always)]
     fn evaluate_similarity(&self, q0: &[u8], q1: &[u8]) -> f32 {
         let num_pq_chunks = self.table.get_num_chunks();
         assert_eq!(q0.len(), num_pq_chunks, "{}", INVALID_PQ_DIMENSION);
         assert_eq!(q1.len(), num_pq_chunks, "{}", INVALID_PQ_DIMENSION);
-        (self.vtable.distance_fn_qq)(&self.table, q0, q1)
+        (self.vtable.distance_fn_qq)(self.table, q0, q1)
     }
 }
 
@@ -242,18 +221,12 @@ mod tests {
     // `PreprocessedDistanceFunction`.
     //
     // This lets us reuse the testing infrastructure for the `QueryComputer`.
-    struct PreprocessedWrapper<T>
-    where
-        T: Deref<Target = FixedChunkPQTable>,
-    {
-        table: DistanceComputer<T>,
+    struct PreprocessedWrapper<'a> {
+        table: DistanceComputer<'a>,
         query: Vec<f32>,
     }
 
-    impl<T> PreprocessedDistanceFunction<&[u8], f32> for PreprocessedWrapper<T>
-    where
-        T: Deref<Target = FixedChunkPQTable>,
-    {
+    impl PreprocessedDistanceFunction<&[u8], f32> for PreprocessedWrapper<'_> {
         fn evaluate_similarity(&self, x: &[u8]) -> f32 {
             self.table.evaluate_similarity(&*self.query, x)
         }

--- a/diskann-providers/src/model/pq/distance/innerproduct.rs
+++ b/diskann-providers/src/model/pq/distance/innerproduct.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 
 use diskann::ANNResult;
 use diskann_utils::object_pool::{self, ObjectPool, PoolOption};
@@ -18,10 +18,7 @@ use crate::model::pq::fixed_chunk_pq_table::{FixedChunkPQTable, pq_dist_lookup_s
 
 /// A `PreprocessedDistanceFunction` for Inner Product.
 #[derive(Debug)]
-pub struct TableIP<T>
-where
-    T: Deref<Target = FixedChunkPQTable>,
-{
+pub struct TableIP<'a> {
     /// Pre-computed inner-products between a query and the pivots.
     /// This table is laid out in row major order like
     /// ```ignore
@@ -41,16 +38,13 @@ where
     num_centers: usize,
 
     /// The parent table for the pivots and other meta-data regarding the PQ Schema.
-    parent: T,
+    parent: &'a FixedChunkPQTable,
 }
 
-impl<T> TableIP<T>
-where
-    T: Deref<Target = FixedChunkPQTable>,
-{
+impl<'a> TableIP<'a> {
     /// Caller must ensure `query.len() == parent.get_dim()` (validated by `QueryComputer::new`).
     pub(crate) fn new(
-        parent: T,
+        parent: &'a FixedChunkPQTable,
         query: &[f32],
         pool: Option<Arc<ObjectPool<Vec<f32>>>>,
     ) -> ANNResult<Self> {
@@ -59,8 +53,11 @@ where
         Ok(object)
     }
 
-    fn new_unpopulated(parent: T, pool: Option<Arc<ObjectPool<Vec<f32>>>>) -> Self {
-        let vec_size = get_lookup_table_size(&parent);
+    fn new_unpopulated(
+        parent: &'a FixedChunkPQTable,
+        pool: Option<Arc<ObjectPool<Vec<f32>>>>,
+    ) -> Self {
+        let vec_size = get_lookup_table_size(parent);
         Self {
             lookup_table: match pool {
                 Some(p) => PoolOption::pooled(&p, object_pool::Undef::new(vec_size)),
@@ -98,10 +95,7 @@ where
     }
 }
 
-impl<T> PreprocessedDistanceFunction<&[u8], f32> for TableIP<T>
-where
-    T: Deref<Target = FixedChunkPQTable>,
-{
+impl PreprocessedDistanceFunction<&[u8], f32> for TableIP<'_> {
     fn evaluate_similarity(&self, changing: &[u8]) -> f32 {
         self.evaluate(changing)
     }

--- a/diskann-providers/src/model/pq/distance/l2.rs
+++ b/diskann-providers/src/model/pq/distance/l2.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 
 use diskann::ANNResult;
 use diskann_utils::object_pool::{self, ObjectPool, PoolOption};
@@ -19,10 +19,7 @@ use crate::model::pq::fixed_chunk_pq_table::{FixedChunkPQTable, pq_dist_lookup_s
 /// A `diskann_vector::PreprocessedDistanceFunction` for table-based lookups
 /// using L2.
 #[derive(Debug)]
-pub struct TableL2<T>
-where
-    T: Deref<Target = FixedChunkPQTable>,
-{
+pub struct TableL2<'a> {
     /// Pre-computed distances between a query and the pivots.
     /// This table is laid out in row major order like
     /// ```ignore
@@ -42,16 +39,13 @@ where
     num_centers: usize,
 
     /// The parent table for the pivots and other metadata regarding the PQ Schema.
-    parent: T,
+    parent: &'a FixedChunkPQTable,
 }
 
-impl<T> TableL2<T>
-where
-    T: Deref<Target = FixedChunkPQTable>,
-{
+impl<'a> TableL2<'a> {
     /// Caller must ensure `query.len() == parent.get_dim()` (validated by `QueryComputer::new`).
     pub(crate) fn new(
-        parent: T,
+        parent: &'a FixedChunkPQTable,
         query: &[f32],
         pool: Option<Arc<ObjectPool<Vec<f32>>>>,
     ) -> ANNResult<Self> {
@@ -60,8 +54,11 @@ where
         Ok(object)
     }
 
-    fn new_unpopulated(parent: T, pool: Option<Arc<ObjectPool<Vec<f32>>>>) -> Self {
-        let vec_size = get_lookup_table_size(&parent);
+    fn new_unpopulated(
+        parent: &'a FixedChunkPQTable,
+        pool: Option<Arc<ObjectPool<Vec<f32>>>>,
+    ) -> Self {
+        let vec_size = get_lookup_table_size(parent);
         Self {
             lookup_table: match pool {
                 Some(p) => PoolOption::pooled(&p, object_pool::Undef::new(vec_size)),
@@ -99,10 +96,7 @@ where
     }
 }
 
-impl<T> PreprocessedDistanceFunction<&[u8], f32> for TableL2<T>
-where
-    T: Deref<Target = FixedChunkPQTable>,
-{
+impl PreprocessedDistanceFunction<&[u8], f32> for TableL2<'_> {
     fn evaluate_similarity(&self, changing: &[u8]) -> f32 {
         self.evaluate(changing)
     }

--- a/diskann-providers/src/model/pq/distance/multi.rs
+++ b/diskann-providers/src/model/pq/distance/multi.rs
@@ -3,8 +3,6 @@
  * Licensed under the MIT license.
  */
 
-use std::ops::Deref;
-
 use diskann::ANNResult;
 use diskann_utils::Reborrow;
 use diskann_vector::{DistanceFunction, PreprocessedDistanceFunction, distance::Metric};
@@ -90,19 +88,21 @@ impl<'a, I: PQVersion> VersionedPQVectorRef<'a, I> {
 /// A wrapper for `FixedChunkPQTable` that contains either one or two inner
 /// `FixedChunkPQTables` with associated versions.
 #[derive(Debug, Clone)]
-pub enum MultiTable<T, I>
+pub enum MultiTable<'a, I>
 where
-    T: Deref<Target = FixedChunkPQTable>,
     I: PQVersion,
 {
     /// Only one table is present with an associated version.
-    One { table: T, version: I },
+    One {
+        table: &'a FixedChunkPQTable,
+        version: I,
+    },
     /// Two tables are present, an incoming "new" table and an outgoing "old" table.
     /// The versions of these tables are recorded respectively in `new_version` and
     /// `old_version`.
     Two {
-        new: T,
-        old: T,
+        new: &'a FixedChunkPQTable,
+        old: &'a FixedChunkPQTable,
         new_version: I,
         old_version: I,
     },
@@ -112,20 +112,24 @@ where
 #[error("provided versions must not be equal")]
 pub struct EqualVersionsError;
 
-impl<T, I> MultiTable<T, I>
+impl<'a, I> MultiTable<'a, I>
 where
-    T: Deref<Target = FixedChunkPQTable>,
     I: PQVersion,
 {
     /// Construct a new `MultiTable` containing a single `FixedChunkPQTable`.
-    pub fn one(table: T, version: I) -> Self {
+    pub fn one(table: &'a FixedChunkPQTable, version: I) -> Self {
         Self::One { table, version }
     }
 
     /// Construct a new `MultiTable` with two `FixedChunkPQTable`s.
     ///
     /// Returns an `Err` if the two provided versions are equal.
-    pub fn two(new: T, old: T, new_version: I, old_version: I) -> Result<Self, EqualVersionsError> {
+    pub fn two(
+        new: &'a FixedChunkPQTable,
+        old: &'a FixedChunkPQTable,
+        new_version: I,
+        old_version: I,
+    ) -> Result<Self, EqualVersionsError> {
         if new_version == old_version {
             Err(EqualVersionsError)
         } else {
@@ -173,23 +177,21 @@ where
 /// Returns `None` for distance computations when the version of the PQ vector does not
 /// match with any version in the local table.
 #[derive(Debug, Clone)]
-pub struct MultiDistanceComputer<T, I>
+pub struct MultiDistanceComputer<'a, I>
 where
-    T: Deref<Target = FixedChunkPQTable>,
     I: PQVersion,
 {
-    table: MultiTable<T, I>,
+    table: MultiTable<'a, I>,
     vtable: VTable,
 }
 
-impl<T, I> MultiDistanceComputer<T, I>
+impl<'a, I> MultiDistanceComputer<'a, I>
 where
-    T: Deref<Target = FixedChunkPQTable>,
     I: PQVersion,
 {
     /// Construct a `MultiDistanceComputer` from the provided table implementing the
     /// requested metric.
-    pub fn new(table: MultiTable<T, I>, metric: Metric) -> Self {
+    pub fn new(table: MultiTable<'a, I>, metric: Metric) -> Self {
         Self {
             table,
             vtable: VTable::new(metric),
@@ -210,10 +212,9 @@ where
     }
 }
 
-impl<T, I> DistanceFunction<&[f32], &VersionedPQVector<I>, Option<f32>>
-    for MultiDistanceComputer<T, I>
+impl<I> DistanceFunction<&[f32], &VersionedPQVector<I>, Option<f32>>
+    for MultiDistanceComputer<'_, I>
 where
-    T: Deref<Target = FixedChunkPQTable>,
     I: PQVersion,
 {
     #[inline(always)]
@@ -222,10 +223,9 @@ where
     }
 }
 
-impl<T, I> DistanceFunction<&[f32], VersionedPQVectorRef<'_, I>, Option<f32>>
-    for MultiDistanceComputer<T, I>
+impl<I> DistanceFunction<&[f32], VersionedPQVectorRef<'_, I>, Option<f32>>
+    for MultiDistanceComputer<'_, I>
 where
-    T: Deref<Target = FixedChunkPQTable>,
     I: PQVersion,
 {
     fn evaluate_similarity(&self, x: &[f32], y: VersionedPQVectorRef<'_, I>) -> Option<f32> {
@@ -255,10 +255,9 @@ where
     }
 }
 
-impl<T, I> DistanceFunction<&VersionedPQVector<I>, &VersionedPQVector<I>, Option<f32>>
-    for MultiDistanceComputer<T, I>
+impl<I> DistanceFunction<&VersionedPQVector<I>, &VersionedPQVector<I>, Option<f32>>
+    for MultiDistanceComputer<'_, I>
 where
-    T: Deref<Target = FixedChunkPQTable>,
     I: PQVersion,
 {
     #[inline(always)]
@@ -278,10 +277,9 @@ where
 ///
 /// If two schemas are used and at least one of the versions of the argument vectors is not
 /// recognized, then return `None`.
-impl<T, I> DistanceFunction<VersionedPQVectorRef<'_, I>, VersionedPQVectorRef<'_, I>, Option<f32>>
-    for MultiDistanceComputer<T, I>
+impl<I> DistanceFunction<VersionedPQVectorRef<'_, I>, VersionedPQVectorRef<'_, I>, Option<f32>>
+    for MultiDistanceComputer<'_, I>
 where
-    T: Deref<Target = FixedChunkPQTable>,
     I: PQVersion,
 {
     fn evaluate_similarity(
@@ -347,30 +345,28 @@ where
 /// performing distance computations with either. Upon a version mismatch with a query,
 /// `None` is returned.
 #[derive(Debug)]
-pub enum MultiQueryComputer<T, I>
+pub enum MultiQueryComputer<'a, I>
 where
-    T: Deref<Target = FixedChunkPQTable>,
     I: PQVersion,
 {
     One {
-        computer: QueryComputer<T>,
+        computer: QueryComputer<'a>,
         version: I,
     },
     Two {
-        new: QueryComputer<T>,
-        old: QueryComputer<T>,
+        new: QueryComputer<'a>,
+        old: QueryComputer<'a>,
         new_version: I,
         old_version: I,
     },
 }
 
-impl<T, I> MultiQueryComputer<T, I>
+impl<'a, I> MultiQueryComputer<'a, I>
 where
-    T: Deref<Target = FixedChunkPQTable>,
     I: PQVersion,
 {
     /// Construct a new `MultiQueryComputer` with the requested metric and query.
-    pub fn new(table: MultiTable<T, I>, metric: Metric, query: &[f32]) -> ANNResult<Self> {
+    pub fn new(table: MultiTable<'a, I>, metric: Metric, query: &[f32]) -> ANNResult<Self> {
         let s = match table {
             MultiTable::One { table, version } => Self::One {
                 computer: { QueryComputer::new(table, metric, query, None)? },
@@ -406,10 +402,9 @@ where
     }
 }
 
-impl<T, I> PreprocessedDistanceFunction<&VersionedPQVector<I>, Option<f32>>
-    for MultiQueryComputer<T, I>
+impl<I> PreprocessedDistanceFunction<&VersionedPQVector<I>, Option<f32>>
+    for MultiQueryComputer<'_, I>
 where
-    T: Deref<Target = FixedChunkPQTable>,
     I: PQVersion,
 {
     #[inline(always)]
@@ -418,10 +413,9 @@ where
     }
 }
 
-impl<T, I> PreprocessedDistanceFunction<VersionedPQVectorRef<'_, I>, Option<f32>>
-    for MultiQueryComputer<T, I>
+impl<I> PreprocessedDistanceFunction<VersionedPQVectorRef<'_, I>, Option<f32>>
+    for MultiQueryComputer<'_, I>
 where
-    T: Deref<Target = FixedChunkPQTable>,
     I: PQVersion,
 {
     fn evaluate_similarity(&self, x: VersionedPQVectorRef<'_, I>) -> Option<f32> {
@@ -536,7 +530,7 @@ mod tests {
 
     /// Test that the table works correctl where there is one inner PQ table.
     fn test_distance_computer_multi_with_one<R>(
-        computer: &MultiDistanceComputer<&'_ FixedChunkPQTable, usize>,
+        computer: &MultiDistanceComputer<'_, usize>,
         table: &FixedChunkPQTable,
         config: &test_utils::TableConfig,
         reference: &<f32 as VectorRepr>::Distance,
@@ -652,7 +646,7 @@ mod tests {
     /// Test that the table works correctly when there are two inner PQ tables.
     #[allow(clippy::too_many_arguments)]
     fn test_distance_computer_multi_with_two<R>(
-        computer: &MultiDistanceComputer<&'_ FixedChunkPQTable, usize>,
+        computer: &MultiDistanceComputer<'_, usize>,
         new: &FixedChunkPQTable,
         old: &FixedChunkPQTable,
         new_config: &test_utils::TableConfig,
@@ -824,7 +818,7 @@ mod tests {
 
     #[allow(clippy::too_many_arguments)]
     fn check_query_computer<R: Rng>(
-        computer: &MultiQueryComputer<&'_ FixedChunkPQTable, usize>,
+        computer: &MultiQueryComputer<'_, usize>,
         table: &FixedChunkPQTable,
         config: &test_utils::TableConfig,
         query: &[f32],
@@ -856,7 +850,7 @@ mod tests {
     }
 
     fn test_query_computer_multi_with_one<'a, R>(
-        mut create: impl FnMut(usize, &[f32]) -> MultiQueryComputer<&'a FixedChunkPQTable, usize>,
+        mut create: impl FnMut(usize, &[f32]) -> MultiQueryComputer<'a, usize>,
         table: &'a FixedChunkPQTable,
         config: &test_utils::TableConfig,
         reference: &<f32 as VectorRepr>::Distance,
@@ -938,7 +932,7 @@ mod tests {
 
     #[allow(clippy::too_many_arguments)]
     fn test_query_computer_multi_with_two<'a, R>(
-        create: impl Fn(usize, usize, &[f32]) -> MultiQueryComputer<&'a FixedChunkPQTable, usize>,
+        create: impl Fn(usize, usize, &[f32]) -> MultiQueryComputer<'a, usize>,
         new: &'a FixedChunkPQTable,
         old: &'a FixedChunkPQTable,
         new_config: &test_utils::TableConfig,


### PR DESCRIPTION
Back in the day, distance and query computers could not carry lifetimes. That has since changed. As such, we can remove the `Deref<Target = FixedChunkPQTable>` bound from PQ distance computers and simplify things a bit.

This is a breaking change and will require a version bump.