### PR TITLE
Add IVF sampled ADC start-point router

### DIFF
--- a/diskann-benchmark/src/disk_index/build.rs
+++ b/diskann-benchmark/src/disk_index/build.rs
@@ -4,11 +4,12 @@
  */
 
 use serde::{Deserialize, Serialize};
-use std::fmt;
+use std::{fmt, fs::File, io::BufWriter, path::Path};
 
 use diskann::{
     graph::config,
     utils::{VectorRepr, ONE},
+    ANNError,
 };
 use diskann_benchmark_runner::utils::MicroSeconds;
 use diskann_disk::{
@@ -16,6 +17,9 @@ use diskann_disk::{
     data_model::AdHoc,
     disk_index_build_parameter::{
         DiskIndexBuildParameters, MemoryBudget, NumPQChunks, DISK_SECTOR_LEN,
+    },
+    search::ivf_pq_router::{
+        build_ivf_pq_router_data, write_ivf_pq_router_binary, IvfPqRouterBuildParams,
     },
     storage::DiskIndexWriter,
 };
@@ -27,7 +31,11 @@ use opentelemetry::trace::Tracer;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use scopeguard::defer;
 
-use crate::{disk_index::json_spancollector::JsonSpanCollector, inputs::disk::DiskIndexBuild};
+use crate::{
+    disk_index::json_spancollector::JsonSpanCollector,
+    inputs::disk::{DiskIndexBuild, IvfPqRouterBuildConfig},
+    utils::datafiles,
+};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub(super) struct DiskBuildStats {
@@ -130,6 +138,9 @@ where
 
     let start = std::time::Instant::now();
     disk_index.build()?;
+    if let Some(ivf_pq_router_build) = &params.ivf_pq_router_build {
+        build_ivf_pq_router_artifact::<T>(params, ivf_pq_router_build)?;
+    }
     let total_time: MicroSeconds = start.elapsed().into();
 
     drop(span);
@@ -141,4 +152,90 @@ where
     };
 
     Ok(DiskBuildStats::new(total_time, span_metrics))
+}
+
+fn build_ivf_pq_router_artifact<T>(
+    params: &DiskIndexBuild,
+    config: &IvfPqRouterBuildConfig,
+) -> anyhow::Result<()>
+where
+    T: VectorRepr,
+{
+    let (training_data, num_points, dim) =
+        load_training_data_as_f32::<T>(&params.data, params.dim, "IVF+PQ router")?;
+    let pool = diskann_providers::utils::create_thread_pool(params.num_threads)?;
+    let build_params = IvfPqRouterBuildParams {
+        num_centroids: config.num_centroids.get(),
+        max_iterations: config.max_iterations.get(),
+        seed: config.seed,
+        fallback_medoid: None,
+        training_sample_size: config.training_sample_size.map(|value| value.get()),
+    };
+    let artifact = build_ivf_pq_router_data(
+        &training_data,
+        num_points,
+        dim,
+        &build_params,
+        pool.as_ref(),
+    )?;
+
+    let file = File::create(&config.save_path).map_err(|err| {
+        anyhow::anyhow!(
+            "failed to create IVF+PQ router artifact {}: {err}",
+            config.save_path
+        )
+    })?;
+    let mut writer = BufWriter::new(file);
+    if is_binary_artifact_path(Path::new(&config.save_path)) {
+        write_ivf_pq_router_binary(&mut writer, &artifact)?;
+    } else {
+        serde_json::to_writer_pretty(writer, &artifact)?;
+    }
+    Ok(())
+}
+
+fn load_training_data_as_f32<T>(
+    data: &diskann_benchmark_runner::files::InputFile,
+    expected_dim: usize,
+    artifact_label: &str,
+) -> anyhow::Result<(Vec<f32>, usize, usize)>
+where
+    T: VectorRepr,
+{
+    let dataset: diskann_utils::views::Matrix<T> =
+        datafiles::load_dataset(datafiles::BinFile(data)).map_err(|err| {
+            anyhow::anyhow!(
+                "failed to load {} training data {}: {err}",
+                artifact_label,
+                data.display()
+            )
+        })?;
+    if dataset.ncols() != expected_dim {
+        anyhow::bail!(
+            "{} training data dimension {} does not match build dim {}",
+            artifact_label,
+            dataset.ncols(),
+            expected_dim
+        );
+    }
+
+    let num_points = dataset.nrows();
+    let dim = dataset.ncols();
+    let value_count = num_points
+        .checked_mul(dim)
+        .ok_or_else(|| anyhow::anyhow!("{} training data shape overflowed", artifact_label))?;
+    let mut training_data = vec![0.0; value_count];
+    for row in 0..num_points {
+        let dst = &mut training_data[row * dim..(row + 1) * dim];
+        T::as_f32_into(dataset.row(row), dst)
+            .map_err(|err| anyhow::Error::from(Into::<ANNError>::into(err)))?;
+    }
+
+    Ok((training_data, num_points, dim))
+}
+
+fn is_binary_artifact_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("bin"))
 }

--- a/diskann-benchmark/src/disk_index/search.rs
+++ b/diskann-benchmark/src/disk_index/search.rs
@@ -4,7 +4,10 @@
  */
 
 use rayon::prelude::*;
-use std::{collections::HashSet, fmt, sync::atomic::AtomicBool, time::Instant};
+use std::{
+    collections::HashSet, fmt, fs::File, io::BufReader, path::Path, sync::atomic::AtomicBool,
+    time::Instant,
+};
 
 use opentelemetry::{global, trace::Span, trace::Tracer};
 use opentelemetry_sdk::trace::SdkTracerProvider;
@@ -14,11 +17,15 @@ use diskann_benchmark_runner::{files::InputFile, utils::MicroSeconds};
 use diskann_disk::{
     data_model::{AdHoc, CachingStrategy},
     search::{
+        ivf_pq_router::{
+            read_ivf_pq_router_binary, IvfPqRouter, IvfPqRouterData, IvfPqStartPointRouter,
+        },
         provider::{
             disk_provider::DiskIndexSearcher,
             disk_vertex_provider_factory::DiskVertexProviderFactory,
         },
         search_mode::SearchMode,
+        start_point_router::StartPointRouter,
     },
     storage::disk_index_reader::DiskIndexReader,
     utils::{instrumentation::PerfLogger, statistics, QueryStatistics},
@@ -36,7 +43,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     disk_index::json_spancollector::JsonSpanCollector,
-    inputs::disk::{DiskIndexLoad, DiskSearchPhase},
+    inputs::disk::{
+        DiskIndexLoad, DiskSearchPhase, DiskStartPointRouter, IvfPqStartPointRouterConfig,
+    },
     utils::{datafiles, SimilarityMeasure},
 };
 
