### PR TITLE
Make build RAM estimation store-owned

### DIFF
--- a/diskann-disk/src/build/builder/build.rs
+++ b/diskann-disk/src/build/builder/build.rs
@@ -4,7 +4,7 @@
  */
 
 //! Disk index builder implementation.
-use std::{marker::PhantomData, mem};
+use std::marker::PhantomData;
 
 use crate::data_model::GraphDataType;
 use diskann::{utils::VectorRepr, ANNResult};
@@ -18,8 +18,8 @@ use tracing::info;
 
 use crate::{
     build::builder::{
-        inmem_builder::build_inmem_index,
-        merged_index::{estimate_build_index_ram_usage, MergedVamanaIndexBuilder},
+        inmem_builder::{build_inmem_index, estimate_build_index_ram_usage},
+        merged_index::MergedVamanaIndexBuilder,
         quantizer::BuildQuantizer,
         tokio::create_runtime,
     },
@@ -29,7 +29,7 @@ use crate::{
         DiskIndexWriter,
     },
     utils::instrumentation::{DiskIndexBuildCheckpoint, PerfLogger},
-    DiskIndexBuildParameters, QuantizationType,
+    DiskIndexBuildParameters,
 };
 
 pub struct DiskIndexBuilder<'a, Data, StorageProvider>
