### PR TITLE
[vectorset] Update docs

### DIFF
--- a/diskann-garnet/README.md
+++ b/diskann-garnet/README.md
@@ -1,35 +1,44 @@
 # diskann-garnet
 
-This crate providers an implementation of `DataProvider` for
+This crate provides an implementation of `DataProvider` for
 [Garnet](https://github.com/microsoft/garnet) as well as FFI endpoints for
 Garnet to access DiskANN functionality. Garnet is a remote cache service
-developed by Microsoft Research, offers Redis compatibility, and has better
+developed by Microsoft Research with Redis compatibility, and has better
 performance, throughput, and lower latency than competitors. With this crate, it
 also supports vector sets, allowing clients to use vector sets for ANN indexing
 and search.
 
 ## Supported Features
 
-diskann-garnet currently supports full precision vectors only with cosine
-distance metrics.
+diskann-garnet currently supports vectors with element types of 32-bit float and 8-bit signed or unsigned integers. Indexes can be full precision or quantized. When the index is quantized, the full precision vectors are still stored in order to rerank the final candidates during search operations, which improves recall.
 
 In addition to the normal vector set operations, the following extensions are
 added:
 
-- `XB8`: When specifying vector input type, you can use `XB8` instead of `FP32`
-  to specify binary data in uint8 format, one byte per dimension.
-- `XPREQ8`: This is a pseudo-quantizer that specifies the vector data will be
-  stored as full precision data in uint8 format.
+### New Element Types
 
-Generally you will use `XB8` with `XPREQ8` to input and store uint8 vectors and
-`FP32` with `NOQUANT` to input and store f32 vectors.
+- `XI8`: signed 8-bit integers
+- `XU8`: unsigned 8-bit integers
 
-Support for binary and scalar quantization is coming, along with support for
-customizing the distance metric.
+### Distance Metrics
 
-Currently there is limit of `2^32 - 1` vectors in a single instance due to
-internal IDs being `u32`. This will probably restriction will be lifted in the
-future.
+Redis always uses cosine distance, but many vector data sets use other metrics. The following metrics can be used by passing `XDISTANCE_METRIC <metric>` options to the `VADD` command. The default is `L2`.
+
+- `COSINE`
+- `XCOSINE_NORMALIZED`
+- `IP` (inner product)
+- `L2` (euclidean)
+
+### New Quantizers
+
+- `XNOQUANT_I8`: full precision 8-bit signed integer
+- `XNOQUANT_U8`: full precision 8-bit unsigned integer
+- `XBIN_I8`: binary quantization of 8-bit signed integer (using DiskANN's spherical quantizer based on RaBitQ)
+- `XBIN_U8`: binary quantization of 8-bit unsigned integer (using DiskANN's spherical quantizer based on RaBitQ)
+
+
+Currently there is a limit of `2^32 - 1` vectors in a single instance due to
+internal IDs being `u32`. This restriction will be lifted in the future.
 
 ## Installing
 
@@ -38,7 +47,7 @@ check out the Garnet repo on Windows or Linux, and if you have a dotnet
 toolchain installed you can just run:
 
 ```sh
-dotnet dotnet run -c Release -f net8.0 --project main/GarnetServer --enable-vector-set-preview
+dotnet run -c Release -f net10.0 --project main/GarnetServer -- --enable-vector-set-preview
 ```
 
 and it will build and launch Garnet with vector sets enabled.
@@ -56,12 +65,13 @@ mkdir ../target/pkg
 mkdir ../target/pkg/linux
 mkdir ../target/pkg/windows
 mkdir ../target/pkg/docs
+cp diskann-garnet.nuspec ../target/pkg
 cp README.md ../target/pkg/linux/libdiskann_garnet.so # dummy file
 cp ../target/release/*.dll ../target/pkg/windows
 cp ../target/release/*.pdb ../target/pkg/windows
 cp README.md ../target/pkg/docs
 nuget pack -BasePath ../target/pkg -OutputDirectory LOCAL_NUGET_PATH
-nuget locals -clear all
+nuget locals all -clear
 ```
 
 You will need to set up a local path to host NuGets and setup
@@ -95,11 +105,11 @@ then replace the files, and rezip.
 mkdir target/nupkg
 cd target/nupkg
 unzip PATH_TO/diskann-garnet.x.y.z.nupkg
-cd ../../diskann-garnet
-cargo build --release
-cp diskann-garnet.nuspec ../target/nupkg/
-cp ../target/release/libdiskann_garnet.so ../target/nupkg/runtimes/linux-x64/native/
-cd ../target/nupkg
+cd ../..
+cargo build --release --package diskann-garnet
+cp diskann-garnet/diskann-garnet.nuspec target/nupkg/
+cp target/release/libdiskann_garnet.so target/nupkg/runtimes/linux-x64/native/
+cd target/nupkg
 zip -r LOCAL_NUGET_PATH/diskann-garnet.X.Y.Z.nupkg *
 dotnet nuget locals all --clear
 ```
@@ -114,11 +124,11 @@ the one you want.
 ## Testing
 
 Unit tests are run in the usual way with `cargo test`, but many are end-to-end
-and run from the Garnet side. These two invocations will the relevant tests:
+and run from the Garnet side. These two invocations will run the relevant tests:
 
 ```
-dotnet test test/Garnet.test -f net8.0 -c Debug --filter RespVectorSetTests
-dotnet test test/Garnet.test -f net8.0 -c Debug --filter DiskANNServiceTests
+dotnet test test/standalone/Garnet.test.vectorset -f net10.0 -c Debug --filter RespVectorSetTests
+dotnet test test/standalone/Garnet.test.extensions -f net10.0 -c Debug --filter DiskANNServiceTests
 ```
 
 ## Client Examples

--- a/vectorset/README.md
+++ b/vectorset/README.md
@@ -2,21 +2,54 @@
 
 Garnet client for benchmarking vector set workloads.
 
-Since Garnet speaks Redis's RESP protocol, this uses the offical Redis Rust
-client. For maximum performance, it uses multiple threads and pipelining.
+Since Garnet speaks Redis's RESP protocol, this uses the official Redis Rust
+client and can additionally be used to run workloads on Redis. For maximum
+performance, it uses multiple threads and pipelining.
+
+Currently it supports an ingestion workload which inserts vectors as fast as possible, and a search workload which queries a vectorset as fast as possible while calculating the recall.
+
+## Element Types, Metrics & Quantizers
+
+Garnet supports additional element types, distance metrics, and quantizers than exist in Redis.  Redis vector sets only support 32-bit float elements, cosine distance, and the NOQUANT (full precision), BIN (binary), and Q8 (scalar 8-bit) quantizers. All Garnet extensions to vectorsets are prefixed with `X` (e.g. `XI8` element type).
+
+### Additional Element Types
+
+Garnet supports signed 8-bit (XI8) and unsigned 8-bit (XU8) vector elements.
+
+### Additional Metrics
+
+Garnet supports specifying the distance metric with `XDISTANCE_METRIC <metric>`. The default is `L2`, and the following metrics are available:
+
+- `COSINE`
+- `XCOSINE_NORMALIZED`
+- `IP` (inner product)
+- `L2` (euclidean)
+
+### Additional Quantizers
+
+Redis supports `NOQUANT`, `BIN`, and `Q8` quantizers for 32-bit float elements. These are supported in Garnet, but use more advanced quantizers than Redis for better performance. `BIN` uses the spherical 1-bit quantizer from DiskANN, and `Q8` uses the minmax 8-bit quantizer from DiskANN.
+
+For `XI8` and `XU8` vectors, the full precision quantizers are `XNOQUANT_I8` and `XNOQUANT_U8` respectively. The spherical 1-bit quantizer is also available via `XBIN_I8` and `XBIN_U8`.
 
 ## Usage
 
-You will need dataset to import in bin format. You can find these on the
+You will need a dataset to import in bin format. You can find these on the
 internet, but the easiest way to get some is to use [Big ANN
 Benchmarks](https://github.com/harsha-simhadri/big-ann-benchmarks)'s
-`create_dataset.py` to download these. Once you have a dataset and Garnet is
-running, cp config.toml.example to config.toml and modify as necessary. Then:
+`create_dataset.py` to download datasets. Once you have a dataset and Garnet is
+running, copy config.toml.example to config.toml and modify as necessary.
 
-`cargo run --release -- --config config.toml --data-type float32 ingest --tasks 32 --degree 48 --l-build 256 /data/wikipedia_cohere/wikipedia_base.bin.crop_nb_10000000`
+Since vectorset has its own workspace in the DiskANN repo, the following examples should be run from the `vectorset` directory in the repo. Running `cargo run --release -- --help` will enumerate
+all the various subcommands and arguments.
 
-will ingest vectors and:
+### Ingest
 
-`cargo run --release -- --config config.toml --data-type float32 query --tasks 32 -k 100 -n 100 --l-search 192 /data/wikipedia_cohere/wikipedia_query.bin /data/wikipedia_cohere/wikipedia-10M-cosine`
+The `ingest` subcommand will ingest vectors and build the index. The following example builds a full precision only index on the wikipedia-10M dataset from big-ann-benchmarks.
 
-will run static search workloads on them reporting QPS and recall.
+`cargo run --release -- --config path/to/config.toml --quantizer no-quant ingest --tasks 32 --degree 48 --l-build 256 --metric inner-product path/to/data/wikipedia_cohere/wikipedia_base.bin.crop_nb_10000000`
+
+### Query
+
+The `query` subcommand queries the database while calculating recall against precomputed ground truth. By default, it will measure 10-recall@10. The following example queries the index created above and reports queries per second (QPS) and recall results.
+
+`cargo run --release -- --config path/to/config.toml --quantizer no-quant query --tasks 32 -k 100 -n 100 --l-search 192 path/to/data/wikipedia_cohere/wikipedia_query.bin path/to/data/wikipedia_cohere/wikipedia-10M`

--- a/vectorset/config.toml.example
+++ b/vectorset/config.toml.example
@@ -2,5 +2,7 @@
 ips = ["127.0.0.1"]
 port = 6379
 secure = false
-# scope = "some-scope-here"
+
+# The following properties are used with Azure Managed Garnet
+# scope = "some-scope"
 # username = "someuser"

--- a/vectorset/src/main.rs
+++ b/vectorset/src/main.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use azure_core::{credentials::TokenCredential, time::OffsetDateTime};
 use azure_identity::AzureCliCredential;
 use clap::{Args, Parser, Subcommand, ValueEnum};
@@ -42,7 +42,7 @@ struct Config {
     ips: Vec<String>,
     port: Option<u16>,
     secure: bool,
-    scope: String,
+    scope: Option<String>,
     username: Option<String>,
 }
 
@@ -248,7 +248,7 @@ impl ToRedisArgs for DistanceMetric {
         let q = match self {
             DistanceMetric::L2 => b"L2".as_slice(),
             DistanceMetric::Cosine => b"COSINE".as_slice(),
-            DistanceMetric::CosineNormalized => b"COSINE_NORMALIZED".as_slice(),
+            DistanceMetric::CosineNormalized => b"XCOSINE_NORMALIZED".as_slice(),
             DistanceMetric::InnerProduct => b"IP".as_slice(),
         };
         out.write_arg(q);
@@ -347,12 +347,19 @@ async fn async_main(opts: Options) -> Result<()> {
         addrs.push(addr);
     }
 
-    let (password, expires) = if config.username.is_some() {
+    let (password, expires, scope) = if config.username.is_some() {
         let credentials = AzureCliCredential::new(None)?;
-        let res = credentials.get_token(&[&config.scope], None).await?;
-        (Some(res.token.secret().to_string()), Some(res.expires_on))
+        let Some(scope) = &config.scope else {
+            return Err(anyhow!("missing scope in config"));
+        };
+        let res = credentials.get_token(&[scope], None).await?;
+        (
+            Some(res.token.secret().to_string()),
+            Some(res.expires_on),
+            Some(scope.to_owned()),
+        )
     } else {
-        (None, None)
+        (None, None, None)
     };
 
     let mut infos = Vec::new();
@@ -370,7 +377,7 @@ async fn async_main(opts: Options) -> Result<()> {
 
     let cred = if config.username.is_some() {
         Some(ExpiringCredential::new(
-            config.scope.clone(),
+            scope.unwrap(),
             config.username.clone().unwrap(),
             AzureCliCredential::new(None)?,
             expires.unwrap(),


### PR DESCRIPTION
Update the READMEs for recent changes. The instructions and descriptions are now accurate for the current Garnet and diskann-garnet.

A small change was made to the name of the cosine normalized metric, since it is prefixed by X; the reason for the prefix only in this case is that the other names are used by the full text index in Redis, which is where vector indices previously lived, but cosine normalized was not an option there.