@@ -64,6 +73,11 @@ pub(super) struct DiskSearchResult {
     pub(super) mean_io_time: f64,
     pub(super) mean_cpu_time: f64,
     pub(super) mean_pq_preprocess_time: f64,
+    pub(super) mean_router_time: f64,
+    pub(super) mean_router_sampled_adc_codes: f64,
+    pub(super) mean_router_probed_lists: f64,
+    pub(super) mean_router_centroid_scores: f64,
+    pub(super) mean_routed_start_points: f64,
     pub(super) mean_comparisons: f64,
     pub(super) mean_hops: f64,
     pub(super) cache_hit_percentage: f64,
@@ -148,6 +162,21 @@ impl DiskSearchResult {
             mean_pq_preprocess_time: statistics::get_mean_stats(statistics, |stats| {
                 stats.query_pq_preprocess_time_us as f64
             }),
+            mean_router_time: statistics::get_mean_stats(statistics, |stats| {
+                stats.router_time_us as f64
+            }),
+            mean_router_sampled_adc_codes: statistics::get_mean_stats(statistics, |stats| {
+                stats.router_sampled_adc_codes as f64
+            }),
+            mean_router_probed_lists: statistics::get_mean_stats(statistics, |stats| {
+                stats.router_probed_lists as f64
+            }),
+            mean_router_centroid_scores: statistics::get_mean_stats(statistics, |stats| {
+                stats.router_centroid_scores as f64
+            }),
+            mean_routed_start_points: statistics::get_mean_stats(statistics, |stats| {
+                stats.routed_start_points_count as f64
+            }),
             mean_comparisons: statistics::get_mean_stats(statistics, |stats| {
                 stats.total_comparisons as f64
             }),
@@ -221,7 +250,9 @@ where
     let vertex_provider_factory =
         DiskVertexProviderFactory::from_disk_index_path(disk_index_path, caching_strategy)?;
 
-    let searcher = &DiskIndexSearcher::<AdHoc<T>, _>::new(
+    let start_point_router = load_start_point_router(search_params)?;
+
+    let searcher = &DiskIndexSearcher::<AdHoc<T>, _>::new_with_start_point_router(
         search_params.num_threads,
         if let Some(lim) = search_params.search_io_limit {
             lim
@@ -232,6 +263,7 @@ where
         vertex_provider_factory,
         search_params.distance.into(),
         None,
+        start_point_router,
     )?;
 
     logger.log_checkpoint("index_loaded");
@@ -358,6 +390,50 @@ where
     })
 }
 
+fn load_start_point_router(
+    search_params: &DiskSearchPhase,
+) -> anyhow::Result<Option<StartPointRouter>> {
+    let Some(router) = &search_params.start_point_router else {
+        return Ok(None);
+    };
+
+    match router {
+        DiskStartPointRouter::IvfPq(config) => {
+            let router_data = load_ivf_pq_router_data(config)?;
+            let router = IvfPqRouter::from_data(router_data)?;
+            let router = IvfPqStartPointRouter::new(
+                router,
+                config.nprobe.get(),
+                config.max_start_points.get(),
+                config.posting_list_samples_per_list.get(),
+            )?;
+            Ok(Some(StartPointRouter::IvfPq(Box::new(router))))
+        }
+    }
+}
+
+fn load_ivf_pq_router_data(
+    config: &IvfPqStartPointRouterConfig,
+) -> anyhow::Result<IvfPqRouterData> {
+    let path = &config.artifact;
+    let file = File::open(&**path)
+        .map_err(|err| anyhow::anyhow!("failed to open IVF+PQ router {}: {err}", path.display()))?;
+    let reader = BufReader::new(file);
+    if is_binary_artifact_path(path) {
+        Ok(read_ivf_pq_router_binary(reader)?)
+    } else {
+        let data: IvfPqRouterData = serde_json::from_reader(reader)?;
+        data.validate()?;
+        Ok(data)
+    }
+}
+
+fn is_binary_artifact_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("bin"))
+}
+
 // Simplified internal structures to reduce parameter count
 pub(super) struct GroundTruthContext {
     gt_ids: Option<Vec<u32>>,
@@ -401,7 +477,7 @@ impl fmt::Display for DiskSearchStats {
         let fmt_us = |v: f64| -> String { format!("{:.1}us", v) };
         let fmt_pct = |v: f64| -> String { format!("{:.1}%", v) };
 
-        let cols: [(&str, usize); 14] = [
+        let cols: [(&str, usize); 16] = [
             ("L", 2),
             ("KNN", 3),
             ("QPS", 8),
@@ -412,6 +488,8 @@ impl fmt::Display for DiskSearchStats {
             ("IO (us)", 10),
             ("CPU (us)", 10),
             ("PQ Preprocess (us)", 20),
+            ("Router (us)", 11),
+            ("Router ADC", 10),
             ("Mean Comps", 11),
             ("Mean Hops", 10),
             ("Cache Hit %", 12),
@@ -451,7 +529,7 @@ impl fmt::Display for DiskSearchStats {
 
         for r in &self.search_results_per_l {
             // Prepare values as strings with numeric formatting
-            let vals: [String; 14] = [
+            let vals: [String; 16] = [
                 format!("{}", r.search_l),
                 format!("{}", self.recall_at),
                 format!("{:.1}", r.qps),
@@ -462,6 +540,8 @@ impl fmt::Display for DiskSearchStats {
                 fmt_us(r.mean_io_time),
                 fmt_us(r.mean_cpu_time),
                 fmt_us(r.mean_pq_preprocess_time),
+                fmt_us(r.mean_router_time),
+                format!("{:.1}", r.mean_router_sampled_adc_codes),
                 format!("{:.1}", r.mean_comparisons),
                 format!("{:.1}", r.mean_hops),
                 fmt_pct(r.cache_hit_percentage),

--- a/diskann-benchmark/src/inputs/disk.rs
+++ b/diskann-benchmark/src/inputs/disk.rs
@@ -70,6 +70,19 @@ pub(crate) struct DiskIndexBuild {
     #[cfg(feature = "disk-index")]
     pub(crate) quantization_type: QuantizationType,
     pub(crate) save_path: String,
+    #[cfg(feature = "disk-index")]
+    #[serde(default)]
+    pub(crate) ivf_pq_router_build: Option<IvfPqRouterBuildConfig>,
+}
+
+#[cfg(feature = "disk-index")]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub(crate) struct IvfPqRouterBuildConfig {
+    pub(crate) save_path: String,
+    pub(crate) num_centroids: NonZeroUsize,
+    pub(crate) max_iterations: NonZeroUsize,
+    pub(crate) seed: u64,
+    pub(crate) training_sample_size: Option<NonZeroUsize>,
 }
 
 #[cfg(feature = "disk-index")]
@@ -170,6 +183,26 @@ pub(crate) struct DiskSearchPhase {
     pub(crate) num_nodes_to_cache: Option<usize>,
     pub(crate) search_io_limit: Option<usize>,
     pub(crate) post_processor: Option<TopkPostProcessor>,
+    #[cfg(feature = "disk-index")]
+    #[serde(default)]
+    pub(crate) start_point_router: Option<DiskStartPointRouter>,
+}
+
+#[cfg(feature = "disk-index")]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(tag = "type")]
+pub(crate) enum DiskStartPointRouter {
+    #[serde(rename = "ivf_pq")]
+    IvfPq(IvfPqStartPointRouterConfig),
+}
+
+#[cfg(feature = "disk-index")]
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub(crate) struct IvfPqStartPointRouterConfig {
+    pub(crate) artifact: InputFile,
+    pub(crate) nprobe: NonZeroUsize,
+    pub(crate) max_start_points: NonZeroUsize,
+    pub(crate) posting_list_samples_per_list: NonZeroUsize,
 }
 
 /////////
@@ -258,6 +291,40 @@ impl DiskIndexBuild {
             }
         };
 
+        #[cfg(feature = "disk-index")]
+        if let Some(ivf_pq_router_build) = &self.ivf_pq_router_build {
+            ivf_pq_router_build.validate()?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "disk-index")]
+impl IvfPqRouterBuildConfig {
+    pub(crate) fn validate(&self) -> anyhow::Result<()> {
+        match Path::new(&self.save_path).parent() {
+            Some(parent_dir) => {
+                let parent_str = parent_dir.to_string_lossy();
+                if !parent_str.is_empty() && !parent_dir.is_dir() {
+                    anyhow::bail!(
+                        "parent directory - {} of ivf_pq_router_build.save_path - {} does not exist",
+                        parent_str,
+                        self.save_path
+                    );
+                }
+            }
+            None => {
+                anyhow::bail!("invalid ivf_pq_router_build.save_path - {}", self.save_path);
+            }
+        }
+        if let Some(training_sample_size) = self.training_sample_size {
+            if training_sample_size < self.num_centroids {
+                anyhow::bail!(
+                    "ivf_pq_router_build.training_sample_size must be at least num_centroids"
+                );
+            }
+        }
         Ok(())
     }
 }
@@ -320,6 +387,36 @@ impl DiskSearchPhase {
                 .context("invalid disk search post processor")?;
         }
 
+        #[cfg(feature = "disk-index")]
+        if let Some(router) = self.start_point_router.as_mut() {
+            router
+                .validate(checker)
+                .context("invalid disk start-point router")?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(feature = "disk-index")]
+impl DiskStartPointRouter {
+    fn validate(&mut self, checker: &mut Checker) -> anyhow::Result<()> {
+        match self {
+            DiskStartPointRouter::IvfPq(config) => config.validate(checker),
+        }
+    }
+}
+
+#[cfg(feature = "disk-index")]
+impl IvfPqStartPointRouterConfig {
+    fn validate(&mut self, checker: &mut Checker) -> anyhow::Result<()> {
+        // Resolve existing artifacts for load-only jobs, but do not fail here:
+        // build-and-search jobs can produce this file earlier in the same
+        // benchmark operation. The search loader reports a missing artifact if
+        // it still cannot be opened at execution time.
+        if let Ok(resolved) = checker.find_input_file(&self.artifact) {
+            self.artifact = InputFile::new(resolved);
+        }
         Ok(())
     }
 }
@@ -344,6 +441,8 @@ impl Example for DiskIndexOperation {
             #[cfg(feature = "disk-index")]
             quantization_type: QuantizationType::PQ { num_chunks: 16 },
             save_path: "sample_index_l50_r32".to_string(),
+            #[cfg(feature = "disk-index")]
+            ivf_pq_router_build: None,
         };
 
         let search = DiskSearchPhase {
@@ -367,6 +466,8 @@ impl Example for DiskIndexOperation {
             num_nodes_to_cache: None,
             search_io_limit: None,
             post_processor: None,
+            #[cfg(feature = "disk-index")]
+            start_point_router: None,
         };
 
         Self {
@@ -447,7 +548,29 @@ impl DiskIndexBuild {
             }
         }
         write_field!(f, "Save Path", self.save_path)?;
+        #[cfg(feature = "disk-index")]
+        match &self.ivf_pq_router_build {
+            Some(config) => write_field!(f, "IVF PQ Build", config)?,
+            None => write_field!(f, "IVF PQ Build", "none")?,
+        }
         Ok(())
+    }
+}
+
+#[cfg(feature = "disk-index")]
+impl fmt::Display for IvfPqRouterBuildConfig {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "save_path={} num_centroids={} max_iterations={} seed={} training_sample_size={}",
+            self.save_path,
+            self.num_centroids,
+            self.max_iterations,
+            self.seed,
+            self.training_sample_size
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "none".to_string())
+        )
     }
 }
 
@@ -499,7 +622,28 @@ impl DiskSearchPhase {
             Some(pp) => write_field!(f, "Post Processor", pp)?,
             None => write_field!(f, "Post Processor", "none")?,
         }
+        #[cfg(feature = "disk-index")]
+        match &self.start_point_router {
+            Some(router) => write_field!(f, "Start Router", router)?,
+            None => write_field!(f, "Start Router", "none")?,
+        }
         Ok(())
+    }
+}
+
+#[cfg(feature = "disk-index")]
+impl fmt::Display for DiskStartPointRouter {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::IvfPq(config) => write!(
+                f,
+                "ivf_pq artifact={} nprobe={} max_start_points={} posting_list_samples_per_list={}",
+                config.artifact.display(),
+                config.nprobe,
+                config.max_start_points,
+                config.posting_list_samples_per_list
+            ),
+        }
     }
 }
 
@@ -507,5 +651,80 @@ impl fmt::Display for DiskSearchPhase {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "Disk Index Search Phase")?;
         self.summarize_fields(f)
+    }
+}
+
+#[cfg(all(test, feature = "disk-index"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserializes_ivf_pq_router_build_config() {
+        let raw = r#"
+        {
+          "save_path": "index.ivf_pq_router.bin",
+          "num_centroids": 2048,
+          "max_iterations": 4,
+          "seed": 42,
+          "training_sample_size": 100000
+        }
+        "#;
+
+        let config: IvfPqRouterBuildConfig = serde_json::from_str(raw).unwrap();
+
+        assert_eq!(config.save_path, "index.ivf_pq_router.bin");
+        assert_eq!(config.num_centroids.get(), 2048);
+        assert_eq!(config.max_iterations.get(), 4);
+        assert_eq!(config.seed, 42);
+        assert_eq!(config.training_sample_size.unwrap().get(), 100000);
+    }
+
+    #[test]
+    fn deserializes_ivf_pq_sampled_adc_start_point_router_config() {
+        let raw = r#"
+        {
+          "source": {
+            "disk-index-source": "Load",
+            "data_type": "float32",
+            "load_path": "test-index"
+          },
+          "search_phase": {
+            "queries": "queries.fbin",
+            "groundtruth": "truth.bin",
+            "search_list": [200],
+            "beam_width": 64,
+            "recall_at": 100,
+            "num_threads": 8,
+            "is_flat_search": false,
+            "distance": "squared_l2",
+            "vector_filters_file": null,
+            "num_nodes_to_cache": null,
+            "search_io_limit": null,
+            "post_processor": null,
+            "start_point_router": {
+              "type": "ivf_pq",
+              "artifact": "router.ivf_pq_router.bin",
+              "nprobe": 8,
+              "max_start_points": 16,
+              "posting_list_samples_per_list": 2048
+            }
+          }
+        }
+        "#;
+
+        let input: DiskIndexOperation = serde_json::from_str(raw).unwrap();
+        let router = input.search_phase.start_point_router.unwrap();
+
+        match router {
+            DiskStartPointRouter::IvfPq(config) => {
+                assert_eq!(
+                    config.artifact.display().to_string(),
+                    "router.ivf_pq_router.bin"
+                );
+                assert_eq!(config.nprobe.get(), 8);
+                assert_eq!(config.max_start_points.get(), 16);
+                assert_eq!(config.posting_list_samples_per_list.get(), 2048);
+            }
+        }
     }
 }

