### PR TITLE
Fix benchmark ground truth for disk_index_siftsmall 10-query workload

### DIFF
--- a/diskann-benchmark/example/async-determinant-diversity.json
+++ b/diskann-benchmark/example/async-determinant-diversity.json
@@ -23,7 +23,7 @@
         "search_phase": {
           "search-type": "topk-determinant-diversity",
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "reps": 5,
           "num_threads": [
             1

--- a/diskann-benchmark/example/disk-index-determinant-diversity.json
+++ b/diskann-benchmark/example/disk-index-determinant-diversity.json
@@ -22,7 +22,7 @@
         },
         "search_phase": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "search_list": [10, 20, 40],
           "beam_width": 4,
           "recall_at": 10,

--- a/diskann-benchmark/example/disk-index.json
+++ b/diskann-benchmark/example/disk-index.json
@@ -22,7 +22,7 @@
         },
         "search_phase": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "search_list": [10, 20, 40],
           "beam_width": 4,
           "recall_at": 10,
@@ -43,7 +43,7 @@
         },
         "search_phase": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "search_list": [10, 20, 40],
           "beam_width": 4,
           "recall_at": 10,

--- a/diskann-benchmark/example/flat-index.json
+++ b/diskann-benchmark/example/flat-index.json
@@ -11,7 +11,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "k": 10,
           "num_threads": [1],
           "reps": 1

