### PR TITLE
Polish `lazy_format!`

### DIFF
--- a/diskann-utils/src/lazystring.rs
+++ b/diskann-utils/src/lazystring.rs
@@ -5,18 +5,65 @@
 
 use std::fmt::{Display, Error, Formatter};
 
-/// A struct used to lazily defer creation of custom async logging messages until we know
-/// that the message is actually needed.
+/// A macro that behaves like `format!` but constructs a [`LazyString`] to defer string
+/// formatting if [`Display`] is unused.
 ///
-/// # Context
+/// ```rust
+/// use diskann_utils::lazy_format;
 ///
-/// Logging in the async context explicitly requires passing of a context pointer to enable
-/// CDB to determine the source of error message. To that end, a custom logging function is
-/// used.
+/// let a: f32 = 10.5;
+/// let b: usize = 20;
 ///
-/// The `LazyString` captures a lambda that constructs the logging message and implements
-/// `std::fmt::Display`, allowing string formatting to only be performed once we know a
-/// message needs to be logged.
+/// let lazy_string = lazy_format!("This is a test. A = {}, B = {}", a, b);
+/// assert_eq!(lazy_string.to_string(), "This is a test. A = 10.5, B = 20");
+///
+/// // Formatting of captured members is deferred until the created `LazyString` is formatted.
+/// #[derive(Default)]
+/// struct Formatted(std::cell::Cell<bool>);
+///
+/// impl Formatted {
+///     fn was_formatted(&self) -> bool {
+///         self.0.get()
+///     }
+///
+///     fn mark_as_formatted(&self) {
+///         self.0.set(true)
+///     }
+/// }
+///
+/// impl std::fmt::Display for Formatted {
+///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+///         if self.was_formatted() {
+///             f.write_str("yes")
+///         } else {
+///             self.mark_as_formatted();
+///             f.write_str("not yet")
+///         }
+///     }
+/// }
+///
+/// let f = Formatted::default();
+/// let lazy = lazy_format!("Was this formatted: {}", f);
+///
+/// assert!(!f.was_formatted(), "string formatting should be deferred");
+/// assert_eq!(lazy.to_string(), "Was this formatted: not yet");
+///
+/// assert!(f.was_formatted());
+/// assert_eq!(lazy.to_string(), "Was this formatted: yes");
+/// ```
+#[macro_export]
+macro_rules! lazy_format {
+    ($($arg:tt)*) => {
+        $crate::LazyString::new(|f: &mut std::fmt::Formatter<'_>| {
+            write!(f, $($arg)*)
+        })
+    }
+}
+
+/// A struct used to lazily defer string formatting until needed. This is used to implement
+/// [`lazy_format`]: a lazy version of the standard `format!` macro.
+///
+/// See [`lazy_format`] for usage.
 pub struct LazyString<F>(F)
 where
     F: Fn(&mut Formatter<'_>) -> Result<(), Error>;
@@ -38,31 +85,6 @@ where
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
         (self.0)(f)
-    }
-}
-
-/// A macro that behaves like `format!` but constructs a `diskann::utils::LazyString`
-/// to enable deferred evaluation of the error message.
-///
-/// Invoking this macro has the following equivalence:
-/// ```ignore
-/// let a: f32 = 10.5;
-/// let b: usize = 20;
-/// // Macro form
-/// let lazy_from_macro = lazy_format("This is a test. A = {}, B = {}", a, b);
-///
-/// // Direct form
-/// let lazy_direct = crate::utils::LazyString::new(|f: &mut std::fmt::Formatter<'_>| {
-///     write!(f, "ihis is a test. A = {}, B = {}", a, b)
-/// });
-/// ```
-#[macro_export]
-macro_rules! lazy_format {
-    ($($arg:tt)*) => {
-        // Must be a full path and only available inside `DiskANN`.
-        $crate::LazyString::new(|f: &mut std::fmt::Formatter<'_>| {
-            write!(f, $($arg)*)
-        })
     }
 }
 

--- a/diskann-utils/src/lazystring.rs
+++ b/diskann-utils/src/lazystring.rs
@@ -3,10 +3,11 @@
  * Licensed under the MIT license.
  */
 
-use std::fmt::{Display, Error, Formatter};
+use std::fmt::{Display, Result, Formatter};
 
 /// A macro that behaves like `format!` but constructs a [`LazyString`] to defer string
-/// formatting if [`Display`] is unused.
+/// formatting until the result is actually displayed. If the [`LazyString`] is never
+/// displayed, this construct has minimal overhead.
 ///
 /// ```rust
 /// use diskann_utils::lazy_format;
