### PR TITLE
Make BlockTransposed cloneable

### DIFF
--- a/diskann-quantization/src/multi_vector/block_transposed.rs
+++ b/diskann-quantization/src/multi_vector/block_transposed.rs
@@ -86,8 +86,8 @@ use diskann_utils::{
 };
 
 use super::matrix::{
-    Defaulted, LayoutError, Mat, MatMut, MatRef, NewMut, NewOwned, NewRef, Overflow, Repr, ReprMut,
-    ReprOwned, SliceError,
+    Defaulted, LayoutError, Mat, MatMut, MatRef, NewCloned, NewMut, NewOwned, NewRef, Overflow,
+    Repr, ReprMut, ReprOwned, SliceError,
 };
 use crate::bits::{AsMutPtr, AsPtr, MutSlicePtr, SlicePtr};
 use crate::utils;
@@ -602,6 +602,23 @@ unsafe impl<T: Copy + Default, const GROUP: usize, const PACK: usize> NewOwned<D
     }
 }
 
+impl<T: Copy, const GROUP: usize, const PACK: usize> NewCloned
+    for BlockTransposedRepr<T, GROUP, PACK>
+{
+    fn new_cloned(v: MatRef<'_, Self>) -> Mat<Self> {
+        let repr = *v.repr();
+        // SAFETY: `v` points to an allocation described by `repr`, which contains
+        // exactly `storage_len` initialized elements.
+        let data =
+            unsafe { std::slice::from_raw_parts(v.as_raw_ptr().cast::<T>(), repr.storage_len()) };
+        let b = data.to_vec().into_boxed_slice();
+
+        // SAFETY: `b` was copied from the complete backing allocation and therefore
+        // has exactly `repr.storage_len()` elements.
+        unsafe { repr.box_to_mat(b) }
+    }
+}
+
 // SAFETY: This checks slice length against storage_len.
 unsafe impl<T: Copy, const GROUP: usize, const PACK: usize> NewRef<T>
     for BlockTransposedRepr<T, GROUP, PACK>
@@ -677,7 +694,7 @@ macro_rules! delegate_to_ref {
 ///
 /// - [`Row`] — a `Copy` handle supporting `Index<usize>` and `.iter()`.
 /// - [`RowMut`] — a mutable handle supporting `IndexMut<usize>`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BlockTransposed<T: Copy, const GROUP: usize, const PACK: usize = 1> {
     data: Mat<BlockTransposedRepr<T, GROUP, PACK>>,
 }
@@ -1254,6 +1271,24 @@ mod tests {
     }
     fn gen_u8(i: usize) -> u8 {
         ((i % 255) + 1) as u8
+    }
+
+    #[test]
+    fn clone_has_independent_backing_allocation() {
+        let mut data = Matrix::new(0, 5, 3);
+        data.as_mut_slice()
+            .iter_mut()
+            .enumerate()
+            .for_each(|(i, value)| *value = (i + 1) as i32);
+        let original = BlockTransposed::<i32, 4, 2>::from_matrix_view(data.as_view());
+        let mut cloned = original.clone();
+
+        assert_eq!(cloned.as_slice(), original.as_slice());
+        assert_ne!(cloned.as_ptr(), original.as_ptr());
+
+        cloned.get_row_mut(0).unwrap()[0] = -1;
+        assert_eq!(original[(0, 0)], 1);
+        assert_eq!(cloned[(0, 0)], -1);
     }
 
     // ── Unified parameterized test ──────────────────────────────────

