### PR TITLE
[diskann-wide] Add sumtree for 64-bit types

### DIFF
--- a/diskann-wide/src/arch/aarch64/double.rs
+++ b/diskann-wide/src/arch/aarch64/double.rs
@@ -289,6 +289,7 @@ mod tests {
 
         // Bit ops
         test_utils::ops::test_bitops!(u64x4, 0xc4491a44af4aa58e, test_neon());
+        test_utils::ops::test_sumtree!(u64x4, 0x529c27f62ea171ec, test_neon());
         test_utils::ops::test_splitjoin!(u64x4 => u64x2, 0x2e301b7e12090d5c, test_neon());
     }
 

--- a/diskann-wide/src/arch/aarch64/i64x2_.rs
+++ b/diskann-wide/src/arch/aarch64/i64x2_.rs
@@ -4,8 +4,8 @@
  */
 
 use crate::{
-    Emulated, SIMDAbs, SIMDMask, SIMDMulAdd, SIMDPartialEq, SIMDPartialOrd, SIMDVector,
-    arch::Scalar, constant::Const, helpers,
+    Emulated, SIMDAbs, SIMDMask, SIMDMulAdd, SIMDPartialEq, SIMDPartialOrd, SIMDSumTree,
+    SIMDVector, arch::Scalar, constant::Const, helpers,
 };
 
 // AArch64 masks
@@ -78,6 +78,18 @@ macros::aarch64_define_bitops!(
     (u64, i64, vmovq_n_s64),
 );
 
+impl SIMDSumTree for i64x2 {
+    #[inline(always)]
+    fn sum_tree(self) -> i64 {
+        if cfg!(miri) {
+            self.emulated().sum_tree()
+        } else {
+            // SAFETY: Allowed by the `Neon` architecture.
+            unsafe { vaddvq_s64(self.0) }
+        }
+    }
+}
+
 ///////////
 // Tests //
 ///////////