@@ -43,7 +44,7 @@ use std::fmt::{Display, Error, Formatter};
 /// }
 ///
 /// let f = Formatted::default();
-/// let lazy = lazy_format!("Was this formatted: {}", f);
+/// let lazy = lazy_format!("Was this formatted: {f}");
 ///
 /// assert!(!f.was_formatted(), "string formatting should be deferred");
 /// assert_eq!(lazy.to_string(), "Was this formatted: not yet");
@@ -66,11 +67,11 @@ macro_rules! lazy_format {
 /// See [`lazy_format`] for usage.
 pub struct LazyString<F>(F)
 where
-    F: Fn(&mut Formatter<'_>) -> Result<(), Error>;
+    F: Fn(&mut Formatter<'_>) -> Result;
 
 impl<F> LazyString<F>
 where
-    F: Fn(&mut Formatter<'_>) -> Result<(), Error>,
+    F: Fn(&mut Formatter<'_>) -> Result,
 {
     /// Construct a new `LazyString` around the provided lambda.
     pub fn new(f: F) -> Self {
@@ -80,13 +81,17 @@ where
 
 impl<F> Display for LazyString<F>
 where
-    F: Fn(&mut Formatter<'_>) -> Result<(), Error>,
+    F: Fn(&mut Formatter<'_>) -> Result,
 {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         (self.0)(f)
     }
 }
+
+///////////
+// Tests //
+///////////
 
 #[cfg(test)]
 mod test {

--- a/diskann-utils/src/lazystring.rs
+++ b/diskann-utils/src/lazystring.rs
@@ -76,12 +76,12 @@ use std::fmt::{Debug, Display, Formatter, Result};
 macro_rules! lazy_format {
     (move, $($arg:tt)*) => {
         $crate::LazyString::new(move |f: &mut std::fmt::Formatter<'_>| {
-            write!(f, $($arg)*)
+            ::core::write!(f, $($arg)*)
         })
     };
     ($($arg:tt)*) => {
         $crate::LazyString::new(|f: &mut std::fmt::Formatter<'_>| {
-            write!(f, $($arg)*)
+            ::core::write!(f, $($arg)*)
         })
     };
 }

--- a/diskann-utils/src/lazystring.rs
+++ b/diskann-utils/src/lazystring.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-use std::fmt::{Display, Result, Formatter};
+use std::fmt::{Display, Formatter, Result};
 
 /// A macro that behaves like `format!` but constructs a [`LazyString`] to defer string
 /// formatting until the result is actually displayed. If the [`LazyString`] is never
@@ -62,9 +62,9 @@ macro_rules! lazy_format {
 }
 
 /// A struct used to lazily defer string formatting until needed. This is used to implement
-/// [`lazy_format`]: a lazy version of the standard `format!` macro.
+/// [`lazy_format!`]: a lazy version of the standard `format!` macro.
 ///
-/// See [`lazy_format`] for usage.
+/// See [`lazy_format!`] for usage.
 pub struct LazyString<F>(F)
 where
     F: Fn(&mut Formatter<'_>) -> Result;
@@ -74,6 +74,7 @@ where
     F: Fn(&mut Formatter<'_>) -> Result,
 {
     /// Construct a new `LazyString` around the provided lambda.
+    #[doc(hidden)]
     pub fn new(f: F) -> Self {
         Self(f)
     }

--- a/diskann-utils/src/lazystring.rs
+++ b/diskann-utils/src/lazystring.rs
@@ -59,7 +59,7 @@ use std::fmt::{Debug, Display, Formatter, Result};
 /// and thus has a lifetime constrained to its arguments.
 ///
 /// If a lazily formatted `'static` compliant variation is needed, the "move" variant
-/// can be used:
+/// can be used (assuming all captured arguments are `'static`):
 ///
 /// ```rust
 /// use diskann_utils::lazy_format;

--- a/diskann-utils/src/lazystring.rs
+++ b/diskann-utils/src/lazystring.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-use std::fmt::{Display, Formatter, Result};
+use std::fmt::{Debug, Display, Formatter, Result};
 
 /// A macro that behaves like `format!` but constructs a [`LazyString`] to defer string
 /// formatting until the result is actually displayed. If the [`LazyString`] is never
@@ -52,13 +52,38 @@ use std::fmt::{Display, Formatter, Result};
 /// assert!(f.was_formatted());
 /// assert_eq!(lazy.to_string(), "Was this formatted: yes");
 /// ```
+///
+/// # Creating lazily formatted `'static` error messages
+///
+/// The default [`LazyString`] created by this macro borrows from its formatted arguments
+/// and thus has a lifetime constrained to its arguments.
+///
+/// If a lazily formatted `'static` compliant variation is needed, the "move" variant
+/// can be used:
+///
+/// ```rust
+/// use diskann_utils::lazy_format;
+///
+/// fn assert_static<T: 'static>(_: &T) {}
+///
+/// let x = 10;
+///
+/// let lazy = lazy_format!(move, "x = {x}");
+/// assert_static(&lazy);
+/// assert_eq!(lazy.to_string(), "x = 10");
+/// ```
 #[macro_export]
 macro_rules! lazy_format {
+    (move, $($arg:tt)*) => {
+        $crate::LazyString::new(move |f: &mut std::fmt::Formatter<'_>| {
+            write!(f, $($arg)*)
+        })
+    };
     ($($arg:tt)*) => {
         $crate::LazyString::new(|f: &mut std::fmt::Formatter<'_>| {
             write!(f, $($arg)*)
         })
-    }
+    };
 }
 
 /// A struct used to lazily defer string formatting until needed. This is used to implement
@@ -90,6 +115,29 @@ where
     }
 }
 
+impl<F> Debug for LazyString<F>
+where
+    F: Fn(&mut Formatter<'_>) -> Result,
+{
+    #[inline]
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+        struct AsDisplay<'a, T>(&'a T);
+
+        impl<T> Debug for AsDisplay<'_, T>
+        where
+            T: Display,
+        {
+            fn fmt(&self, f: &mut Formatter<'_>) -> Result {
+                write!(f, "{}", self.0)
+            }
+        }
+
+        f.debug_tuple("LazyString")
+            .field(&AsDisplay(&self))
+            .finish()
+    }
+}
+
 ///////////
 // Tests //
 ///////////
@@ -97,6 +145,8 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+
+    fn assert_static<T: 'static>(_: &T) {}
 
     #[test]
     fn test_lazy_string() {
@@ -110,5 +160,12 @@ mod test {
 
         let lazy = lazy_format!("Lazy Message: x = {x}, y = {y}");
         assert_eq!(lazy.to_string(), "Lazy Message: x = 10.5, y = 20");
+
+        let lazy = lazy_format!(move, "Lazy Message: x = {}, y = {y}", x);
+        assert_static(&lazy);
+        assert_eq!(lazy.to_string(), "Lazy Message: x = 10.5, y = 20");
+
+        // Verify that `Debug` at least runs.
+        let _ = format!("{:?}", lazy);
     }
 }

--- a/diskann-utils/src/lazystring.rs
+++ b/diskann-utils/src/lazystring.rs
@@ -121,19 +121,8 @@ where
 {
     #[inline]
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-        struct AsDisplay<'a, T>(&'a T);
-
-        impl<T> Debug for AsDisplay<'_, T>
-        where
-            T: Display,
-        {
-            fn fmt(&self, f: &mut Formatter<'_>) -> Result {
-                write!(f, "{}", self.0)
-            }
-        }
-
         f.debug_tuple("LazyString")
-            .field(&AsDisplay(&self))
+            .field(&format_args!("{self}"))
             .finish()
     }
 }
@@ -166,6 +155,9 @@ mod test {
         assert_eq!(lazy.to_string(), "Lazy Message: x = 10.5, y = 20");
 
         // Verify that `Debug` at least runs.
-        let _ = format!("{:?}", lazy);
+        assert_eq!(
+            format!("{:?}", lazy),
+            "LazyString(Lazy Message: x = 10.5, y = 20)",
+        );
     }
 }


### PR DESCRIPTION
I recently used this utility and noticed that the docs were a little out of date.

In addition, with some extra work (i.e., adding a `move` variant to `lazy_format!`), the created `LazyString` can be both `'static` and `Debug`, allowing it to be passed to `ANNError::message`. This enables error reporting like
```rust
let x = "context";
let y = 10;

let err = ANNError::message(
    ANNErrorKind::Opaque,
    lazy_format!(move, "error message: {x} - {y}),
);
```
The generated code is as-if we wrote
```rust
let x = "context";
let y = 10;

#[derive(Debug)]
struct Message {
    x: &'static str,
    y: usize,
}

impl std::fmt::Display for Message {
    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
        write!(f, "errro message: {} - {}", self.x, self.y)
    }
}

let err = ANNError::message(
    ANNErrorKind::Opaque,
    Message { x, y }
);
```
But is more ergonomic to construct. The main benefit here is that it moves string formatting out of the error construction site and up to the error reporting site. Depending on the context, this code motion can clean up the lower level code.