--- a/diskann-disk/src/search/ivf_pq_router.rs
+++ b/diskann-disk/src/search/ivf_pq_router.rs
@@ -1,0 +1,656 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+//! IVF posting-list router data for query-time PQ start-point selection.
+//!
+//! The router owns only IVF centroids and posting IDs. Query-time ADC scoring
+//! is performed by the disk search provider with the already-loaded global PQ
+//! compressed vectors.
+
+use std::{
+    cmp::Ordering,
+    collections::BinaryHeap,
+    io::{Read, Write},
+    mem::size_of,
+};
+
+use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use diskann::{ANNError, ANNResult};
+use diskann_providers::utils::{ParallelIteratorInPool, RayonThreadPoolRef};
+use rand::{rngs::StdRng, seq::index::sample, SeedableRng};
+use rayon::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::utils::k_means_clustering;
+
+const BINARY_MAGIC: &[u8; 16] = b"DISKANNIVFPQ0001";
+const BINARY_VERSION: u32 = 1;
+const NO_FALLBACK_MEDOID: u64 = u64::MAX;
+
+/// Serialized IVF posting-list router data.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IvfPqRouterData {
+    pub dim: usize,
+    pub centroids: Vec<f32>,
+    pub offsets: Vec<usize>,
+    pub posting_ids: Vec<u32>,
+    pub fallback_medoid: Option<u32>,
+}
+
+/// Build parameters for an IVF posting-list router artifact.
+#[derive(Debug, Clone, Copy)]
+pub struct IvfPqRouterBuildParams {
+    pub num_centroids: usize,
+    pub max_iterations: usize,
+    pub seed: u64,
+    pub fallback_medoid: Option<u32>,
+    pub training_sample_size: Option<usize>,
+}
+
+/// In-memory IVF posting-list router.
+#[derive(Debug, Clone)]
+pub struct IvfPqRouter {
+    dim: usize,
+    centroids: Vec<f32>,
+    offsets: Vec<usize>,
+    posting_ids: Vec<u32>,
+    fallback_medoid: Option<u32>,
+}
+
+/// IVF cells selected for one query plus the number of scored centroids.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProbedCells {
+    pub cells: Vec<usize>,
+    pub centroid_scores: usize,
+}
+
+impl IvfPqRouterData {
+    /// Validate the artifact shape.
+    pub fn validate(&self) -> ANNResult<()> {
+        validate_layout(
+            self.dim,
+            &self.centroids,
+            &self.offsets,
+            self.posting_ids.len(),
+        )
+    }
+}
+
+impl IvfPqRouter {
+    /// Construct a router from serialized fields.
+    pub fn new(
+        dim: usize,
+        centroids: Vec<f32>,
+        offsets: Vec<usize>,
+        posting_ids: Vec<u32>,
+        fallback_medoid: Option<u32>,
+    ) -> ANNResult<Self> {
+        validate_layout(dim, &centroids, &offsets, posting_ids.len())?;
+        Ok(Self {
+            dim,
+            centroids,
+            offsets,
+            posting_ids,
+            fallback_medoid,
+        })
+    }
+
+    /// Construct a router from serialized data.
+    pub fn from_data(data: IvfPqRouterData) -> ANNResult<Self> {
+        Self::new(
+            data.dim,
+            data.centroids,
+            data.offsets,
+            data.posting_ids,
+            data.fallback_medoid,
+        )
+    }
+
+    /// Export the router as serializable data.
+    pub fn to_data(&self) -> IvfPqRouterData {
+        IvfPqRouterData {
+            dim: self.dim,
+            centroids: self.centroids.clone(),
+            offsets: self.offsets.clone(),
+            posting_ids: self.posting_ids.clone(),
+            fallback_medoid: self.fallback_medoid,
+        }
+    }
+
+    /// Return the vector dimension.
+    pub fn dim(&self) -> usize {
+        self.dim
+    }
+
+    /// Return the number of IVF centroids.
+    pub fn num_centroids(&self) -> usize {
+        self.offsets.len() - 1
+    }
+
+    /// Return the number of indexed postings.
+    pub fn num_points(&self) -> usize {
+        self.posting_ids.len()
+    }
+
+    /// Return the fallback medoid embedded in the artifact, if present.
+    pub fn fallback_medoid(&self) -> Option<u32> {
+        self.fallback_medoid
+    }
+
+    /// Return posting IDs for one IVF cell.
+    pub fn posting_ids(&self, cell: usize) -> &[u32] {
+        let start = self.offsets[cell];
+        let end = self.offsets[cell + 1];
+        &self.posting_ids[start..end]
+    }
+
+    /// Return the centroid vector for one IVF cell.
+    pub fn centroid(&self, cell: usize) -> &[f32] {
+        &self.centroids[cell * self.dim..(cell + 1) * self.dim]
+    }
+
+    /// Return probed cells for a query.
+    pub fn probe_cells_with_stats(&self, query: &[f32], nprobe: usize) -> ANNResult<ProbedCells> {
+        if query.len() != self.dim {
+            return Err(index_error(format!(
+                "query dimension {} does not match IVF+PQ router dimension {}",
+                query.len(),
+                self.dim
+            )));
+        }
+        if nprobe == 0 {
+            return Err(index_error("nprobe must be positive"));
+        }
+
+        let cells = select_nearest_centroids(
+            (0..self.num_centroids()).map(|cell| (cell, squared_l2(query, self.centroid(cell)))),
+            nprobe,
+        );
+
+        Ok(ProbedCells {
+            cells,
+            centroid_scores: self.num_centroids(),
+        })
+    }
+
+    /// Return resident heap bytes, excluding allocator overhead.
+    pub fn memory_bytes(&self) -> usize {
+        self.centroids.len() * size_of::<f32>()
+            + self.offsets.len() * size_of::<usize>()
+            + self.posting_ids.len() * size_of::<u32>()
+    }
+}
+
+/// Query-time routing parameters around an IVF posting-list router.
+#[derive(Debug, Clone)]
+pub struct IvfPqStartPointRouter {
+    router: IvfPqRouter,
+    nprobe: usize,
+    max_start_points: usize,
+    posting_list_samples_per_list: usize,
+}
+
+impl IvfPqStartPointRouter {
+    /// Construct query-time routing parameters.
+    pub fn new(
+        router: IvfPqRouter,
+        nprobe: usize,
+        max_start_points: usize,
+        posting_list_samples_per_list: usize,
+    ) -> ANNResult<Self> {
+        if nprobe == 0 {
+            return Err(index_error("nprobe must be positive"));
+        }
+        if max_start_points == 0 {
+            return Err(index_error("max_start_points must be positive"));
+        }
+        if posting_list_samples_per_list == 0 {
+            return Err(index_error(
+                "posting_list_samples_per_list must be positive",
+            ));
+        }
+        Ok(Self {
+            router,
+            nprobe,
+            max_start_points,
+            posting_list_samples_per_list,
+        })
+    }
+
+    /// Return probed cells and centroid-score count for a query.
+    pub fn probe_cells_with_stats(&self, query: &[f32]) -> ANNResult<ProbedCells> {
+        self.router.probe_cells_with_stats(query, self.nprobe)
+    }
+
+    /// Return posting IDs for one cell.
+    pub fn posting_ids(&self, cell: usize) -> &[u32] {
+        self.router.posting_ids(cell)
+    }
+
+    /// Return configured start-point cap.
+    pub fn max_start_points(&self) -> usize {
+        self.max_start_points
+    }
+
+    /// Return configured sample count per probed posting list.
+    pub fn posting_list_samples_per_list(&self) -> usize {
+        self.posting_list_samples_per_list
+    }
+
+    /// Return number of indexed postings.
+    pub fn num_points(&self) -> usize {
+        self.router.num_points()
+    }
+
+    /// Return fallback medoid from the artifact, if present.
+    pub fn fallback_medoid(&self) -> Option<u32> {
+        self.router.fallback_medoid()
+    }
+
+    /// Return resident heap bytes, excluding allocator overhead.
+    pub fn memory_bytes(&self) -> usize {
+        self.router.memory_bytes()
+    }
+}
+
+/// Build an IVF posting-list router artifact from full-precision f32 data.
+pub fn build_ivf_pq_router_data(
+    data: &[f32],
+    num_points: usize,
+    dim: usize,
+    params: &IvfPqRouterBuildParams,
+    pool: RayonThreadPoolRef<'_>,
+) -> ANNResult<IvfPqRouterData> {
+    validate_build_inputs(data, num_points, dim, params)?;
+
+    let centroid_values = params
+        .num_centroids
+        .checked_mul(dim)
+        .ok_or_else(|| index_error("num_centroids multiplied by dim overflowed"))?;
+    let mut centroids = vec![0.0; centroid_values];
+    let mut rng = StdRng::seed_from_u64(params.seed);
+    let mut cancellation_token = false;
+    let training_sample = sample_training_data(data, num_points, dim, params, &mut rng)?;
+    let training_data = training_sample.as_deref().unwrap_or(data);
+    let training_points = params
+        .training_sample_size
+        .unwrap_or(num_points)
+        .min(num_points);
+
+    let (_closest_docs, _closest_center, _residual) = k_means_clustering(
+        training_data,
+        training_points,
+        dim,
+        &mut centroids,
+        params.num_centroids,
+        params.max_iterations,
+        &mut rng,
+        &mut cancellation_token,
+        pool,
+    )?;
+
+    let closest_docs = assign_points_to_centroids(data, num_points, dim, &centroids, pool);
+    let (offsets, posting_ids) = posting_lists_to_layout(closest_docs, num_points)?;
+
+    Ok(IvfPqRouterData {
+        dim,
+        centroids,
+        offsets,
+        posting_ids,
+        fallback_medoid: params.fallback_medoid,
+    })
+}
+
+/// Write a binary IVF+PQ router artifact.
+pub fn write_ivf_pq_router_binary<W: Write>(
+    mut writer: W,
+    data: &IvfPqRouterData,
+) -> ANNResult<()> {
+    data.validate()?;
+    writer.write_all(BINARY_MAGIC)?;
+    writer.write_u32::<LittleEndian>(BINARY_VERSION)?;
+    writer.write_u64::<LittleEndian>(data.dim as u64)?;
+    writer.write_u64::<LittleEndian>((data.centroids.len() / data.dim) as u64)?;
+    writer.write_u64::<LittleEndian>(data.posting_ids.len() as u64)?;
+    writer.write_u64::<LittleEndian>(data.fallback_medoid.map_or(NO_FALLBACK_MEDOID, u64::from))?;
+
+    for &value in &data.centroids {
+        writer.write_f32::<LittleEndian>(value)?;
+    }
+    for &offset in &data.offsets {
+        writer.write_u64::<LittleEndian>(offset as u64)?;
+    }
+    for &id in &data.posting_ids {
+        writer.write_u32::<LittleEndian>(id)?;
+    }
+    Ok(())
+}
+
+/// Read a binary IVF+PQ router artifact.
+pub fn read_ivf_pq_router_binary<R: Read>(mut reader: R) -> ANNResult<IvfPqRouterData> {
+    let mut magic = [0u8; 16];
+    reader.read_exact(&mut magic)?;
+    if magic != *BINARY_MAGIC {
+        return Err(index_error("invalid IVF+PQ router binary magic"));
+    }
+    let version = reader.read_u32::<LittleEndian>()?;
+    if version != BINARY_VERSION {
+        return Err(index_error(format!(
+            "unsupported IVF+PQ router binary version {version}"
+        )));
+    }
+    let dim = usize::try_from(reader.read_u64::<LittleEndian>()?)?;
+    let num_centroids = usize::try_from(reader.read_u64::<LittleEndian>()?)?;
+    let num_postings = usize::try_from(reader.read_u64::<LittleEndian>()?)?;
+    let fallback_raw = reader.read_u64::<LittleEndian>()?;
+    let fallback_medoid = if fallback_raw == NO_FALLBACK_MEDOID {
+        None
+    } else {
+        Some(u32::try_from(fallback_raw)?)
+    };
+
+    let mut centroids = vec![0.0; num_centroids * dim];
+    for value in &mut centroids {
+        *value = reader.read_f32::<LittleEndian>()?;
+    }
+    let mut offsets = vec![0usize; num_centroids + 1];
+    for offset in &mut offsets {
+        *offset = usize::try_from(reader.read_u64::<LittleEndian>()?)?;
+    }
+    let mut posting_ids = vec![0u32; num_postings];
+    for id in &mut posting_ids {
+        *id = reader.read_u32::<LittleEndian>()?;
+    }
+
+    let data = IvfPqRouterData {
+        dim,
+        centroids,
+        offsets,
+        posting_ids,
+        fallback_medoid,
+    };
+    data.validate()?;
+    Ok(data)
+}
+
+fn validate_build_inputs(
+    data: &[f32],
+    num_points: usize,
+    dim: usize,
+    params: &IvfPqRouterBuildParams,
+) -> ANNResult<()> {
+    if dim == 0 {
+        return Err(index_error("dim must be positive"));
+    }
+    if num_points == 0 {
+        return Err(index_error("num_points must be positive"));
+    }
+    if data.len() != num_points * dim {
+        return Err(index_error("data length must equal num_points * dim"));
+    }
+    if params.num_centroids == 0 {
+        return Err(index_error("num_centroids must be positive"));
+    }
+    if params.num_centroids > num_points {
+        return Err(index_error("num_centroids must not exceed num_points"));
+    }
+    if params.max_iterations == 0 {
+        return Err(index_error("max_iterations must be positive"));
+    }
+    if let Some(sample_size) = params.training_sample_size {
+        if sample_size == 0 {
+            return Err(index_error("training_sample_size must be positive"));
+        }
+        if sample_size < params.num_centroids {
+            return Err(index_error(
+                "training_sample_size must be at least num_centroids",
+            ));
+        }
+        if sample_size > num_points {
+            return Err(index_error(
+                "training_sample_size must not exceed num_points",
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_layout(
+    dim: usize,
+    centroids: &[f32],
+    offsets: &[usize],
+    posting_count: usize,
+) -> ANNResult<()> {
+    if dim == 0 {
+        return Err(index_error("IVF+PQ router dim must be positive"));
+    }
+    if centroids.is_empty() || !centroids.len().is_multiple_of(dim) {
+        return Err(index_error(
+            "IVF+PQ router centroids length must be a positive multiple of dim",
+        ));
+    }
+    let num_centroids = centroids.len() / dim;
+    if offsets.len() != num_centroids + 1 {
+        return Err(index_error(format!(
+            "IVF+PQ router offsets length {} must equal num_centroids + 1 ({})",
+            offsets.len(),
+            num_centroids + 1
+        )));
+    }
+    if offsets.first().copied() != Some(0) {
+        return Err(index_error("IVF+PQ router first offset must be zero"));
+    }
+    if offsets.last().copied() != Some(posting_count) {
+        return Err(index_error(
+            "IVF+PQ router last offset must equal posting count",
+        ));
+    }
+    if !offsets.windows(2).all(|pair| pair[0] <= pair[1]) {
+        return Err(index_error("IVF+PQ router offsets must be sorted"));
+    }
+    Ok(())
+}
+
+fn sample_training_data(
+    data: &[f32],
+    num_points: usize,
+    dim: usize,
+    params: &IvfPqRouterBuildParams,
+    rng: &mut StdRng,
+) -> ANNResult<Option<Vec<f32>>> {
+    let Some(sample_size) = params.training_sample_size else {
+        return Ok(None);
+    };
+    if sample_size == num_points {
+        return Ok(None);
+    }
+
+    let mut sample_indices = sample(rng, num_points, sample_size).into_vec();
+    sample_indices.sort_unstable();
+
+    let sample_values = sample_size
+        .checked_mul(dim)
+        .ok_or_else(|| index_error("training_sample_size multiplied by dim overflowed"))?;
+    let mut sampled = Vec::with_capacity(sample_values);
+    for point in sample_indices {
+        sampled.extend_from_slice(&data[point * dim..(point + 1) * dim]);
+    }
+    Ok(Some(sampled))
+}
+
+fn assign_points_to_centroids(
+    data: &[f32],
+    num_points: usize,
+    dim: usize,
+    centroids: &[f32],
+    pool: RayonThreadPoolRef<'_>,
+) -> Vec<Vec<usize>> {
+    let num_centroids = centroids.len() / dim;
+    let closest_center: Vec<usize> = (0..num_points)
+        .into_par_iter()
+        .map(|point| nearest_centroid(&data[point * dim..(point + 1) * dim], centroids, dim))
+        .collect_in_pool(pool);
+
+    let mut closest_docs = vec![Vec::new(); num_centroids];
+    for (doc, center) in closest_center.into_iter().enumerate() {
+        closest_docs[center].push(doc);
+    }
+    closest_docs
+}
+
+fn posting_lists_to_layout(
+    closest_docs: Vec<Vec<usize>>,
+    num_points: usize,
+) -> ANNResult<(Vec<usize>, Vec<u32>)> {
+    let mut offsets = Vec::with_capacity(closest_docs.len() + 1);
+    let mut posting_ids = Vec::with_capacity(num_points);
+    offsets.push(0);
+    for docs in closest_docs {
+        for doc in docs {
+            posting_ids
+                .push(u32::try_from(doc).map_err(|_| index_error("posting ID must fit into u32"))?);
+        }
+        offsets.push(posting_ids.len());
+    }
+    Ok((offsets, posting_ids))
+}
+
+fn nearest_centroid(point: &[f32], centroids: &[f32], dim: usize) -> usize {
+    let num_centroids = centroids.len() / dim;
+    let mut best = 0usize;
+    let mut best_distance = f32::INFINITY;
+    for cell in 0..num_centroids {
+        let distance = squared_l2(point, &centroids[cell * dim..(cell + 1) * dim]);
+        if distance < best_distance {
+            best_distance = distance;
+            best = cell;
+        }
+    }
+    best
+}
+
+fn squared_l2(left: &[f32], right: &[f32]) -> f32 {
+    left.iter()
+        .zip(right)
+        .map(|(a, b)| {
+            let delta = a - b;
+            delta * delta
+        })
+        .sum()
+}
+
+fn select_nearest_centroids<I>(scores: I, limit: usize) -> Vec<usize>
+where
+    I: IntoIterator<Item = (usize, f32)>,
+{
+    let mut heap = BinaryHeap::with_capacity(limit);
+    for (cell, distance) in scores {
+        let candidate = CentroidProbe { distance, cell };
+        if heap.len() < limit {
+            heap.push(candidate);
+        } else if let Some(worst) = heap.peek() {
+            if candidate < *worst {
+                heap.pop();
+                heap.push(candidate);
+            }
+        }
+    }
+
+    let mut selected: Vec<_> = heap.into_iter().collect();
+    selected.sort_unstable_by(|a, b| a.distance.total_cmp(&b.distance).then(a.cell.cmp(&b.cell)));
+    selected.into_iter().map(|probe| probe.cell).collect()
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CentroidProbe {
+    distance: f32,
+    cell: usize,
+}
+
+impl PartialEq for CentroidProbe {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other).is_eq()
+    }
+}
+
+impl Eq for CentroidProbe {}
+
+impl PartialOrd for CentroidProbe {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for CentroidProbe {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.distance
+            .total_cmp(&other.distance)
+            .then(self.cell.cmp(&other.cell))
+    }
+}
+
+fn index_error(message: impl std::fmt::Display) -> ANNError {
+    ANNError::log_index_error(message.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use diskann_providers::utils::create_thread_pool;
+
+    use super::*;
+
+    #[test]
+    fn probes_nearest_centroids() {
+        let router = IvfPqRouter::new(
+            2,
+            vec![0.0, 0.0, 10.0, 10.0, 2.0, 2.0],
+            vec![0, 1, 2, 3],
+            vec![0, 1, 2],
+            Some(0),
+        )
+        .unwrap();
+
+        let probed = router.probe_cells_with_stats(&[1.9, 2.1], 2).unwrap();
+
+        assert_eq!(probed.cells, vec![2, 0]);
+        assert_eq!(probed.centroid_scores, 3);
+    }
+
+    #[test]
+    fn binary_round_trip_preserves_router_data() {
+        let data = IvfPqRouterData {
+            dim: 2,
+            centroids: vec![0.0, 0.0, 1.0, 1.0],
+            offsets: vec![0, 2, 3],
+            posting_ids: vec![10, 11, 12],
+            fallback_medoid: Some(10),
+        };
+
+        let mut bytes = Vec::new();
+        write_ivf_pq_router_binary(&mut bytes, &data).unwrap();
+        let decoded = read_ivf_pq_router_binary(bytes.as_slice()).unwrap();
+
+        assert_eq!(decoded, data);
+    }
+
+    #[test]
+    fn build_ivf_pq_router_assigns_all_points() {
+        let data = [0.0, 0.0, 0.1, 0.1, 10.0, 10.0, 10.1, 10.1];
+        let params = IvfPqRouterBuildParams {
+            num_centroids: 2,
+            max_iterations: 2,
+            seed: 7,
+            fallback_medoid: None,
+            training_sample_size: None,
+        };
+        let pool = create_thread_pool(1).unwrap();
+
+        let artifact = build_ivf_pq_router_data(&data, 4, 2, &params, pool.as_ref()).unwrap();
+
+        assert_eq!(artifact.posting_ids.len(), 4);
+        assert_eq!(artifact.offsets.first(), Some(&0));
+        assert_eq!(artifact.offsets.last(), Some(&4));
+    }
+}

--- a/diskann-disk/src/search/mod.rs
+++ b/diskann-disk/src/search/mod.rs
@@ -5,7 +5,9 @@
 
 //! Model module containing data structures, providers, and traits for disk index operations
 
+pub mod ivf_pq_router;
 pub mod pq;
 pub mod provider;
 pub mod search_mode;
+pub mod start_point_router;
 pub mod traits;

--- a/diskann-disk/src/search/provider/disk_provider.rs
+++ b/diskann-disk/src/search/provider/disk_provider.rs
@@ -4,7 +4,8 @@
  */
 
 use std::{
-    collections::HashMap,
+    cmp::Ordering,
+    collections::{BinaryHeap, HashMap},
     num::NonZeroUsize,
     sync::{
         atomic::{AtomicU64, AtomicUsize},
@@ -49,11 +50,13 @@ use tracing::debug;
 use crate::{
     data_model::{CachingStrategy, GraphHeader},
     search::{
+        ivf_pq_router::IvfPqStartPointRouter,
         provider::{
             aligned_file_reader::AlignedFileReaderFactory,
             disk_vertex_provider_factory::DiskVertexProviderFactory,
         },
         search_mode::SearchMode,
+        start_point_router::StartPointRouter,
         traits::{VertexProvider, VertexProviderFactory},
     },
     storage::{api::AsyncDiskLoadContext, disk_index_reader::DiskIndexReader},
@@ -90,6 +93,9 @@ where
 
     /// The number of IO operations that can be done in parallel.
     search_io_limit: usize,
+
+    /// Optional query-time router used to seed graph traversal.
+    start_point_router: Option<Arc<StartPointRouter>>,
 }
 
 impl<Data> DataProvider for DiskProvider<Data>
@@ -171,6 +177,7 @@ where
             metric,
             num_points,
             ctx.search_io_limit,
+            None,
         )
     }
 }
@@ -185,6 +192,7 @@ where
         metric: Metric,
         num_points: usize,
         search_io_limit: usize,
+        start_point_router: Option<StartPointRouter>,
     ) -> ANNResult<Self> {
         let distance_comparer =
             Data::VectorDataType::distance(metric, Some(graph_header.metadata().dims));
@@ -198,6 +206,7 @@ where
             num_points,
             metric,
             search_io_limit,
+            start_point_router: start_point_router.map(Arc::new),
         })
     }
 }