@@ -162,7 +162,7 @@ where
         match determine_build_strategy::<Data>(
             &self.index_configuration,
             self.disk_build_param.build_memory_limit().in_bytes() as f64,
-            self.disk_build_param.build_quantization(),
+            &self.build_quantizer,
         ) {
             IndexBuildStrategy::Merged => {
                 MergedVamanaIndexBuilder::<Data, _>::new(
@@ -198,22 +198,19 @@ where
     }
 }
 
-pub(crate) enum IndexBuildStrategy {
+enum IndexBuildStrategy {
     OneShot,
     Merged,
 }
 
-pub(crate) fn determine_build_strategy<Data: GraphDataType>(
+fn determine_build_strategy<Data: GraphDataType>(
     index_configuration: &IndexConfiguration,
     index_build_ram_limit_in_bytes: f64,
-    build_quantization_type: &QuantizationType,
+    build_quantizer: &BuildQuantizer,
 ) -> IndexBuildStrategy {
-    let estimated_index_ram_in_bytes = estimate_build_index_ram_usage(
-        index_configuration.max_points as u64,
-        index_configuration.dim as u64,
-        mem::size_of::<Data::VectorDataType>() as u64,
-        index_configuration.config.max_degree().get() as u64,
-        build_quantization_type,
+    let estimated_index_ram_in_bytes = estimate_build_index_ram_usage::<Data::VectorDataType>(
+        index_configuration,
+        build_quantizer,
     );
 
     info!(

--- a/diskann-disk/src/build/builder/inmem_builder.rs
+++ b/diskann-disk/src/build/builder/inmem_builder.rs
@@ -27,7 +27,8 @@ use diskann_providers::{
     model::graph::provider::async_::{
         common::{FullPrecision, NoDeletes, NoStore, Quantized, SetElementHelper, VectorStore},
         inmem::{
-            DefaultProvider, DefaultProviderParameters, FullPrecisionProvider, SetStartPoints,
+            CreateFullPrecision, DefaultProvider, DefaultProviderParameters, FullPrecisionProvider,
+            SetStartPoints,
         },
     },
     model::IndexConfiguration,
@@ -300,6 +301,48 @@ where
     }
 }
 
+fn provider_parameters(config: &IndexConfiguration) -> DefaultProviderParameters {
+    DefaultProviderParameters {
+        max_points: config.max_points,
+        frozen_points: ONE,
+        metric: config.dist_metric,
+        dim: config.dim,
+        max_degree: config.config.max_degree_u32().get(),
+        prefetch_lookahead: config.prefetch_lookahead.map(|x| x.get()),
+        prefetch_cache_line_level: config.prefetch_cache_line_level,
+    }
+}
+
+/// Headroom for allocations the per-store estimates do not model.
+const OVERHEAD_FACTOR: f64 = 1.1f64;
+
+/// Estimate the RAM an in-memory build of `config` will consume, in bytes.
+///
+/// Dispatches over the same precursor combinations [`new_inmem_index_builder`] constructs.
+pub(super) fn estimate_build_index_ram_usage<T>(
+    config: &IndexConfiguration,
+    build_quantizer: &BuildQuantizer,
+) -> f64
+where
+    T: VectorRepr,
+{
+    let params = provider_parameters(config);
+    let full_precision =
+        CreateFullPrecision::<T>::new(params.dim, params.prefetch_cache_line_level);
+
+    let bytes = match build_quantizer {
+        BuildQuantizer::NoQuant(no_store) => {
+            params.estimated_bytes(&full_precision, no_store, &NoDeletes)
+        }
+        BuildQuantizer::Scalar1Bit(quantizer) => {
+            params.estimated_bytes(&NoStore, quantizer, &NoDeletes)
+        }
+        BuildQuantizer::PQ(table) => params.estimated_bytes(&NoStore, table, &NoDeletes),
+    };
+
+    OVERHEAD_FACTOR * bytes as f64
+}
+
 pub(super) async fn build_inmem_index<T, StorageProvider>(
     config: IndexConfiguration,
     quantizer: &BuildQuantizer,
@@ -324,15 +367,7 @@ where
     }));
 
     let index_config = config.config.clone();
-    let provider_parameters = DefaultProviderParameters {
-        max_points: config.max_points,
-        frozen_points: ONE,
-        metric: config.dist_metric,
-        dim: config.dim,
-        max_degree: index_config.max_degree_u32().get(),
-        prefetch_lookahead: config.prefetch_lookahead.map(|x| x.get()),
-        prefetch_cache_line_level: config.prefetch_cache_line_level,
-    };
+    let provider_parameters = provider_parameters(&config);
     let index = new_inmem_index_builder::<T>(index_config, provider_parameters, quantizer)?;
     let medoid_id =
         set_start_point_to_medoid::<T, _>(&index, data_path, config.random_seed, storage_provider)?;
@@ -475,4 +510,82 @@ async fn run_final_prune<T: VectorRepr>(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod ram_estimation_tests {
+    use diskann_providers::model::graph::provider::async_::inmem::WithBits;
+    use diskann_providers::model::FixedChunkPQTable;
+    use diskann_quantization::scalar::ScalarQuantizer;
+    use diskann_vector::distance::Metric;
+    use rstest::rstest;
+
+    use super::*;
+
+    const DIM: usize = 128;
+    const NUM_CHUNKS: usize = 16;
+
+    fn config(max_points: usize, max_degree: u32) -> IndexConfiguration {
+        let graph_config = diskann::graph::config::Builder::new(
+            max_degree as usize,
+            diskann::graph::config::MaxDegree::new(max_degree as usize),
+            100,
+            Metric::L2.into(),
+        )
+        .build()
+        .unwrap();
+
+        IndexConfiguration::new(Metric::L2, DIM, max_points, ONE, 1, graph_config)
+    }
+
+    fn pq_quantizer() -> BuildQuantizer {
+        let pq_table = vec![0.0f32; 256 * DIM].into_boxed_slice();
+        let chunk_offsets = (0..=NUM_CHUNKS)
+            .map(|chunk| chunk * (DIM / NUM_CHUNKS))
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        BuildQuantizer::PQ(FixedChunkPQTable::new(DIM, pq_table, chunk_offsets).unwrap())
+    }
+
+    fn sq_quantizer() -> BuildQuantizer {
+        BuildQuantizer::Scalar1Bit(WithBits::<1>::new(ScalarQuantizer::new(
+            1.0,
+            vec![0.0f32; DIM],
+            None,
+        )))
+    }
+
+    /// Regression test pinning the estimate for each quantization mode.
+    ///
+    /// The expected values are recorded, not recomputed: recomputing them would just be a second
+    /// copy of the formula. Scalar and product coincide because at these parameters both compress
+    /// a vector into the same 64-byte aligned row.
+    #[rstest]
+    #[case::full_precision(BuildQuantizer::NoQuant(NoStore), 859_285.0)]
+    #[case::scalar_1bit(sq_quantizer(), 365_995.0)]
+    #[case::product(pq_quantizer(), 365_995.0)]
+    fn estimate_matches_recorded_value(
+        #[case] build_quantizer: BuildQuantizer,
+        #[case] expected: f64,
+    ) {
+        let actual =
+            estimate_build_index_ram_usage::<f32>(&config(1000, 50), &build_quantizer).round();
+        assert_eq!(actual, expected);
+    }
+
+    /// The estimate must respond to the inputs the build strategy varies.
+    #[rstest]
+    #[case::full_precision(BuildQuantizer::NoQuant(NoStore))]
+    #[case::scalar_1bit(sq_quantizer())]
+    #[case::product(pq_quantizer())]
+    fn estimate_grows_with_points_and_degree(#[case] build_quantizer: BuildQuantizer) {
+        let baseline = estimate_build_index_ram_usage::<f32>(&config(1000, 50), &build_quantizer);
+
+        assert!(
+            estimate_build_index_ram_usage::<f32>(&config(2000, 50), &build_quantizer) > baseline
+        );
+        assert!(
+            estimate_build_index_ram_usage::<f32>(&config(1000, 100), &build_quantizer) > baseline
+        );
+    }
 }

--- a/diskann-disk/src/build/builder/merged_index.rs
+++ b/diskann-disk/src/build/builder/merged_index.rs
@@ -2,16 +2,13 @@
  * Copyright (c) Microsoft Corporation.
  * Licensed under the MIT license.
  */
-use std::{
-    marker::PhantomData,
-    mem::{self, size_of},
-};
+use std::{marker::PhantomData, mem, mem::size_of};
 
 use crate::data_model::GraphDataType;
 use diskann::{utils::VectorRepr, ANNResult};
 use diskann_providers::storage::{StorageReadProvider, StorageWriteProvider};
 use diskann_providers::{
-    model::{IndexConfiguration, GRAPH_SLACK_FACTOR, MAX_PQ_TRAINING_SET_SIZE},
+    model::{IndexConfiguration, MAX_PQ_TRAINING_SET_SIZE},
     utils::{
         load_metadata_from_file, RayonThreadPoolRef, SampleVectorReader, SamplingDensity,
         READ_WRITE_BLOCK_SIZE,
@@ -22,43 +19,18 @@ use rand::seq::SliceRandom;
 use tracing::info;
 
 use crate::{
-    build::builder::{inmem_builder::build_inmem_index, quantizer::BuildQuantizer},
+    build::builder::{
+        inmem_builder::{build_inmem_index, estimate_build_index_ram_usage},
+        quantizer::BuildQuantizer,
+    },
     storage::{CachedReader, CachedWriter, DiskIndexWriter},
     utils::instrumentation::{BuildMergedVamanaIndexCheckpoint, PerfLogger},
     utils::partition_with_ram_budget,
-    DiskIndexBuildParameters, QuantizationType,
+    DiskIndexBuildParameters,
 };
-
-/// Overhead factor for RAM estimation during index build (10% buffer).
-const OVERHEAD_FACTOR: f64 = 1.1f64;
 
 /// Number of nearest shards each vector is assigned to during partitioning.
 const PARTITION_ASSIGNMENTS_PER_VECTOR: usize = 2;
-
-/// Estimate RAM usage in bytes for building an index.
-#[inline]
-pub(super) fn estimate_build_index_ram_usage(
-    num_points: u64,
-    dim: u64,
-    datasize: u64,
-    graph_degree: u64,
-    build_quantization_type: &QuantizationType,
-) -> f64 {
-    let graph_size =
-        (num_points * graph_degree * mem::size_of::<u32>() as u64) as f64 * GRAPH_SLACK_FACTOR;
-
-    let single_vec_size = match *build_quantization_type {
-        QuantizationType::FP => dim.next_multiple_of(8u64) * datasize,
-        // We can skip PQ pivots data as it is very small(~3MB) for even large datasets like OAI-3072.
-        QuantizationType::PQ { num_chunks } => num_chunks as u64,
-        // `+ std::mem::size_of::<f32>()` for f32 compensation metadata for the scalar quantizer.
-        QuantizationType::SQ { nbits, .. } => {
-            (nbits as u64 * dim).div_ceil(8) + std::mem::size_of::<f32>() as u64
-        }
-    };
-
-    OVERHEAD_FACTOR * (graph_size + (single_vec_size * num_points) as f64)
-}
 
 /// Builds a merged Vamana index from overlapping dataset shards.
 pub(super) struct MergedVamanaIndexBuilder<'a, Data, StorageProvider>
@@ -109,8 +81,7 @@ where
         let output_vamana = self.index_writer.get_mem_index_file();
         let max_degree = self.index_configuration.config.pruned_degree_u32().get();
 
-        let num_parts =
-            self.partition_data(&dataset_file, &merged_index_prefix, max_degree, pool)?;
+        let num_parts = self.partition_data(&dataset_file, &merged_index_prefix, pool)?;
         logger.log_checkpoint(BuildMergedVamanaIndexCheckpoint::PartitionData);
 
         for shard_id in 0..num_parts {
@@ -125,26 +96,27 @@ where
         Ok(())
     }
 
-    fn create_shard_index_config(&self, shard_base_file: &str) -> ANNResult<IndexConfiguration> {
+    /// The index configuration each shard is built with, before its point count is known.
+    fn shard_index_config(&self) -> ANNResult<IndexConfiguration> {
         let base_config = self.index_configuration;
-        let storage_provider = self.storage_provider;
 
-        let search_list_size = base_config.config.l_build().get();
-        let pruned_degree = base_config.config.pruned_degree().get();
-
-        let low_degree_params = diskann::graph::config::Builder::new(
-            2 * pruned_degree / 3,
+        let mut index_config = (*base_config).clone();
+        index_config.config = diskann::graph::config::Builder::new(
+            2 * base_config.config.pruned_degree().get() / 3,
             diskann::graph::config::MaxDegree::default_slack(),
-            search_list_size,
+            base_config.config.l_build().get(),
             base_config.dist_metric.into(),
         )
         .build()?;
 
-        let metadata = load_metadata_from_file(storage_provider, shard_base_file)?;
+        Ok(index_config)
+    }
 
-        let mut index_config = (*base_config).clone();
+    fn create_shard_index_config(&self, shard_base_file: &str) -> ANNResult<IndexConfiguration> {
+        let metadata = load_metadata_from_file(self.storage_provider, shard_base_file)?;
+
+        let mut index_config = self.shard_index_config()?;
         index_config.max_points = metadata.npoints();
-        index_config.config = low_degree_params;
 
         Ok(index_config)
     }
@@ -425,11 +397,13 @@ where
         &mut self,
         dataset_file: &str,
         merged_index_prefix: &str,
-        max_degree: u32,
         pool: RayonThreadPoolRef<'_>,
     ) -> ANNResult<usize> {
         let sampling_rate = MAX_PQ_TRAINING_SET_SIZE / self.index_configuration.max_points as f64;
         let ram_budget_in_bytes = self.disk_build_param.build_memory_limit().in_bytes() as f64;
+
+        let shard_config = self.shard_index_config()?;
+        let build_quantizer = self.build_quantizer;
 
         partition_with_ram_budget::<Data::VectorDataType, _, _>(
             dataset_file,
@@ -442,15 +416,10 @@ where
             &mut self.rng,
             pool,
             |num_points, dim| {
-                let datasize = std::mem::size_of::<Data::VectorDataType>() as u64;
-                let graph_degree = 2 * max_degree / 3;
-                estimate_build_index_ram_usage(
-                    num_points,
-                    dim,
-                    datasize,
-                    graph_degree as u64,
-                    self.disk_build_param.build_quantization(),
-                )
+                let mut config = shard_config.clone();
+                config.max_points = num_points as usize;
+                config.dim = dim as usize;
+                estimate_build_index_ram_usage::<Data::VectorDataType>(&config, build_quantizer)
             },
         )
     }

--- a/diskann-disk/src/utils/partition.rs
+++ b/diskann-disk/src/utils/partition.rs
@@ -623,14 +623,11 @@ mod partition_test {
             &mut diskann_providers::utils::create_rnd_in_tests(),
             pool.as_ref(),
             |num_points, dim| {
-                // Simple RAM estimation for test - capture datasize and graph_degree from context
-                use diskann_providers::model::GRAPH_SLACK_FACTOR;
-
+                // A deliberately crude stand-in for the production estimator: this test only
+                // exercises how `partition_with_ram_budget` reacts to the callback.
                 let datasize = std::mem::size_of::<f32>() as u64;
                 let graph_degree = max_degree as u64;
-                let dataset_size = (num_points * dim.next_multiple_of(8u64) * datasize) as f64;
-                let graph_size = (num_points * graph_degree * 4) as f64 * GRAPH_SLACK_FACTOR;
-                1.1 * (dataset_size + graph_size)
+                (num_points * (dim * datasize + graph_degree * 4)) as f64
             },
         )?;
 

--- a/diskann-providers/src/model/graph/provider/async_/common.rs
+++ b/diskann-providers/src/model/graph/provider/async_/common.rs
@@ -100,8 +100,17 @@ unsafe impl<T: bytemuck::Pod + Sync> Sync for AlignedMemoryVectorStore<T> {}
 // SAFETY: It's not really, but the `bytemuck::Pod` bound helps mitigate the fallout.
 unsafe impl<T: bytemuck::Pod + Send> Send for AlignedMemoryVectorStore<T> {}
 
+/// The allocation shape of an [`AlignedMemoryVectorStore`], derived once and shared by
+/// [`AlignedMemoryVectorStore::with_capacity`] and [`AlignedMemoryVectorStore::estimate_bytes`].
+struct AlignedLayout {
+    /// Per-vector element count after padding each vector to a 64 byte boundary.
+    padded_vector_dim: usize,
+
+    element_count: usize,
+}
+
 impl<T: bytemuck::Pod> AlignedMemoryVectorStore<T> {
-    pub fn with_capacity(max_vectors: usize, dim: usize) -> Self {
+    fn layout(max_vectors: usize, dim: usize) -> AlignedLayout {
         let elem_size = mem::size_of::<T>();
         assert!(64 % elem_size == 0);
         let vector_size = elem_size * dim;
@@ -122,9 +131,25 @@ impl<T: bytemuck::Pod> AlignedMemoryVectorStore<T> {
         // correct alignment. This means we need some extra elements at the end to compensate.
         let last_elems: usize = 64 / elem_size - 1;
 
-        let count = max_vectors * padded_vector_dim + last_elems;
+        AlignedLayout {
+            padded_vector_dim,
+            element_count: max_vectors * padded_vector_dim + last_elems,
+        }
+    }
+
+    /// The number of heap bytes [`Self::with_capacity`] will allocate for these arguments.
+    pub fn estimate_bytes(max_vectors: usize, dim: usize) -> usize {
+        Self::layout(max_vectors, dim).element_count * mem::size_of::<T>()
+    }
+
+    pub fn with_capacity(max_vectors: usize, dim: usize) -> Self {
+        let AlignedLayout {
+            padded_vector_dim,
+            element_count,
+        } = Self::layout(max_vectors, dim);
+
         let mut store: UnsafeCell<Vec<T>> =
-            UnsafeCell::new(vec![<T as bytemuck::Zeroable>::zeroed(); count]);
+            UnsafeCell::new(vec![<T as bytemuck::Zeroable>::zeroed(); element_count]);
 
         let start_index = store.get_mut().as_ptr().align_offset(64);
 
@@ -458,6 +483,27 @@ impl Default for TestCallCount {
     }
 }
 
+/// Estimate the heap footprint a precursor's store will occupy once created.
+///
+/// Implementations must derive their result from the same sizing helpers the corresponding
+/// constructor uses; re-deriving the arithmetic here reintroduces the drift this trait exists to
+/// prevent. Allocations growing with `total_points` are counted, fixed overheads are not.
+pub trait EstimateBytes {
+    fn estimated_bytes(&self, total_points: usize) -> usize;
+}
+
+impl EstimateBytes for NoStore {
+    fn estimated_bytes(&self, _total_points: usize) -> usize {
+        0
+    }
+}
+
+impl EstimateBytes for NoDeletes {
+    fn estimated_bytes(&self, _total_points: usize) -> usize {
+        0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::num::NonZeroUsize;
@@ -488,5 +534,42 @@ mod tests {
                 msg
             );
         }
+    }
+
+    /// `estimate_bytes` must describe the allocation `with_capacity` actually makes, including
+    /// the alignment slack at the end of the buffer.
+    #[rstest::rstest]
+    #[case::exactly_one_cache_line(16)]
+    #[case::unaligned(17)]
+    #[case::sub_cache_line(3)]
+    #[case::zero_vectors_still_reserves_slack(0)]
+    fn estimate_bytes_matches_allocation(#[case] dim: usize) {
+        for max_vectors in [0usize, 1, 7, 1000] {
+            let store = AlignedMemoryVectorStore::<f32>::with_capacity(max_vectors, dim);
+
+            // SAFETY: no other reference to the store exists in this test.
+            let allocated = unsafe { &*store.store.get() }.len() * mem::size_of::<f32>();
+
+            assert_eq!(
+                AlignedMemoryVectorStore::<f32>::estimate_bytes(max_vectors, dim),
+                allocated,
+                "dim={dim}, max_vectors={max_vectors}"
+            );
+        }
+    }
+
+    #[test]
+    fn layout_pads_vectors_to_cache_line() {
+        // 16 f32 elements are exactly one cache line, so no padding is added.
+        assert_eq!(
+            AlignedMemoryVectorStore::<f32>::layout(4, 16).padded_vector_dim,
+            16
+        );
+
+        // 17 elements spill into a second cache line and are padded up to it.
+        assert_eq!(
+            AlignedMemoryVectorStore::<f32>::layout(4, 17).padded_vector_dim,
+            32
+        );
     }
 }

--- a/diskann-providers/src/model/graph/provider/async_/fast_memory_quant_vector_provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/fast_memory_quant_vector_provider.rs
@@ -59,6 +59,12 @@ type DistanceComputer<'a> = pq::distance::DistanceComputer<'a>;
 type QueryComputer<'a> = pq::distance::QueryComputer<'a>;
 
 impl FastMemoryQuantVectorProviderAsync {
+    /// The number of heap bytes [`Self::new`] will allocate for these arguments, excluding the PQ
+    /// pivot table and the distance-table pool.
+    pub fn estimate_bytes(max_vectors: usize, num_chunks: usize) -> usize {
+        AlignedMemoryVectorStore::<u8>::estimate_bytes(max_vectors, num_chunks)
+    }
+
     pub fn new(dist_metric: Metric, max_vectors: usize, pq_chunk_table: FixedChunkPQTable) -> Self {
         let dim = pq_chunk_table.get_num_chunks();
         let quant_vectors = AlignedMemoryVectorStore::with_capacity(max_vectors, dim);

--- a/diskann-providers/src/model/graph/provider/async_/fast_memory_vector_provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/fast_memory_vector_provider.rs
@@ -58,6 +58,11 @@ pub struct FastMemoryVectorProviderAsync<T: VectorRepr> {
 }
 
 impl<T: VectorRepr> FastMemoryVectorProviderAsync<T> {
+    /// The number of heap bytes [`Self::new`] will allocate for these arguments.
+    pub fn estimate_bytes(max_vectors: usize, dim: usize) -> usize {
+        AlignedMemoryVectorStore::<T>::estimate_bytes(max_vectors, dim)
+    }
+
     pub fn new(
         max_vectors: usize,
         dim: usize,

--- a/diskann-providers/src/model/graph/provider/async_/inmem/full_precision.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/full_precision.rs
@@ -29,8 +29,8 @@ use diskann_vector::{DistanceFunction, PreprocessedDistanceFunction, distance::M
 use crate::model::graph::provider::async_::{
     FastMemoryVectorProviderAsync, SimpleNeighborProviderAsync,
     common::{
-        CreateVectorStore, FullPrecision, NoDeletes, NoStore, Panics, PrefetchCacheLineLevel,
-        SetElementHelper,
+        CreateVectorStore, EstimateBytes, FullPrecision, NoDeletes, NoStore, Panics,
+        PrefetchCacheLineLevel, SetElementHelper,
     },
     inmem::DefaultProvider,
     postprocess::{AsDeletionCheck, DeletionCheck, RemoveDeletedIdsAndCopy},
@@ -84,6 +84,15 @@ where
             self.prefetch_cache_line_level,
             prefetch_lookahead,
         )
+    }
+}
+
+impl<T> EstimateBytes for CreateFullPrecision<T>
+where
+    T: VectorRepr,
+{
+    fn estimated_bytes(&self, total_points: usize) -> usize {
+        FullPrecisionStore::<T>::estimate_bytes(total_points, self.dim)
     }
 }
 

--- a/diskann-providers/src/model/graph/provider/async_/inmem/product.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/product.rs
@@ -28,7 +28,8 @@ use crate::model::{
         FastMemoryQuantVectorProviderAsync, FastMemoryVectorProviderAsync,
         SimpleNeighborProviderAsync,
         common::{
-            CreateVectorStore, Hybrid, NoStore, Panics, Quantized, SetElementHelper, VectorStore,
+            CreateVectorStore, EstimateBytes, Hybrid, NoStore, Panics, Quantized, SetElementHelper,
+            VectorStore,
         },
         distances,
         inmem::{
@@ -61,6 +62,12 @@ impl VectorStore for DefaultQuant {
 
     fn count_for_get_vector(&self) -> usize {
         self.num_get_calls.get()
+    }
+}
+
+impl EstimateBytes for FixedChunkPQTable {
+    fn estimated_bytes(&self, total_points: usize) -> usize {
+        DefaultQuant::estimate_bytes(total_points, self.get_num_chunks())
     }
 }
 

--- a/diskann-providers/src/model/graph/provider/async_/inmem/provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/provider.rs
@@ -277,10 +277,6 @@ pub struct DefaultProviderParameters {
 /// Start points occupy a single trailing block in the neighbor provider.
 const NEIGHBOR_START_POINTS: usize = 1;
 
-/// `max_degree` in [`DefaultProviderParameters`] is already the true maximum degree, so the
-/// neighbor provider applies no further slack.
-const NEIGHBOR_SLACK_FACTOR: f32 = 1.0;
-
 impl DefaultProviderParameters {
     pub fn simple(max_points: usize, dim: usize, metric: Metric, max_degree: u32) -> Self {
         Self {
@@ -315,7 +311,6 @@ impl DefaultProviderParameters {
                 npts,
                 NEIGHBOR_START_POINTS,
                 self.max_degree,
-                NEIGHBOR_SLACK_FACTOR,
             )
     }
 }
@@ -348,7 +343,6 @@ impl<U, V, D, Ctx> DefaultProvider<U, V, D, Ctx> {
                 npts,
                 NEIGHBOR_START_POINTS,
                 params.max_degree,
-                NEIGHBOR_SLACK_FACTOR,
             ),
             deleted: delete_precursor.create(npts),
             metric: params.metric,

--- a/diskann-providers/src/model/graph/provider/async_/inmem/provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/provider.rs
@@ -22,8 +22,8 @@ use crate::{
     model::graph::provider::async_::{
         SimpleNeighborProviderAsync, StartPoints, TableDeleteProviderAsync,
         common::{
-            CreateDeleteProvider, CreateVectorStore, NoDeletes, NoStore, PrefetchCacheLineLevel,
-            SetElementHelper, VectorStore,
+            CreateDeleteProvider, CreateVectorStore, EstimateBytes, NoDeletes, NoStore,
+            PrefetchCacheLineLevel, SetElementHelper, VectorStore,
         },
     },
     storage::{AsyncIndexMetadata, AsyncQuantLoadContext, DiskGraphOnly, LoadWith, SaveWith},
@@ -274,6 +274,13 @@ pub struct DefaultProviderParameters {
     pub max_degree: u32,
 }
 
+/// Start points occupy a single trailing block in the neighbor provider.
+const NEIGHBOR_START_POINTS: usize = 1;
+
+/// `max_degree` in [`DefaultProviderParameters`] is already the true maximum degree, so the
+/// neighbor provider applies no further slack.
+const NEIGHBOR_SLACK_FACTOR: f32 = 1.0;
+
 impl DefaultProviderParameters {
     pub fn simple(max_points: usize, dim: usize, metric: Metric, max_degree: u32) -> Self {
         Self {
@@ -286,6 +293,31 @@ impl DefaultProviderParameters {
             max_degree,
         }
     }
+
+    /// Estimate the heap footprint [`DefaultProvider::new_empty`] would allocate for these
+    /// parameters and precursors, without allocating anything.
+    pub fn estimated_bytes<CU, CV, CD>(
+        &self,
+        base_precursor: &CU,
+        aux_precursor: &CV,
+        delete_precursor: &CD,
+    ) -> usize
+    where
+        CU: EstimateBytes,
+        CV: EstimateBytes,
+        CD: EstimateBytes,
+    {
+        let npts = self.max_points + self.frozen_points.get();
+        base_precursor.estimated_bytes(npts)
+            + aux_precursor.estimated_bytes(npts)
+            + delete_precursor.estimated_bytes(npts)
+            + SimpleNeighborProviderAsync::estimate_bytes(
+                npts,
+                NEIGHBOR_START_POINTS,
+                self.max_degree,
+                NEIGHBOR_SLACK_FACTOR,
+            )
+    }
 }
 
 impl<U, V, D, Ctx> DefaultProvider<U, V, D, Ctx> {
@@ -297,7 +329,6 @@ impl<U, V, D, Ctx> DefaultProvider<U, V, D, Ctx> {
     /// * `base_precursor`: A precursor type for the base layer.
     /// * `aux_precursor`: A precursor type for the auxiliary layer.
     /// * `delete_precursor`: A precursor type for the delete layer.
-    /// * `neighbor_precursor`: A precursor type for the neighbor layer.
     pub fn new_empty<CU, CV, CD>(
         params: DefaultProviderParameters,
         base_precursor: CU,
@@ -313,7 +344,12 @@ impl<U, V, D, Ctx> DefaultProvider<U, V, D, Ctx> {
         Ok(Self {
             base_vectors: base_precursor.create(npts, params.metric, params.prefetch_lookahead),
             aux_vectors: aux_precursor.create(npts, params.metric, params.prefetch_lookahead),
-            neighbor_provider: SimpleNeighborProviderAsync::new(npts, 1, params.max_degree, 1.0),
+            neighbor_provider: SimpleNeighborProviderAsync::new(
+                npts,
+                NEIGHBOR_START_POINTS,
+                params.max_degree,
+                NEIGHBOR_SLACK_FACTOR,
+            ),
             deleted: delete_precursor.create(npts),
             metric: params.metric,
             start_points: StartPoints::new(params.max_points as u32, params.frozen_points)?,

--- a/diskann-providers/src/model/graph/provider/async_/inmem/scalar.rs
+++ b/diskann-providers/src/model/graph/provider/async_/inmem/scalar.rs
@@ -40,8 +40,8 @@ use crate::{
     model::graph::provider::async_::{
         FastMemoryVectorProviderAsync, SimpleNeighborProviderAsync,
         common::{
-            AlignedMemoryVectorStore, CreateVectorStore, NoStore, Quantized, SetElementHelper,
-            TestCallCount, VectorStore,
+            AlignedMemoryVectorStore, CreateVectorStore, EstimateBytes, NoStore, Quantized,
+            SetElementHelper, TestCallCount, VectorStore,
         },
         inmem::{FullPrecisionProvider, FullPrecisionStore},
         postprocess::{AsDeletionCheck, DeletionCheck, RemoveDeletedIdsAndCopy},
@@ -100,6 +100,15 @@ impl<const NBITS: usize> SQStore<NBITS>
 where
     Unsigned: Representation<NBITS>,
 {
+    /// The number of heap bytes [`Self::new`] will allocate for these arguments, excluding the
+    /// trained quantizer.
+    pub fn estimate_bytes(num_vectors: usize, dim: usize) -> usize {
+        AlignedMemoryVectorStore::<u8>::estimate_bytes(
+            num_vectors,
+            CVRef::<NBITS>::canonical_bytes(dim),
+        )
+    }
+
     pub(super) fn new(
         quantizer: ScalarQuantizer,
         num_vectors: usize,
@@ -334,6 +343,15 @@ where
         prefetch_lookahead: Option<usize>,
     ) -> Self::Target {
         SQStore::new(self.quantizer, max_points, metric, prefetch_lookahead)
+    }
+}
+
+impl<const NBITS: usize> EstimateBytes for WithBits<NBITS>
+where
+    Unsigned: Representation<NBITS>,
+{
+    fn estimated_bytes(&self, total_points: usize) -> usize {
+        SQStore::<NBITS>::estimate_bytes(total_points, self.quantizer.dim())
     }
 }
 

--- a/diskann-providers/src/model/graph/provider/async_/simple_neighbor_provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/simple_neighbor_provider.rs
@@ -16,7 +16,7 @@ use crate::storage::{
 };
 
 pub struct SimpleNeighborProviderAsync {
-    // Each adjacency list is stored in a fixed size slice of size max_degree * graph_slack_factor + 1.
+    // Each adjacency list is stored in a fixed size slice of size max_degree + 1.
     // The length of the list is stored in the extra element at the end as a u32.
     graph: AlignedMemoryVectorStore<u32>,
     locks: Vec<RwLock<()>>,
@@ -27,35 +27,25 @@ pub struct SimpleNeighborProviderAsync {
 
 impl SimpleNeighborProviderAsync {
     /// The number of `u32` slots reserved per adjacency list, including the leading length slot.
-    fn row_width(max_degree: u32, graph_slack_factor: f32) -> usize {
-        (max_degree as f32 * graph_slack_factor) as usize + 1
+    fn row_width(max_degree: u32) -> usize {
+        max_degree as usize + 1
     }
 
     /// The number of heap bytes [`Self::new`] will allocate for these arguments.
-    pub fn estimate_bytes(
-        max_points: usize,
-        num_start_points: usize,
-        max_degree: u32,
-        graph_slack_factor: f32,
-    ) -> usize {
+    pub fn estimate_bytes(max_points: usize, num_start_points: usize, max_degree: u32) -> usize {
         let size = max_points + num_start_points;
-        AlignedMemoryVectorStore::<u32>::estimate_bytes(
-            size,
-            Self::row_width(max_degree, graph_slack_factor),
-        ) + size * std::mem::size_of::<RwLock<()>>()
+        AlignedMemoryVectorStore::<u32>::estimate_bytes(size, Self::row_width(max_degree))
+            + size * std::mem::size_of::<RwLock<()>>()
     }
 
-    pub fn new(
-        max_points: usize,
-        num_start_points: usize,
-        max_degree: u32,
-        graph_slack_factor: f32,
-    ) -> Self {
+    /// Construct an empty provider.
+    ///
+    /// `max_degree` is the *physical* maximum adjacency list length. Any graph slack factor
+    /// must already be applied by the caller, since slack is resolved when the index
+    /// configuration is built.
+    pub fn new(max_points: usize, num_start_points: usize, max_degree: u32) -> Self {
         let size = max_points + num_start_points;
-        let graph = AlignedMemoryVectorStore::with_capacity(
-            size,
-            Self::row_width(max_degree, graph_slack_factor),
-        );
+        let graph = AlignedMemoryVectorStore::with_capacity(size, Self::row_width(max_degree));
         let locks = (0..size).map(|_| RwLock::new(())).collect::<Vec<_>>();
 
         Self {
@@ -182,13 +172,8 @@ impl SimpleNeighborProviderAsync {
                 })?;
 
                 // The provided `max_degree` here is the observed maximum degree in the input
-                // file. Therefore, we don't need to apply a slack factor to it.
-                Ok(Self::new(
-                    max_points,
-                    num_start_points,
-                    max_degree as u32,
-                    1.0,
-                ))
+                // file, which is already a physical degree.
+                Ok(Self::new(max_points, num_start_points, max_degree as u32))
             },
         )
     }
@@ -387,7 +372,7 @@ mod tests {
 
     #[test]
     fn test_neighbor_provider() {
-        let neighbor_provider = SimpleNeighborProviderAsync::new(10, 1, 5, 1.0);
+        let neighbor_provider = SimpleNeighborProviderAsync::new(10, 1, 5);
 
         let adj_list = vec![1, 2, 3];
         neighbor_provider.set_neighbors_sync(1, &adj_list).unwrap();
@@ -417,8 +402,7 @@ mod tests {
         let max_points = 8;
         let additional_points = 2;
 
-        let provider =
-            SimpleNeighborProviderAsync::new(max_points, additional_points, max_degree, 1.0);
+        let provider = SimpleNeighborProviderAsync::new(max_points, additional_points, max_degree);
 
         // Setup a virtual storage provider with memory filesystem
         let storage = VirtualStorageProvider::new_memory();

--- a/diskann-providers/src/model/graph/provider/async_/simple_neighbor_provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/simple_neighbor_provider.rs
@@ -26,6 +26,25 @@ pub struct SimpleNeighborProviderAsync {
 }
 
 impl SimpleNeighborProviderAsync {
+    /// The number of `u32` slots reserved per adjacency list, including the leading length slot.
+    fn row_width(max_degree: u32, graph_slack_factor: f32) -> usize {
+        (max_degree as f32 * graph_slack_factor) as usize + 1
+    }
+
+    /// The number of heap bytes [`Self::new`] will allocate for these arguments.
+    pub fn estimate_bytes(
+        max_points: usize,
+        num_start_points: usize,
+        max_degree: u32,
+        graph_slack_factor: f32,
+    ) -> usize {
+        let size = max_points + num_start_points;
+        AlignedMemoryVectorStore::<u32>::estimate_bytes(
+            size,
+            Self::row_width(max_degree, graph_slack_factor),
+        ) + size * std::mem::size_of::<RwLock<()>>()
+    }
+
     pub fn new(
         max_points: usize,
         num_start_points: usize,
@@ -35,7 +54,7 @@ impl SimpleNeighborProviderAsync {
         let size = max_points + num_start_points;
         let graph = AlignedMemoryVectorStore::with_capacity(
             size,
-            (max_degree as f32 * graph_slack_factor) as usize + 1,
+            Self::row_width(max_degree, graph_slack_factor),
         );
         let locks = (0..size).map(|_| RwLock::new(())).collect::<Vec<_>>();
 


### PR DESCRIPTION
# Make build RAM estimation store-owned

Stacked on #1271 — review against `wuw92/refactor-disk-build-structure-main`.

## Why

Addresses https://github.com/microsoft/DiskANN/pull/1271#discussion_r3653942378.

The build RAM estimate was a hand-written byte formula with no link to the stores it described, so layout changes silently invalidated it. 

## What

Make each store answer for its own size, so an allocation and its estimate cannot diverge. Every estimate mirrors one constructor at its own level and knows only what that constructor directly builds:

```
DefaultProviderParameters::estimated_bytes        mirrors  new_empty
  ├─ CU/CV/CD: EstimateBytes                      mirrors  CreateVectorStore::create
  │    ├─ CreateFullPrecision<T> ─┐
  │    ├─ FixedChunkPQTable       ├─ <Store>::estimate_bytes   mirrors  <Store>::new
  │    ├─ WithBits<NBITS>       ──┘
  │    └─ NoStore / NoDeletes → 0
  └─ SimpleNeighborProviderAsync::estimate_bytes   mirrors  SimpleNeighborProviderAsync::new
       └─ AlignedMemoryVectorStore::estimate_bytes mirrors  with_capacity
```

The estimator moves beside the in-memory builder.
Scoped to the stores disk build uses; small or fixed overheads such as PQ pivots stay uncounted.

Also removes the `graph_slack_factor` parameter from `SimpleNeighborProviderAsync`: slack is already folded into `max_degree`, so every call site passed `1.0`.

