### PR TITLE
Add two missing CI features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ env:
   CARGO_TERM_COLOR: always
   # The features we want to explicitly test. For example, the `flatbuffers-build` feature
   # of `diskann-quantization` requires additional setup and so must not be included by default.
-  DISKANN_FEATURES: "virtual_storage,spherical-quantization,product-quantization,tracing,experimental_diversity_search,disk-index,flatbuffers,linalg,codegen"
+  DISKANN_FEATURES: "virtual_storage,spherical-quantization,product-quantization,tracing,experimental_diversity_search,disk-index,flatbuffers,linalg,codegen,multi-vector,bftree"
 
   # Intel SDE version used for baseline and AVX-512 emulation jobs.
   SDE_VERSION: "sde-external-10.8.0-2026-03-15-lin"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,7 +17,7 @@ env:
   RUST_CONFIG: 'build.rustflags=["-Dwarnings"]'
   RUST_BACKTRACE: 1
   CARGO_TERM_COLOR: always
-  DISKANN_FEATURES: "virtual_storage,spherical-quantization,product-quantization,tracing,experimental_diversity_search,disk-index,flatbuffers,linalg,codegen"
+  DISKANN_FEATURES: "virtual_storage,spherical-quantization,product-quantization,tracing,experimental_diversity_search,disk-index,flatbuffers,linalg,codegen,multi-vector,bftree"
 
 defaults:
   run:

--- a/diskann-benchmark/src/index/bftree/full_precision_streaming.rs
+++ b/diskann-benchmark/src/index/bftree/full_precision_streaming.rs
@@ -224,13 +224,15 @@ where
     }
 }
 
+type BfTreeStreamingPayload<T> = (
+    bigann::WithData<T, u32, Managed<T, StreamStats>>,
+    BfTreeFPIndex<T>,
+);
+
 fn bftree_streaming<T>(
     input: &BfTreeDynamicRun,
     max_points: usize,
-) -> anyhow::Result<(
-    bigann::WithData<T, u32, Managed<T, StreamStats>>,
-    BfTreeFPIndex<T>,
-)>
+) -> anyhow::Result<BfTreeStreamingPayload<T>>
 where
     T: bytemuck::Pod + VectorRepr + SampleableForStart,
 {

--- a/diskann-benchmark/src/index/bftree/spherical_streaming.rs
+++ b/diskann-benchmark/src/index/bftree/spherical_streaming.rs
@@ -226,13 +226,15 @@ impl Benchmark for StreamingSpherical {
     }
 }
 
+type BfTreeStreamingPayload = (
+    bigann::WithData<f32, u32, Managed<f32, StreamStats>>,
+    BfTreeSQIndex,
+);
+
 fn bftree_sq_streaming_impl(
     input: &BfTreeSphericalDynamicRun,
     max_points: usize,
-) -> anyhow::Result<(
-    bigann::WithData<f32, u32, Managed<f32, StreamStats>>,
-    BfTreeSQIndex,
-)> {
+) -> anyhow::Result<BfTreeStreamingPayload> {
     let topk = match input.search_phase() {
         SearchPhase::Topk(topk) => topk,
         _ => anyhow::bail!("Only TopK is currently supported by the streaming index"),


### PR DESCRIPTION
These features correspond to two recently added entries in `diskann-benchmark` that missed updating the CI feature set. The type aliases in the `diskann-benchmark/src/index/bftree/*` are in response to clippy lints now running on that code.