@@ -256,6 +265,11 @@ struct IOTracker {
     io_time_us: AtomicU64,
     preprocess_time_us: AtomicU64,
     io_count: AtomicUsize,
+    router_time_us: AtomicU64,
+    router_sampled_adc_codes: AtomicUsize,
+    router_probed_lists: AtomicUsize,
+    router_centroid_scores: AtomicUsize,
+    routed_start_points_count: AtomicUsize,
 }
 
 impl Default for IOTracker {
@@ -264,6 +278,11 @@ impl Default for IOTracker {
             io_time_us: AtomicU64::new(0),
             preprocess_time_us: AtomicU64::new(0),
             io_count: AtomicUsize::new(0),
+            router_time_us: AtomicU64::new(0),
+            router_sampled_adc_codes: AtomicUsize::new(0),
+            router_probed_lists: AtomicUsize::new(0),
+            router_centroid_scores: AtomicUsize::new(0),
+            routed_start_points_count: AtomicUsize::new(0),
         }
     }
 }
@@ -284,6 +303,255 @@ impl IOTracker {
 
     fn io_count(&self) -> usize {
         self.io_count.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn record_router_stats(&self, stats: &StartPointRoutingStats) {
+        Self::add_time(&self.router_time_us, stats.router_time_us);
+        self.router_sampled_adc_codes.fetch_add(
+            stats.sampled_adc_codes,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        self.router_probed_lists
+            .fetch_add(stats.probed_lists, std::sync::atomic::Ordering::Relaxed);
+        self.router_centroid_scores
+            .fetch_add(stats.centroid_scores, std::sync::atomic::Ordering::Relaxed);
+        self.routed_start_points_count.fetch_add(
+            stats.routed_start_points,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
+
+    fn router_time_us(&self) -> u64 {
+        Self::time(&self.router_time_us)
+    }
+
+    fn router_sampled_adc_codes(&self) -> usize {
+        self.router_sampled_adc_codes
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn router_probed_lists(&self) -> usize {
+        self.router_probed_lists
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn router_centroid_scores(&self) -> usize {
+        self.router_centroid_scores
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn routed_start_points_count(&self) -> usize {
+        self.routed_start_points_count
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct StartPointRoutingStats {
+    router_time_us: u64,
+    sampled_adc_codes: usize,
+    probed_lists: usize,
+    centroid_scores: usize,
+    routed_start_points: usize,
+}
+
+#[derive(Debug, Clone)]
+struct StartPointRoutingOutput {
+    ids: Vec<u32>,
+    stats: StartPointRoutingStats,
+}
+
+fn route_ivf_pq_start_points<Data>(
+    provider: &DiskProvider<Data>,
+    pq_scratch: &mut PQScratch,
+    router: &IvfPqStartPointRouter,
+    query: &[f32],
+    fallback_medoid: u32,
+) -> ANNResult<StartPointRoutingOutput>
+where
+    Data: GraphDataType<VectorIdType = u32>,
+{
+    if router.num_points() != provider.num_points {
+        return Err(ANNError::log_index_error(format!(
+            "ivf_pq router posting count {} does not match disk index point count {}",
+            router.num_points(),
+            provider.num_points
+        )));
+    }
+
+    let batch_size = pq_scratch.max_vectors();
+    if batch_size == 0 {
+        return Err(ANNError::message(
+            diskann::ANNErrorKind::IndexError,
+            "pq scratch must support at least one vector",
+        ));
+    }
+
+    let route_timer = Instant::now();
+    let probed = router.probe_cells_with_stats(query)?;
+    let mut stats = StartPointRoutingStats {
+        centroid_scores: probed.centroid_scores,
+        ..StartPointRoutingStats::default()
+    };
+    let mut best = BoundedStartPoints::new(router.max_start_points());
+    let mut selected_ids = Vec::new();
+
+    for cell in probed.cells {
+        let posting_ids = router.posting_ids(cell);
+        let sample_count = posting_ids
+            .len()
+            .min(router.posting_list_samples_per_list());
+        if sample_count == 0 {
+            continue;
+        }
+
+        stats.probed_lists += 1;
+        selected_ids.clear();
+        append_sampled_posting_ids(posting_ids, sample_count, &mut selected_ids);
+
+        for ids in selected_ids.chunks(batch_size) {
+            if let Some(&bad_id) = ids.iter().find(|&&id| id as usize >= provider.num_points) {
+                return Err(ANNError::log_index_error(format!(
+                    "ivf_pq router posting id {bad_id} is out of bounds for {} points",
+                    provider.num_points
+                )));
+            }
+
+            compute_pq_distance(
+                ids,
+                provider.pq_data.get_num_chunks(),
+                &pq_scratch.aligned_pqtable_dist_scratch,
+                provider.pq_data.pq_compressed_data().as_slice(),
+                &mut pq_scratch.aligned_pq_coord_scratch,
+                &mut pq_scratch.aligned_dist_scratch,
+            )?;
+            stats.sampled_adc_codes += ids.len();
+            for (index, &id) in ids.iter().enumerate() {
+                best.push(pq_scratch.aligned_dist_scratch[index], id);
+            }
+        }
+    }
+
+    let mut routed: Vec<u32> = best
+        .into_sorted_vec()
+        .into_iter()
+        .map(|(_distance, id)| id)
+        .collect();
+    if routed.is_empty() {
+        routed.push(router.fallback_medoid().unwrap_or(fallback_medoid));
+    }
+    stats.routed_start_points = routed.len();
+    stats.router_time_us = route_timer.elapsed().as_micros() as u64;
+
+    Ok(StartPointRoutingOutput { ids: routed, stats })
+}
+
+fn append_sampled_posting_ids(
+    posting_ids: &[u32],
+    sample_count: usize,
+    selected_ids: &mut Vec<u32>,
+) {
+    if sample_count == 0 {
+        return;
+    }
+    debug_assert!(sample_count <= posting_ids.len());
+    for offset in 0..sample_count {
+        let posting_index = strided_posting_index(posting_ids.len(), sample_count, offset);
+        selected_ids.push(posting_ids[posting_index]);
+    }
+}
+
+fn strided_posting_index(list_len: usize, sample_count: usize, offset: usize) -> usize {
+    debug_assert!(list_len > 0);
+    debug_assert!(sample_count > 0);
+    debug_assert!(sample_count <= list_len);
+    debug_assert!(offset < sample_count);
+
+    if sample_count == 1 {
+        return 0;
+    }
+    offset.saturating_mul(list_len - 1) / (sample_count - 1)
+}
+
+fn compare_start_points(left: &(f32, u32), right: &(f32, u32)) -> Ordering {
+    left.0
+        .total_cmp(&right.0)
+        .then_with(|| left.1.cmp(&right.1))
+}
+
+#[derive(Debug, Clone, Copy)]
+struct StartPointScore {
+    distance: f32,
+    id: u32,
+}
+
+impl StartPointScore {
+    fn as_tuple(self) -> (f32, u32) {
+        (self.distance, self.id)
+    }
+}
+
+impl PartialEq for StartPointScore {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other).is_eq()
+    }
+}
+
+impl Eq for StartPointScore {}
+
+impl PartialOrd for StartPointScore {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for StartPointScore {
+    fn cmp(&self, other: &Self) -> Ordering {
+        compare_start_points(&self.as_tuple(), &other.as_tuple())
+    }
+}
+
+struct BoundedStartPoints {
+    limit: usize,
+    heap: BinaryHeap<StartPointScore>,
+}
+
+impl BoundedStartPoints {
+    fn new(limit: usize) -> Self {
+        Self {
+            limit,
+            heap: BinaryHeap::with_capacity(limit),
+        }
+    }
+
+    fn push(&mut self, distance: f32, id: u32) {
+        if self.limit == 0 {
+            return;
+        }
+
+        let candidate = StartPointScore { distance, id };
+        if self.heap.len() < self.limit {
+            self.heap.push(candidate);
+            return;
+        }
+
+        let Some(worst) = self.heap.peek() else {
+            return;
+        };
+        if candidate < *worst {
+            self.heap.pop();
+            self.heap.push(candidate);
+        }
+    }
+
+    fn into_sorted_vec(self) -> Vec<(f32, u32)> {
+        let mut values: Vec<_> = self
+            .heap
+            .into_iter()
+            .map(StartPointScore::as_tuple)
+            .collect();
+        values.sort_unstable_by(compare_start_points);
+        values
     }
 }
 
@@ -621,6 +889,7 @@ where
     io_tracker: &'a IOTracker,
     scratch: PoolOption<DiskSearchScratch<Data, VP>>,
     query: &'a [Data::VectorDataType],
+    start_points: Vec<u32>,
 }
 
 impl<Data, VP> DiskAccessor<'_, Data, VP>
@@ -667,16 +936,15 @@ where
     VP: VertexProvider<Data>,
 {
     async fn starting_points(&self) -> ANNResult<Vec<u32>> {
-        let start_vertex_id = self.provider.graph_header.metadata().medoid as u32;
-        Ok(vec![start_vertex_id])
+        Ok(self.start_points.clone())
     }
 
     async fn start_point_distances<F>(&mut self, mut f: F) -> ANNResult<()>
     where
         F: FnMut(Self::Id, f32) + Send,
     {
-        let start_vertex_id = self.provider.graph_header.metadata().medoid as u32;
-        self.pq_distances(&[start_vertex_id], |dist, id| f(id, dist))
+        let start_points = self.start_points.clone();
+        self.pq_distances(&start_points, |dist, id| f(id, dist))
     }
 
     fn expand_beam<Itr, P, F>(
@@ -751,25 +1019,44 @@ where
         // Decode caller's native vector representation into `f32`; downstream PQ kernels operate purely on `&[f32]`.
         let f32_query = Data::VectorDataType::as_f32(query).into_ann_result()?;
         scratch.pq_scratch.set(&f32_query)?;
-        let start_vertex_id = provider.graph_header.metadata().medoid as u32;
+        let medoid = provider.graph_header.metadata().medoid as u32;
 
         let timer = Instant::now();
         quantizer_preprocess(
             &mut scratch.pq_scratch,
             &provider.pq_data,
             provider.metric,
-            &[start_vertex_id],
+            &[medoid],
         )?;
         IOTracker::add_time(
             &io_tracker.preprocess_time_us,
             timer.elapsed().as_micros() as u64,
         );
 
+        let route_output = match provider.start_point_router.as_deref() {
+            Some(StartPointRouter::IvfPq(router)) => route_ivf_pq_start_points(
+                provider,
+                &mut scratch.pq_scratch,
+                router,
+                &f32_query,
+                medoid,
+            )?,
+            None => StartPointRoutingOutput {
+                ids: vec![medoid],
+                stats: StartPointRoutingStats {
+                    routed_start_points: 1,
+                    ..StartPointRoutingStats::default()
+                },
+            },
+        };
+        io_tracker.record_router_stats(&route_output.stats);
+
         Ok(Self {
             provider,
             io_tracker,
             scratch,
             query,
+            start_points: route_output.ids,
         })
     }
 
@@ -872,6 +1159,27 @@ where
         metric: Metric,
         runtime: Option<Runtime>,
     ) -> ANNResult<Self> {
+        Self::new_with_start_point_router(
+            num_threads,
+            search_io_limit,
+            disk_index_reader,
+            vertex_provider_factory,
+            metric,
+            runtime,
+            None,
+        )
+    }
+
+    /// Create a new disk searcher with an optional start-point router.
+    pub fn new_with_start_point_router(
+        num_threads: usize,
+        search_io_limit: usize,
+        disk_index_reader: &DiskIndexReader,
+        vertex_provider_factory: ProviderFactory,
+        metric: Metric,
+        runtime: Option<Runtime>,
+        start_point_router: Option<StartPointRouter>,
+    ) -> ANNResult<Self> {
         let runtime = match runtime {
             Some(rt) => rt,
             None => tokio::runtime::Builder::new_current_thread().build()?,
@@ -909,6 +1217,7 @@ where
             metric,
             metadata.num_pts.into_usize(),
             search_io_limit,
+            start_point_router,
         )?;
 
         let index = DiskANNIndex::new(config, disk_provider, NonZeroUsize::new(num_threads));
@@ -1199,6 +1508,11 @@ where
         query_stats.total_vertices_loaded = io_tracker.io_count() as u32;
         query_stats.query_pq_preprocess_time_us =
             IOTracker::time(&io_tracker.preprocess_time_us) as u128;
+        query_stats.router_time_us = io_tracker.router_time_us() as u128;
+        query_stats.router_sampled_adc_codes = io_tracker.router_sampled_adc_codes() as u32;
+        query_stats.router_probed_lists = io_tracker.router_probed_lists() as u32;
+        query_stats.router_centroid_scores = io_tracker.router_centroid_scores() as u32;
+        query_stats.routed_start_points_count = io_tracker.routed_start_points_count() as u32;
         query_stats.cpu_time_us = query_stats.total_execution_time_us
             - query_stats.io_time_us
             - query_stats.query_pq_preprocess_time_us;
@@ -1224,6 +1538,41 @@ fn ensure_vertex_loaded<Data: GraphDataType, V: VertexProvider<Data>>(
         vertex_provider.process_loaded_node(id, idx)?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod ivf_sampled_adc_router_tests {
+    use super::*;
+
+    #[test]
+    fn append_sampled_posting_ids_spreads_samples_across_entire_list() {
+        let posting_ids = [10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
+        let mut sampled = Vec::new();
+
+        append_sampled_posting_ids(&posting_ids, 4, &mut sampled);
+
+        assert_eq!(sampled, vec![10, 13, 16, 19]);
+    }
+
+    #[test]
+    fn bounded_start_points_keeps_best_distances_with_id_tiebreak() {
+        let mut best = BoundedStartPoints::new(3);
+        for (distance, id) in [
+            (4.0, 4),
+            (1.0, 30),
+            (2.0, 20),
+            (1.0, 10),
+            (3.0, 1),
+            (0.5, 99),
+        ] {
+            best.push(distance, id);
+        }
+
+        assert_eq!(
+            best.into_sorted_vec(),
+            vec![(0.5, 99), (1.0, 10), (1.0, 30)]
+        );
+    }
 }
 
 #[cfg(test)]

--- a/diskann-disk/src/search/start_point_router.rs
+++ b/diskann-disk/src/search/start_point_router.rs
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+//! Query-time start-point routers for disk graph search.
+
+use crate::search::ivf_pq_router::IvfPqStartPointRouter;
+
+/// Query-time router used to seed disk Vamana traversal.
+#[derive(Debug, Clone)]
+pub enum StartPointRouter {
+    /// IVF router that samples probed posting lists and scores IDs with global PQ.
+    IvfPq(Box<IvfPqStartPointRouter>),
+}
+
+impl StartPointRouter {
+    /// Return resident router bytes, excluding allocator overhead.
+    pub fn memory_bytes(&self) -> usize {
+        match self {
+            Self::IvfPq(router) => router.memory_bytes(),
+        }
+    }
+}

--- a/diskann-disk/src/utils/statistics.rs
+++ b/diskann-disk/src/utils/statistics.rs
@@ -18,6 +18,9 @@ pub struct QueryStatistics {
     /// Time spent in query preprocessing for the PQ in microseconds.
     pub query_pq_preprocess_time_us: u128,
 
+    /// Time spent routing query-specific graph start points.
+    pub router_time_us: u128,
+
     /// Total number of IO operations issued.
     pub total_io_operations: u32,
 
@@ -32,6 +35,18 @@ pub struct QueryStatistics {
 
     /// Number of hops performed during search.
     pub search_hops: u32,
+
+    /// Number of sampled posting-list PQ codes scored by the router.
+    pub router_sampled_adc_codes: u32,
+
+    /// Number of IVF posting lists probed by the router.
+    pub router_probed_lists: u32,
+
+    /// Number of IVF centroids scored by the router.
+    pub router_centroid_scores: u32,
+
+    /// Number of start points returned by the router.
+    pub routed_start_points_count: u32,
 }
 
 /// Calculates the percentile value of a specific metric in a list of QueryStats.

--- a/rfcs/00001-ivf-pq-posting-list-sampled-adc-router.en.md
+++ b/rfcs/00001-ivf-pq-posting-list-sampled-adc-router.en.md
@@ -1,0 +1,388 @@
+# RFC: IVF+PQ Posting-List Sampled ADC Start-Point Router
+
+| | |
+|---|---|
+| Authors | Xiaowei Jiang, Codex |
+| Created | 2026-07-28 |
+| Status | Draft |
+| Related docs | N/A |
+
+## Summary
+
+This RFC proposes **IVF+PQ posting-list sampled ADC routing** as the default experimental start-point router for the next phase of DiskANN disk Vamana research.
+
+Recommended default configuration:
+
+```json
+{
+  "type": "ivf_pq",
+  "artifact": "outputs/msturingann10m_user_c2048.ivf_pq_router.bin",
+  "nprobe": 8,
+  "max_start_points": 16,
+  "posting_list_samples_per_list": 2048
+}
+```
+
+This design does not add residual PQ and does not duplicate PQ codes in a sidecar. It adds only an IVF posting-list artifact. At query time, it probes top IVF cells, samples up to 2048 point IDs from each probed posting list, scores those samples with the existing DiskANN global PQ ADC path, selects 16 query-specific start points, and then hands control to the existing disk Vamana traversal.
+
+The recommendation is data-driven. On MSTuringANN 10M with `L=200` and `recall@100`, `sampled_adc_np8_s2048_msp16` improves recall by 3.46 points over baseline, reduces IOs/hops by 45.9%, reduces comparisons by 48.0%, keeps mean latency effectively unchanged, and improves p95 and p999 latency. It is the best balanced operating point from the current sweep.
+
+## Background
+
+The current DiskANN disk Vamana search path is:
+
+1. Start from the medoid or a small fixed set of entry points.
+2. Run best-first graph traversal.
+3. Read disk graph adjacency lists.
+4. Use in-memory global PQ compressed vectors to score neighbor IDs.
+5. Continue frontier expansion until the `search_list` / beam condition is satisfied.
+
+This path is robust: the disk graph format is mature, traversal is stable, and storage scales well. Its weakness is that query-agnostic entry points can waste early hops and IOs in graph regions that are far from the query.
+
+The core hypothesis is:
+
+```text
+If a router can find query-relevant start points with bounded RAM and CPU cost,
+Vamana traversal can reach better recall with fewer IOs, hops, and comparisons.
+```
+
+Previous directions included:
+
+- IVF-only representatives: low memory, but not query-specific enough.
+- IVF+global PQ flat scan: strong quality, but probing-list flat scan is not well controlled at larger scale.
+- Block summary / block sampled ADC: useful for 1B scaling discussion, but simple summaries have not produced stable quality yet.
+- Residual PQ: useful as an ablation, but it adds another per-point code layout and should not be the default path yet.
+
+Posting-list sampled ADC is the pragmatic middle point: it preserves query-aware ADC start-point selection while bounding router scoring by `nprobe * posting_list_samples_per_list`.
+
+## Architecture
+
+```mermaid
+flowchart TD
+    subgraph Build["Build Time"]
+        B0["Base vectors"]
+        B1["DiskANN build"]
+        B2["Disk Vamana graph"]
+        B3["Global PQ compressed vectors"]
+        B4["Train IVF centroids, C=2048"]
+        B5["Assign all points to IVF cells"]
+        B6["IVF posting-list router artifact"]
+
+        B0 --> B1
+        B1 --> B2
+        B1 --> B3
+        B0 --> B4
+        B4 --> B5
+        B5 --> B6
+    end
+
+    subgraph Query["Query Time"]
+        Q0["Query vector"]
+        Q1["Score IVF centroids"]
+        Q2["Select nprobe=8 cells"]
+        Q3["Sample up to 2048 IDs per posting list"]
+        Q4["Global PQ ADC scoring"]
+        Q5["Select max_start_points=16"]
+        Q6["Seed Disk Vamana traversal"]
+        Q7["Existing graph traversal with global PQ"]
+        Q8["Final candidates"]
+
+        Q0 --> Q1
+        Q1 --> Q2
+        Q2 --> Q3
+        B6 --> Q1
+        B6 --> Q3
+        B3 --> Q4
+        Q0 --> Q4
+        Q3 --> Q4
+        Q4 --> Q5
+        Q5 --> Q6
+        B2 --> Q7
+        B3 --> Q7
+        Q6 --> Q7
+        Q7 --> Q8
+    end
+```
+
+## Recommended Design
+
+### Default operating point
+
+Default treatment:
+
+| Parameter | Value |
+|---|---:|
+| IVF cells | 2048 |
+| load mode | mmap |
+| nprobe | 8 |
+| posting_list_samples_per_list | 2048 |
+| max_start_points | 16 |
+| distance | squared_l2 |
+| search_list L | 200 |
+| recall_at | 100 |
+
+Why this point:
+
+1. `msp=16` is the strongest stable lever in the current sweep. Compared with `msp=8`, it usually adds 1.1 to 1.8 recall points and further reduces graph work.
+2. `nprobe=8` keeps router CPU cost lower and avoids spreading the query over too many cells.
+3. `sample=2048` bounds router ADC scoring at roughly 16K codes/query and is already sufficient to improve entry-point quality substantially.
+4. It is the only treatment in this run that clearly improves recall and graph work without increasing mean latency.
+
+### High-recall ablation
+
+Keep `nprobe=16, sample=4096, msp=16` as the high-recall ablation.
+
+This point produces the highest recall, but router cost and latency are much higher. It answers the quality-ceiling question for sampled ADC, but it is not the default system configuration.
+
+## Evidence
+
+Experiment setup:
+
+| Item | Value |
+|---|---|
+| Dataset | MSTuringANN 10M |
+| Data type / dim | float32 / 100 |
+| Distance | squared_l2 |
+| Disk index build | derived from `/Users/xiaoweijiang/Downloads/config_build.json` |
+| Search config | derived from `/Users/xiaoweijiang/Downloads/config_search_l200_r100.json` |
+| L | 200 |
+| recall_at | 100 |
+| beam_width | 64 |
+| num_threads | 4 |
+| num_nodes_to_cache | 50000 |
+| IVF build | C=2048, training_sample_size=100000, max_iterations=4 |
+| Raw report | prior local sweep, summarized here |
+
+Core results:
+
+| variant | recall@100 (%) | IOs / hops | comparisons | mean latency us | p95 us | p999 us | router us | router codes |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| baseline | 73.48 | 491.18 | 23360.02 | 1498.62 | 2056 | 9069 | 0.00 | 0.00 |
+| sampled_adc_np8_s2048_msp16 | 76.94 | 265.77 | 12144.88 | 1498.45 | 1893 | 6845 | 610.28 | 16219.65 |
+| sampled_adc_np8_s4096_msp16 | 77.38 | 262.79 | 11998.40 | 1948.32 | 2324 | 8823 | 1069.60 | 29970.23 |
+| sampled_adc_np16_s4096_msp16 | 77.47 | 260.25 | 11871.79 | 2918.50 | 3342 | 9088 | 2076.44 | 59517.07 |
+| scan_np16_scan65536_msp16 | 77.33 | 260.20 | 11870.72 | 3151.17 | 3607 | 7990 | 2271.79 | 65412.18 |
+
+Recommended point versus baseline:
+
+| metric | baseline | recommended | delta |
+|---|---:|---:|---:|
+| recall@100 | 73.48% | 76.94% | +3.46 points |
+| IOs / hops | 491.18 | 265.77 | -225.41, -45.9% |
+| comparisons | 23360.02 | 12144.88 | -11215.14, -48.0% |
+| mean latency | 1498.62 us | 1498.45 us | -0.17 us, ~0.0% |
+| p95 latency | 2056 us | 1893 us | -163 us, -7.9% |
+| p999 latency | 9069 us | 6845 us | -2224 us, -24.5% |
+
+Interpretation:
+
+- Headline metrics are recall@100, IOs/hops, comparisons, latency, p95, and p999.
+- `sampled ADC codes` is a router CPU diagnostic. It is not the headline outcome.
+- Local machine latency can be affected by thermals, background load, and cache state. Therefore, this RFC prioritizes recall, IOs/hops, and comparisons as the more stable decision metrics, then uses latency to check whether system cost is under control.
+- `sampled_adc_np8_s2048_msp16` is valuable because roughly 16K sampled ADC codes/query nearly halves graph traversal work without an observed mean-latency regression.
+- `sampled_adc_np16_s4096_msp16` adds only 0.53 recall points over the default point, but increases router codes from roughly 16K to roughly 60K and almost doubles mean latency. It is a high-recall ablation, not the default.
+- The high-recall flat-scan point is close in recall to sampled ADC high-recall, but it has higher router latency and a less scalable probed-list scan budget.
+
+## Build Artifact
+
+The IVF+PQ router artifact owns only IVF centroids and posting IDs:
+
+```text
+dim
+centroids:   C * dim * f32
+offsets:     (C + 1) * usize
+posting_ids: N * u32
+fallback_medoid
+```
+
+Current MSTuringANN 10M artifact:
+
+```text
+outputs/msturingann10m_user_c2048.ivf_pq_router.bin
+```
+
+Approximate in-process bytes after the current implementation loads the artifact, excluding allocator overhead:
+
+| component | 10M, C=2048, dim=100 | 1B, C=2048, dim=100 |
+|---|---:|---:|
+| centroids | 0.78 MiB | 0.78 MiB |
+| offsets | 16 KiB | 16 KiB |
+| posting_ids | 38.15 MiB | 3.73 GiB |
+
+Notes:
+
+- Posting IDs cost `4 * N` bytes. They must be included in IVF memory accounting.
+- The minimal implementation in this PR loads centroids, offsets, and posting IDs into process memory. mmap loading is future scaling work.
+- This RFC does not add residual PQ codes, so it does not add `N * M_res` bytes.
+- DiskANN's existing global PQ compressed vectors are still used by traversal. The sampled ADC router reuses them, so they are not counted as incremental router memory.
+
+## Query Algorithm
+
+Inputs:
+
+```text
+query q
+IVF centroids
+IVF posting lists
+global PQ code view
+nprobe = 8
+posting_list_samples_per_list = 2048
+max_start_points = 16
+```
+
+Flow:
+
+1. Score all IVF centroids against `q`.
+2. Use bounded top-k selection to choose the top `nprobe` cells.
+3. For each selected cell, take at most `posting_list_samples_per_list` sample IDs from the posting list.
+4. Reuse the existing global PQ ADC path to compute query-aware approximate distances for sampled IDs.
+5. Select the top `max_start_points` across all samples.
+6. Deduplicate and fall back to the medoid if needed.
+7. Use those IDs as initial entry points for disk Vamana traversal.
+8. Keep graph traversal, disk IO, and PQ neighbor scoring unchanged.
+
+Complexity:
+
+```text
+centroid scoring: O(C * dim)
+router ADC scoring upper bound: O(nprobe * posting_list_samples_per_list * pq_chunks)
+graph traversal: unchanged, but starts from better points
+```
+
+With the default configuration:
+
+```text
+8 * 2048 = 16384 PQ codes / query
+```
+
+This is much more controllable than a full flat scan over probed posting lists, especially as N grows.
+
+## Why Not Flat Scan
+
+On the 10M, C=2048, nprobe=16 setting, the high-recall flat-scan row is effective:
+
+```text
+scan_np16_scan65536_msp16:
+recall@100 = 77.33
+IOs = 260.20
+comparisons = 11870.72
+mean latency = 3151.17 us
+router scanned codes = 65412.18
+```
+
+It is not the default because:
+
+1. Mean latency is 110.3% higher than baseline and about 2.1x higher than the recommended sampled ADC point.
+2. Its scan budget is tied to probed-list length and becomes harder to control as N grows.
+3. Sampled ADC gets 76.94 recall with roughly 16K codes, improves recall by 3.46 points, and keeps latency flat.
+4. High-recall sampled ADC reaches 77.47 recall with roughly 60K codes, slightly above the high-recall flat-scan point.
+
+Flat scan should remain a quality upper-bound / ablation, not the scaling path.
+
+## Why Not Residual PQ
+
+Residual PQ has a clear benefit: points inside an IVF cell can be represented with residual encodings, which should be better suited for cell-local ADC.
+
+It is not the default for now:
+
+1. It adds `N * M_res` residual codes, increasing query-time memory.
+2. DiskANN traversal already needs global PQ vectors. Adding residual PQ creates two long-lived PQ code layouts unless future work proves residual PQ can replace traversal PQ.
+3. Current experiments show that reusing global PQ with sampled ADC already improves entry-point quality substantially.
+4. Residual PQ is better kept as an ablation to test whether cell-local residual distances further improve routed start quality.
+
+## Scaling Notes
+
+The default design in this RFC solves the immediate problem of avoiding full flat scan inside probed IVF lists. It is not a complete 1B product architecture by itself.
+
+Impact at 1B scale:
+
+- If C stays at 2048, each posting list averages about 488K points. A flat scan with `nprobe=8` would touch about 3.9M points/query, which is not practical.
+- Sampled ADC fixes scoring cost at `nprobe * sample`, for example 16K codes/query, instead of growing linearly with N.
+- Posting IDs still cost `4 * N` bytes, roughly 3.73 GiB at 1B. mmap improves load shape, but does not remove total data size.
+- Global PQ vectors are still the larger query-time memory component. With 64 PQ chunks, 1B raw PQ codes are about 64 GiB.
+
+Further work needed for 1B:
+
+1. Hierarchical IVF centroid probing, to avoid flat scanning too many centroids.
+2. Posting-order canonical PQ layout, to reduce random gather and duplicate PQ layouts.
+3. Shard-aware / tiered router artifacts, keeping cold postings and PQ codes in mmap / SSD-friendly layouts.
+4. A sampling strategy that evolves from fixed prefix/sample to workload-aware or learned sampling.
+5. Linux/x86_64 smaps-level memory audits, separating heap, anonymous RSS, and file-backed RSS.
+
+## Benchmark Plan
+
+Default regression benchmark:
+
+```text
+dataset: MSTuringANN 10M
+L: 200
+recall_at: 100
+distance: squared_l2
+beam_width: 64
+num_nodes_to_cache: 50000
+baseline: start_point_router = null
+treatment: nprobe=8, posting_list_samples_per_list=2048, max_start_points=16
+high-recall ablation: nprobe=16, posting_list_samples_per_list=4096, max_start_points=16
+```
+
+Required metrics:
+
+- recall@100
+- IOs / hops
+- comparisons
+- mean latency
+- p95 / p999 latency
+- router time
+- sampled ADC codes
+- query-time memory / RSS audit, if the environment supports it
+
+Decision order:
+
+1. Does treatment improve recall?
+2. Do IOs/hops/comparisons decrease?
+3. Are latency, p95, and p999 within budget?
+4. Do router sampled codes explain CPU cost?
+5. Does memory fit the target scale budget?
+
+## Rollout
+
+Phase 1: keep the current implementation as a benchmark opt-in path.
+
+- Baseline remains unchanged.
+- Sampled ADC is enabled only when `start_point_router.type = ivf_pq` and `posting_list_samples_per_list` is configured.
+- Flat scan and residual PQ remain ablations.
+
+Phase 2: add stability validation.
+
+- Repeat the default point to verify latency is not an artifact of local machine state.
+- Run 10M multi-dataset comparisons, especially clustered and non-clustered datasets.
+- Add memory audit.
+
+Phase 3: scaling path.
+
+- Design hierarchical IVF + sampled ADC for 100M/1B.
+- Optimize posting-order PQ layout.
+- Add mmap artifact loading and validate file-backed page behavior and IO patterns.
+
+## Open Questions
+
+1. Is the current sampling strategy stable enough, or do we need deterministic dispersed sampling / learned sampling?
+2. Is `nprobe=8, sample=2048, msp=16` still the best balanced point on clustered datasets?
+3. Should the next sweep include `msp=12` or `msp=24` to validate the boundary around `msp=16`?
+4. Can posting-order canonical PQ layout remove most global-PQ random gather cost?
+5. At 1B scale, does the router artifact need mmap or a hierarchical router to control RSS and page fault patterns?
+
+## Decision
+
+Adopt `IVF+PQ posting-list sampled ADC` as the default experimental design for the next phase. The recommended default point is:
+
+```text
+C=2048
+nprobe=8
+posting_list_samples_per_list=2048
+max_start_points=16
+L=200
+recall_at=100
+```
+
+`nprobe=16, sample=4096, msp=16` remains the high-recall ablation. Flat scan and residual PQ remain comparison experiments, not the default path.

--- a/rfcs/00001-ivf-pq-posting-list-sampled-adc-router.zh.md
+++ b/rfcs/00001-ivf-pq-posting-list-sampled-adc-router.zh.md
@@ -1,0 +1,388 @@
+# RFC: IVF+PQ Posting-List Sampled ADC Start-Point Router
+
+| | |
+|---|---|
+| 作者 | Xiaowei Jiang, Codex |
+| 创建时间 | 2026-07-28 |
+| 状态 | Draft |
+| 相关文档 | N/A |
+
+## 摘要
+
+本文提议把 **IVF+PQ posting-list sampled ADC router** 作为下一阶段 DiskANN disk Vamana start-point router 的默认实验方案。
+
+推荐默认配置：
+
+```json
+{
+  "type": "ivf_pq",
+  "artifact": "outputs/msturingann10m_user_c2048.ivf_pq_router.bin",
+  "nprobe": 8,
+  "max_start_points": 16,
+  "posting_list_samples_per_list": 2048
+}
+```
+
+这个方案不引入 residual PQ，也不复制一份 PQ code sidecar。它只新增一个 IVF posting-list artifact，query 时先选择 top IVF cells，然后在每个 probed posting list 内抽样最多 2048 个点，用 DiskANN 已有 global PQ ADC 估距，选出 16 个 query-specific start points，再交给现有 disk Vamana traversal。
+
+推荐该配置的主要原因是数据驱动的：在 MSTuringANN 10M、`L=200`、`recall@100` 实验中，`sampled_adc_np8_s2048_msp16` 相比 baseline recall 提升 3.46 points，IO/hops 降低 45.9%，comparisons 降低 48.0%，mean latency 基本不变，p95 和 p999 还更低。它是当前 sweep 中最适合做默认实验点的 balanced operating point。
+
+## 背景
+
+DiskANN disk Vamana search 的主路径是：
+
+1. 从 medoid 或少量固定入口点开始。
+2. 执行 best-first graph traversal。
+3. 读 disk graph adjacency。
+4. 用内存中的 global PQ compressed vectors 对 neighbor 做近似距离估计。
+5. 持续扩展 frontier，直到满足 `search_list` / beam 条件。
+
+这个路径的强项是 graph traversal 稳定、图格式成熟、磁盘存储可扩展。弱点是入口点不够 query-aware 时，早期 hops 和 IO 可能浪费在离 query 较远的图区域。
+
+本 RFC 的核心假设是：
+
+```text
+如果 router 能用有限 RAM/CPU 预算为 query 找到更接近真实邻域的多个 start points，
+Vamana traversal 可以用更少 IO、hops、comparisons 达到更高 recall。
+```
+
+之前尝试过的路线包括：
+
+- IVF-only representatives：内存低，但入口点不够 query-specific。
+- IVF+global PQ flat scan：质量高，但 probed lists 内 flat scan 对大规模数据不够可控。
+- block summary / block sampled ADC：有助于 1B scaling 讨论，但当前简单 summary 质量不稳定。
+- residual PQ：可以做 ablation，但会新增一整份 per-point code，不适合作为默认第一路线。
+
+posting-list sampled ADC 是当前更务实的中间点：保留 query-specific ADC selection，同时把 router scoring 上界控制为 `nprobe * posting_list_samples_per_list`。
+
+## 架构图
+
+```mermaid
+flowchart TD
+    subgraph Build["Build Time"]
+        B0["Base vectors"]
+        B1["DiskANN build"]
+        B2["Disk Vamana graph"]
+        B3["Global PQ compressed vectors"]
+        B4["Train IVF centroids, C=2048"]
+        B5["Assign all points to IVF cells"]
+        B6["IVF posting-list router artifact"]
+
+        B0 --> B1
+        B1 --> B2
+        B1 --> B3
+        B0 --> B4
+        B4 --> B5
+        B5 --> B6
+    end
+
+    subgraph Query["Query Time"]
+        Q0["Query vector"]
+        Q1["Score IVF centroids"]
+        Q2["Select nprobe=8 cells"]
+        Q3["Sample up to 2048 IDs per posting list"]
+        Q4["Global PQ ADC scoring"]
+        Q5["Select max_start_points=16"]
+        Q6["Seed Disk Vamana traversal"]
+        Q7["Existing graph traversal with global PQ"]
+        Q8["Final candidates"]
+
+        Q0 --> Q1
+        Q1 --> Q2
+        Q2 --> Q3
+        B6 --> Q1
+        B6 --> Q3
+        B3 --> Q4
+        Q0 --> Q4
+        Q3 --> Q4
+        Q4 --> Q5
+        Q5 --> Q6
+        B2 --> Q7
+        B3 --> Q7
+        Q6 --> Q7
+        Q7 --> Q8
+    end
+```
+
+## 推荐方案
+
+### 默认实验点
+
+默认 treatment：
+
+| 参数 | 值 |
+|---|---:|
+| IVF cells | 2048 |
+| load mode | mmap |
+| nprobe | 8 |
+| posting_list_samples_per_list | 2048 |
+| max_start_points | 16 |
+| distance | squared_l2 |
+| search_list L | 200 |
+| recall_at | 100 |
+
+选择这个点的原因：
+
+1. `msp=16` 是当前 sweep 中最稳定的收益来源。相比 `msp=8`，它通常提升 1.1 到 1.8 recall points，并继续降低 graph work。
+2. `nprobe=8` 保持 router CPU 预算较低，避免把 query 扩散到过多 cells。
+3. `sample=2048` 把 router ADC scoring 控制在约 16K codes/query，在本机实验里已经足够提供明显入口质量收益。
+4. 它是本轮数据中唯一一个“recall 和 graph work 明显改善，同时 mean latency 没有增加”的 treatment。
+
+### High-recall ablation
+
+保留 `nprobe=16, sample=4096, msp=16` 作为 high-recall ablation。
+
+这个点给出最高 recall，但 router cost 和 latency 明显更高。它适合回答“sampled ADC 质量上限接近哪里”，不适合作为默认系统配置。
+
+## 数据依据
+
+实验条件：
+
+| 项目 | 值 |
+|---|---|
+| Dataset | MSTuringANN 10M |
+| Data type / dim | float32 / 100 |
+| Distance | squared_l2 |
+| Disk index build | `/Users/xiaoweijiang/Downloads/config_build.json` 派生 |
+| Search config | `/Users/xiaoweijiang/Downloads/config_search_l200_r100.json` 派生 |
+| L | 200 |
+| recall_at | 100 |
+| beam_width | 64 |
+| num_threads | 4 |
+| num_nodes_to_cache | 50000 |
+| IVF build | C=2048, training_sample_size=100000, max_iterations=4 |
+| Raw report | prior local sweep, summarized here |
+
+核心结果：
+
+| variant | recall@100 (%) | IOs / hops | comparisons | mean latency us | p95 us | p999 us | router us | router codes |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| baseline | 73.48 | 491.18 | 23360.02 | 1498.62 | 2056 | 9069 | 0.00 | 0.00 |
+| sampled_adc_np8_s2048_msp16 | 76.94 | 265.77 | 12144.88 | 1498.45 | 1893 | 6845 | 610.28 | 16219.65 |
+| sampled_adc_np8_s4096_msp16 | 77.38 | 262.79 | 11998.40 | 1948.32 | 2324 | 8823 | 1069.60 | 29970.23 |
+| sampled_adc_np16_s4096_msp16 | 77.47 | 260.25 | 11871.79 | 2918.50 | 3342 | 9088 | 2076.44 | 59517.07 |
+| scan_np16_scan65536_msp16 | 77.33 | 260.20 | 11870.72 | 3151.17 | 3607 | 7990 | 2271.79 | 65412.18 |
+
+默认推荐点相对 baseline 的变化：
+
+| metric | baseline | recommended | delta |
+|---|---:|---:|---:|
+| recall@100 | 73.48% | 76.94% | +3.46 points |
+| IOs / hops | 491.18 | 265.77 | -225.41, -45.9% |
+| comparisons | 23360.02 | 12144.88 | -11215.14, -48.0% |
+| mean latency | 1498.62 us | 1498.45 us | -0.17 us, ~0.0% |
+| p95 latency | 2056 us | 1893 us | -163 us, -7.9% |
+| p999 latency | 9069 us | 6845 us | -2224 us, -24.5% |
+
+解读：
+
+- Headline metrics 应看 recall@100、IOs/hops、comparisons、latency/p95/p999。
+- `sampled ADC codes` 是 router CPU 诊断指标，不是主结论。
+- 本机 latency 会受散热、后台程序、cache state 影响；因此 RFC 把 recall、IO/hops、comparisons 作为更稳定的决策依据，再用 latency 判断系统代价是否失控。
+- `sampled_adc_np8_s2048_msp16` 的关键价值是：以约 16K sampled ADC codes 的 router cost，把 graph traversal work 接近腰斩，并且没有观察到 mean latency 回退。
+- `sampled_adc_np16_s4096_msp16` 只比默认点多 0.53 recall points，但 router codes 从约 16K 增到约 60K，mean latency 接近翻倍。因此它是 high-recall ablation，不是默认点。
+- flat scan high-recall 点和 sampled ADC high-recall 点 recall 接近，但 flat scan router latency 更高，且 probed-list scan budget 更难向 1B 扩展。
+
+## Build Artifact
+
+IVF+PQ router artifact 只负责存 IVF centroids 和 posting IDs：
+
+```text
+dim
+centroids:   C * dim * f32
+offsets:     (C + 1) * usize
+posting_ids: N * u32
+fallback_medoid
+```
+
+当前 MSTuringANN 10M artifact：
+
+```text
+outputs/msturingann10m_user_c2048.ivf_pq_router.bin
+```
+
+当前实现加载 artifact 后的近似 in-process bytes，不含 allocator overhead：
+
+| component | 10M, C=2048, dim=100 | 1B, C=2048, dim=100 |
+|---|---:|---:|
+| centroids | 0.78 MiB | 0.78 MiB |
+| offsets | 16 KiB | 16 KiB |
+| posting_ids | 38.15 MiB | 3.73 GiB |
+
+注意：
+
+- posting IDs 是 `4 * N` bytes，这是之前讨论 IVF 内存时必须计入的部分。
+- 这个 PR 的最小实现直接把 centroids、offsets 和 posting IDs 载入进程内存；mmap load mode 属于后续 scaling work。
+- 本 RFC 不新增 residual PQ codes，因此不会额外增加 `N * M_res` bytes。
+- DiskANN 已有 global PQ compressed vectors 仍由 traversal 使用；sampled ADC router 只是复用它，不把它算作新增 router memory。
+
+## Query Algorithm
+
+输入：
+
+```text
+query q
+IVF centroids
+IVF posting lists
+global PQ code view
+nprobe = 8
+posting_list_samples_per_list = 2048
+max_start_points = 16
+```
+
+流程：
+
+1. 对所有 IVF centroids 计算 `distance(q, centroid)`。
+2. 用 bounded top-k selection 选择 top `nprobe` cells。
+3. 对每个 selected cell，从 posting list 里取最多 `posting_list_samples_per_list` 个 sample IDs。
+4. 对 sample IDs 复用 existing global PQ ADC，计算 query-aware approximate distance。
+5. 在所有 sampled IDs 中选 top `max_start_points`。
+6. 去重，必要时用 medoid fallback。
+7. 把这些 IDs 作为 Disk Vamana traversal 的初始入口。
+8. 后续 graph traversal、disk IO、PQ neighbor scoring 保持不变。
+
+复杂度：
+
+```text
+centroid scoring: O(C * dim)
+router ADC scoring upper bound: O(nprobe * posting_list_samples_per_list * pq_chunks)
+graph traversal: unchanged, but starts from better points
+```
+
+默认配置下 router ADC 上界约为：
+
+```text
+8 * 2048 = 16384 PQ codes / query
+```
+
+这比对 probed lists 做 full flat scan 更可控，尤其是当 N 增长时。
+
+## 为什么不是 Flat Scan
+
+在 10M、C=2048、nprobe=16 的 setting 下，flat scan high-recall 点确实有效：
+
+```text
+scan_np16_scan65536_msp16:
+recall@100 = 77.33
+IOs = 260.20
+comparisons = 11870.72
+mean latency = 3151.17 us
+router scanned codes = 65412.18
+```
+
+但它不是默认方案，原因是：
+
+1. mean latency 比 baseline 高 110.3%，比推荐 sampled ADC 点高约 2.1x。
+2. 它的 scan budget 和 probed-list 长度绑定，N 变大时更容易失控。
+3. sampled ADC 用约 16K codes 已经拿到 76.94 recall，比 baseline 高 3.46 points，并保持 latency 不变。
+4. high-recall sampled ADC 用约 60K codes 达到 77.47 recall，已经略高于 flat scan high-recall 点。
+
+因此 flat scan 应保留为 quality upper-bound / ablation，而不是 scaling path。
+
+## 为什么不是 Residual PQ
+
+Residual PQ 的好处是每个 IVF cell 内的点可以用 residual encoding 表达，理论上更适合 cell-local ADC。
+
+但当前默认不选 residual PQ：
+
+1. 它需要新增 `N * M_res` residual codes，query-time memory 比 sampled ADC 方案高。
+2. DiskANN traversal 已经需要 global PQ vectors。新增 residual PQ 会造成两套 PQ code 长期共存，除非未来证明它能替代 traversal PQ。
+3. 当前实验已经证明复用 global PQ sampled ADC 足以显著改善入口质量。
+4. residual PQ 更适合作为 ablation：验证 cell-local residual distance 是否能继续提升 routed start quality。
+
+## Scaling Notes
+
+本 RFC 的默认方案解决的是“不要在 probed IVF lists 里 full flat scan”的问题，而不是一次性完成 1B 产品化。
+
+对 1B 的影响：
+
+- 如果 C 固定为 2048，平均每个 posting list 约 488K points，flat scan `nprobe=8` 会触达约 3.9M points/query，不现实。
+- sampled ADC 把 scoring 上界固定到 `nprobe * sample`，例如 16K codes/query，不随 N 线性增长。
+- 但 posting IDs 仍然是 `4 * N` bytes，1B 约 3.73 GiB。使用 mmap 可以改善加载形态，但不消除总数据规模。
+- global PQ vectors 仍是更大的 query-time memory 主体。例如 64 PQ chunks 时，1B raw PQ codes 约 64 GiB。
+
+后续要让系统更适合 1B，需要继续探索：
+
+1. hierarchical IVF centroid probing，避免 flat scan 过多 centroids。
+2. posting-order canonical PQ layout，减少 random gather 和重复 PQ code layout。
+3. shard-aware / tiered router artifact，把 cold postings 和 PQ codes 留在 mmap / SSD friendly layout。
+4. sample strategy 从固定 prefix/sample 演进为 workload-aware 或 learned sample。
+5. Linux/x86_64 smaps 级 memory audit，把 heap、anonymous RSS、file-backed RSS 拆开看。
+
+## Benchmark Plan
+
+默认回归 benchmark：
+
+```text
+dataset: MSTuringANN 10M
+L: 200
+recall_at: 100
+distance: squared_l2
+beam_width: 64
+num_nodes_to_cache: 50000
+baseline: start_point_router = null
+treatment: nprobe=8, posting_list_samples_per_list=2048, max_start_points=16
+high-recall ablation: nprobe=16, posting_list_samples_per_list=4096, max_start_points=16
+```
+
+必须记录：
+
+- recall@100
+- IOs / hops
+- comparisons
+- mean latency
+- p95 / p999 latency
+- router time
+- sampled ADC codes
+- query-time memory / RSS audit, 如果实验环境支持
+
+判断顺序：
+
+1. treatment 是否提升 recall。
+2. IOs/hops/comparisons 是否下降。
+3. latency/p95/p999 是否在可接受范围内。
+4. router sampled codes 是否解释了 CPU cost。
+5. memory 是否符合规模预算。
+
+## Rollout
+
+阶段 1：保持当前实现为 benchmark opt-in path。
+
+- 默认 baseline 不变。
+- 只有配置 `start_point_router.type = ivf_pq` 且设置 `posting_list_samples_per_list` 时启用 sampled ADC。
+- flat scan 和 residual PQ 保留为 ablation。
+
+阶段 2：补齐稳定性验证。
+
+- 重复运行默认点，确认 latency 不是偶然受本机状态影响。
+- 跑 10M 多数据集对比，尤其关注 clustered / non-clustered 数据。
+- 增加 memory audit。
+
+阶段 3：scaling path。
+
+- 针对 100M/1B 设计 hierarchical IVF + sampled ADC。
+- 优化 posting-order PQ layout。
+- 增加 mmap artifact loading，并验证 file-backed page behavior 和 IO pattern。
+
+## Open Questions
+
+1. 当前 sample 选择策略是否足够稳定，还是需要 deterministic dispersed sampling / learned sampling？
+2. `nprobe=8, sample=2048, msp=16` 在 clustered 数据集上是否仍是 best balanced point？
+3. 是否需要把 `msp=12` 或 `msp=24` 加入 sweep，确认 `msp=16` 的边界？
+4. posting-order PQ canonical layout 能否消除 global PQ random gather 的主要成本？
+5. 在 1B 规模下，router artifact 是否需要 mmap 或分层 router 才能控制 RSS 和 page fault pattern？
+
+## Decision
+
+采用 `IVF+PQ posting-list sampled ADC` 作为下一阶段默认实验方案。默认推荐点是：
+
+```text
+C=2048
+nprobe=8
+posting_list_samples_per_list=2048
+max_start_points=16
+L=200
+recall_at=100
+```
+
+`nprobe=16, sample=4096, msp=16` 作为 high-recall ablation；flat scan 和 residual PQ 保留为对照实验，不作为默认 path。


### PR DESCRIPTION
## Summary
- add a focused IVF posting-list sampled ADC start-point router for disk search
- build and load an IVF+PQ router artifact with centroids, posting offsets, posting IDs, and fallback medoid
- route queries by probing IVF cells, strided sampling posting lists, scoring sampled IDs with existing global PQ ADC, and seeding disk Vamana traversal
- wire benchmark build/search config for `ivf_pq_router_build` and `start_point_router`
- include bilingual RFC for the sampled ADC design

## Scope
This intentionally excludes residual PQ, PQ sidecars, block routers, hierarchy, posting-order PQ layout, mmap artifact loading, and experiment result artifacts.

## Validation
- `cargo fmt --all --check`
- `cargo test -p diskann-disk ivf -- --nocapture`
- `cargo test -p diskann-benchmark --features disk-index ivf_pq -- --nocapture`
- `cargo clippy -p diskann-disk --tests -- -D warnings`
- `cargo clippy -p diskann-benchmark --features disk-index --bins --tests -- -D warnings`