@@ -117,6 +129,8 @@ mod tests {
     test_utils::ops::test_abs!(i64x2, 0xb8f702ba85375041, test_neon());
 
     test_utils::ops::test_cmp!(i64x2, 0xfae27072c6b70885, test_neon());
+
+    test_utils::ops::test_sumtree!(i64x2, 0xbef8abe303356cc3, test_neon());
 
     // Bit ops
     test_utils::ops::test_bitops!(i64x2, 0xbe927713ea310164, test_neon());

--- a/diskann-wide/src/arch/aarch64/u64x2_.rs
+++ b/diskann-wide/src/arch/aarch64/u64x2_.rs
@@ -8,7 +8,7 @@ use crate::{
     arch::Scalar,
     constant::Const,
     helpers,
-    traits::{SIMDMask, SIMDMulAdd, SIMDPartialEq, SIMDPartialOrd, SIMDVector},
+    traits::{SIMDMask, SIMDMulAdd, SIMDPartialEq, SIMDPartialOrd, SIMDSumTree, SIMDVector},
 };
 
 // AArch64 masks
@@ -89,6 +89,18 @@ macros::aarch64_define_bitops!(
     (u64, i64, vmovq_n_s64),
 );
 
+impl SIMDSumTree for u64x2 {
+    #[inline(always)]
+    fn sum_tree(self) -> u64 {
+        if cfg!(miri) {
+            self.emulated().sum_tree()
+        } else {
+            // SAFETY: Allowed by the `Neon` architecture.
+            unsafe { vaddvq_u64(self.0) }
+        }
+    }
+}
+
 ///////////
 // Tests //
 ///////////
@@ -127,6 +139,8 @@ mod tests {
     test_utils::ops::test_fma!(u64x2, 0x28540d9936a9e803, test_neon());
 
     test_utils::ops::test_cmp!(u64x2, 0xfae27072c6b70885, test_neon());
+
+    test_utils::ops::test_sumtree!(u64x2, 0xe1dc2d07ae014508, test_neon());
 
     // Bit ops
     test_utils::ops::test_bitops!(u64x2, 0xbe927713ea310164, test_neon());

--- a/diskann-wide/src/arch/mod.rs
+++ b/diskann-wide/src/arch/mod.rs
@@ -691,11 +691,13 @@ pub trait Architecture: sealed::Sealed {
     vector!(
         u64x2: <Self, u64, 2, mask_u64x2>
         + SIMDUnsigned
+        + SIMDSumTree
     );
     vector!(
         u64x4: <Self, u64, 4, mask_u64x4>
         + SplitJoin<Halved = Self::u64x2>
         + SIMDUnsigned
+        + SIMDSumTree
     );
 
     //---------//

--- a/diskann-wide/src/arch/x86_64/v3/u64x2_.rs
+++ b/diskann-wide/src/arch/x86_64/v3/u64x2_.rs
@@ -15,7 +15,9 @@ use crate::{
     },
     constant::Const,
     helpers,
-    traits::{AsSIMD, SIMDMask, SIMDMulAdd, SIMDPartialEq, SIMDPartialOrd, SIMDVector},
+    traits::{
+        AsSIMD, SIMDMask, SIMDMulAdd, SIMDPartialEq, SIMDPartialOrd, SIMDSumTree, SIMDVector,
+    },
 };
 
 /////
@@ -134,6 +136,20 @@ impl SIMDPartialOrd for u64x2 {
     }
 }
 
+impl SIMDSumTree for u64x2 {
+    #[inline(always)]
+    fn sum_tree(self) -> u64 {
+        let x = self.to_underlying();
+        // SAFETY: `_mm_unpackhi_epi64`, `_mm_add_epi64`, and `_mm_cvtsi128_si64` require
+        // SSE2, implied by V3.
+        unsafe {
+            let hi = _mm_unpackhi_epi64(x, x);
+            let sum = _mm_add_epi64(x, hi);
+            _mm_cvtsi128_si64(sum) as u64
+        }
+    }
+}
+
 ///////////
 // Tests //
 ///////////
@@ -173,6 +189,8 @@ mod test_x86_u64 {
     test_utils::ops::test_fma!(u64x2, 0xcb45c9f29a44719f, V3::new_checked_uncached());
 
     test_utils::ops::test_cmp!(u64x2, 0x92486698bb7603e7, V3::new_checked_uncached());
+
+    test_utils::ops::test_sumtree!(u64x2, 0xe1dc2d07ae014508, V3::new_checked_uncached());
 
     // Bit ops
     test_utils::ops::test_bitops!(u64x2, 0xf9566b095125ca45, V3::new_checked_uncached());

--- a/diskann-wide/src/arch/x86_64/v3/u64x4_.rs
+++ b/diskann-wide/src/arch/x86_64/v3/u64x4_.rs
@@ -15,7 +15,9 @@ use crate::{
     },
     constant::Const,
     helpers,
-    traits::{AsSIMD, SIMDMask, SIMDMulAdd, SIMDPartialEq, SIMDPartialOrd, SIMDVector},
+    traits::{
+        AsSIMD, SIMDMask, SIMDMulAdd, SIMDPartialEq, SIMDPartialOrd, SIMDSumTree, SIMDVector,
+    },
 };
 
 /////
@@ -142,6 +144,22 @@ impl SIMDPartialOrd for u64x4 {
     }
 }
 
+impl SIMDSumTree for u64x4 {
+    #[inline(always)]
+    fn sum_tree(self) -> u64 {
+        let x = self.to_underlying();
+        // SAFETY: The AVX2 and SSE2 intrinsics used here are implied by V3.
+        unsafe {
+            let hi = _mm256_extracti128_si256(x, 1);
+            let lo = _mm256_castsi256_si128(x);
+            let sum_dual = _mm_add_epi64(lo, hi);
+            let sum_hi = _mm_unpackhi_epi64(sum_dual, sum_dual);
+            let sum = _mm_add_epi64(sum_dual, sum_hi);
+            _mm_cvtsi128_si64(sum) as u64
+        }
+    }
+}
+
 ///////////
 // Tests //
 ///////////
@@ -182,6 +200,8 @@ mod test_x86_u64 {
 
     test_utils::ops::test_cmp!(u64x4, 0x0beda0dd5141ec40, V3::new_checked_uncached());
     test_utils::ops::test_splitjoin!(u64x4 => u64x2, 0xb151fcd6141b10c9, V3::new_checked_uncached());
+
+    test_utils::ops::test_sumtree!(u64x4, 0x529c27f62ea171ec, V3::new_checked_uncached());
 
     // Bit ops
     test_utils::ops::test_bitops!(u64x4, 0xb1ac2e16327a8d5e, V3::new_checked_uncached());

--- a/diskann-wide/src/arch/x86_64/v4/u64x2_.rs
+++ b/diskann-wide/src/arch/x86_64/v4/u64x2_.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     constant::Const,
     helpers,
-    traits::{SIMDMask, SIMDMulAdd, SIMDVector},
+    traits::{SIMDMask, SIMDMulAdd, SIMDSumTree, SIMDVector},
 };
 
 /////
