### PR TITLE
[diskann-garnet] Add persistence for quantized indexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,7 +789,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-garnet"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "bytemuck",
  "crossbeam",

--- a/diskann-garnet/Cargo.toml
+++ b/diskann-garnet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diskann-garnet"
-version = "3.0.0"
+version = "4.0.0"
 edition = "2024"
 authors.workspace = true
 license.workspace = true

--- a/diskann-garnet/diskann-garnet.nuspec
+++ b/diskann-garnet/diskann-garnet.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>diskann-garnet</id>
-    <version>3.0.0</version>
+    <version>4.0.0</version>
     <readme>docs/README.md</readme>
     <authors>Microsoft</authors>
     <projectUrl>https://github.com/microsoft/DiskANN</projectUrl>

--- a/diskann-garnet/src/ffi_recall_tests.rs
+++ b/diskann-garnet/src/ffi_recall_tests.rs
@@ -156,6 +156,7 @@ mod tests {
         store.clear();
         let callbacks = store.callbacks();
         let ctx = Context::new(0);
+        let mut quant_needed = false;
 
         let reduce_dimensions = 0;
         let l_build = 100;
@@ -174,6 +175,7 @@ mod tests {
                 callbacks.delete_callback(),
                 callbacks.rmw_callback(),
                 callbacks.filter_callback(),
+                &mut quant_needed,
             )
         };
         assert!(!index_ptr.is_null());
