### PR TITLE
Fix bitmask label file size overflow

### DIFF
--- a/src/label_helper.cpp
+++ b/src/label_helper.cpp
@@ -162,7 +162,8 @@ bool label_helper::read_bitmask_from_file(const std::string& bitmask_label_file,
     infile.read((char *)(&num_points_in_file), sizeof(std::uint32_t));
     infile.read((char *)(&bitmask_size), sizeof(std::uint32_t));
 
-    size_t bitmask_data_size = num_points_in_file * bitmask_size * sizeof(std::uint64_t);
+    size_t bitmask_data_size =
+        static_cast<size_t>(num_points_in_file) * bitmask_size * sizeof(std::uint64_t);
     if (file_size != (sizeof(std::uint32_t) * 2 + bitmask_data_size))
     {
         return false;


### PR DESCRIPTION
Promote the point count to size_t before calculating the bitmask payload size so large valid label files are not rejected.

<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
- [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Briefly explain your changes.

#### Any other comments?