--- a/diskann-benchmark/example/graph-index-bftree-spherical.json
+++ b/diskann-benchmark/example/graph-index-bftree-spherical.json
@@ -23,7 +23,7 @@
                 "search_phase": {
                     "search-type": "topk",
                     "queries": "disk_index_sample_query_10pts.fbin",
-                    "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+                    "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
                     "reps": 5,
                     "num_threads": [
                         1

--- a/diskann-benchmark/example/graph-index-bftree-stream.json
+++ b/diskann-benchmark/example/graph-index-bftree-stream.json
@@ -20,7 +20,7 @@
         "search_phase": {
           "search-type": "topk",
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "reps": 1,
           "num_threads": [
             1

--- a/diskann-benchmark/example/graph-index-bftree.json
+++ b/diskann-benchmark/example/graph-index-bftree.json
@@ -20,7 +20,7 @@
         "search_phase": {
           "search-type": "topk",
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "reps": 5,
           "num_threads": [
             1

--- a/diskann-benchmark/example/graph-index-dynamic.json
+++ b/diskann-benchmark/example/graph-index-dynamic.json
@@ -20,7 +20,7 @@
         "search_phase": {
             "search-type": "topk",
             "queries": "disk_index_sample_query_10pts.fbin",
-            "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+            "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
             "reps": 1,
             "num_threads": [
               2

--- a/diskann-benchmark/example/graph-index-spherical-quantization.json
+++ b/diskann-benchmark/example/graph-index-spherical-quantization.json
@@ -21,7 +21,7 @@
         "search_phase": {
           "search-type": "topk",
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "reps": 5,
           "num_threads": [
             8
@@ -78,7 +78,7 @@
         "search_phase": {
           "search-type": "topk",
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "reps": 5,
           "num_threads": [
             8
@@ -135,7 +135,7 @@
         "search_phase": {
           "search-type": "topk",
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "reps": 5,
           "num_threads": [
             8
@@ -194,7 +194,7 @@
         "search_phase": {
           "search-type": "topk",
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "reps": 5,
           "num_threads": [
             8
@@ -251,7 +251,7 @@
         "search_phase": {
           "search-type": "topk",
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "reps": 5,
           "num_threads": [
             8

--- a/diskann-benchmark/example/graph-index.json
+++ b/diskann-benchmark/example/graph-index.json
@@ -23,7 +23,7 @@
         "search_phase": {
           "search-type": "topk",
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "reps": 5,
           "num_threads": [
             1
@@ -54,7 +54,7 @@
         "search_phase": {
           "search-type": "topk",
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "reps": 5,
           "num_threads": [
             1
@@ -98,7 +98,7 @@
         "search_phase": {
           "search-type": "topk",
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "reps": 5,
           "num_threads": [
             1
@@ -140,7 +140,7 @@
         "search_phase": {
           "search-type": "topk",
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "reps": 5,
           "num_threads": [
             1
@@ -184,7 +184,7 @@
         "search_phase": {
           "search-type": "topk",
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "reps": 5,
           "num_threads": [
             1
@@ -226,7 +226,7 @@
         "search_phase": {
           "search-type": "topk",
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "reps": 5,
           "num_threads": [
             1

--- a/diskann-benchmark/example/minmax-exhaustive.json
+++ b/diskann-benchmark/example/minmax-exhaustive.json
@@ -11,7 +11,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -46,7 +46,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -79,7 +79,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -114,7 +114,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -147,7 +147,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -180,7 +180,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -215,7 +215,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -250,7 +250,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -283,7 +283,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -318,7 +318,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -353,7 +353,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -388,7 +388,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [

--- a/diskann-benchmark/example/product-exhaustive.json
+++ b/diskann-benchmark/example/product-exhaustive.json
@@ -11,7 +11,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [

--- a/diskann-benchmark/example/product.json
+++ b/diskann-benchmark/example/product.json
@@ -27,7 +27,7 @@
           "search_phase": {
             "search-type": "topk",
             "queries": "disk_index_sample_query_10pts.fbin",
-            "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+            "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
             "reps": 5,
             "num_threads": [
               1

--- a/diskann-benchmark/example/scalar.json
+++ b/diskann-benchmark/example/scalar.json
@@ -23,7 +23,7 @@
           "search_phase": {
             "search-type": "topk",
             "queries": "disk_index_sample_query_10pts.fbin",
-            "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+            "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
             "reps": 5,
             "num_threads": [
               1
@@ -67,7 +67,7 @@
           "search_phase": {
             "search-type": "topk",
             "queries": "disk_index_sample_query_10pts.fbin",
-            "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+            "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
             "reps": 5,
             "num_threads": [
               1
@@ -111,7 +111,7 @@
             "search_phase": {
               "search-type": "topk",
               "queries": "disk_index_sample_query_10pts.fbin",
-              "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+              "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
               "reps": 5,
               "num_threads": [
                 1

--- a/diskann-benchmark/example/spherical-exhaustive.json
+++ b/diskann-benchmark/example/spherical-exhaustive.json
@@ -11,7 +11,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -47,7 +47,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -83,7 +83,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -121,7 +121,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -157,7 +157,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -193,7 +193,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -231,7 +231,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -267,7 +267,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -303,7 +303,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -341,7 +341,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -379,7 +379,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [
@@ -415,7 +415,7 @@
         "distance": "squared_l2",
         "search": {
           "queries": "disk_index_sample_query_10pts.fbin",
-          "groundtruth": "disk_index_10pts_idx_uint32_truth_search_res.bin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
           "num_threads": 1,
           "recalls": {
             "recall_k": [

--- a/test_data/disk_index_search/disk_index_10pts_idx_uint32_exact_ground_truth.bin
+++ b/test_data/disk_index_search/disk_index_10pts_idx_uint32_exact_ground_truth.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de012fa2aba9dc6e67031d90ca0422bd8189871293322ad179cd12a6ea22ebbb
+size 808

--- a/test_data/disk_index_search/disk_index_10pts_idx_uint32_truth_search_res.bin
+++ b/test_data/disk_index_search/disk_index_10pts_idx_uint32_truth_search_res.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:de012fa2aba9dc6e67031d90ca0422bd8189871293322ad179cd12a6ea22ebbb
-size 808
+oid sha256:118cb7f1ee5b2c432ee17d35d92866066cc970fe75969e0f29753528f1c38cfa
+size 408

--- a/test_data/disk_index_search/disk_index_10pts_idx_uint32_truth_search_res.bin
+++ b/test_data/disk_index_search/disk_index_10pts_idx_uint32_truth_search_res.bin
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:118cb7f1ee5b2c432ee17d35d92866066cc970fe75969e0f29753528f1c38cfa
-size 408
+oid sha256:de012fa2aba9dc6e67031d90ca0422bd8189871293322ad179cd12a6ea22ebbb
+size 808


### PR DESCRIPTION
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
- [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?

#### Reference Issues/PRs

Fixes #1172.

#### What does this implement/fix? Briefly explain your changes.

This PR adds an exact brute-force ground-truth file for benchmark examples using
the `disk_index_siftsmall_learn_256pts_data.fbin` and
`disk_index_sample_query_10pts.fbin` workload.

- Added
  `test_data/disk_index_search/disk_index_10pts_idx_uint32_exact_ground_truth.bin`,
  generated using `compute_groundtruth`.
- Updated the applicable benchmark example configurations to use the new exact
  ground-truth file.
- Added no dependencies and made no API changes.

This fixes the recall mismatch where `flat-search` could report recall below
1.0 because the benchmark configurations previously referenced results that
were not exact brute-force ground truth.

#### Any other comments?

Validated with:

- `cargo test --locked --workspace`
- All benchmark example JSON files parse successfully.