@@ -73,6 +73,13 @@ macros::x86_avx512_load_store!(
 
 macros::x86_avx512_int_comparisons!(u64x2, _mm_cmp_epu64_mask, "avx512f,avx512vl");
 
+impl SIMDSumTree for u64x2 {
+    #[inline(always)]
+    fn sum_tree(self) -> u64 {
+        self.retarget().sum_tree()
+    }
+}
+
 ///////////
 // Tests //
 ///////////
@@ -111,6 +118,8 @@ mod test_x86_u64 {
     test_utils::ops::test_fma!(u64x2, 0xcb45c9f29a44719f, V4::new_checked_uncached());
 
     test_utils::ops::test_cmp!(u64x2, 0x92486698bb7603e7, V4::new_checked_uncached());
+
+    test_utils::ops::test_sumtree!(u64x2, 0xe1dc2d07ae014508, V4::new_checked_uncached());
 
     // Bit ops
     test_utils::ops::test_bitops!(u64x2, 0xf9566b095125ca45, V4::new_checked_uncached());

--- a/diskann-wide/src/arch/x86_64/v4/u64x4_.rs
+++ b/diskann-wide/src/arch/x86_64/v4/u64x4_.rs
@@ -17,7 +17,7 @@ use crate::{
     },
     constant::Const,
     helpers,
-    traits::{SIMDMask, SIMDMulAdd, SIMDVector},
+    traits::{SIMDMask, SIMDMulAdd, SIMDSumTree, SIMDVector},
 };
 
 /////
@@ -81,6 +81,13 @@ macros::x86_avx512_load_store!(
 
 macros::x86_avx512_int_comparisons!(u64x4, _mm256_cmp_epu64_mask, "avx512f,avx512vl");
 
+impl SIMDSumTree for u64x4 {
+    #[inline(always)]
+    fn sum_tree(self) -> u64 {
+        self.retarget().sum_tree()
+    }
+}
+
 ///////////
 // Tests //
 ///////////
@@ -120,6 +127,8 @@ mod test_x86_u64 {
 
     test_utils::ops::test_cmp!(u64x4, 0x0beda0dd5141ec40, V4::new_checked_uncached());
     test_utils::ops::test_splitjoin!(u64x4 => u64x2, 0xb151fcd6141b10c9, V4::new_checked_uncached());
+
+    test_utils::ops::test_sumtree!(u64x4, 0x529c27f62ea171ec, V4::new_checked_uncached());
 
     // Bit ops
     test_utils::ops::test_bitops!(u64x4, 0xb1ac2e16327a8d5e, V4::new_checked_uncached());

--- a/diskann-wide/src/emulated.rs
+++ b/diskann-wide/src/emulated.rs
@@ -544,6 +544,8 @@ macro_rules! impl_sumtree {
 impl_sumtree!(f32, 1, 2, 4, 8, 16);
 impl_sumtree!(i32, 4, 8, 16);
 impl_sumtree!(u32, 4, 8, 16);
+impl_sumtree!(i64, 2, 4);
+impl_sumtree!(u64, 2, 4);
 
 ////////////////
 // Conversion //
@@ -970,6 +972,12 @@ mod test_emulated {
     test_utils::ops::test_sumtree!(Emulated<u32, 4>, 0x5e4cffc86a21e90d, SC);
     test_utils::ops::test_sumtree!(Emulated<u32, 8>, 0xf43f19adb43bc611, SC);
     test_utils::ops::test_sumtree!(Emulated<u32, 16>, 0xa43dfe10aa9de860, SC);
+
+    test_utils::ops::test_sumtree!(Emulated<i64, 2>, 0xbef8abe303356cc3, SC);
+    test_utils::ops::test_sumtree!(Emulated<i64, 4>, 0x9aef214494ff5cd2, SC);
+
+    test_utils::ops::test_sumtree!(Emulated<u64, 2>, 0xe1dc2d07ae014508, SC);
+    test_utils::ops::test_sumtree!(Emulated<u64, 4>, 0x529c27f62ea171ec, SC);
 
     /////////////////
     // conversions //


### PR DESCRIPTION
Add `SIMDSumTree` requirement/impls for `u64x2` and `u64x4` types (and for the currently one-off `i64x2` in Neon).

This is part of a series of PRs for better AVX-512 1-bit kernels.

AI Disclaimer: the author cannot currently type well, a directed agent did most of the changes. Fortunately, most are mechanical.