### PR TITLE
Update rust-toolchain to 1.95

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -1,6 +1,6 @@
 # DiskANN Repository - Agent Onboarding Guide
 
-**Last Updated**: 2026-02-11 (based on v0.45.0, Rust 1.92)
+**Last Updated**: 2026-02-11 (based on v0.55.0, Rust 1.95)
 
 This guide helps coding agents understand how to work efficiently with the DiskANN repository.
 

--- a/diskann-benchmark-runner/src/internal/regression.rs
+++ b/diskann-benchmark-runner/src/internal/regression.rs
@@ -229,7 +229,7 @@ impl<'a> Checks<'a> {
         // We can now package everything together!
         debug_assert_eq!(input_to_parsed.len(), inputs.jobs().len());
 
-        let checks = std::iter::zip(inputs.into_inner(), input_to_parsed.into_iter())
+        let checks = std::iter::zip(inputs.into_inner(), input_to_parsed)
             .map(|(input, index)| {
                 // This index should always be inbounds.
                 let inner = &parsed.inner[index];

--- a/diskann-benchmark/src/index/search/knn.rs
+++ b/diskann-benchmark/src/index/search/knn.rs
@@ -107,7 +107,7 @@ where
     ) -> anyhow::Result<Vec<SearchResults>> {
         let results = core_search::search_all(
             self.clone(),
-            parameters.into_iter(),
+            parameters,
             core_search::graph::knn::Aggregator::new(
                 groundtruth,
                 recall_k,
@@ -139,7 +139,7 @@ where
     ) -> anyhow::Result<Vec<SearchResults>> {
         let results = core_search::search_all(
             self.clone(),
-            parameters.into_iter(),
+            parameters,
             core_search::graph::knn::Aggregator::new(
                 groundtruth,
                 recall_k,
@@ -171,7 +171,7 @@ where
     ) -> anyhow::Result<Vec<SearchResults>> {
         let results = core_search::search_all(
             self.clone(),
-            parameters.into_iter(),
+            parameters,
             core_search::graph::knn::Aggregator::new(
                 groundtruth,
                 recall_k,

--- a/diskann-benchmark/src/index/search/range.rs
+++ b/diskann-benchmark/src/index/search/range.rs
@@ -90,7 +90,7 @@ where
     ) -> anyhow::Result<Vec<RangeSearchResults>> {
         let results = core_search::search_all(
             self.clone(),
-            parameters.into_iter(),
+            parameters,
             core_search::graph::range::Aggregator::new(groundtruth),
         )?;
 

--- a/diskann-disk/src/search/provider/disk_provider.rs
+++ b/diskann-disk/src/search/provider/disk_provider.rs
@@ -1083,10 +1083,8 @@ where
             stats,
         };
 
-        for ((vertex_id, distance), associated_data) in indices
-            .into_iter()
-            .zip(distances.into_iter())
-            .zip(associated_data.into_iter())
+        for ((vertex_id, distance), associated_data) in
+            indices.into_iter().zip(distances).zip(associated_data)
         {
             search_result.results.push(SearchResultItem {
                 vertex_id,

--- a/diskann-disk/src/search/provider/disk_sector_graph.rs
+++ b/diskann-disk/src/search/provider/disk_sector_graph.rs
@@ -184,8 +184,8 @@ impl<AlignedReaderType: AlignedFileReader> DiskSectorGraph<AlignedReaderType> {
     #[inline]
     /// Gets the index for the sector that contains the node with the given vertex_id
     pub fn node_sector_index(&self, vertex_id: u32) -> u64 {
-        1 + if self.num_nodes_per_sector > 0 {
-            vertex_id as u64 / self.num_nodes_per_sector
+        1 + if let Some(r) = (vertex_id as u64).checked_div(self.num_nodes_per_sector) {
+            r
         } else {
             vertex_id as u64 * self.num_sectors_per_node as u64
         }

--- a/diskann-garnet/src/provider.rs
+++ b/diskann-garnet/src/provider.rs
@@ -452,15 +452,9 @@ impl<T: VectorRepr> GarnetProvider<T> {
         };
 
         let quantizer = match &self.quantizer {
-            Some(q) => {
-                if !q.is_trained() {
-                    q
-                } else {
-                    // Quantizer already trained, bail.
-                    return false;
-                }
-            }
+            Some(q) if !q.is_trained() => q,
             None => return false,
+            Some(_) => return false,
         };
 
         let rows = quantizer.required_vectors();

--- a/diskann-inmem/src/provider.rs
+++ b/diskann-inmem/src/provider.rs
@@ -102,7 +102,7 @@ where
         let bytes = layers::Layer::bytes(&layer);
         let mut data = Matrix::new(0u8, start_points.len(), bytes.value());
 
-        for (row, point) in std::iter::zip(data.row_iter_mut(), start_points.into_iter()) {
+        for (row, point) in std::iter::zip(data.row_iter_mut(), start_points) {
             layers::Set::set(&layer, point, row)?;
         }
 

--- a/diskann-quantization/tests/compile-fail/error/inline_error_align.stderr
+++ b/diskann-quantization/tests/compile-fail/error/inline_error_align.stderr
@@ -1,22 +1,27 @@
 error[E0080]: evaluation panicked: error type has alignment stricter than 8
- --> src/error.rs
+ --> $RUST/core/src/panic.rs
+  |
+  |           $crate::panicking::panic_fmt($crate::const_format_args!($($t)+));
+  |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `diskann_quantization::error::InlineError::new::<Error>::{constant#1}` failed here
+  |
+ ::: src/error.rs
   |
   | /             assert!(
   | |                 std::mem::align_of::<T>() <= std::mem::align_of::<&'static ErrorVTable>(),
   | |                 "error type has alignment stricter than 8"
   | |             )
-  | |_____________^ evaluation of `diskann_quantization::error::InlineError::new::<Error>::{constant#1}` failed here
+  | |_____________- in this macro invocation
 
 note: erroneous constant encountered
-   --> src/error.rs
-    |
-    | /         const {
-    | |             assert!(
-    | |                 std::mem::align_of::<T>() <= std::mem::align_of::<&'static ErrorVTable>(),
-    | |                 "error type has alignment stricter than 8"
-    | |             )
-    | |         };
-    | |_________^
+ --> src/error.rs
+  |
+  | /         const {
+  | |             assert!(
+  | |                 std::mem::align_of::<T>() <= std::mem::align_of::<&'static ErrorVTable>(),
+  | |                 "error type has alignment stricter than 8"
+  | |             )
+  | |         };
+  | |_________^
 
 note: the above error was encountered while instantiating `fn InlineError::new::<Error>`
   --> tests/compile-fail/error/inline_error_align.rs:24:13

--- a/diskann-quantization/tests/compile-fail/error/inline_error_size.stderr
+++ b/diskann-quantization/tests/compile-fail/error/inline_error_size.stderr
@@ -1,14 +1,19 @@
 error[E0080]: evaluation panicked: error type is too big
+ --> $RUST/core/src/panic.rs
+  |
+  |         $crate::panicking::panic_fmt($crate::const_format_args!($($t)+));
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `diskann_quantization::error::InlineError::<4>::new::<Error>::{constant#0}` failed here
+  |
+ ::: src/error.rs
+  |
+  |         const { assert!(std::mem::size_of::<T>() <= N, "error type is too big") };
+  |                 --------------------------------------------------------------- in this macro invocation
+
+note: erroneous constant encountered
  --> src/error.rs
   |
   |         const { assert!(std::mem::size_of::<T>() <= N, "error type is too big") };
-  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ evaluation of `diskann_quantization::error::InlineError::<4>::new::<Error>::{constant#0}` failed here
-
-note: erroneous constant encountered
-   --> src/error.rs
-    |
-    |         const { assert!(std::mem::size_of::<T>() <= N, "error type is too big") };
-    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 note: the above error was encountered while instantiating `fn InlineError::<4>::new::<Error>`
   --> tests/compile-fail/error/inline_error_size.rs:21:13

--- a/diskann-wide/src/test_utils/distribution.rs
+++ b/diskann-wide/src/test_utils/distribution.rs
@@ -82,12 +82,16 @@ macro_rules! finite {
                     // infinity/NaN).
                     //
                     // The mantissa is allowed to be all zeros.
-                    (<$T>::EXPONENT_MASK | <$T>::MANTISSA_MASK, false, true)
+                    (
+                        <$T as Layout>::EXPONENT_MASK | <$T as Layout>::MANTISSA_MASK,
+                        false,
+                        true,
+                    )
                 } else if weight < 95 {
                     // Generate a subnormal floating point number.
                     //
                     // The exponent must be all zero and the mantissa cannot be zero.
-                    (<$T>::MANTISSA_MASK, true, false)
+                    (<$T as Layout>::MANTISSA_MASK, true, false)
                 } else {
                     // Generate zero.
                     (0, true, true)

--- a/diskann-wide/src/test_utils/dot_product.rs
+++ b/diskann-wide/src/test_utils/dot_product.rs
@@ -297,7 +297,7 @@ mod tests {
             for right in b {
                 let dot: i32 = (*left)
                     .into_iter()
-                    .zip((*right).into_iter())
+                    .zip(*right)
                     .map(|(l, r)| (l as i32) * (r as i32))
                     .sum();
                 for b in bases {
@@ -333,7 +333,7 @@ mod tests {
             for right in a {
                 let dot: i32 = (*left)
                     .into_iter()
-                    .zip((*right).into_iter())
+                    .zip(*right)
                     .map(|(l, r)| (l as i32) * (r as i32))
                     .sum();
                 for b in bases {
@@ -370,7 +370,7 @@ mod tests {
             for right in a {
                 let dot: u32 = (*left)
                     .into_iter()
-                    .zip((*right).into_iter())
+                    .zip(*right)
                     .map(|(l, r)| (l as u32) * (r as u32))
                     .sum();
                 for b in bases {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "1.92"
+channel = "1.95"
+components = ["rust-src"]


### PR DESCRIPTION
Recent reversion of rust-analyzer require 1.94 or newer.