--- a/diskann-quantization/src/multi_vector/block_transposed.rs
+++ b/diskann-quantization/src/multi_vector/block_transposed.rs
@@ -1280,10 +1280,20 @@ mod tests {
             .iter_mut()
             .enumerate()
             .for_each(|(i, value)| *value = (i + 1) as i32);
-        let original = BlockTransposed::<i32, 4, 2>::from_matrix_view(data.as_view());
+        let mut original = BlockTransposed::<i32, 4, 2>::from_matrix_view(data.as_view());
+        let column_padding = linear_index::<4, 2>(0, 3, original.ncols());
+        let row_padding = linear_index::<4, 2>(5, 0, original.ncols());
+        let row_and_column_padding = linear_index::<4, 2>(5, 3, original.ncols());
+        original.as_mut_slice()[column_padding] = -10;
+        original.as_mut_slice()[row_padding] = -11;
+        original.as_mut_slice()[row_and_column_padding] = -12;
+
         let mut cloned = original.clone();
 
         assert_eq!(cloned.as_slice(), original.as_slice());
+        assert_eq!(cloned.as_slice()[column_padding], -10);
+        assert_eq!(cloned.as_slice()[row_padding], -11);
+        assert_eq!(cloned.as_slice()[row_and_column_padding], -12);
         assert_ne!(cloned.as_ptr(), original.as_ptr());
 
         cloned.get_row_mut(0).unwrap()[0] = -1;

--- a/diskann-quantization/src/multi_vector/block_transposed.rs
+++ b/diskann-quantization/src/multi_vector/block_transposed.rs
@@ -607,11 +607,8 @@ impl<T: Copy, const GROUP: usize, const PACK: usize> NewCloned
 {
     fn new_cloned(v: MatRef<'_, Self>) -> Mat<Self> {
         let repr = *v.repr();
-        // SAFETY: `v` points to an allocation described by `repr`, which contains
-        // exactly `storage_len` initialized elements.
-        let data =
-            unsafe { std::slice::from_raw_parts(v.as_raw_ptr().cast::<T>(), repr.storage_len()) };
-        let b = data.to_vec().into_boxed_slice();
+        let data = BlockTransposedRef::new(v).as_slice();
+        let b: Box<[T]> = data.into();
 
         // SAFETY: `b` was copied from the complete backing allocation and therefore
         // has exactly `repr.storage_len()` elements.
@@ -717,6 +714,10 @@ pub struct BlockTransposedMut<'a, T: Copy, const GROUP: usize, const PACK: usize
 // ── BlockTransposedRef (core read implementations) ───────────────
 
 impl<'a, T: Copy, const GROUP: usize, const PACK: usize> BlockTransposedRef<'a, T, GROUP, PACK> {
+    fn new(data: MatRef<'a, BlockTransposedRepr<T, GROUP, PACK>>) -> Self {
+        Self { data }
+    }
+
     /// Returns the number of logical rows.
     #[inline]
     pub fn nrows(&self) -> usize {
@@ -1033,9 +1034,7 @@ impl<'a, T: Copy, const GROUP: usize, const PACK: usize> BlockTransposedMut<'a, 
 impl<T: Copy, const GROUP: usize, const PACK: usize> BlockTransposed<T, GROUP, PACK> {
     /// Borrow as an immutable [`BlockTransposedRef`].
     pub fn as_view(&self) -> BlockTransposedRef<'_, T, GROUP, PACK> {
-        BlockTransposedRef {
-            data: self.data.as_view(),
-        }
+        BlockTransposedRef::new(self.data.as_view())
     }
 
     /// Borrow as a mutable [`BlockTransposedMut`].

--- a/diskann-quantization/src/multi_vector/block_transposed.rs
+++ b/diskann-quantization/src/multi_vector/block_transposed.rs
@@ -606,13 +606,11 @@ impl<T: Copy, const GROUP: usize, const PACK: usize> NewCloned
     for BlockTransposedRepr<T, GROUP, PACK>
 {
     fn new_cloned(v: MatRef<'_, Self>) -> Mat<Self> {
-        let repr = *v.repr();
-        let data = BlockTransposedRef::new(v).as_slice();
-        let b: Box<[T]> = data.into();
+        let b: Box<[T]> = BlockTransposedRef::new(v).as_slice().into();
 
         // SAFETY: `b` was copied from the complete backing allocation and therefore
-        // has exactly `repr.storage_len()` elements.
-        unsafe { repr.box_to_mat(b) }
+        // has exactly `v.repr().storage_len()` elements.
+        unsafe { v.repr().box_to_mat(b) }
     }
 }
 

--- a/diskann-quantization/src/multi_vector/block_transposed.rs
+++ b/diskann-quantization/src/multi_vector/block_transposed.rs
@@ -888,12 +888,14 @@ impl<'a, T: Copy, const GROUP: usize, const PACK: usize> BlockTransposedRef<'a, 
 // ── BlockTransposedMut ───────────────────────────────────────────
 
 impl<'a, T: Copy, const GROUP: usize, const PACK: usize> BlockTransposedMut<'a, T, GROUP, PACK> {
+    fn new(data: MatMut<'a, BlockTransposedRepr<T, GROUP, PACK>>) -> Self {
+        Self { data }
+    }
+
     /// Borrow as an immutable [`BlockTransposedRef`].
     #[inline]
     pub fn as_view(&self) -> BlockTransposedRef<'_, T, GROUP, PACK> {
-        BlockTransposedRef {
-            data: self.data.as_view(),
-        }
+        BlockTransposedRef::new(self.data.as_view())
     }
 
     // ── Delegated read methods ───────────────────────────────────
@@ -1021,9 +1023,7 @@ impl<'a, T: Copy, const GROUP: usize, const PACK: usize> BlockTransposedMut<'a, 
     // ── Private helpers ──────────────────────────────────────────
 
     fn reborrow_mut(&mut self) -> BlockTransposedMut<'_, T, GROUP, PACK> {
-        BlockTransposedMut {
-            data: self.data.reborrow_mut(),
-        }
+        BlockTransposedMut::new(self.data.reborrow_mut())
     }
 }
 
@@ -1037,9 +1037,7 @@ impl<T: Copy, const GROUP: usize, const PACK: usize> BlockTransposed<T, GROUP, P
 
     /// Borrow as a mutable [`BlockTransposedMut`].
     pub fn as_view_mut(&mut self) -> BlockTransposedMut<'_, T, GROUP, PACK> {
-        BlockTransposedMut {
-            data: self.data.as_view_mut(),
-        }
+        BlockTransposedMut::new(self.data.as_view_mut())
     }
 
     // ── Delegated read methods ───────────────────────────────────
@@ -2006,9 +2004,7 @@ mod tests {
         let mat = BlockTransposed::<f32, 4>::new(nrows, ncols);
         let raw: &[f32] = mat.as_slice();
 
-        let mat_ref = BlockTransposedRef {
-            data: repr.new_ref(raw).unwrap(),
-        };
+        let mat_ref = BlockTransposedRef::new(repr.new_ref(raw).unwrap());
         assert_eq!(mat_ref.nrows(), nrows);
         assert_eq!(mat_ref.ncols(), ncols);
         for row in 0..nrows {
@@ -2018,9 +2014,7 @@ mod tests {
         }
 
         let mut buf = raw.to_vec();
-        let mat_mut = BlockTransposedMut {
-            data: repr.new_mut(&mut buf).unwrap(),
-        };
+        let mat_mut = BlockTransposedMut::new(repr.new_mut(&mut buf).unwrap());
         assert_eq!(mat_mut.nrows(), nrows);
         assert_eq!(mat_mut.ncols(), ncols);
 


### PR DESCRIPTION
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [x] Does this PR modify any existing APIs?
- [x] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?

#### Reference Issues/PRs

Fixes #1248.

#### What does this implement/fix? Briefly explain your changes.

This makes `diskann_quantization::multi_vector::BlockTransposed` implement `Clone`.

The block-transposed representation now implements `NewCloned` by copying its complete backing allocation, including row, column, and packing padding. This lets the existing `Mat<T>` clone machinery provide a deep clone without reconstructing the logical matrix or changing its physical layout.

A regression test verifies that the clone preserves the complete backing storage, owns a distinct allocation, and can be mutated without affecting the original.

#### Any other comments?

Validated with:

- `cargo test -p diskann-quantization`
- `cargo clippy -p diskann-quantization --all-targets -- -D warnings`