### PR TITLE
PiPNN 5/6: add dedicated benchmark pipelines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,7 +476,6 @@ dependencies = [
  "diskann-disk",
  "diskann-inmem",
  "diskann-label-filter",
- "diskann-pipnn",
  "diskann-providers",
  "diskann-quantization",
  "diskann-tools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,7 @@ dependencies = [
  "diskann-disk",
  "diskann-inmem",
  "diskann-label-filter",
+ "diskann-pipnn",
  "diskann-providers",
  "diskann-quantization",
  "diskann-tools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "diskann-disk",
  "diskann-inmem",
  "diskann-label-filter",
+ "diskann-pipnn",
  "diskann-providers",
  "diskann-quantization",
  "diskann-tools",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,7 +474,6 @@ dependencies = [
  "diskann-disk",
  "diskann-inmem",
  "diskann-label-filter",
- "diskann-pipnn",
  "diskann-providers",
  "diskann-quantization",
  "diskann-tools",

--- a/diskann-benchmark/Cargo.toml
+++ b/diskann-benchmark/Cargo.toml
@@ -32,6 +32,7 @@ diskann-label-filter.workspace = true
 diskann-tools = { workspace = true }
 diskann-disk = { workspace = true, optional = true }
 diskann-bftree = { workspace = true, optional = true }
+diskann-pipnn = { workspace = true, optional = true }
 cfg-if.workspace = true
 diskann-benchmark-runner = { workspace = true }
 opentelemetry = { workspace = true, optional = true }
@@ -82,3 +83,6 @@ disk-index = [
     "dep:opentelemetry_sdk",
     "dep:scopeguard",
 ]
+
+# Enable PiPNN graph construction.
+pipnn = ["dep:diskann-pipnn", "diskann-disk/pipnn"]

--- a/diskann-benchmark/Cargo.toml
+++ b/diskann-benchmark/Cargo.toml
@@ -32,7 +32,6 @@ diskann-label-filter.workspace = true
 diskann-tools = { workspace = true }
 diskann-disk = { workspace = true, optional = true }
 diskann-bftree = { workspace = true, optional = true }
-diskann-pipnn = { workspace = true, optional = true }
 cfg-if.workspace = true
 diskann-benchmark-runner = { workspace = true }
 opentelemetry = { workspace = true, optional = true }
@@ -85,4 +84,4 @@ disk-index = [
 ]
 
 # Enable PiPNN graph construction.
-pipnn = ["dep:diskann-pipnn", "diskann-disk/pipnn"]
+pipnn = ["diskann/pipnn", "diskann-disk/pipnn"]

--- a/diskann-benchmark/example/pipnn-disk-index.json
+++ b/diskann-benchmark/example/pipnn-disk-index.json
@@ -1,0 +1,46 @@
+{
+  "search_directories": [
+    "test_data/disk_index_search"
+  ],
+  "jobs": [
+    {
+      "type": "disk-index",
+      "content": {
+        "source": {
+          "disk-index-source": "Build",
+          "data_type": "float32",
+          "data": "disk_index_siftsmall_learn_256pts_data.fbin",
+          "distance": "squared_l2",
+          "dim": 128,
+          "max_degree": 32,
+          "l_build": 50,
+          "alpha": 1.2,
+          "num_threads": 1,
+          "build_ram_limit_gb": 2.0,
+          "num_pq_chunks": 128,
+          "build_algorithm": {
+            "algorithm": "PiPNN",
+            "c_max": 64,
+            "c_min": 16,
+            "p_samp": 0.05,
+            "fanout": [4, 2],
+            "k": 2,
+            "replicas": 1
+          },
+          "save_path": "pipnn_disk_index"
+        },
+        "search_phase": {
+          "queries": "disk_index_sample_query_10pts.fbin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
+          "search_list": [10, 20, 40],
+          "beam_width": 4,
+          "recall_at": 10,
+          "num_threads": 1,
+          "is_flat_search": false,
+          "distance": "squared_l2",
+          "vector_filters_file": null
+        }
+      }
+    }
+  ]
+}

--- a/diskann-benchmark/example/pipnn-graph-index.json
+++ b/diskann-benchmark/example/pipnn-graph-index.json
@@ -1,0 +1,47 @@
+{
+  "search_directories": [
+    "test_data/disk_index_search"
+  ],
+  "jobs": [
+    {
+      "type": "graph-index-build",
+      "content": {
+        "source": {
+          "index-source": "Build",
+          "data_type": "float32",
+          "data": "disk_index_siftsmall_learn_256pts_data.fbin",
+          "distance": "squared_l2",
+          "max_degree": 32,
+          "l_build": 50,
+          "alpha": 1.2,
+          "backedge_ratio": 1.0,
+          "num_threads": 1,
+          "start_point_strategy": "first_vector",
+          "build_algorithm": {
+            "algorithm": "PiPNN",
+            "c_max": 64,
+            "c_min": 16,
+            "p_samp": 0.05,
+            "fanout": [4, 2],
+            "k": 2,
+            "replicas": 1
+          }
+        },
+        "search_phase": {
+          "search-type": "topk",
+          "queries": "disk_index_sample_query_10pts.fbin",
+          "groundtruth": "disk_index_10pts_idx_uint32_exact_ground_truth.bin",
+          "reps": 1,
+          "num_threads": [1],
+          "runs": [
+            {
+              "search_n": 10,
+              "search_l": [10, 20, 40],
+              "recall_k": 10
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/diskann-benchmark/src/disk_index/build.rs
+++ b/diskann-benchmark/src/disk_index/build.rs
@@ -84,6 +84,7 @@ where
         params.l_build,
         metric.into(),
         |b| {
+            b.alpha(params.alpha);
             b.saturate_after_prune(true);
         },
     )
@@ -93,11 +94,23 @@ where
 
     let metadata = load_metadata_from_file(storage_provider, &data_path)?;
 
-    let build_parameters = DiskIndexBuildParameters::new(
-        MemoryBudget::try_from_gb(params.build_ram_limit_gb)?,
-        params.quantization_type,
-        NumPQChunks::new_with(params.num_pq_chunks.get(), metadata.ndims())?,
-    );
+    let search_pq_chunks = NumPQChunks::new_with(params.num_pq_chunks.get(), metadata.ndims())?;
+    let build_parameters = match &params.build_algorithm {
+        diskann_disk::BuildAlgorithm::Vamana => DiskIndexBuildParameters::new(
+            MemoryBudget::try_from_gb(params.build_ram_limit_gb)?,
+            params.quantization_type.ok_or_else(|| {
+                anyhow::anyhow!("quantization_type is required for Vamana builds")
+            })?,
+            search_pq_chunks,
+        ),
+        #[cfg(feature = "pipnn")]
+        diskann_disk::BuildAlgorithm::PiPNN(config) => DiskIndexBuildParameters::new_pipnn(
+            MemoryBudget::try_from_gb(params.build_ram_limit_gb)?,
+            search_pq_chunks,
+            config.clone(),
+        ),
+        _ => anyhow::bail!("unsupported disk graph-build algorithm"),
+    };
 
     let index_configuration = IndexConfiguration::new(
         metric,

--- a/diskann-benchmark/src/index/benchmarks.rs
+++ b/diskann-benchmark/src/index/benchmarks.rs
@@ -229,6 +229,9 @@ where
                         single_or_multi_insert,
                     )
                 };
+                // PiPNN is selected before constructing the incremental provider:
+                // explicit batch selection must never allocate an incremental
+                // index and then silently fall through to Vamana insertion.
                 #[cfg(feature = "pipnn")]
                 let result = match build.build_algorithm() {
                     diskann_disk::BuildAlgorithm::PiPNN(parameters) => {

--- a/diskann-benchmark/src/index/benchmarks.rs
+++ b/diskann-benchmark/src/index/benchmarks.rs
@@ -211,26 +211,40 @@ where
         writeln!(output, "{}", input)?;
         let (index, build_stats) = match &input.source {
             IndexSource::Build(build) => {
-                let (index, build_stats) = run_build(
-                    build,
-                    common::FullPrecision,
-                    None,
-                    output,
-                    |data| {
-                        let index = diskann_async::new_index::<T, _>(
-                            build.try_as_config()?.build()?,
-                            build.inmem_parameters(data.nrows(), data.ncols()),
-                            common::NoDeletes,
-                        )?;
-                        build::set_start_points(
-                            index.provider(),
-                            data.as_view(),
-                            *build.start_point_strategy(),
-                        )?;
-                        Ok(index)
-                    },
-                    single_or_multi_insert,
-                )?;
+                let mut incremental = || {
+                    run_build(
+                        build,
+                        common::FullPrecision,
+                        None,
+                        output,
+                        |data| {
+                            let index = diskann_async::new_index::<T, _>(
+                                build.try_as_config()?.build()?,
+                                build.inmem_parameters(data.nrows(), data.ncols()),
+                                common::NoDeletes,
+                            )?;
+                            build::set_start_points(
+                                index.provider(),
+                                data.as_view(),
+                                *build.start_point_strategy(),
+                            )?;
+                            Ok(index)
+                        },
+                        single_or_multi_insert,
+                    )
+                };
+                #[cfg(feature = "pipnn")]
+                let result = match build.build_algorithm() {
+                    diskann_disk::BuildAlgorithm::PiPNN(parameters) => {
+                        let data =
+                            Arc::new(datafiles::load_dataset(datafiles::BinFile(build.data()))?);
+                        build::pipnn_build(data, build, parameters)
+                    }
+                    _ => incremental(),
+                };
+                #[cfg(not(feature = "pipnn"))]
+                let result = incremental();
+                let (index, build_stats) = result?;
 
                 // save the index if requested
                 if let Some(save_path) = build.save_path() {

--- a/diskann-benchmark/src/index/benchmarks.rs
+++ b/diskann-benchmark/src/index/benchmarks.rs
@@ -233,9 +233,8 @@ where
                         single_or_multi_insert,
                     )
                 };
-                // PiPNN is selected before constructing the incremental provider:
-                // explicit batch selection must never allocate an incremental
-                // index and then silently fall through to Vamana insertion.
+                // PiPNN uses the batch build path. Do not create an incremental
+                // provider or run Vamana insertion.
                 #[cfg(feature = "pipnn")]
                 let result = match build.build_algorithm() {
                     diskann_disk::BuildAlgorithm::PiPNN(parameters) => {

--- a/diskann-benchmark/src/index/benchmarks.rs
+++ b/diskann-benchmark/src/index/benchmarks.rs
@@ -229,9 +229,8 @@ where
                         single_or_multi_insert,
                     )
                 };
-                // PiPNN is selected before constructing the incremental provider:
-                // explicit batch selection must never allocate an incremental
-                // index and then silently fall through to Vamana insertion.
+                // PiPNN uses the batch build path. Do not create an incremental
+                // provider or run Vamana insertion.
                 #[cfg(feature = "pipnn")]
                 let result = match build.build_algorithm() {
                     diskann_disk::BuildAlgorithm::PiPNN(parameters) => {

--- a/diskann-benchmark/src/index/benchmarks.rs
+++ b/diskann-benchmark/src/index/benchmarks.rs
@@ -233,6 +233,9 @@ where
                         single_or_multi_insert,
                     )
                 };
+                // PiPNN is selected before constructing the incremental provider:
+                // explicit batch selection must never allocate an incremental
+                // index and then silently fall through to Vamana insertion.
                 #[cfg(feature = "pipnn")]
                 let result = match build.build_algorithm() {
                     diskann_disk::BuildAlgorithm::PiPNN(parameters) => {

--- a/diskann-benchmark/src/index/benchmarks.rs
+++ b/diskann-benchmark/src/index/benchmarks.rs
@@ -207,26 +207,40 @@ where
         writeln!(output, "{}", input)?;
         let (index, build_stats) = match &input.source {
             IndexSource::Build(build) => {
-                let (index, build_stats) = run_build(
-                    build,
-                    common::FullPrecision,
-                    None,
-                    output,
-                    |data| {
-                        let index = diskann_async::new_index::<T, _>(
-                            build.try_as_config()?.build()?,
-                            build.inmem_parameters(data.nrows(), data.ncols()),
-                            common::NoDeletes,
-                        )?;
-                        build::set_start_points(
-                            index.provider(),
-                            data.as_view(),
-                            *build.start_point_strategy(),
-                        )?;
-                        Ok(index)
-                    },
-                    single_or_multi_insert,
-                )?;
+                let mut incremental = || {
+                    run_build(
+                        build,
+                        common::FullPrecision,
+                        None,
+                        output,
+                        |data| {
+                            let index = diskann_async::new_index::<T, _>(
+                                build.try_as_config()?.build()?,
+                                build.inmem_parameters(data.nrows(), data.ncols()),
+                                common::NoDeletes,
+                            )?;
+                            build::set_start_points(
+                                index.provider(),
+                                data.as_view(),
+                                *build.start_point_strategy(),
+                            )?;
+                            Ok(index)
+                        },
+                        single_or_multi_insert,
+                    )
+                };
+                #[cfg(feature = "pipnn")]
+                let result = match build.build_algorithm() {
+                    diskann_disk::BuildAlgorithm::PiPNN(parameters) => {
+                        let data =
+                            Arc::new(datafiles::load_dataset(datafiles::BinFile(build.data()))?);
+                        build::pipnn_build(data, build, parameters)
+                    }
+                    _ => incremental(),
+                };
+                #[cfg(not(feature = "pipnn"))]
+                let result = incremental();
+                let (index, build_stats) = result?;
 
                 // save the index if requested
                 if let Some(save_path) = build.save_path() {

--- a/diskann-benchmark/src/index/build.rs
+++ b/diskann-benchmark/src/index/build.rs
@@ -5,6 +5,8 @@
 
 use std::{num::NonZeroUsize, sync::Arc};
 
+#[cfg(feature = "pipnn")]
+use diskann::graph::AdjacencyList;
 use diskann::{
     graph::{DiskANNIndex, StartPointStrategy},
     provider::{self, DataProvider, DefaultContext},
@@ -167,10 +169,18 @@ where
                 .context("PiPNN cannot connect a start point to an empty dataset")
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
-    let start_neighbors: Vec<_> = start_sources
+    let degree = graph.pruned_degree().get();
+    let start_neighbors = start_sources
         .into_iter()
-        .map(|source| adjacency[source].clone())
-        .collect();
+        .map(|source| {
+            let source_id = u32::try_from(source).context("PiPNN start source exceeds u32::MAX")?;
+            let mut neighbors = AdjacencyList::with_capacity(degree);
+            neighbors.push(source_id);
+            neighbors.extend_from_slice(&adjacency[source]);
+            neighbors.truncate(degree);
+            Ok(neighbors)
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
     let batch_elapsed = started.elapsed();
 
     // Unlike incremental insertion, PiPNN finishes all batch-build scratch
@@ -458,5 +468,15 @@ mod pipnn_tests {
                 .get_vector_sync(starts[0] as usize)
         };
         assert_eq!(start, [0.0, 0.0]);
+        let mut neighbors = AdjacencyList::new();
+        index
+            .provider()
+            .neighbors()
+            .get_neighbors_sync(starts[0] as usize, &mut neighbors)
+            .unwrap();
+        assert!(
+            neighbors.contains(0),
+            "start slot must enter the real graph"
+        );
     }
 }

--- a/diskann-benchmark/src/index/build.rs
+++ b/diskann-benchmark/src/index/build.rs
@@ -167,11 +167,8 @@ where
                 .or_else(|| {
                     data.row_iter()
                         .enumerate()
-                        .min_by(|(_, left), (_, right)| {
-                            distance
-                                .evaluate_similarity(start, left)
-                                .total_cmp(&distance.evaluate_similarity(start, right))
-                        })
+                        .map(|(index, row)| (index, distance.evaluate_similarity(start, row)))
+                        .min_by(|(_, left), (_, right)| left.total_cmp(right))
                         .map(|(index, _)| index)
                 })
                 .context("PiPNN cannot connect a start point to an empty dataset")

--- a/diskann-benchmark/src/index/build.rs
+++ b/diskann-benchmark/src/index/build.rs
@@ -20,10 +20,17 @@ use diskann_providers::{
     model::{configuration::IndexConfiguration, graph::provider::async_::inmem::SetStartPoints},
     storage::{AsyncIndexMetadata, LoadWith, SaveWith},
 };
+#[cfg(feature = "pipnn")]
+use diskann_providers::{
+    index::diskann_async,
+    model::graph::provider::async_::common::{self, SetElementHelper},
+};
 use diskann_utils::{
     future::AsyncFriendly,
     views::{Matrix, MatrixView},
 };
+#[cfg(feature = "pipnn")]
+use diskann_vector::DistanceFunction;
 use indicatif::{ProgressBar, ProgressStyle};
 use serde::Serialize;
 
@@ -105,6 +112,114 @@ where
     }
 }
 
+#[cfg(feature = "pipnn")]
+pub(crate) fn pipnn_build<T>(
+    data: Arc<Matrix<T>>,
+    input: &IndexBuild,
+    parameters: &diskann_disk::PiPNNParameters,
+) -> anyhow::Result<(diskann_async::MemoryIndex<T>, BuildStats)>
+where
+    T: diskann::graph::SampleableForStart + diskann::utils::VectorRepr,
+{
+    use anyhow::Context;
+
+    let npoints = data.nrows();
+    let dimensions = data.ncols();
+    let metric = input.distance().into();
+    let graph = input.try_as_config()?.build()?;
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(input.num_threads())
+        .build()
+        .context("failed to create PiPNN build thread pool")?;
+
+    let started = std::time::Instant::now();
+    let adjacency = {
+        let context =
+            diskann_pipnn::PiPNNBuildContext::new(parameters.into(), &graph, metric, &pool)?;
+        diskann_pipnn::build_graph(data.as_view(), &context)?
+    };
+    let start_points = input
+        .start_point_strategy()
+        .compute(data.as_view())
+        .map_err(|error| {
+            ANNError::new(
+                diskann::ANNErrorKind::DiskANN(StartPointComputeError),
+                error,
+            )
+        })?;
+    let distance = T::distance(metric, Some(dimensions));
+    let start_sources = start_points
+        .row_iter()
+        .map(|start| {
+            let bytes: &[u8] = bytemuck::cast_slice(start);
+            data.row_iter()
+                .position(|row| bytemuck::cast_slice::<T, u8>(row) == bytes)
+                .or_else(|| {
+                    data.row_iter()
+                        .enumerate()
+                        .min_by(|(_, left), (_, right)| {
+                            distance
+                                .evaluate_similarity(start, left)
+                                .total_cmp(&distance.evaluate_similarity(start, right))
+                        })
+                        .map(|(index, _)| index)
+                })
+                .context("PiPNN cannot connect a start point to an empty dataset")
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    let start_neighbors: Vec<_> = start_sources
+        .into_iter()
+        .map(|source| adjacency[source].clone())
+        .collect();
+
+    // Unlike incremental insertion, PiPNN finishes all batch-build scratch
+    // before allocating the provider that owns the searchable index.
+    let index = diskann_async::new_index::<T, _>(
+        graph,
+        input.inmem_parameters(npoints, dimensions),
+        common::NoDeletes,
+    )?;
+    for (id, vector) in data.row_iter().enumerate() {
+        let id = u32::try_from(id).context("PiPNN point ID exceeds u32::MAX")?;
+        index.data_provider.base_vectors.set_element(&id, vector)?;
+    }
+    for (id, neighbors) in adjacency.into_iter().enumerate() {
+        index
+            .provider()
+            .neighbors()
+            .set_neighbors_sync(id, &neighbors)?;
+    }
+    index.provider().set_start_points(start_points.row_iter())?;
+    let start_ids = index.provider().starting_points()?;
+    anyhow::ensure!(
+        start_ids.len() == start_neighbors.len(),
+        "PiPNN provider created {} start slots for {} start vectors",
+        start_ids.len(),
+        start_neighbors.len()
+    );
+    for (start_id, neighbors) in start_ids.into_iter().zip(&start_neighbors) {
+        index
+            .provider()
+            .neighbors()
+            .set_neighbors_sync(start_id as usize, neighbors)?;
+    }
+
+    let total_time = MicroSeconds::from(started.elapsed());
+    let per_vector = MicroSeconds::new(
+        total_time
+            .as_micros()
+            .checked_div(u64::try_from(npoints)?)
+            .context("PiPNN build received an empty dataset")?,
+    );
+    let stats = BuildStats {
+        kind: BuildKind::PiPNN,
+        total_time,
+        vectors_inserted: npoints,
+        insert_latencies: percentiles::compute_percentiles(&mut [per_vector])?,
+    };
+    Ok((index, stats))
+}
+
 #[cfg(any(feature = "scalar-quantization", feature = "spherical-quantization"))]
 pub(crate) fn only_single_insert<DP, T, S>(
     index: Arc<DiskANNIndex<DP>>,
@@ -153,6 +268,8 @@ where
 pub(crate) enum BuildKind {
     SingleInsert,
     MultiInsert,
+    #[cfg(feature = "pipnn")]
+    PiPNN,
 }
 
 impl std::fmt::Display for BuildKind {
@@ -160,6 +277,8 @@ impl std::fmt::Display for BuildKind {
         match self {
             Self::SingleInsert => write!(f, "single insert"),
             Self::MultiInsert => write!(f, "multi insert"),
+            #[cfg(feature = "pipnn")]
+            Self::PiPNN => write!(f, "PiPNN"),
         }
     }
 }
@@ -284,4 +403,56 @@ where
     .await?;
 
     Ok(index)
+}
+
+#[cfg(all(test, feature = "pipnn"))]
+mod pipnn_tests {
+    use super::*;
+
+    #[test]
+    fn dedicated_pipeline_respects_the_requested_start_strategy() {
+        let input: IndexBuild = serde_json::from_value(serde_json::json!({
+            "data_type": "float32",
+            "data": "unused.fbin",
+            "distance": "squared_l2",
+            "max_degree": 4,
+            "l_build": 8,
+            "start_point_strategy": "first_vector",
+            "alpha": 1.2,
+            "backedge_ratio": 1.0,
+            "num_threads": 2,
+            "multi_insert": null,
+            "save_path": null,
+            "build_algorithm": {
+                "algorithm": "PiPNN",
+                "c_max": 8,
+                "c_min": 2,
+                "p_samp": 0.5,
+                "fanout": [2],
+                "k": 2,
+                "replicas": 1
+            }
+        }))
+        .unwrap();
+        let diskann_disk::BuildAlgorithm::PiPNN(parameters) = input.build_algorithm() else {
+            panic!("expected PiPNN parameters");
+        };
+        let mut data = Matrix::new(0.0_f32, 16, 2);
+        for (index, row) in data.row_iter_mut().enumerate() {
+            row.copy_from_slice(&[index as f32, (index % 3) as f32]);
+        }
+
+        let (index, stats) = pipnn_build(Arc::new(data), &input, parameters).unwrap();
+        assert_eq!(stats.vectors_inserted, 16);
+        let starts = index.provider().starting_points().unwrap();
+        assert_eq!(starts.len(), 1);
+        // SAFETY: the completed build has no concurrent vector writers.
+        let start = unsafe {
+            index
+                .data_provider
+                .base_vectors
+                .get_vector_sync(starts[0] as usize)
+        };
+        assert_eq!(start, [0.0, 0.0]);
+    }
 }

--- a/diskann-benchmark/src/index/build.rs
+++ b/diskann-benchmark/src/index/build.rs
@@ -115,6 +115,28 @@ where
 }
 
 #[cfg(feature = "pipnn")]
+/// Run the dedicated batch lifecycle and install its result in a searchable provider.
+///
+/// Incremental Vamana interleaves provider allocation with per-point insertion.
+/// PiPNN must not use that path: its partitions and candidate graph are complete
+/// before a provider exists. The benchmark lifecycle is therefore:
+///
+/// ```text
+/// Arc<Matrix<T>> ──> PiPNN core ──> Vec<AdjacencyList<u32>>
+///       │                                      │
+///       ├──> start vectors ──> source IDs      │
+///       │                                      v
+///       └──────────────────────────────> provider installation ──> MemoryIndex
+/// ```
+///
+/// | Interval | Included in build statistics | Large owner |
+/// | --- | --- | --- |
+/// | batch graph + start computation | yes | input matrix, core stage outputs |
+/// | provider allocation | no (setup, matching incremental path) | empty provider |
+/// | vectors, edges, and start-slot installation | yes | searchable provider |
+///
+/// The returned provider is a benchmark/search adapter; provider concerns do not
+/// leak back into `diskann-pipnn`.
 pub(crate) fn pipnn_build<T>(
     data: Arc<Matrix<T>>,
     input: &IndexBuild,
@@ -150,6 +172,10 @@ where
             )
         })?;
     let distance = T::distance(metric, Some(dimensions));
+    // Provider start vectors occupy frozen slots outside the real point-ID
+    // range. Connect each slot to an identical source row when one exists;
+    // synthetic strategies fall back to the nearest real row under the build
+    // metric. `total_cmp` gives deterministic ordering for all finite/NaN bits.
     let start_sources = start_points
         .row_iter()
         .map(|start| {
@@ -170,6 +196,9 @@ where
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
     let degree = graph.pruned_degree().get();
+    // Seed every frozen start slot with its source point followed by that
+    // point's outgoing row. Truncation applies the same graph degree bound as
+    // real rows, and including the source guarantees entry into the real graph.
     let start_neighbors = start_sources
         .into_iter()
         .map(|source| {
@@ -193,6 +222,8 @@ where
     // Provider allocation is setup, just as it is for the incremental path;
     // BuildStats covers graph construction plus provider installation.
     let install_started = std::time::Instant::now();
+    // Install vectors before edges so a successfully returned MemoryIndex never
+    // exposes graph IDs whose source vectors are absent.
     for (id, vector) in data.row_iter().enumerate() {
         let id = u32::try_from(id).context("PiPNN point ID exceeds u32::MAX")?;
         index.data_provider.base_vectors.set_element(&id, vector)?;

--- a/diskann-benchmark/src/index/build.rs
+++ b/diskann-benchmark/src/index/build.rs
@@ -171,6 +171,7 @@ where
         .into_iter()
         .map(|source| adjacency[source].clone())
         .collect();
+    let batch_elapsed = started.elapsed();
 
     // Unlike incremental insertion, PiPNN finishes all batch-build scratch
     // before allocating the provider that owns the searchable index.
@@ -179,6 +180,9 @@ where
         input.inmem_parameters(npoints, dimensions),
         common::NoDeletes,
     )?;
+    // Provider allocation is setup, just as it is for the incremental path;
+    // BuildStats covers graph construction plus provider installation.
+    let install_started = std::time::Instant::now();
     for (id, vector) in data.row_iter().enumerate() {
         let id = u32::try_from(id).context("PiPNN point ID exceeds u32::MAX")?;
         index.data_provider.base_vectors.set_element(&id, vector)?;
@@ -204,7 +208,7 @@ where
             .set_neighbors_sync(start_id as usize, neighbors)?;
     }
 
-    let total_time = MicroSeconds::from(started.elapsed());
+    let total_time = MicroSeconds::from(batch_elapsed + install_started.elapsed());
     let per_vector = MicroSeconds::new(
         total_time
             .as_micros()

--- a/diskann-benchmark/src/index/build.rs
+++ b/diskann-benchmark/src/index/build.rs
@@ -5,8 +5,6 @@
 
 use std::{num::NonZeroUsize, sync::Arc};
 
-#[cfg(feature = "pipnn")]
-use diskann::graph::AdjacencyList;
 use diskann::{
     graph::{DiskANNIndex, StartPointStrategy},
     provider::{self, DataProvider, DefaultContext},
@@ -195,21 +193,14 @@ where
                 .context("PiPNN cannot connect a start point to an empty dataset")
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
-    let degree = graph.pruned_degree().get();
-    // Seed every frozen start slot with its source point followed by that
-    // point's outgoing row. Truncation applies the same graph degree bound as
-    // real rows, and including the source guarantees entry into the real graph.
-    let start_neighbors = start_sources
+    // A frozen start slot carries the chosen source vector, so expanding it
+    // must expose exactly that real source's outgoing row. Prepending the source
+    // ID would consume one degree slot and discard a graph edge, changing every
+    // search from the graph produced by the core builder.
+    let start_neighbors: Vec<_> = start_sources
         .into_iter()
-        .map(|source| {
-            let source_id = u32::try_from(source).context("PiPNN start source exceeds u32::MAX")?;
-            let mut neighbors = AdjacencyList::with_capacity(degree);
-            neighbors.push(source_id);
-            neighbors.extend_from_slice(&adjacency[source]);
-            neighbors.truncate(degree);
-            Ok(neighbors)
-        })
-        .collect::<anyhow::Result<Vec<_>>>()?;
+        .map(|source| adjacency[source].clone())
+        .collect();
     let batch_elapsed = started.elapsed();
 
     // Unlike incremental insertion, PiPNN finishes all batch-build scratch
@@ -453,6 +444,7 @@ where
 #[cfg(all(test, feature = "pipnn"))]
 mod pipnn_tests {
     use super::*;
+    use diskann::graph::AdjacencyList;
 
     #[test]
     fn dedicated_pipeline_respects_the_requested_start_strategy() {
@@ -505,9 +497,12 @@ mod pipnn_tests {
             .neighbors()
             .get_neighbors_sync(starts[0] as usize, &mut neighbors)
             .unwrap();
-        assert!(
-            neighbors.contains(0),
-            "start slot must enter the real graph"
-        );
+        let mut source_neighbors = AdjacencyList::new();
+        index
+            .provider()
+            .neighbors()
+            .get_neighbors_sync(0, &mut source_neighbors)
+            .unwrap();
+        assert_eq!(neighbors, source_neighbors);
     }
 }

--- a/diskann-benchmark/src/index/build.rs
+++ b/diskann-benchmark/src/index/build.rs
@@ -134,7 +134,7 @@ where
 /// | vectors, edges, and start-slot installation | yes | searchable provider |
 ///
 /// The returned provider is a benchmark/search adapter; provider concerns do not
-/// leak back into `diskann-pipnn`.
+/// leak back into `diskann::graph::pipnn`.
 pub(crate) fn pipnn_build<T>(
     data: Arc<Matrix<T>>,
     input: &IndexBuild,
@@ -156,9 +156,13 @@ where
 
     let started = std::time::Instant::now();
     let adjacency = {
-        let context =
-            diskann_pipnn::PiPNNBuildContext::new(parameters.into(), &graph, metric, &pool)?;
-        diskann_pipnn::build_graph(data.as_view(), &context)?
+        let context = diskann::graph::pipnn::PiPNNBuildContext::new(
+            parameters.into(),
+            &graph,
+            metric,
+            &pool,
+        )?;
+        diskann::graph::pipnn::build_graph(data.as_view(), &context)?
     };
     let start_points = input
         .start_point_strategy()

--- a/diskann-benchmark/src/index/build.rs
+++ b/diskann-benchmark/src/index/build.rs
@@ -113,28 +113,14 @@ where
 }
 
 #[cfg(feature = "pipnn")]
-/// Run the dedicated batch lifecycle and install its result in a searchable provider.
+/// Build a PiPNN graph and install it in a searchable provider.
 ///
-/// Incremental Vamana interleaves provider allocation with per-point insertion.
-/// PiPNN must not use that path: its partitions and candidate graph are complete
-/// before a provider exists. The benchmark lifecycle is therefore:
+/// PiPNN completes its graph before provider creation. The function also computes
+/// start vectors and their source IDs. It then installs vectors, edges, and start
+/// slots in a new `MemoryIndex`.
 ///
-/// ```text
-/// Arc<Matrix<T>> ──> PiPNN core ──> Vec<AdjacencyList<u32>>
-///       │                                      │
-///       ├──> start vectors ──> source IDs      │
-///       │                                      v
-///       └──────────────────────────────> provider installation ──> MemoryIndex
-/// ```
-///
-/// | Interval | Included in build statistics | Large owner |
-/// | --- | --- | --- |
-/// | batch graph + start computation | yes | input matrix, core stage outputs |
-/// | provider allocation | no (setup, matching incremental path) | empty provider |
-/// | vectors, edges, and start-slot installation | yes | searchable provider |
-///
-/// The returned provider is a benchmark/search adapter; provider concerns do not
-/// leak back into `diskann::graph::pipnn`.
+/// `BuildStats` includes graph construction and provider installation. It does
+/// not include provider allocation.
 pub(crate) fn pipnn_build<T>(
     data: Arc<Matrix<T>>,
     input: &IndexBuild,
@@ -169,10 +155,9 @@ where
         .compute(data.as_view())
         .map_err(ANNError::new)?;
     let distance = T::distance(metric, Some(dimensions));
-    // Provider start vectors occupy frozen slots outside the real point-ID
-    // range. Connect each slot to an identical source row when one exists;
-    // synthetic strategies fall back to the nearest real row under the build
-    // metric. `total_cmp` gives deterministic ordering for all finite/NaN bits.
+    // Start vectors use frozen IDs outside the real point-ID range. Connect each
+    // frozen ID to its source row. For a synthetic start vector, connect it to
+    // the nearest real row. `total_cmp` gives a deterministic total order.
     let start_sources = start_points
         .row_iter()
         .map(|start| {
@@ -192,28 +177,24 @@ where
                 .context("PiPNN cannot connect a start point to an empty dataset")
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
-    // A frozen start slot carries the chosen source vector, so expanding it
-    // must expose exactly that real source's outgoing row. Prepending the source
-    // ID would consume one degree slot and discard a graph edge, changing every
-    // search from the graph produced by the core builder.
+    // A frozen slot stores the selected source vector. Its adjacency must equal
+    // that source row. Adding the source ID would remove one graph edge because
+    // the row has a fixed degree.
     let start_neighbors: Vec<_> = start_sources
         .into_iter()
         .map(|source| adjacency[source].clone())
         .collect();
     let batch_elapsed = started.elapsed();
 
-    // Unlike incremental insertion, PiPNN finishes all batch-build scratch
-    // before allocating the provider that owns the searchable index.
     let index = diskann_async::new_index::<T, _>(
         graph,
         input.inmem_parameters(npoints, dimensions),
         common::NoDeletes,
     )?;
-    // Provider allocation is setup, just as it is for the incremental path;
-    // BuildStats covers graph construction plus provider installation.
+    // `BuildStats` excludes provider allocation and includes provider installation.
     let install_started = std::time::Instant::now();
-    // Install vectors before edges so a successfully returned MemoryIndex never
-    // exposes graph IDs whose source vectors are absent.
+    // Install vectors before edges. A returned index must contain a vector for
+    // every graph ID.
     for (id, vector) in data.row_iter().enumerate() {
         let id = u32::try_from(id).context("PiPNN point ID exceeds u32::MAX")?;
         index.data_provider.base_vectors.set_element(&id, vector)?;
@@ -482,9 +463,9 @@ mod pipnn_tests {
         assert!(stats.insert_latencies.is_none());
         let starts = index.provider().starting_points().unwrap();
         assert_eq!(starts.len(), 1);
-        // SAFETY: `starting_points` returns provider-installed frozen IDs, so
-        // `starts[0] < base_vectors.total()`. The completed build has no concurrent
-        // vector writers, so no mutable alias exists for the returned shared slice.
+        // SAFETY: `starting_points` returns installed frozen IDs. Therefore,
+        // `starts[0] < base_vectors.total()`. The completed build has no vector
+        // writer, so the returned shared slice has no mutable alias.
         let start = unsafe {
             index
                 .data_provider

--- a/diskann-benchmark/src/index/build.rs
+++ b/diskann-benchmark/src/index/build.rs
@@ -245,17 +245,11 @@ where
     }
 
     let total_time = MicroSeconds::from(batch_elapsed + install_started.elapsed());
-    let per_vector = MicroSeconds::new(
-        total_time
-            .as_micros()
-            .checked_div(u64::try_from(npoints)?)
-            .context("PiPNN build received an empty dataset")?,
-    );
     let stats = BuildStats {
         kind: BuildKind::PiPNN,
         total_time,
         vectors_inserted: npoints,
-        insert_latencies: percentiles::compute_percentiles(&mut [per_vector])?,
+        insert_latencies: None,
     };
     Ok((index, stats))
 }
@@ -328,7 +322,8 @@ pub(crate) struct BuildStats {
     pub(crate) kind: BuildKind,
     pub(crate) total_time: MicroSeconds,
     pub(crate) vectors_inserted: usize,
-    pub(crate) insert_latencies: percentiles::Percentiles<MicroSeconds>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) insert_latencies: Option<percentiles::Percentiles<MicroSeconds>>,
 }
 
 impl BuildStats {
@@ -349,7 +344,7 @@ impl BuildStats {
             kind,
             total_time,
             vectors_inserted,
-            insert_latencies: percentiles::compute_percentiles(&mut latencies)?,
+            insert_latencies: Some(percentiles::compute_percentiles(&mut latencies)?),
         })
     }
 }
@@ -359,11 +354,15 @@ impl std::fmt::Display for BuildStats {
         writeln!(f, "Index Build Time: {}s", self.total_time.as_seconds())?;
         writeln!(f, "Vectors Inserted: {}", self.vectors_inserted)?;
         writeln!(f, "Kind: {}", self.kind)?;
-        write!(
-            f,
-            "Insert Latencies:\n  average: {}us\n      p90: {}\n      p99: {}\n\n",
-            self.insert_latencies.mean, self.insert_latencies.p90, self.insert_latencies.p99,
-        )
+        if let Some(latencies) = &self.insert_latencies {
+            write!(
+                f,
+                "Insert Latencies:\n  average: {}us\n      p90: {}\n      p99: {}\n\n",
+                latencies.mean, latencies.p90, latencies.p99,
+            )
+        } else {
+            writeln!(f, "Insert Latencies: not measured for batch construction\n")
+        }
     }
 }
 
@@ -485,6 +484,7 @@ mod pipnn_tests {
 
         let (index, stats) = pipnn_build(Arc::new(data), &input, parameters).unwrap();
         assert_eq!(stats.vectors_inserted, 16);
+        assert!(stats.insert_latencies.is_none());
         let starts = index.provider().starting_points().unwrap();
         assert_eq!(starts.len(), 1);
         // SAFETY: the completed build has no concurrent vector writers.

--- a/diskann-benchmark/src/index/build.rs
+++ b/diskann-benchmark/src/index/build.rs
@@ -482,7 +482,9 @@ mod pipnn_tests {
         assert!(stats.insert_latencies.is_none());
         let starts = index.provider().starting_points().unwrap();
         assert_eq!(starts.len(), 1);
-        // SAFETY: the completed build has no concurrent vector writers.
+        // SAFETY: `starting_points` returns provider-installed frozen IDs, so
+        // `starts[0] < base_vectors.total()`. The completed build has no concurrent
+        // vector writers, so no mutable alias exists for the returned shared slice.
         let start = unsafe {
             index
                 .data_provider

--- a/diskann-benchmark/src/index/build.rs
+++ b/diskann-benchmark/src/index/build.rs
@@ -167,12 +167,7 @@ where
     let start_points = input
         .start_point_strategy()
         .compute(data.as_view())
-        .map_err(|error| {
-            ANNError::new(
-                diskann::ANNErrorKind::DiskANN(StartPointComputeError),
-                error,
-            )
-        })?;
+        .map_err(ANNError::new)?;
     let distance = T::distance(metric, Some(dimensions));
     // Provider start vectors occupy frozen slots outside the real point-ID
     // range. Connect each slot to an identical source row when one exists;

--- a/diskann-benchmark/src/index/build.rs
+++ b/diskann-benchmark/src/index/build.rs
@@ -178,8 +178,8 @@ where
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
     // A frozen slot stores the selected source vector. Its adjacency must equal
-    // that source row. Adding the source ID would remove one graph edge because
-    // the row has a fixed degree.
+    // that source row. Adding the source ID removes one graph edge because the
+    // row has a fixed degree.
     let start_neighbors: Vec<_> = start_sources
         .into_iter()
         .map(|source| adjacency[source].clone())

--- a/diskann-benchmark/src/index/streaming/stats.rs
+++ b/diskann-benchmark/src/index/streaming/stats.rs
@@ -179,9 +179,15 @@ where
                         let mut r = table.row(row);
                         r.insert(stage, 0);
                         r.insert(stats.kind, 1);
-                        r.insert(format!("{:.1}us", stats.insert_latencies.mean), 2);
-                        r.insert(stats.insert_latencies.p90, 3);
-                        r.insert(stats.insert_latencies.p99, 4);
+                        if let Some(latencies) = &stats.insert_latencies {
+                            r.insert(format!("{:.1}us", latencies.mean), 2);
+                            r.insert(latencies.p90, 3);
+                            r.insert(latencies.p99, 4);
+                        } else {
+                            r.insert("not measured", 2);
+                            r.insert("-", 3);
+                            r.insert("-", 4);
+                        }
 
                         row += 1;
                         stage += 1;

--- a/diskann-benchmark/src/inputs/disk.rs
+++ b/diskann-benchmark/src/inputs/disk.rs
@@ -15,6 +15,8 @@ use diskann_benchmark_runner::{files::InputFile, utils::datatype::DataType, Chec
 #[cfg(feature = "disk-index")]
 use diskann_disk::search::search_mode::SearchMode;
 #[cfg(feature = "disk-index")]
+use diskann_disk::BuildAlgorithm;
+#[cfg(feature = "disk-index")]
 use diskann_disk::QuantizationType;
 use diskann_providers::storage::{get_compressed_pq_file, get_disk_index_file, get_pq_pivot_file};
 use serde::{Deserialize, Serialize};
@@ -64,12 +66,25 @@ pub(crate) struct DiskIndexBuild {
     pub(crate) dim: usize,
     pub(crate) max_degree: usize,
     pub(crate) l_build: usize,
+    #[serde(default = "default_alpha")]
+    pub(crate) alpha: f32,
     pub(crate) num_threads: usize,
+    /// Graph-build RAM limit. PiPNN falls back to Vamana when its estimated
+    /// one-shot peak exceeds this value.
     pub(crate) build_ram_limit_gb: f64,
     pub(crate) num_pq_chunks: NonZeroUsize,
     #[cfg(feature = "disk-index")]
-    pub(crate) quantization_type: QuantizationType,
+    #[serde(default)]
+    pub(crate) quantization_type: Option<QuantizationType>,
+    /// Build algorithm: "Vamana" (default) or "PiPNN" with config params.
+    #[cfg(feature = "disk-index")]
+    #[serde(default)]
+    pub(crate) build_algorithm: BuildAlgorithm,
     pub(crate) save_path: String,
+}
+
+fn default_alpha() -> f32 {
+    diskann::graph::config::defaults::ALPHA
 }
 
 #[cfg(feature = "disk-index")]
@@ -230,10 +245,23 @@ impl DiskIndexBuild {
         if self.num_threads == 0 {
             anyhow::bail!("num_threads must be positive");
         }
-        if self.build_ram_limit_gb <= 0.0 {
+        if !self.alpha.is_finite() || self.alpha < 1.0 {
+            anyhow::bail!("alpha must be finite and at least 1.0");
+        }
+        if !self.build_ram_limit_gb.is_finite() || self.build_ram_limit_gb <= 0.0 {
             anyhow::bail!("build_ram_limit_gb must be strictly positive");
         }
-
+        #[cfg(feature = "disk-index")]
+        match &self.build_algorithm {
+            BuildAlgorithm::Vamana if self.quantization_type.is_none() => {
+                anyhow::bail!("quantization_type is required for Vamana builds");
+            }
+            #[cfg(feature = "pipnn")]
+            BuildAlgorithm::PiPNN(_) if self.quantization_type.is_some() => {
+                anyhow::bail!("PiPNN graph construction is full precision; omit quantization_type");
+            }
+            _ => {}
+        }
         // Relative save path with respect to output directory is not supported.
         if checker.output_directory().is_some() {
             anyhow::bail!("relative save_path with respect to output_directory is not supported");
@@ -338,11 +366,14 @@ impl Example for DiskIndexOperation {
             dim: 128,
             max_degree: 32,
             l_build: 50,
+            alpha: default_alpha(),
             num_threads: 8,
             build_ram_limit_gb: 16.0,
             num_pq_chunks: NonZeroUsize::new(16).unwrap(),
             #[cfg(feature = "disk-index")]
-            quantization_type: QuantizationType::PQ { num_chunks: 16 },
+            quantization_type: Some(QuantizationType::PQ { num_chunks: 16 }),
+            #[cfg(feature = "disk-index")]
+            build_algorithm: BuildAlgorithm::default(),
             save_path: "sample_index_l50_r32".to_string(),
         };
 
@@ -422,30 +453,35 @@ impl DiskIndexBuild {
         write_field!(f, "Dim", self.dim)?;
         write_field!(f, "Max Degree", self.max_degree)?;
         write_field!(f, "L Build", self.l_build)?;
+        write_field!(f, "Alpha", self.alpha)?;
         write_field!(f, "Build Threads", self.num_threads)?;
         write_field!(f, "Build RAM Limit GB", self.build_ram_limit_gb)?;
         write_field!(f, "PQ Chunks", self.num_pq_chunks)?;
         #[cfg(feature = "disk-index")]
-        match &self.quantization_type {
-            QuantizationType::FP => write_field!(f, "Quantization", "full precision")?,
-            QuantizationType::PQ { num_chunks } => {
-                write_field!(f, "Quantization", format!("pq, chunks {num_chunks}"))?
-            }
-            QuantizationType::SQ {
-                nbits,
-                standard_deviation,
-            } => {
-                if let Some(sd) = standard_deviation {
-                    write_field!(
-                        f,
-                        "Quantization",
-                        format!("sq, nbits {nbits}, stdev {}", sd.into_inner())
-                    )?
-                } else {
-                    write_field!(f, "Quantization", format!("sq, nbits {nbits}"))?
+        if let Some(quantization_type) = &self.quantization_type {
+            match quantization_type {
+                QuantizationType::FP => write_field!(f, "Quantization", "full precision")?,
+                QuantizationType::PQ { num_chunks } => {
+                    write_field!(f, "Quantization", format!("pq, chunks {num_chunks}"))?
+                }
+                QuantizationType::SQ {
+                    nbits,
+                    standard_deviation,
+                } => {
+                    if let Some(sd) = standard_deviation {
+                        write_field!(
+                            f,
+                            "Quantization",
+                            format!("sq, nbits {nbits}, stdev {}", sd.into_inner())
+                        )?
+                    } else {
+                        write_field!(f, "Quantization", format!("sq, nbits {nbits}"))?
+                    }
                 }
             }
         }
+        #[cfg(feature = "disk-index")]
+        write_field!(f, "Build Algorithm", self.build_algorithm)?;
         write_field!(f, "Save Path", self.save_path)?;
         Ok(())
     }

--- a/diskann-benchmark/src/inputs/disk.rs
+++ b/diskann-benchmark/src/inputs/disk.rs
@@ -69,14 +69,14 @@ pub(crate) struct DiskIndexBuild {
     #[serde(default = "default_alpha")]
     pub(crate) alpha: f32,
     pub(crate) num_threads: usize,
-    /// Memory budget for bounded disk-index pipeline stages. Explicit PiPNN
-    /// graph construction remains one-shot and is not silently replaced.
+    /// Memory budget for disk-index stages that support bounded work.
+    /// PiPNN always uses its one-shot graph build.
     pub(crate) build_ram_limit_gb: f64,
     pub(crate) num_pq_chunks: NonZeroUsize,
     #[cfg(feature = "disk-index")]
     #[serde(default)]
     pub(crate) quantization_type: Option<QuantizationType>,
-    /// Build algorithm: "Vamana" (default) or "PiPNN" with config params.
+    /// Build algorithm: `Vamana` by default, or `PiPNN` with its parameters.
     #[cfg(feature = "disk-index")]
     #[serde(default)]
     pub(crate) build_algorithm: BuildAlgorithm,

--- a/diskann-benchmark/src/inputs/disk.rs
+++ b/diskann-benchmark/src/inputs/disk.rs
@@ -478,12 +478,12 @@ impl DiskIndexBuild {
                         write_field!(f, "Quantization", format!("sq, nbits {nbits}"))?
                     }
                 }
+                QuantizationType::Spherical(bits) => write_field!(
+                    f,
+                    "Quantization",
+                    format!("spherical, nbits {}", bits.as_usize())
+                )?,
             }
-            QuantizationType::Spherical(bits) => write_field!(
-                f,
-                "Quantization",
-                format!("spherical, nbits {}", bits.as_usize())
-            )?,
         }
         #[cfg(feature = "disk-index")]
         write_field!(f, "Build Algorithm", self.build_algorithm)?;

--- a/diskann-benchmark/src/inputs/disk.rs
+++ b/diskann-benchmark/src/inputs/disk.rs
@@ -69,8 +69,8 @@ pub(crate) struct DiskIndexBuild {
     #[serde(default = "default_alpha")]
     pub(crate) alpha: f32,
     pub(crate) num_threads: usize,
-    /// Graph-build RAM limit. PiPNN falls back to Vamana when its estimated
-    /// one-shot peak exceeds this value.
+    /// Memory budget for bounded disk-index pipeline stages. Explicit PiPNN
+    /// graph construction remains one-shot and is not silently replaced.
     pub(crate) build_ram_limit_gb: f64,
     pub(crate) num_pq_chunks: NonZeroUsize,
     #[cfg(feature = "disk-index")]

--- a/diskann-benchmark/src/inputs/disk.rs
+++ b/diskann-benchmark/src/inputs/disk.rs
@@ -15,6 +15,8 @@ use diskann_benchmark_runner::{files::InputFile, utils::datatype::DataType, Chec
 #[cfg(feature = "disk-index")]
 use diskann_disk::search::search_mode::SearchMode;
 #[cfg(feature = "disk-index")]
+use diskann_disk::BuildAlgorithm;
+#[cfg(feature = "disk-index")]
 use diskann_disk::QuantizationType;
 use diskann_providers::storage::{get_compressed_pq_file, get_disk_index_file, get_pq_pivot_file};
 use serde::{Deserialize, Serialize};
@@ -64,12 +66,25 @@ pub(crate) struct DiskIndexBuild {
     pub(crate) dim: usize,
     pub(crate) max_degree: usize,
     pub(crate) l_build: usize,
+    #[serde(default = "default_alpha")]
+    pub(crate) alpha: f32,
     pub(crate) num_threads: usize,
+    /// Graph-build RAM limit. PiPNN falls back to Vamana when its estimated
+    /// one-shot peak exceeds this value.
     pub(crate) build_ram_limit_gb: f64,
     pub(crate) num_pq_chunks: NonZeroUsize,
     #[cfg(feature = "disk-index")]
-    pub(crate) quantization_type: QuantizationType,
+    #[serde(default)]
+    pub(crate) quantization_type: Option<QuantizationType>,
+    /// Build algorithm: "Vamana" (default) or "PiPNN" with config params.
+    #[cfg(feature = "disk-index")]
+    #[serde(default)]
+    pub(crate) build_algorithm: BuildAlgorithm,
     pub(crate) save_path: String,
+}
+
+fn default_alpha() -> f32 {
+    diskann::graph::config::defaults::ALPHA
 }
 
 #[cfg(feature = "disk-index")]
@@ -230,10 +245,23 @@ impl DiskIndexBuild {
         if self.num_threads == 0 {
             anyhow::bail!("num_threads must be positive");
         }
-        if self.build_ram_limit_gb <= 0.0 {
+        if !self.alpha.is_finite() || self.alpha < 1.0 {
+            anyhow::bail!("alpha must be finite and at least 1.0");
+        }
+        if !self.build_ram_limit_gb.is_finite() || self.build_ram_limit_gb <= 0.0 {
             anyhow::bail!("build_ram_limit_gb must be strictly positive");
         }
-
+        #[cfg(feature = "disk-index")]
+        match &self.build_algorithm {
+            BuildAlgorithm::Vamana if self.quantization_type.is_none() => {
+                anyhow::bail!("quantization_type is required for Vamana builds");
+            }
+            #[cfg(feature = "pipnn")]
+            BuildAlgorithm::PiPNN(_) if self.quantization_type.is_some() => {
+                anyhow::bail!("PiPNN graph construction is full precision; omit quantization_type");
+            }
+            _ => {}
+        }
         // Relative save path with respect to output directory is not supported.
         if checker.output_directory().is_some() {
             anyhow::bail!("relative save_path with respect to output_directory is not supported");
@@ -338,11 +366,14 @@ impl Example for DiskIndexOperation {
             dim: 128,
             max_degree: 32,
             l_build: 50,
+            alpha: default_alpha(),
             num_threads: 8,
             build_ram_limit_gb: 16.0,
             num_pq_chunks: NonZeroUsize::new(16).unwrap(),
             #[cfg(feature = "disk-index")]
-            quantization_type: QuantizationType::PQ { num_chunks: 16 },
+            quantization_type: Some(QuantizationType::PQ { num_chunks: 16 }),
+            #[cfg(feature = "disk-index")]
+            build_algorithm: BuildAlgorithm::default(),
             save_path: "sample_index_l50_r32".to_string(),
         };
 
@@ -422,27 +453,30 @@ impl DiskIndexBuild {
         write_field!(f, "Dim", self.dim)?;
         write_field!(f, "Max Degree", self.max_degree)?;
         write_field!(f, "L Build", self.l_build)?;
+        write_field!(f, "Alpha", self.alpha)?;
         write_field!(f, "Build Threads", self.num_threads)?;
         write_field!(f, "Build RAM Limit GB", self.build_ram_limit_gb)?;
         write_field!(f, "PQ Chunks", self.num_pq_chunks)?;
         #[cfg(feature = "disk-index")]
-        match &self.quantization_type {
-            QuantizationType::FP => write_field!(f, "Quantization", "full precision")?,
-            QuantizationType::PQ { num_chunks } => {
-                write_field!(f, "Quantization", format!("pq, chunks {num_chunks}"))?
-            }
-            QuantizationType::SQ {
-                nbits,
-                standard_deviation,
-            } => {
-                if let Some(sd) = standard_deviation {
-                    write_field!(
-                        f,
-                        "Quantization",
-                        format!("sq, nbits {nbits}, stdev {}", sd.into_inner())
-                    )?
-                } else {
-                    write_field!(f, "Quantization", format!("sq, nbits {nbits}"))?
+        if let Some(quantization_type) = &self.quantization_type {
+            match quantization_type {
+                QuantizationType::FP => write_field!(f, "Quantization", "full precision")?,
+                QuantizationType::PQ { num_chunks } => {
+                    write_field!(f, "Quantization", format!("pq, chunks {num_chunks}"))?
+                }
+                QuantizationType::SQ {
+                    nbits,
+                    standard_deviation,
+                } => {
+                    if let Some(sd) = standard_deviation {
+                        write_field!(
+                            f,
+                            "Quantization",
+                            format!("sq, nbits {nbits}, stdev {}", sd.into_inner())
+                        )?
+                    } else {
+                        write_field!(f, "Quantization", format!("sq, nbits {nbits}"))?
+                    }
                 }
             }
             QuantizationType::Spherical(bits) => write_field!(
@@ -451,6 +485,8 @@ impl DiskIndexBuild {
                 format!("spherical, nbits {}", bits.as_usize())
             )?,
         }
+        #[cfg(feature = "disk-index")]
+        write_field!(f, "Build Algorithm", self.build_algorithm)?;
         write_field!(f, "Save Path", self.save_path)?;
         Ok(())
     }

--- a/diskann-benchmark/src/inputs/graph_index.rs
+++ b/diskann-benchmark/src/inputs/graph_index.rs
@@ -725,6 +725,30 @@ pub(crate) struct IndexBuild {
     #[cfg(feature = "pipnn")]
     #[serde(default)]
     build_algorithm: diskann_disk::BuildAlgorithm,
+    #[cfg(not(feature = "pipnn"))]
+    #[serde(default)]
+    build_algorithm: Option<serde_json::Value>,
+}
+
+#[cfg(not(feature = "pipnn"))]
+fn validate_disabled_build_algorithm(
+    build_algorithm: Option<&serde_json::Value>,
+) -> Result<(), anyhow::Error> {
+    let Some(build_algorithm) = build_algorithm else {
+        return Ok(());
+    };
+    let algorithm = build_algorithm
+        .as_object()
+        .and_then(|object| object.get("algorithm"))
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| anyhow!("build_algorithm must be an object containing an algorithm tag"))?;
+    match algorithm {
+        "Vamana" => Ok(()),
+        "PiPNN" => Err(anyhow!(
+            "PiPNN graph construction requires the `pipnn` feature"
+        )),
+        other => Err(anyhow!("unrecognized graph build algorithm `{other}`")),
+    }
 }
 
 impl IndexBuild {
@@ -830,6 +854,9 @@ impl IndexBuild {
     }
 
     pub(crate) fn validate(&mut self, checker: &mut Checker) -> Result<(), anyhow::Error> {
+        #[cfg(not(feature = "pipnn"))]
+        validate_disabled_build_algorithm(self.build_algorithm.as_ref())?;
+
         self.data.resolve(checker)?;
 
         // We allow overwriting of already existing save paths, since users like to do this
@@ -909,6 +936,8 @@ impl Example for IndexBuild {
             save_path: None,
             #[cfg(feature = "pipnn")]
             build_algorithm: diskann_disk::BuildAlgorithm::Vamana,
+            #[cfg(not(feature = "pipnn"))]
+            build_algorithm: None,
         }
     }
 }
@@ -1497,5 +1526,25 @@ impl std::fmt::Display for DynamicIndexRun {
         self.build.summarize_fields(f)?;
 
         Ok(())
+    }
+}
+
+#[cfg(all(test, not(feature = "pipnn")))]
+mod disabled_pipnn_tests {
+    use super::*;
+
+    #[test]
+    fn pipnn_request_fails_closed_without_the_feature() {
+        let pipnn = serde_json::json!({
+            "algorithm": "PiPNN",
+            "c_max": 512,
+            "fanout": [8, 3]
+        });
+        let error = validate_disabled_build_algorithm(Some(&pipnn)).unwrap_err();
+        assert!(error.to_string().contains("requires the `pipnn` feature"));
+
+        let vamana = serde_json::json!({ "algorithm": "Vamana" });
+        validate_disabled_build_algorithm(Some(&vamana)).unwrap();
+        validate_disabled_build_algorithm(None).unwrap();
     }
 }

--- a/diskann-benchmark/src/inputs/graph_index.rs
+++ b/diskann-benchmark/src/inputs/graph_index.rs
@@ -683,6 +683,30 @@ pub(crate) struct IndexBuild {
     #[cfg(feature = "pipnn")]
     #[serde(default)]
     build_algorithm: diskann_disk::BuildAlgorithm,
+    #[cfg(not(feature = "pipnn"))]
+    #[serde(default)]
+    build_algorithm: Option<serde_json::Value>,
+}
+
+#[cfg(not(feature = "pipnn"))]
+fn validate_disabled_build_algorithm(
+    build_algorithm: Option<&serde_json::Value>,
+) -> Result<(), anyhow::Error> {
+    let Some(build_algorithm) = build_algorithm else {
+        return Ok(());
+    };
+    let algorithm = build_algorithm
+        .as_object()
+        .and_then(|object| object.get("algorithm"))
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| anyhow!("build_algorithm must be an object containing an algorithm tag"))?;
+    match algorithm {
+        "Vamana" => Ok(()),
+        "PiPNN" => Err(anyhow!(
+            "PiPNN graph construction requires the `pipnn` feature"
+        )),
+        other => Err(anyhow!("unrecognized graph build algorithm `{other}`")),
+    }
 }
 
 impl IndexBuild {
@@ -788,6 +812,9 @@ impl IndexBuild {
     }
 
     pub(crate) fn validate(&mut self, checker: &mut Checker) -> Result<(), anyhow::Error> {
+        #[cfg(not(feature = "pipnn"))]
+        validate_disabled_build_algorithm(self.build_algorithm.as_ref())?;
+
         self.data.resolve(checker)?;
 
         // We allow overwriting of already existing save paths, since users like to do this
@@ -867,6 +894,8 @@ impl Example for IndexBuild {
             save_path: None,
             #[cfg(feature = "pipnn")]
             build_algorithm: diskann_disk::BuildAlgorithm::Vamana,
+            #[cfg(not(feature = "pipnn"))]
+            build_algorithm: None,
         }
     }
 }
@@ -1455,5 +1484,25 @@ impl std::fmt::Display for DynamicIndexRun {
         self.build.summarize_fields(f)?;
 
         Ok(())
+    }
+}
+
+#[cfg(all(test, not(feature = "pipnn")))]
+mod disabled_pipnn_tests {
+    use super::*;
+
+    #[test]
+    fn pipnn_request_fails_closed_without_the_feature() {
+        let pipnn = serde_json::json!({
+            "algorithm": "PiPNN",
+            "c_max": 512,
+            "fanout": [8, 3]
+        });
+        let error = validate_disabled_build_algorithm(Some(&pipnn)).unwrap_err();
+        assert!(error.to_string().contains("requires the `pipnn` feature"));
+
+        let vamana = serde_json::json!({ "algorithm": "Vamana" });
+        validate_disabled_build_algorithm(Some(&vamana)).unwrap();
+        validate_disabled_build_algorithm(None).unwrap();
     }
 }

--- a/diskann-benchmark/src/inputs/graph_index.rs
+++ b/diskann-benchmark/src/inputs/graph_index.rs
@@ -969,6 +969,10 @@ impl std::fmt::Display for IndexBuild {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "index-source")] // Use tagged enums for JSON
+#[allow(
+    clippy::large_enum_variant,
+    reason = "build configuration is parsed once; boxing would add indirection to every source access"
+)]
 pub enum IndexSource {
     Load(IndexLoad),
     Build(IndexBuild),

--- a/diskann-benchmark/src/inputs/graph_index.rs
+++ b/diskann-benchmark/src/inputs/graph_index.rs
@@ -730,6 +730,21 @@ pub(crate) struct IndexBuild {
     build_algorithm: Option<serde_json::Value>,
 }
 
+#[cfg(feature = "pipnn")]
+fn validate_dynamic_build_algorithm(
+    build_algorithm: &diskann_disk::BuildAlgorithm,
+) -> Result<(), anyhow::Error> {
+    match build_algorithm {
+        diskann_disk::BuildAlgorithm::Vamana => Ok(()),
+        diskann_disk::BuildAlgorithm::PiPNN(_) => Err(anyhow!(
+            "PiPNN is a batch builder and is not supported by graph-index-dynamic-run"
+        )),
+        _ => Err(anyhow!(
+            "the selected graph build algorithm is not supported by graph-index-dynamic-run"
+        )),
+    }
+}
+
 #[cfg(not(feature = "pipnn"))]
 fn validate_disabled_build_algorithm(
     build_algorithm: Option<&serde_json::Value>,
@@ -1481,6 +1496,9 @@ impl DynamicIndexRun {
     }
 
     pub(crate) fn validate(&mut self, checker: &mut Checker) -> anyhow::Result<()> {
+        #[cfg(feature = "pipnn")]
+        validate_dynamic_build_algorithm(self.build.build_algorithm())?;
+
         self.build.validate(checker)?;
         self.runbook_params.validate(checker)?;
         self.search_phase.validate(checker)?;
@@ -1526,6 +1544,21 @@ impl std::fmt::Display for DynamicIndexRun {
         self.build.summarize_fields(f)?;
 
         Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "pipnn"))]
+mod dynamic_pipnn_tests {
+    use super::*;
+
+    #[test]
+    fn dynamic_run_rejects_the_batch_only_pipnn_algorithm() {
+        let error = validate_dynamic_build_algorithm(&diskann_disk::BuildAlgorithm::PiPNN(
+            diskann_disk::PiPNNParameters::default(),
+        ))
+        .unwrap_err();
+        assert!(error.to_string().contains("not supported"));
+        validate_dynamic_build_algorithm(&diskann_disk::BuildAlgorithm::Vamana).unwrap();
     }
 }
 

--- a/diskann-benchmark/src/inputs/graph_index.rs
+++ b/diskann-benchmark/src/inputs/graph_index.rs
@@ -688,6 +688,21 @@ pub(crate) struct IndexBuild {
     build_algorithm: Option<serde_json::Value>,
 }
 
+#[cfg(feature = "pipnn")]
+fn validate_dynamic_build_algorithm(
+    build_algorithm: &diskann_disk::BuildAlgorithm,
+) -> Result<(), anyhow::Error> {
+    match build_algorithm {
+        diskann_disk::BuildAlgorithm::Vamana => Ok(()),
+        diskann_disk::BuildAlgorithm::PiPNN(_) => Err(anyhow!(
+            "PiPNN is a batch builder and is not supported by graph-index-dynamic-run"
+        )),
+        _ => Err(anyhow!(
+            "the selected graph build algorithm is not supported by graph-index-dynamic-run"
+        )),
+    }
+}
+
 #[cfg(not(feature = "pipnn"))]
 fn validate_disabled_build_algorithm(
     build_algorithm: Option<&serde_json::Value>,
@@ -1439,6 +1454,9 @@ impl DynamicIndexRun {
     }
 
     pub(crate) fn validate(&mut self, checker: &mut Checker) -> anyhow::Result<()> {
+        #[cfg(feature = "pipnn")]
+        validate_dynamic_build_algorithm(self.build.build_algorithm())?;
+
         self.build.validate(checker)?;
         self.runbook_params.validate(checker)?;
         self.search_phase.validate(checker)?;
@@ -1484,6 +1502,21 @@ impl std::fmt::Display for DynamicIndexRun {
         self.build.summarize_fields(f)?;
 
         Ok(())
+    }
+}
+
+#[cfg(all(test, feature = "pipnn"))]
+mod dynamic_pipnn_tests {
+    use super::*;
+
+    #[test]
+    fn dynamic_run_rejects_the_batch_only_pipnn_algorithm() {
+        let error = validate_dynamic_build_algorithm(&diskann_disk::BuildAlgorithm::PiPNN(
+            diskann_disk::PiPNNParameters::default(),
+        ))
+        .unwrap_err();
+        assert!(error.to_string().contains("not supported"));
+        validate_dynamic_build_algorithm(&diskann_disk::BuildAlgorithm::Vamana).unwrap();
     }
 }
 

--- a/diskann-benchmark/src/inputs/graph_index.rs
+++ b/diskann-benchmark/src/inputs/graph_index.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-use std::num::{NonZero, NonZeroU32, NonZeroUsize};
+use std::num::{NonZeroU32, NonZeroUsize};
 
 use anyhow::{anyhow, Context};
 use diskann::{
@@ -722,6 +722,9 @@ pub(crate) struct IndexBuild {
     num_threads: usize,
     multi_insert: Option<MultiInsert>,
     save_path: Option<String>,
+    #[cfg(feature = "pipnn")]
+    #[serde(default)]
+    build_algorithm: diskann_disk::BuildAlgorithm,
 }
 
 impl IndexBuild {
@@ -787,9 +790,12 @@ impl IndexBuild {
         num_points: usize,
         dim: usize,
     ) -> DefaultProviderParameters {
+        let frozen_points =
+            NonZeroUsize::new(self.start_point_strategy.count()).unwrap_or(NonZeroUsize::MIN);
+
         DefaultProviderParameters {
             max_points: num_points,
-            frozen_points: NonZero::new(self.start_point_strategy.count()).unwrap(),
+            frozen_points,
             metric: self.distance.into(),
             dim,
             max_degree: self.exact_max_degree() as u32,
@@ -855,7 +861,11 @@ impl IndexBuild {
         self.num_threads
     }
 
-    #[cfg(any(feature = "spherical-quantization", feature = "bftree"))]
+    #[cfg(any(
+        feature = "spherical-quantization",
+        feature = "bftree",
+        feature = "pipnn"
+    ))]
     pub(crate) fn distance(&self) -> SimilarityMeasure {
         self.distance
     }
@@ -875,6 +885,11 @@ impl IndexBuild {
     pub(crate) fn save_path(&self) -> Option<&str> {
         self.save_path.as_deref()
     }
+
+    #[cfg(feature = "pipnn")]
+    pub(crate) fn build_algorithm(&self) -> &diskann_disk::BuildAlgorithm {
+        &self.build_algorithm
+    }
 }
 
 impl Example for IndexBuild {
@@ -892,6 +907,8 @@ impl Example for IndexBuild {
             insert_retry: None,
             start_point_strategy: StartPointStrategy::Medoid,
             save_path: None,
+            #[cfg(feature = "pipnn")]
+            build_algorithm: diskann_disk::BuildAlgorithm::Vamana,
         }
     }
 }

--- a/diskann-benchmark/src/inputs/graph_index.rs
+++ b/diskann-benchmark/src/inputs/graph_index.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-use std::num::{NonZero, NonZeroU32, NonZeroUsize};
+use std::num::{NonZeroU32, NonZeroUsize};
 
 use anyhow::{anyhow, Context};
 use diskann::{
@@ -680,6 +680,9 @@ pub(crate) struct IndexBuild {
     num_threads: usize,
     multi_insert: Option<MultiInsert>,
     save_path: Option<String>,
+    #[cfg(feature = "pipnn")]
+    #[serde(default)]
+    build_algorithm: diskann_disk::BuildAlgorithm,
 }
 
 impl IndexBuild {
@@ -745,9 +748,12 @@ impl IndexBuild {
         num_points: usize,
         dim: usize,
     ) -> DefaultProviderParameters {
+        let frozen_points =
+            NonZeroUsize::new(self.start_point_strategy.count()).unwrap_or(NonZeroUsize::MIN);
+
         DefaultProviderParameters {
             max_points: num_points,
-            frozen_points: NonZero::new(self.start_point_strategy.count()).unwrap(),
+            frozen_points,
             metric: self.distance.into(),
             dim,
             max_degree: self.exact_max_degree() as u32,
@@ -813,7 +819,11 @@ impl IndexBuild {
         self.num_threads
     }
 
-    #[cfg(any(feature = "spherical-quantization", feature = "bftree"))]
+    #[cfg(any(
+        feature = "spherical-quantization",
+        feature = "bftree",
+        feature = "pipnn"
+    ))]
     pub(crate) fn distance(&self) -> SimilarityMeasure {
         self.distance
     }
@@ -833,6 +843,11 @@ impl IndexBuild {
     pub(crate) fn save_path(&self) -> Option<&str> {
         self.save_path.as_deref()
     }
+
+    #[cfg(feature = "pipnn")]
+    pub(crate) fn build_algorithm(&self) -> &diskann_disk::BuildAlgorithm {
+        &self.build_algorithm
+    }
 }
 
 impl Example for IndexBuild {
@@ -850,6 +865,8 @@ impl Example for IndexBuild {
             insert_retry: None,
             start_point_strategy: StartPointStrategy::Medoid,
             save_path: None,
+            #[cfg(feature = "pipnn")]
+            build_algorithm: diskann_disk::BuildAlgorithm::Vamana,
         }
     }
 }

--- a/diskann-benchmark/src/inputs/graph_index.rs
+++ b/diskann-benchmark/src/inputs/graph_index.rs
@@ -927,6 +927,10 @@ impl std::fmt::Display for IndexBuild {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "index-source")] // Use tagged enums for JSON
+#[allow(
+    clippy::large_enum_variant,
+    reason = "build configuration is parsed once; boxing would add indirection to every source access"
+)]
 pub enum IndexSource {
     Load(IndexLoad),
     Build(IndexBuild),

--- a/diskann-benchmark/src/main.rs
+++ b/diskann-benchmark/src/main.rs
@@ -312,6 +312,25 @@ mod tests {
         run_integration_test(raw);
     }
 
+    #[test]
+    #[cfg(feature = "pipnn")]
+    fn pipnn_graph_index_integration() {
+        let raw = value_from_file(&example_directory().join("pipnn-graph-index.json"));
+        run_integration_test(raw);
+    }
+
+    #[test]
+    #[cfg(all(feature = "disk-index", feature = "pipnn"))]
+    fn pipnn_disk_index_integration() {
+        let mut raw = value_from_file(&example_directory().join("pipnn-disk-index.json"));
+        let directory = tempfile::tempdir().unwrap();
+        let save_path = directory.path().join("pipnn_disk_index");
+        *raw.pointer_mut("/jobs/0/content/source/save_path")
+            .expect("PiPNN disk example must declare save_path") =
+            Value::String(save_path.to_string_lossy().into_owned());
+        run_integration_test(raw);
+    }
+
     /////////////////////////
     //    Flat Search      //
     /////////////////////////

--- a/diskann-benchmark/src/main.rs
+++ b/diskann-benchmark/src/main.rs
@@ -264,7 +264,7 @@ mod tests {
         }
     }
 
-    fn run_integration_test(mut raw: serde_json::Value) {
+    fn run_integration_test(mut raw: serde_json::Value) -> Vec<Value> {
         // First, parse and modify the input file to establish paths relative to the
         // directory building the dispatcher.
         // let mut raw = serde_json::from_str(json_string).unwrap();
@@ -299,6 +299,7 @@ mod tests {
 
         let results: Vec<Value> = load_from_file(&output_path);
         assert_eq!(results.len(), num_jobs(&raw));
+        results
     }
 
     ////////////////////////////////
@@ -314,7 +315,11 @@ mod tests {
     #[cfg(feature = "pipnn")]
     fn pipnn_graph_index_integration() {
         let raw = value_from_file(&example_directory().join("pipnn-graph-index.json"));
-        run_integration_test(raw);
+        let results = run_integration_test(raw);
+        let result = &results[0]["results"];
+        assert_eq!(result["build"]["kind"], "PiPNN");
+        assert_eq!(result["build"]["vectors_inserted"], 256);
+        assert_eq!(result["search"]["Topk"].as_array().unwrap().len(), 3);
     }
 
     #[test]

--- a/diskann-benchmark/src/main.rs
+++ b/diskann-benchmark/src/main.rs
@@ -310,6 +310,25 @@ mod tests {
         run_integration_test(raw);
     }
 
+    #[test]
+    #[cfg(feature = "pipnn")]
+    fn pipnn_graph_index_integration() {
+        let raw = value_from_file(&example_directory().join("pipnn-graph-index.json"));
+        run_integration_test(raw);
+    }
+
+    #[test]
+    #[cfg(all(feature = "disk-index", feature = "pipnn"))]
+    fn pipnn_disk_index_integration() {
+        let mut raw = value_from_file(&example_directory().join("pipnn-disk-index.json"));
+        let directory = tempfile::tempdir().unwrap();
+        let save_path = directory.path().join("pipnn_disk_index");
+        *raw.pointer_mut("/jobs/0/content/source/save_path")
+            .expect("PiPNN disk example must declare save_path") =
+            Value::String(save_path.to_string_lossy().into_owned());
+        run_integration_test(raw);
+    }
+
     /////////////////////////
     //    Flat Search      //
     /////////////////////////

--- a/diskann-benchmark/src/main.rs
+++ b/diskann-benchmark/src/main.rs
@@ -266,7 +266,7 @@ mod tests {
         }
     }
 
-    fn run_integration_test(mut raw: serde_json::Value) {
+    fn run_integration_test(mut raw: serde_json::Value) -> Vec<Value> {
         // First, parse and modify the input file to establish paths relative to the
         // directory building the dispatcher.
         // let mut raw = serde_json::from_str(json_string).unwrap();
@@ -301,6 +301,7 @@ mod tests {
 
         let results: Vec<Value> = load_from_file(&output_path);
         assert_eq!(results.len(), num_jobs(&raw));
+        results
     }
 
     ////////////////////////////////
@@ -316,7 +317,11 @@ mod tests {
     #[cfg(feature = "pipnn")]
     fn pipnn_graph_index_integration() {
         let raw = value_from_file(&example_directory().join("pipnn-graph-index.json"));
-        run_integration_test(raw);
+        let results = run_integration_test(raw);
+        let result = &results[0]["results"];
+        assert_eq!(result["build"]["kind"], "PiPNN");
+        assert_eq!(result["build"]["vectors_inserted"], 256);
+        assert_eq!(result["search"]["Topk"].as_array().unwrap().len(), 3);
     }
 
     #[test]


### PR DESCRIPTION
## Purpose

This PR adds dedicated benchmark routes for PiPNN graph and disk builds.

PiPNN builds adjacency in one batch. The benchmark must not use the incremental Vamana insertion path.

## Main changes

- Graph inputs accept `BuildAlgorithm::PiPNN`.
- `pipnn_build` creates the requested Rayon pool and calls the PiPNN core.
- The graph route installs vectors, adjacency rows, and frozen start points after the batch build.
- The disk route calls the production builder from #1291.
- Feature-disabled PiPNN requests fail with an error.
- Dynamic graph jobs reject the batch-only algorithm.
- Example JSON files cover graph and disk routes.

`BuildStats` reports one batch duration. It does not report synthetic per-insert latency.

## Review order

1. Review PiPNN input parsing in `inputs/graph_index.rs` and `inputs/disk.rs`.
2. Review `index/build.rs::pipnn_build` in execution order.
3. Review route selection in `index/benchmarks.rs`.
4. Review the disk route into `diskann-disk`.
5. Review example inputs and CLI tests.

## Validation

- Tests check the requested start strategy and frozen adjacency.
- Tests check that batch builds omit insert percentiles.
- Tests check feature-disabled and dynamic-job errors.
- CLI tests cover graph and disk dispatch.
- All-target Clippy passes.

## Stack

Stack 5/6. Depends on #1291. #1295 adds optional HashPrune merging.