### PR TITLE
fix: prefetch compilation on x86_64 without AVX2

### DIFF
--- a/diskann-inmem/src/provider.rs
+++ b/diskann-inmem/src/provider.rs
@@ -608,7 +608,7 @@ unsafe fn prefetch(ptr: *const u8, len: usize) {
 /// # Safety
 ///
 /// The memory range `[ptr, ptr.add(len))` must be valid.
-#[cfg(not(any(target_arch = "x86_64", target_feature = "avx2")))]
+#[cfg(not(all(target_arch = "x86_64", target_feature = "avx2")))]
 unsafe fn prefetch(_ptr: *const u8, _len: usize) {}
 
 /// # Safety


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
- [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.

The fallback `prefetch` implementation uses not(any(...)), which disables it on x86_64 when AVX2 is not enabled. This leaves no prefetch implementation available and causes compilation to fail. It is changed to not(all(...)).

This allows diskann-inmem to compile on x86_64 targets without AVX2 enabled.`