### PR TITLE
[diskann-garnet] set_attribute with empty string deletes attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-garnet"
-version = "4.0.2"
+version = "4.0.3"
 dependencies = [
  "bytemuck",
  "crossbeam",

--- a/diskann-garnet/Cargo.toml
+++ b/diskann-garnet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diskann-garnet"
-version = "4.0.2"
+version = "4.0.3"
 edition = "2024"
 authors.workspace = true
 license.workspace = true

--- a/diskann-garnet/diskann-garnet.nuspec
+++ b/diskann-garnet/diskann-garnet.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>diskann-garnet</id>
-    <version>4.0.2</version>
+    <version>4.0.3</version>
     <readme>docs/README.md</readme>
     <authors>Microsoft</authors>
     <projectUrl>https://github.com/microsoft/DiskANN</projectUrl>

--- a/diskann-garnet/src/dyn_index.rs
+++ b/diskann-garnet/src/dyn_index.rs
@@ -23,6 +23,8 @@ pub(crate) trait DynIndex: Send + Sync {
 
     fn set_attributes(&self, context: &Context, id: &GarnetId, data: &[u8]) -> ANNResult<()>;
 
+    fn delete_attributes(&self, context: &Context, id: &GarnetId) -> ANNResult<()>;
+
     fn search_vector(
         &self,
         context: &Context,
@@ -87,6 +89,13 @@ impl<T: VectorRepr> DynIndex for DiskANNIndex<GarnetProvider<T>> {
         self.inner
             .provider()
             .set_attributes(context, id, data)
+            .map_err(|e| e.into())
+    }
+
+    fn delete_attributes(&self, context: &Context, id: &GarnetId) -> ANNResult<()> {
+        self.inner
+            .provider()
+            .delete_attributes(context, id)
             .map_err(|e| e.into())
     }
 

--- a/diskann-garnet/src/lib.rs
+++ b/diskann-garnet/src/lib.rs
@@ -590,10 +590,17 @@ pub unsafe extern "C" fn set_attribute(
         return false;
     }
 
-    if attribute_len > 0 && !attribute_data.is_null() {
+    if !attribute_data.is_null() {
         let attr_data: &[u8] = unsafe { slice::from_raw_parts(attribute_data, attribute_len) };
-        if index.inner.set_attributes(&ctx, &id, attr_data).is_err() {
-            return false;
+        if !attr_data.is_empty() {
+            if index.inner.set_attributes(&ctx, &id, attr_data).is_err() {
+                return false;
+            }
+        } else {
+            // Empty attribute string is interpreted as deletion
+            if index.inner.delete_attributes(&ctx, &id).is_err() {
+                return false;
+            }
         }
     }
 
@@ -839,7 +846,8 @@ mod tests {
     use diskann_vector::distance::Metric;
 
     use crate::{
-        Index, IndexState, PolyCow, SearchResults, VectorQuantType, drop_index, garnet::GarnetId,
+        Index, IndexState, PolyCow, SearchResults, VectorQuantType, drop_index,
+        garnet::{Context, GarnetId, Term},
         test_utils::Store,
     };
 
@@ -990,5 +998,75 @@ mod tests {
 
         let res = super::interpret_vector(VectorQuantType::Invalid, &ptr::null() as &*const u8, 0);
         assert!(res.is_none());
+    }
+
+    #[test]
+    fn set_and_delete_attributes() {
+        let store = Store::new();
+        let mut quant_needed = false;
+
+        let index_ptr = unsafe {
+            super::create_index(
+                0,
+                2,
+                0,
+                VectorQuantType::NoQuant,
+                Metric::L2.into(),
+                10,
+                8,
+                store.callbacks().read_callback(),
+                store.callbacks().write_callback(),
+                store.callbacks().delete_callback(),
+                store.callbacks().rmw_callback(),
+                store.callbacks().filter_callback(),
+                &mut quant_needed,
+            )
+        };
+
+        assert!(!index_ptr.is_null());
+
+        let id = 0u32;
+        let eid = GarnetId::from(bytemuck::bytes_of(&id));
+        let metadata = b"{'foo': 0}";
+        let ctx = Context::new(0);
+        let v = [0.0f32, 0.0f32];
+
+        assert!(store.get(ctx.term(Term::Attributes).get(), &eid).is_none());
+
+        assert_eq!(
+            unsafe {
+                super::insert(
+                    ctx.get(),
+                    index_ptr,
+                    eid.as_ptr(),
+                    eid.len(),
+                    bytemuck::cast_slice::<f32, u8>(&v).as_ptr(),
+                    v.len(),
+                    metadata.as_ptr(),
+                    metadata.len(),
+                )
+            },
+            1
+        );
+        assert_eq!(
+            store.get(ctx.term(Term::Attributes).get(), &eid),
+            Some(metadata.as_slice().to_owned())
+        );
+
+        assert!(unsafe {
+            super::set_attribute(
+                ctx.get(),
+                index_ptr,
+                eid.as_ptr(),
+                eid.len(),
+                b"".as_ptr(),
+                0,
+            )
+        });
+        assert!(store.get(ctx.term(Term::Attributes).get(), &eid).is_none());
+
+        unsafe {
+            drop_index(0, index_ptr);
+        }
     }
 }

--- a/diskann-garnet/src/provider.rs
+++ b/diskann-garnet/src/provider.rs
@@ -421,6 +421,22 @@ impl<T: VectorRepr> GarnetProvider<T> {
             Err(GarnetError::Write.into())
         }
     }
+
+    pub(crate) fn delete_attributes(
+        &self,
+        context: &Context,
+        id: &GarnetId,
+    ) -> Result<(), GarnetProviderError> {
+        if self
+            .callbacks
+            .delete_eid(&context.term(Term::Attributes), id)
+        {
+            Ok(())
+        } else {
+            Err(GarnetError::Delete.into())
+        }
+    }
+
     pub(crate) fn vector_id_exists(&self, context: &Context, id: &GarnetId) -> bool {
         let iid = match self.to_internal_id(context, id) {
             Ok(iid) => iid,


### PR DESCRIPTION
This changes the FFI call `set_attribute()` to interpret an empty attribute string as deletion. This saves some space within Garnet since empty values have some overhead.