### PR TITLE
Upgrade Rust toolchain to 1.95 and fix clippy lints

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,6 +1,6 @@
 # DiskANN Repository - Agent Onboarding Guide
 
-**Last Updated**: 2026-02-11 (based on v0.45.0, Rust 1.92)
+**Last Updated**: 2026-07-14 (based on v0.45.0, Rust 1.95)
 
 This guide helps coding agents understand how to work efficiently with the DiskANN repository.
 

--- a/diskann-benchmark-runner/src/internal/regression.rs
+++ b/diskann-benchmark-runner/src/internal/regression.rs
@@ -229,7 +229,7 @@ impl<'a> Checks<'a> {
         // We can now package everything together!
         debug_assert_eq!(input_to_parsed.len(), inputs.jobs().len());
 
-        let checks = std::iter::zip(inputs.into_inner(), input_to_parsed.into_iter())
+        let checks = std::iter::zip(inputs.into_inner(), input_to_parsed)
             .map(|(input, index)| {
                 // This index should always be inbounds.
                 let inner = &parsed.inner[index];

--- a/diskann-benchmark/src/index/search/knn.rs
+++ b/diskann-benchmark/src/index/search/knn.rs
@@ -108,7 +108,7 @@ where
     ) -> anyhow::Result<Vec<SearchResults>> {
         let results = core_search::search_all(
             self.clone(),
-            parameters.into_iter(),
+            parameters,
             core_search::graph::knn::Aggregator::new(
                 groundtruth,
                 recall_k,
@@ -140,7 +140,7 @@ where
     ) -> anyhow::Result<Vec<SearchResults>> {
         let results = core_search::search_all(
             self.clone(),
-            parameters.into_iter(),
+            parameters,
             core_search::graph::knn::Aggregator::new(
                 groundtruth,
                 recall_k,
@@ -172,7 +172,7 @@ where
     ) -> anyhow::Result<Vec<SearchResults>> {
         let results = core_search::search_all(
             self.clone(),
-            parameters.into_iter(),
+            parameters,
             core_search::graph::knn::Aggregator::new(
                 groundtruth,
                 recall_k,

--- a/diskann-benchmark/src/index/search/range.rs
+++ b/diskann-benchmark/src/index/search/range.rs
@@ -90,7 +90,7 @@ where
     ) -> anyhow::Result<Vec<RangeSearchResults>> {
         let results = core_search::search_all(
             self.clone(),
-            parameters.into_iter(),
+            parameters,
             core_search::graph::range::Aggregator::new(groundtruth),
         )?;
 

--- a/diskann-disk/src/search/provider/disk_provider.rs
+++ b/diskann-disk/src/search/provider/disk_provider.rs
@@ -1075,10 +1075,8 @@ where
             stats,
         };
 
-        for ((vertex_id, distance), associated_data) in indices
-            .into_iter()
-            .zip(distances.into_iter())
-            .zip(associated_data.into_iter())
+        for ((vertex_id, distance), associated_data) in
+            indices.into_iter().zip(distances).zip(associated_data)
         {
             search_result.results.push(SearchResultItem {
                 vertex_id,

--- a/diskann-disk/src/search/provider/disk_sector_graph.rs
+++ b/diskann-disk/src/search/provider/disk_sector_graph.rs
@@ -179,6 +179,9 @@ impl<AlignedReaderType: AlignedFileReader> DiskSectorGraph<AlignedReaderType> {
 
     #[inline]
     /// Gets the index for the sector that contains the node with the given vertex_id
+    // The `else` branch is not a divide-by-zero guard: for the multiple-sectors-per-node
+    // layout it computes a genuinely different index, so `checked_div` does not model this.
+    #[allow(clippy::manual_checked_ops)]
     pub fn node_sector_index(&self, vertex_id: u32) -> u64 {
         1 + if self.num_nodes_per_sector > 0 {
             vertex_id as u64 / self.num_nodes_per_sector

--- a/diskann-garnet/src/provider.rs
+++ b/diskann-garnet/src/provider.rs
@@ -437,15 +437,10 @@ impl<T: VectorRepr> GarnetProvider<T> {
         };
 
         let quantizer = match &self.quantizer {
-            Some(q) => {
-                if !q.is_trained() {
-                    q
-                } else {
-                    // Quantizer already trained, bail.
-                    return false;
-                }
-            }
-            None => return false,
+            // Only proceed when there is an untrained quantizer; a missing or
+            // already-trained quantizer means there is nothing to do, so bail.
+            Some(q) if !q.is_trained() => q,
+            _ => return false,
         };
 
         let rows = quantizer.required_vectors();

--- a/diskann-wide/src/test_utils/dot_product.rs
+++ b/diskann-wide/src/test_utils/dot_product.rs
@@ -297,7 +297,7 @@ mod tests {
             for right in b {
                 let dot: i32 = (*left)
                     .into_iter()
-                    .zip((*right).into_iter())
+                    .zip(*right)
                     .map(|(l, r)| (l as i32) * (r as i32))
                     .sum();
                 for b in bases {
@@ -333,7 +333,7 @@ mod tests {
             for right in a {
                 let dot: i32 = (*left)
                     .into_iter()
-                    .zip((*right).into_iter())
+                    .zip(*right)
                     .map(|(l, r)| (l as i32) * (r as i32))
                     .sum();
                 for b in bases {
@@ -370,7 +370,7 @@ mod tests {
             for right in a {
                 let dot: u32 = (*left)
                     .into_iter()
-                    .zip((*right).into_iter())
+                    .zip(*right)
                     .map(|(l, r)| (l as u32) * (r as u32))
                     .sum();
                 for b in bases {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.92"
+channel = "1.95"


### PR DESCRIPTION
## Summary

Bumps the pinned Rust toolchain from **1.92 → 1.95** and fixes the clippy warnings that surface under 1.95. All CI clippy jobs run with `-Dwarnings`, so each warning is a hard failure.

## Changes

- **`rust-toolchain.toml`**: `channel = "1.92"` → `"1.95"`. CI reads the channel via `rustup show`, so no workflow edits are needed.
- **Clippy fixes** (all three CI configs — default, all-features, and per-crate no-default-features — pass clean):
  - `useless_conversion`: removed redundant `.into_iter()` calls in `diskann-benchmark-runner`, `diskann-benchmark`, `diskann-disk`, and `diskann-wide` test helpers (plus the follow-up `unused_parens` / rustfmt reflow they triggered).
  - `collapsible_match`: folded the nested `is_trained()` check into a match guard in `GarnetProvider::train_quantizer`. Written as `Some(q) if !q.is_trained() => q, _ => return false` to stay exhaustive (clippy's own `--fix` produced a non-exhaustive match).
  - `manual_checked_ops`: added a targeted `#[allow]` + comment on `DiskSectorGraph::node_sector_index`. The `else` branch is genuine multi-sector-per-node layout logic, not a divide-by-zero guard, so `checked_div` would be semantically wrong.
- **`agents.md`**: refreshed the toolchain reference to 1.95.

## Validation (local, under 1.95)

- `cargo clippy` with `-Dwarnings` — default features, all features, and per-crate no-default-features: **0 warnings**.
- `cargo fmt --all --check`: clean.
- `--locked` (`Cargo.lock`): unchanged.
- Tests for all changed crates pass (e.g. `diskann-garnet` 40/40).

## Notes

The SDE baseline/AVX-512, codecov, and CodeQL gates aren't reproducible on Windows locally and are left to CI; the diff is lint-only, so risk is low.