@@ -281,28 +283,28 @@ mod tests {
 
     #[test]
     fn grid_l2_recall_1d_100() {
-        let store = Store;
+        let store = Store::new();
         let recall = run_grid_recall(&store, 1, 100, 3);
         assert!(recall >= 0.99, "1D grid recall too low: {recall:.4}");
     }
 
     #[test]
     fn grid_l2_recall_2d_10() {
-        let store = Store;
+        let store = Store::new();
         let recall = run_grid_recall(&store, 2, 10, 3);
         assert!(recall >= 0.99, "2D grid recall too low: {recall:.4}");
     }
 
     #[test]
     fn grid_l2_recall_3d_7() {
-        let store = Store;
+        let store = Store::new();
         let recall = run_grid_recall(&store, 3, 7, 3);
         assert!(recall >= 0.99, "3D grid recall too low: {recall:.4}");
     }
 
     #[test]
     fn grid_l2_recall_4d_5() {
-        let store = Store;
+        let store = Store::new();
         let recall = run_grid_recall(&store, 4, 5, 3);
         assert!(recall >= 0.99, "4D grid recall too low: {recall:.4}");
     }
@@ -345,7 +347,7 @@ mod tests {
     /// Circle with 100 points, radius=1.0, cosine distance, k=5
     #[test]
     fn circle_cosine_recall_r1_100pt() {
-        let store = Store;
+        let store = Store::new();
         let recall = run_circle_recall(&store, 100, 1.0, 5);
         assert!(recall >= 0.99, "circle r=1 recall too low: {recall:.4}");
     }
@@ -353,7 +355,7 @@ mod tests {
     /// Circle with 93 points, radius=534.0, cosine distance, k=5
     #[test]
     fn circle_cosine_recall_r534_93pt() {
-        let store = Store;
+        let store = Store::new();
         let recall = run_circle_recall(&store, 93, 534.0, 5);
         assert!(recall >= 0.99, "circle r=534 recall too low: {recall:.4}");
     }
@@ -361,7 +363,7 @@ mod tests {
     /// Circle with 50 points, radius=10.0, cosine distance, k=3
     #[test]
     fn circle_cosine_recall_r10_50pt() {
-        let store = Store;
+        let store = Store::new();
         let recall = run_circle_recall(&store, 50, 10.0, 3);
         assert!(recall >= 0.99, "circle r=10 recall too low: {recall:.4}");
     }

--- a/diskann-garnet/src/ffi_tests.rs
+++ b/diskann-garnet/src/ffi_tests.rs
@@ -39,6 +39,7 @@ mod tests {
     ) -> (*const c_void, Context) {
         let callbacks = store.callbacks();
         let ctx = Context::new(0);
+        let mut quant_needed = false;
 
         let dim: u32 = 2;
         let reduce_dim = 0;
@@ -59,6 +60,7 @@ mod tests {
                 callbacks.delete_callback(),
                 callbacks.rmw_callback(),
                 callbacks.filter_callback(),
+                &mut quant_needed,
             )
         };
 
@@ -67,7 +69,7 @@ mod tests {
 
     #[test]
     fn basic_create_index() {
-        let store = Store;
+        let store = Store::new();
         let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
         assert!(!index_ptr.is_null());
 
@@ -78,7 +80,7 @@ mod tests {
 
     #[test]
     fn create_index_with_invalid_metric_returns_null() {
-        let store = Store;
+        let store = Store::new();
 
         // Test with invalid metric type values — passed as raw i32
         let invalid_metrics = [-1, -2, 99, i32::MAX, i32::MIN];
@@ -96,7 +98,7 @@ mod tests {
 
     #[test]
     fn create_index_with_valid_metrics() {
-        let store = Store;
+        let store = Store::new();
 
         // Test all valid metric types
         let valid_metrics = [
@@ -122,7 +124,7 @@ mod tests {
 
     #[test]
     fn add_check_and_remove_vector() {
-        let store = Store;
+        let store = Store::new();
         let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
 
         // Vector id with 4 bytes size
@@ -174,7 +176,7 @@ mod tests {
 
     #[test]
     fn update_vector_attributes() {
-        let store = Store;
+        let store = Store::new();
         let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
 
         // Vector id with 4 bytes size
@@ -259,7 +261,7 @@ mod tests {
 
     #[test]
     fn external_id_exists_lifecycle() {
-        let store = Store;
+        let store = Store::new();
         let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
 
         // EID 1
@@ -348,7 +350,7 @@ mod tests {
 
     #[test]
     fn internal_id_exists_lifecycle() {
-        let store = Store;
+        let store = Store::new();
         let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
 
         let bad_iid_bytes = [0u8; 5];
@@ -418,7 +420,7 @@ mod tests {
     /// Using u64 external IDs, insert some vectors and ensure search results are same.
     #[test]
     fn search_with_large_external_ids() {
-        let store = Store;
+        let store = Store::new();
         let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
 
         let id1 = 1234u64;
@@ -526,7 +528,7 @@ mod tests {
 
     #[test]
     fn search_element() {
-        let store = Store;
+        let store = Store::new();
         let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
 
         let id1 = 1234u64;
@@ -630,7 +632,7 @@ mod tests {
 
     #[test]
     fn continue_search() {
-        let store = Store;
+        let store = Store::new();
         let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
         let mut output_id_buffer = vec![0u8; 2 * (mem::size_of::<u64>() + mem::size_of::<u32>())];
         let mut output_dists = vec![0f32; 2];
@@ -732,7 +734,7 @@ mod tests {
 
     #[test]
     fn search_without_filter() {
-        let store = Store;
+        let store = Store::new();
         let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
 
         unsafe {
@@ -760,7 +762,7 @@ mod tests {
 
     #[test]
     fn search_with_null_bitmap_same_as_unfiltered() {
-        let store = Store;
+        let store = Store::new();
         let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
 
         unsafe {
@@ -788,7 +790,7 @@ mod tests {
 
     #[test]
     fn basic_quant_bootstrap_lifecycle_bin() {
-        let store = Store;
+        let store = Store::new();
         let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::Bin);
         let index = unsafe { &*index_ptr.cast::<Index>() };
 
@@ -890,51 +892,75 @@ mod tests {
     }
 
     #[test]
-    fn recreate_basic() {
-        let store = Store;
-        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::Q8);
+    fn recreate_basic_with_float_vectors() {
+        for quant_type in [
+            VectorQuantType::NoQuant,
+            VectorQuantType::Bin,
+            VectorQuantType::Q8,
+        ] {
+            let store = Store::new();
+            let (index_ptr, ctx) = create_test_index(&store, quant_type);
 
-        // add vectors
-        assert_eq!(
-            insert_f32_vector(&ctx, index_ptr, 10, &[1.0, 0.0]),
-            InsertResult::Success
-        );
-        assert_eq!(
-            insert_f32_vector(&ctx, index_ptr, 20, &[0.0, 1.0]),
-            InsertResult::Success
-        );
-        assert_eq!(
-            insert_f32_vector(&ctx, index_ptr, 30, &[1.0, 1.0]),
-            InsertResult::Success
-        );
+            // add vectors
+            assert_eq!(
+                insert_f32_vector(&ctx, index_ptr, 10, &[1.0, 0.0]),
+                InsertResult::Success,
+                "failed to insert id=10 with quant_type={quant_type:?}",
+            );
+            assert_eq!(
+                insert_f32_vector(&ctx, index_ptr, 20, &[0.0, 1.0]),
+                InsertResult::Success,
+                "failed to insert id=20 with quant_type={quant_type:?}",
+            );
+            assert_eq!(
+                insert_f32_vector(&ctx, index_ptr, 30, &[1.0, 1.0]),
+                InsertResult::Success,
+                "failed to insert id=30 with quant_type={quant_type:?}",
+            );
 
-        // do a search; save results
-        let qv = [0.0f32, 0.0];
-        let (orig_ids, orig_dists) = do_search(&ctx, index_ptr, &qv, 10, None);
-        assert!(!orig_ids.is_empty());
-        assert!(!orig_dists.is_empty());
+            // do a search; save results
+            let qv = [0.0f32, 0.0];
+            let (orig_ids, orig_dists) = do_search(&ctx, index_ptr, &qv, 10, None);
+            assert!(
+                !orig_ids.is_empty(),
+                "got empty id list for quant_type={quant_type:?}"
+            );
+            assert!(
+                !orig_dists.is_empty(),
+                "got empty dist list for quant_type={quant_type:?}"
+            );
 
-        let orig_num_vectors = unsafe { card(ctx.get(), index_ptr) } as usize;
+            let orig_num_vectors = unsafe { card(ctx.get(), index_ptr) } as usize;
 
-        // drop index
-        unsafe {
-            drop_index(ctx.get(), index_ptr);
-        }
+            // drop index
+            unsafe {
+                drop_index(ctx.get(), index_ptr);
+            }
 
-        // create_index with the same store
-        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::Q8);
+            // create_index with the same store
+            let (index_ptr, ctx) = create_test_index(&store, quant_type);
 
-        // check num vectors is the same
-        let num_vectors = unsafe { card(ctx.get(), index_ptr) } as usize;
-        assert_eq!(num_vectors, orig_num_vectors);
+            // check num vectors is the same
+            let num_vectors = unsafe { card(ctx.get(), index_ptr) } as usize;
+            assert_eq!(
+                num_vectors, orig_num_vectors,
+                "term count mismatch for quant_type={quant_type:?}"
+            );
 
-        // do a search; check results match above
-        let (ids, dists) = do_search(&ctx, index_ptr, &qv, 10, None);
-        assert_eq!(ids, orig_ids);
-        assert_eq!(dists, orig_dists);
+            // do a search; check results match above
+            let (ids, dists) = do_search(&ctx, index_ptr, &qv, 10, None);
+            assert_eq!(
+                ids, orig_ids,
+                "recreated search didn't match ids for quant_type={quant_type:?}"
+            );
+            assert_eq!(
+                dists, orig_dists,
+                "recreated search didn't match dists for quant_type={quant_type:?}"
+            );
 
-        unsafe {
-            drop_index(ctx.get(), index_ptr);
+            unsafe {
+                drop_index(ctx.get(), index_ptr);
+            }
         }
     }
 }

--- a/diskann-garnet/src/ffi_tests.rs
+++ b/diskann-garnet/src/ffi_tests.rs
@@ -37,8 +37,6 @@ mod tests {
         quant_type: VectorQuantType,
         metric_type: i32,
     ) -> (*const c_void, Context) {
-        store.clear();
-
         let callbacks = store.callbacks();
         let ctx = Context::new(0);
 
@@ -885,6 +883,55 @@ mod tests {
         let qv = [0.5f32, 0.5];
         let (ids, _dists) = do_search(&ctx, index_ptr, &qv, 10, None);
         assert!(!ids.is_empty(), "no results found");
+
+        unsafe {
+            drop_index(ctx.get(), index_ptr);
+        }
+    }
+
+    #[test]
+    fn recreate_basic() {
+        let store = Store;
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::Q8);
+
+        // add vectors
+        assert_eq!(
+            insert_f32_vector(&ctx, index_ptr, 10, &[1.0, 0.0]),
+            InsertResult::Success
+        );
+        assert_eq!(
+            insert_f32_vector(&ctx, index_ptr, 20, &[0.0, 1.0]),
+            InsertResult::Success
+        );
+        assert_eq!(
+            insert_f32_vector(&ctx, index_ptr, 30, &[1.0, 1.0]),
+            InsertResult::Success
+        );
+
+        // do a search; save results
+        let qv = [0.0f32, 0.0];
+        let (orig_ids, orig_dists) = do_search(&ctx, index_ptr, &qv, 10, None);
+        assert!(!orig_ids.is_empty());
+        assert!(!orig_dists.is_empty());
+
+        let orig_num_vectors = unsafe { card(ctx.get(), index_ptr) } as usize;
+
+        // drop index
+        unsafe {
+            drop_index(ctx.get(), index_ptr);
+        }
+
+        // create_index with the same store
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::Q8);
+
+        // check num vectors is the same
+        let num_vectors = unsafe { card(ctx.get(), index_ptr) } as usize;
+        assert_eq!(num_vectors, orig_num_vectors);
+
+        // do a search; check results match above
+        let (ids, dists) = do_search(&ctx, index_ptr, &qv, 10, None);
+        assert_eq!(ids, orig_ids);
+        assert_eq!(dists, orig_dists);
 
         unsafe {
             drop_index(ctx.get(), index_ptr);

--- a/diskann-garnet/src/fsm.rs
+++ b/diskann-garnet/src/fsm.rs
@@ -589,7 +589,7 @@ mod tests {
 
     #[test]
     fn create_fresh() {
-        let store = Store;
+        let store = Store::new();
         let ctx = Context::new(0);
 
         // A fresh FSM should result in full block of all zeroes.
@@ -602,7 +602,7 @@ mod tests {
 
     #[test]
     fn basic_next_id() {
-        let store = Store;
+        let store = Store::new();
         let ctx = Context::new(0);
 
         let fsm = FreeSpaceMap::new(&ctx, store.callbacks(), false, true).unwrap();
@@ -617,7 +617,7 @@ mod tests {
 
     #[test]
     fn basic_delete() {
-        let store = Store;
+        let store = Store::new();
         let ctx = Context::new(0);
 
         let fsm = FreeSpaceMap::new(&ctx, store.callbacks(), false, true).unwrap();
@@ -662,7 +662,7 @@ mod tests {
 
     #[test]
     fn basic_id_reuse() {
-        let store = Store;
+        let store = Store::new();
         let ctx = Context::new(0);
 
         let fsm = FreeSpaceMap::new(&ctx, store.callbacks(), false, true).unwrap();
@@ -685,7 +685,7 @@ mod tests {
 
     #[test]
     fn basic_recovery() {
-        let store = Store;
+        let store = Store::new();
         let ctx = Context::new(0);
 
         let fsm = FreeSpaceMap::new(&ctx, store.callbacks(), false, true).unwrap();
@@ -707,7 +707,7 @@ mod tests {
 
     #[test]
     fn dynamic_expansion() {
-        let store = Store;
+        let store = Store::new();
         let ctx = Context::new(0);
 
         let fsm = FreeSpaceMap::new(&ctx, store.callbacks(), false, true).unwrap();

--- a/diskann-garnet/src/lib.rs
+++ b/diskann-garnet/src/lib.rs
@@ -178,7 +178,7 @@ fn create_index_impl<T: VectorRepr>(
     max_degree: usize,
     callbacks: Callbacks,
     context: Context,
-) -> Result<Arc<Index>, GarnetProviderError> {
+) -> Result<(Arc<Index>, bool), GarnetProviderError> {
     let provider = GarnetProvider::<T>::new(
         dim,
         quant_type,
@@ -192,13 +192,24 @@ fn create_index_impl<T: VectorRepr>(
     } else {
         AtomicUsize::new(IndexState::NoStartPoints as usize)
     };
-    Ok(Arc::new(Index {
-        inner: Box::new(DiskANNIndex::new_with_current_thread_runtime(
-            config, provider,
-        )),
-        quant_type,
-        state,
-    }))
+
+    let quant_needed = match quant_type {
+        VectorQuantType::Bin | VectorQuantType::XBinI8 | VectorQuantType::XBinU8 => {
+            provider.quantization_needed()
+        }
+        _ => false,
+    };
+
+    Ok((
+        Arc::new(Index {
+            inner: Box::new(DiskANNIndex::new_with_current_thread_runtime(
+                config, provider,
+            )),
+            quant_type,
+            state,
+        }),
+        quant_needed,
+    ))
 }
 
 /// # Safety
@@ -218,7 +229,10 @@ pub unsafe extern "C" fn create_index(
     delete_callback: DeleteCallback,
     rmw_callback: ReadModifyWriteCallback,
     filter_callback: FilterCallback,
+    quantization_needed: *mut bool,
 ) -> *const c_void {
+    unsafe { *quantization_needed = false };
+
     let metric_type = match Metric::try_from(metric_type) {
         Ok(m) => m,
         Err(_) => return ptr::null(),
@@ -251,7 +265,7 @@ pub unsafe extern "C" fn create_index(
     match quant_type {
         VectorQuantType::Invalid => ptr::null(),
         VectorQuantType::XNoQuantU8 | VectorQuantType::XBinU8 => {
-            if let Ok(index) = create_index_impl::<u8>(
+            if let Ok((index, quant_needed)) = create_index_impl::<u8>(
                 quant_type,
                 config,
                 dim as usize,
@@ -260,13 +274,14 @@ pub unsafe extern "C" fn create_index(
                 callbacks,
                 context,
             ) {
+                unsafe { *quantization_needed = quant_needed };
                 Arc::into_raw(index).cast::<c_void>()
             } else {
                 ptr::null()
             }
         }
         VectorQuantType::XNoQuantI8 | VectorQuantType::XBinI8 => {
-            if let Ok(index) = create_index_impl::<i8>(
+            if let Ok((index, quant_needed)) = create_index_impl::<i8>(
                 quant_type,
                 config,
                 dim as usize,
@@ -275,13 +290,14 @@ pub unsafe extern "C" fn create_index(
                 callbacks,
                 context,
             ) {
+                unsafe { *quantization_needed = quant_needed };
                 Arc::into_raw(index).cast::<c_void>()
             } else {
                 ptr::null()
             }
         }
         VectorQuantType::NoQuant | VectorQuantType::Bin | VectorQuantType::Q8 => {
-            if let Ok(index) = create_index_impl::<f32>(
+            if let Ok((index, quant_needed)) = create_index_impl::<f32>(
                 quant_type,
                 config,
                 dim as usize,
@@ -290,6 +306,7 @@ pub unsafe extern "C" fn create_index(
                 callbacks,
                 context,
             ) {
+                unsafe { *quantization_needed = quant_needed };
                 Arc::into_raw(index).cast::<c_void>()
             } else {
                 ptr::null()
@@ -886,7 +903,8 @@ mod tests {
     }
 
     fn check_create_index(quant_type: VectorQuantType) {
-        let store = Store;
+        let store = Store::new();
+        let mut quant_needed = false;
         let index_ptr = unsafe {
             super::create_index(
                 0,
@@ -901,6 +919,7 @@ mod tests {
                 store.callbacks().delete_callback(),
                 store.callbacks().rmw_callback(),
                 store.callbacks().filter_callback(),
+                &mut quant_needed,
             )
         };
         assert!(!index_ptr.is_null());
@@ -915,7 +934,8 @@ mod tests {
 
     #[test]
     fn create_index() {
-        let store = Store;
+        let store = Store::new();
+        let mut quant_needed = false;
 
         let index_ptr = unsafe {
             super::create_index(
@@ -931,6 +951,7 @@ mod tests {
                 store.callbacks().delete_callback(),
                 store.callbacks().rmw_callback(),
                 store.callbacks().filter_callback(),
+                &mut quant_needed,
             )
         };
         assert!(index_ptr.is_null());

--- a/diskann-garnet/src/provider.rs
+++ b/diskann-garnet/src/provider.rs
@@ -208,7 +208,15 @@ impl<T: VectorRepr> GarnetProvider<T> {
                 let quantizer = Box::new(quantization::MinMax8Bit::new(dim, metric_type)?)
                     as Box<dyn GarnetQuantizer>;
                 let canonical_bytes = quantizer.bytes();
-                // NOTE: Q8 needs no training, so it always starts with backfill complete.
+                // NOTE: Q8 needs no training, so it always starts with backfill
+                // complete. However, we still need to load the start point if
+                // it exists.
+
+                let mut qsv = Poly::broadcast(0u8, canonical_bytes, AlignToEight)?;
+                if callbacks.read_single_iid(&context.term(Term::Quantized), 0, &mut qsv) {
+                    start_point_quant_cache.insert(0, qsv);
+                }
+
                 (Some(quantizer), canonical_bytes, true)
             }
             VectorQuantType::Bin | VectorQuantType::XBinU8 | VectorQuantType::XBinI8 => {

--- a/diskann-garnet/src/provider.rs
+++ b/diskann-garnet/src/provider.rs
@@ -55,6 +55,13 @@ use crate::{
     },
 };
 
+/// Quantization state and table are stored under this key in Garnet under the metadata
+/// term.
+///
+/// The first byte is a boolean reflecting whether backfill is complete. The remaining
+/// bytes are the serialized quant table.
+const QUANT_STATE_KEY: u32 = u32::from_be_bytes(*b"_qnt");
+
 #[derive(Clone)]
 struct AdjList(AdjacencyList<u32>);
 
@@ -208,6 +215,7 @@ impl<T: VectorRepr> GarnetProvider<T> {
                 let quantizer = Box::new(quantization::MinMax8Bit::new(dim, metric_type)?)
                     as Box<dyn GarnetQuantizer>;
                 let canonical_bytes = quantizer.bytes();
+
                 // NOTE: Q8 needs no training, so it always starts with backfill
                 // complete. However, we still need to load the start point if
                 // it exists.
@@ -223,7 +231,29 @@ impl<T: VectorRepr> GarnetProvider<T> {
                 let quantizer =
                     Box::new(quantization::Spherical1Bit::new(dim)) as Box<dyn GarnetQuantizer>;
                 let canonical_bytes = quantizer.bytes();
-                (Some(quantizer), canonical_bytes, false)
+                let mut all_quantized = false;
+
+                if let Some(total_quant_state) =
+                    callbacks.read_varsize_iid::<u8>(&context.term(Term::Metadata), QUANT_STATE_KEY)
+                {
+                    if total_quant_state.len() <= 1 {
+                        return Err(GarnetProviderError::InvalidQuantizer);
+                    }
+
+                    all_quantized = total_quant_state[0] != 0;
+
+                    quantizer.deserialize(&total_quant_state[1..])?;
+
+                    // Cache the saved start point, which should already exist if quantization is complete
+                    let mut qsv = Poly::broadcast(0u8, canonical_bytes, AlignToEight)?;
+                    if callbacks.read_single_iid(&context.term(Term::Quantized), 0, &mut qsv) {
+                        start_point_quant_cache.insert(0, qsv);
+                    } else if all_quantized {
+                        return Err(GarnetProviderError::StartPoint);
+                    }
+                }
+
+                (Some(quantizer), canonical_bytes, all_quantized)
             }
         };
         let quant_buffer_pool =
@@ -475,6 +505,23 @@ impl<T: VectorRepr> GarnetProvider<T> {
         };
         match quantizer.train(self.metric_type, view) {
             Ok(()) => {
+                let quant_state = if let Ok(s) = quantizer.serialize() {
+                    s
+                } else {
+                    return false;
+                };
+
+                let mut total_quant_state = vec![0u8; quant_state.len() + 1];
+                total_quant_state[1..].copy_from_slice(&quant_state);
+
+                if !self.callbacks.write_iid(
+                    &context.term(Term::Metadata),
+                    QUANT_STATE_KEY,
+                    &total_quant_state,
+                ) {
+                    return false;
+                }
+
                 self.fsm.enable_quantization();
                 true
             }
@@ -570,6 +617,20 @@ impl<T: VectorRepr> GarnetProvider<T> {
 
             // Now that all vectors have quant vectors associated, unlock ID reuse.
             self.fsm.enable_reuse();
+
+            if !self.callbacks.rmw_iid::<_, u8>(
+                &context.term(Term::Metadata),
+                QUANT_STATE_KEY,
+                1,
+                |data| {
+                    data[0] = 1;
+                },
+            ) {
+                // NOTE: This return is unrecoverable in the current design, as there is no way to
+                // signal that backfill failed.
+                return;
+            }
+
             // Signal to the index that it is now safe to operate in quantized mode.
             self.all_quantized.store(true, Ordering::Release);
         }
@@ -587,6 +648,16 @@ impl<T: VectorRepr> GarnetProvider<T> {
     /// Returns quantization status. If this is true, the index is operating fully quantized.
     pub(crate) fn is_quantized(&self) -> bool {
         self.quantizer.is_some() && self.all_quantized.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn quantization_needed(&self) -> bool {
+        if let Some(quantizer) = &self.quantizer {
+            !self.is_quantized()
+                && quantizer.is_trained()
+                && self.max_internal_id() as usize > quantizer.required_vectors()
+        } else {
+            false
+        }
     }
 
     pub(crate) fn get_full_vector(
@@ -1692,19 +1763,31 @@ impl<T: VectorRepr> InplaceDeleteStrategy<GarnetProvider<T>> for DynamicQuantiza
 
 #[cfg(test)]
 mod tests {
-    use diskann::provider::{Delete, SetElement};
+    use std::mem;
+
+    use diskann::{
+        graph::{
+            config::{self, defaults::GRAPH_SLACK_FACTOR},
+            search,
+        },
+        provider::{Delete, SetElement},
+    };
+    use diskann_providers::index::wrapped_async::DiskANNIndex;
     use diskann_vector::distance::Metric;
+    use rand::Rng;
 
     use crate::{
-        VectorQuantType,
-        garnet::{Context, GarnetId},
-        provider::GarnetProvider,
+        SearchResults, VectorQuantType,
+        dyn_index::DynIndex,
+        garnet::{Context, GarnetId, Term},
+        provider::{GarnetProvider, QUANT_STATE_KEY},
+        quantization::{GarnetQuantizer, Spherical1Bit},
         test_utils::Store,
     };
 
     #[tokio::test]
     async fn simple_insert_delete() {
-        let store = Store;
+        let store = Store::new();
         let ctx = Context::new(0);
         let provider = GarnetProvider::<f32>::new(
             2,
@@ -1723,5 +1806,290 @@ mod tests {
 
         let res = provider.delete(&ctx, &id).await;
         assert!(res.is_ok());
+    }
+
+    fn create_2d_f32_index(
+        quant_type: VectorQuantType,
+        metric: Metric,
+        store: &Store,
+        ctx: &Context,
+    ) -> DiskANNIndex<GarnetProvider<f32>> {
+        let provider =
+            GarnetProvider::<f32>::new(2, quant_type, metric, 10, store.callbacks(), ctx).unwrap();
+
+        let config = config::Builder::new(
+            (10.0 / GRAPH_SLACK_FACTOR) as usize,
+            config::MaxDegree::Value(10),
+            10,
+            metric.into(),
+        )
+        .build()
+        .unwrap();
+
+        DiskANNIndex::new_with_current_thread_runtime(config, provider)
+    }
+
+    /// Test that restarts during phase one quant bootstrap work.
+    /// Phase one is all index activity before the index has the required
+    /// number of vectors to begin quantization.
+    #[test]
+    fn restart_during_quant_bootstrap_phase_one() {
+        let store = Store::new();
+        let ctx = Context::new(0);
+        let index = create_2d_f32_index(VectorQuantType::Bin, Metric::L2, &store, &ctx);
+        let provider = index.inner.provider();
+        let required_vecs = Spherical1Bit::new(2).required_vectors();
+
+        let mut rng = rand::rng();
+
+        let mut last_inserted_id = 0;
+        let mut first_insert = true;
+        for id in 0..required_vecs as u32 / 2 {
+            let v = [rng.random(), rng.random()];
+
+            if first_insert {
+                provider.maybe_set_start_point(&ctx, &v).unwrap();
+                first_insert = false;
+            }
+
+            DynIndex::insert(
+                &index,
+                &ctx,
+                &GarnetId::from(bytemuck::bytes_of::<u32>(&id)),
+                bytemuck::cast_slice::<f32, u8>(&v),
+            )
+            .unwrap();
+            last_inserted_id = id;
+        }
+
+        assert!(!provider.is_quantized());
+        let max_id = provider.max_internal_id();
+        assert_eq!(max_id, last_inserted_id + 1);
+
+        // There should be no saved quant state.
+        assert!(
+            !provider
+                .callbacks
+                .exists_iid(&ctx.term(Term::Metadata), QUANT_STATE_KEY),
+            "quant state should not be stored yet"
+        );
+
+        // Quantization is not needed yet
+        assert!(!provider.quantization_needed());
+
+        let params = search::Knn::new(10, 10, None).unwrap();
+        let mut output_ids = vec![0u8; mem::size_of::<u32>() * 2 * 10];
+        let mut output_dists = vec![0f32; 10];
+        let mut output = SearchResults::new(
+            output_ids.as_mut_ptr(),
+            output_ids.len(),
+            output_dists.as_mut_ptr(),
+            output_dists.len(),
+        );
+        let query = [0.0f32, 0.0f32];
+        let results = DynIndex::search_vector(
+            &index,
+            &ctx,
+            bytemuck::cast_slice::<f32, u8>(&query),
+            params,
+            &mut output,
+        )
+        .unwrap();
+
+        assert_eq!(results.result_count, 10);
+    }
+
+    /// Test that restarts during phase two quant bootstrap work.
+    /// Phase two starts when there are enough vectors to begin quantizing, and
+    /// lasts until quant vector backfill is complete.
+    #[test]
+    fn restart_during_quant_bootstrap_phase_two() {
+        let store = Store::new();
+        let ctx = Context::new(0);
+        let index = create_2d_f32_index(VectorQuantType::Bin, Metric::L2, &store, &ctx);
+        let provider = index.inner.provider();
+        let required_vecs = Spherical1Bit::new(2).required_vectors();
+
+        let mut rng = rand::rng();
+
+        let mut last_inserted_id = 0;
+        let mut first_insert = true;
+        for id in 0..required_vecs as u32 + 100 {
+            let v = [rng.random(), rng.random()];
+
+            if first_insert {
+                provider.maybe_set_start_point(&ctx, &v).unwrap();
+                first_insert = false;
+            }
+
+            DynIndex::insert(
+                &index,
+                &ctx,
+                &GarnetId::from(bytemuck::bytes_of::<u32>(&id)),
+                bytemuck::cast_slice::<f32, u8>(&v),
+            )
+            .unwrap();
+            last_inserted_id = id;
+        }
+
+        // Train the quantizer
+        assert!(provider.train_quantizer(&ctx));
+
+        // is_quantized won't be true until backfill is complete
+        assert!(!provider.is_quantized());
+        let max_id = provider.max_internal_id();
+        assert_eq!(max_id, last_inserted_id + 1);
+
+        // There should be saved quant state.
+        assert!(
+            provider
+                .callbacks
+                .exists_iid(&ctx.term(Term::Metadata), QUANT_STATE_KEY),
+            "quant state missing"
+        );
+
+        let tqs = provider
+            .callbacks
+            .read_varsize_iid::<u8>(&ctx.term(Term::Metadata), QUANT_STATE_KEY)
+            .unwrap();
+        assert!(tqs.len() > 1, "quant state too small");
+        assert_eq!(tqs[0], 0, "quant state should be pre-backfill");
+
+        // Drop and re-create the index, keeping the same backing store
+        let index = create_2d_f32_index(VectorQuantType::Bin, Metric::L2, &store, &ctx);
+        let provider = index.inner.provider();
+
+        assert!(!provider.is_quantized());
+        let max_id = provider.max_internal_id();
+        assert_eq!(max_id, last_inserted_id + 1);
+
+        // Quant should be needed now, since backfill has never run
+        assert!(provider.quantization_needed());
+
+        // Quant state should be deserialized and able to compress
+        let tv = [1.0f32, -1.0];
+        let mut tqv = vec![
+            0u8;
+            provider
+                .quantizer
+                .as_ref()
+                .expect("quantizer_missing")
+                .bytes()
+        ];
+        assert!(
+            provider
+                .quantizer
+                .as_ref()
+                .expect("quantizer missing")
+                .compress(&tv, &mut tqv)
+                .is_ok(),
+            "quant compression failed"
+        );
+    }
+
+    /// Test that restarts during phase three quant bootstrap work.
+    /// Phase three starts once backfill is complete and lasts for the remaining
+    /// life of the index.
+    #[test]
+    fn restart_during_quant_bootstrap_phase_three() {
+        let store = Store::new();
+        let ctx = Context::new(0);
+        let index = create_2d_f32_index(VectorQuantType::Bin, Metric::L2, &store, &ctx);
+        let provider = index.inner.provider();
+        let required_vecs = Spherical1Bit::new(2).required_vectors();
+
+        let mut rng = rand::rng();
+
+        let mut last_inserted_id = 0;
+        let mut first_insert = true;
+        for id in 0..required_vecs as u32 + 100 {
+            let v = [rng.random(), rng.random()];
+
+            if first_insert {
+                provider.maybe_set_start_point(&ctx, &v).unwrap();
+                first_insert = false;
+            }
+
+            DynIndex::insert(
+                &index,
+                &ctx,
+                &GarnetId::from(bytemuck::bytes_of::<u32>(&id)),
+                bytemuck::cast_slice::<f32, u8>(&v),
+            )
+            .unwrap();
+            last_inserted_id = id;
+        }
+
+        // Train the quantizer
+        assert!(provider.train_quantizer(&ctx));
+
+        // Run backfill
+        for job_id in 0..4 {
+            provider.backfill_quant_vectors(&ctx, job_id, 4);
+        }
+
+        // Drop and re-create the index, keeping the same backing store
+        let index = create_2d_f32_index(VectorQuantType::Bin, Metric::L2, &store, &ctx);
+        let provider = index.inner.provider();
+
+        // Index should think it is fully quantized
+        assert!(provider.is_quantized());
+
+        // Quantization should not be needed anymore
+        assert!(!provider.quantization_needed());
+
+        // There should be saved quant state.
+        assert!(
+            provider
+                .callbacks
+                .exists_iid(&ctx.term(Term::Metadata), QUANT_STATE_KEY),
+            "quant state missing"
+        );
+
+        // all quantized state should match index
+        let tqs = provider
+            .callbacks
+            .read_varsize_iid::<u8>(&ctx.term(Term::Metadata), QUANT_STATE_KEY)
+            .unwrap();
+        assert!(tqs.len() > 1, "quant state too small");
+        assert_eq!(tqs[0], 1, "quant state should be post-backfill");
+
+        // Every quant vector should be present in the store
+        for id in 0..last_inserted_id {
+            assert!(
+                provider
+                    .callbacks
+                    .exists_iid(&ctx.term(Term::Quantized), id)
+            );
+        }
+
+        // Searches should still work and use quantized vectors
+        let params = search::Knn::new(10, 10, None).unwrap();
+        let mut output_ids = vec![0u8; mem::size_of::<u32>() * 2 * 10];
+        let mut output_dists = vec![0f32; 10];
+        let mut output = SearchResults::new(
+            output_ids.as_mut_ptr(),
+            output_ids.len(),
+            output_dists.as_mut_ptr(),
+            output_dists.len(),
+        );
+        let query = [0.0f32, 0.0f32];
+
+        store.clear_read_counts();
+
+        let results = DynIndex::search_vector(
+            &index,
+            &ctx,
+            bytemuck::cast_slice::<f32, u8>(&query),
+            params,
+            &mut output,
+        )
+        .unwrap();
+
+        assert_eq!(results.result_count, 10);
+
+        // Should be some full reads for reranking, but most reads should be
+        // quantized
+        assert!(store.full_reads() < store.quant_reads());
     }
 }

--- a/diskann-garnet/src/quantization.rs
+++ b/diskann-garnet/src/quantization.rs
@@ -4,7 +4,7 @@ use diskann::utils::VectorRepr;
 use diskann_quantization::{
     CompressInto,
     algorithms::{Transform, TransformKind, transforms::NewTransformError},
-    alloc::{GlobalAllocator, ScopedAllocator},
+    alloc::{GlobalAllocator, Poly, ScopedAllocator},
     minmax,
     num::POSITIVE_ONE_F32,
     spherical::{
@@ -34,6 +34,10 @@ pub(crate) enum GarnetQuantizerError {
     ZeroDim,
     #[error("Transform error: {0}")]
     BadTransform(#[from] NewTransformError),
+    #[error("Unsupported serialization/deserialization")]
+    UnsupportedSerialization,
+    #[error("Quantizer deserialization error: {0}")]
+    Deserialization(Box<dyn std::error::Error + Send + Sync + 'static>),
 }
 
 /// Quantizer trait that all diskann-garnet quantizers must implement
@@ -55,6 +59,10 @@ pub(crate) trait GarnetQuantizer: Send + Sync {
     fn distance_computer(&self) -> Result<GarnetDistanceComputer, GarnetQuantizerError>;
     /// Returns a query computer for comparing distances to a particular query
     fn query_computer(&self, query: &[f32]) -> Result<GarnetQueryComputer, GarnetQuantizerError>;
+    // Serialize the quantizer state.
+    fn serialize(&self) -> Result<Poly<[u8], GlobalAllocator>, GarnetQuantizerError>;
+    // Deserialize the quantizer state.
+    fn deserialize(&self, state: &[u8]) -> Result<(), GarnetQuantizerError>;
 }
 
 /// Type-erased distance computer
@@ -172,6 +180,29 @@ impl GarnetQuantizer for Spherical1Bit {
             Err(GarnetQuantizerError::NoQuantizer)
         }
     }
+
+    fn serialize(&self) -> Result<Poly<[u8], GlobalAllocator>, GarnetQuantizerError> {
+        let guard = self.inner.read().unwrap();
+        if let Some(quantizer) = &*guard {
+            quantizer
+                .serialize(GlobalAllocator)
+                .map_err(|e| GarnetQuantizerError::Alloc(Box::new(e)))
+        } else {
+            Err(GarnetQuantizerError::NoQuantizer)
+        }
+    }
+
+    fn deserialize(&self, state: &[u8]) -> Result<(), GarnetQuantizerError> {
+        let mut guard = self.inner.write().unwrap();
+        if guard.is_some() {
+            Err(GarnetQuantizerError::UnsupportedSerialization)
+        } else {
+            let q = spherical::iface::Impl::<1>::try_deserialize(state, GlobalAllocator)
+                .map_err(|e| GarnetQuantizerError::Deserialization(Box::new(e)))?;
+            *guard = Some(q);
+            Ok(())
+        }
+    }
 }
 
 impl DynDistanceComputer for iface::DistanceComputer {
@@ -272,6 +303,14 @@ impl GarnetQuantizer for MinMax8Bit {
             self.metric,
         )?);
         Ok(computer)
+    }
+
+    fn serialize(&self) -> Result<Poly<[u8], GlobalAllocator>, GarnetQuantizerError> {
+        Err(GarnetQuantizerError::UnsupportedSerialization)
+    }
+
+    fn deserialize(&self, _state: &[u8]) -> Result<(), GarnetQuantizerError> {
+        Err(GarnetQuantizerError::UnsupportedSerialization)
     }
 }
 

--- a/diskann-garnet/src/test_utils.rs
+++ b/diskann-garnet/src/test_utils.rs
@@ -3,28 +3,51 @@
  * Licensed under the MIT license.
  */
 
-use crate::garnet::{Callbacks, ReadDataCallback, RmwDataCallback, TERM_BITMASK};
+use crate::garnet::{Callbacks, ReadDataCallback, RmwDataCallback, TERM_BITMASK, Term};
 use core::slice;
 use dashmap::DashMap;
-use std::ffi::c_void;
+use std::{
+    ffi::c_void,
+    sync::atomic::{AtomicUsize, Ordering},
+};
 
 thread_local! {
     pub static STORE: DashMap<Vec<u8>, Vec<u8>> = DashMap::new();
+    pub static FULL_READS: AtomicUsize = const { AtomicUsize::new(0) };
+    pub static QUANT_READS: AtomicUsize = const { AtomicUsize::new(0) };
 }
 
-pub struct Store;
+/// Mock storage for testing.
+///
+/// Wraps a `()` to force use of the constructor and ensures storage starts empty.
+///
+/// This is implemented as a thread local DashMap.
+pub struct Store(());
 
 impl Store {
+    pub fn new() -> Store {
+        let store = Store(());
+        store.clear();
+        store
+    }
+
+    pub fn attach() -> Store {
+        Store(())
+    }
+
     pub fn callbacks(&self) -> Callbacks {
         Callbacks::new(test_read, test_write, test_delete, test_rmw, test_filter)
     }
 
     pub fn clear(&self) {
         STORE.with(|s| s.clear());
+        FULL_READS.with(|fr| fr.store(0, Ordering::Release));
+        QUANT_READS.with(|qr| qr.store(0, Ordering::Release));
     }
 
     pub fn set(&self, context: u64, key: &[u8], value: &[u8]) {
         let context = context & TERM_BITMASK;
+
         let mut k = Vec::new();
         k.extend_from_slice(bytemuck::bytes_of(&context));
         k.extend_from_slice(key);
@@ -33,6 +56,13 @@ impl Store {
 
     pub fn get(&self, context: u64, key: &[u8]) -> Option<Vec<u8>> {
         let context = context & TERM_BITMASK;
+
+        if context == Term::Vector as u64 {
+            FULL_READS.with(|fr| fr.fetch_add(1, Ordering::AcqRel));
+        } else if context == Term::Quantized as u64 {
+            QUANT_READS.with(|qr| qr.fetch_add(1, Ordering::AcqRel));
+        }
+
         let mut k = Vec::new();
         k.extend_from_slice(bytemuck::bytes_of(&context));
         k.extend_from_slice(key);
@@ -54,8 +84,17 @@ impl Store {
         })
     }
 
-    pub fn count(&self) -> usize {
-        STORE.with(|s| s.len())
+    pub fn clear_read_counts(&self) {
+        FULL_READS.with(|fr| fr.store(0, Ordering::Release));
+        QUANT_READS.with(|qr| qr.store(0, Ordering::Release));
+    }
+
+    pub fn full_reads(&self) -> usize {
+        FULL_READS.with(|fr| fr.load(Ordering::Acquire))
+    }
+
+    pub fn quant_reads(&self) -> usize {
+        QUANT_READS.with(|qr| qr.load(Ordering::Acquire))
     }
 }
 
@@ -80,7 +119,7 @@ unsafe extern "C" fn test_read(
         let id = &ids[pos..pos + len as usize];
         pos += len as usize;
 
-        let store = Store;
+        let store = Store::attach();
         if let Some(v) = store.get(ctx, id) {
             unsafe {
                 cb(idx, cb_ctx, v.as_ptr(), v.len());
@@ -99,7 +138,7 @@ unsafe extern "C" fn test_write(
     let id = unsafe { slice::from_raw_parts(id_bytes, id_len) };
     let val = unsafe { slice::from_raw_parts(val_bytes, val_len) };
 
-    let store = Store;
+    let store = Store::attach();
     store.set(ctx, id, val);
     true
 }
@@ -107,7 +146,7 @@ unsafe extern "C" fn test_write(
 unsafe extern "C" fn test_delete(ctx: u64, id_bytes: *const u8, id_len: usize) -> bool {
     let id = unsafe { slice::from_raw_parts(id_bytes, id_len) };
 
-    let store = Store;
+    let store = Store::attach();
     store.delete(ctx, id)
 }
 
@@ -121,7 +160,7 @@ unsafe extern "C" fn test_rmw(
 ) -> bool {
     let id = unsafe { slice::from_raw_parts(id_bytes, id_len) };
 
-    let store = Store;
+    let store = Store::attach();
     let mut val = if let Some(v) = store.get(ctx, id) {
         v
     } else {
@@ -152,8 +191,7 @@ mod tests {
 
     #[test]
     fn basic() {
-        let store = Store;
-        store.clear();
+        let store = Store::new();
         let callbacks = store.callbacks();
         let ctx = Context::new(0);
 
@@ -210,8 +248,7 @@ mod tests {
         use crate::provider::GarnetProvider;
         use diskann_vector::distance::Metric;
 
-        let store: Store = Store;
-        store.clear();
+        let store: Store = Store::new();
         let callbacks = store.callbacks();
         let ctx: Context = Context::new(0);
 

--- a/diskann-garnet/src/test_utils.rs
+++ b/diskann-garnet/src/test_utils.rs
@@ -53,6 +53,10 @@ impl Store {
             }
         })
     }
+
+    pub fn count(&self) -> usize {
+        STORE.with(|s| s.len())
+    }
 }
 
 unsafe extern "C" fn test_read(


### PR DESCRIPTION
Quantizer state was not persisted to the store so the index would operate in full precision mode after a restart. This PR adds support for reloading and resuming quantized indexes.

For Q8 quantizers, the quantized start point cache needs to be filled on restart. For BIN quantizers, the quantizer code book must be saved and loaded as well as a flag indicating whether backfill is complete or not.

Note, because we can't signal errors during backfill yet, we cannot fully recover if the index is restarted during backfill. This will be addressed in the future as it will require some FFI changes.