### PR TITLE
[diskann-wide] Fix compilation for next-gen trait solver

### DIFF
--- a/diskann-wide/src/arch/aarch64/mod.rs
+++ b/diskann-wide/src/arch/aarch64/mod.rs
@@ -345,7 +345,7 @@ impl arch::Architecture for Neon {
         T0: AddLifetime,
         F: for<'a> FTarget1<Self, R, T0::Of<'a>>,
     {
-        let f: unsafe fn(Self, T0::Of<'_>) -> R = Self::run_function_with_1::<F, _, _>;
+        let f: unsafe fn(Self, T0::Of<'_>) -> R = Self::run_function_with_1::<F, T0, R>;
 
         // SAFETY: The presence of `self` as an argument attests that it is safe to construct
         // a `Neon` architecture. Additionally, since `Neon` is a `Copy` zero-sized type,
@@ -360,7 +360,7 @@ impl arch::Architecture for Neon {
         F: for<'a, 'b> FTarget2<Self, R, T0::Of<'a>, T1::Of<'b>>,
     {
         let f: unsafe fn(Self, T0::Of<'_>, T1::Of<'_>) -> R =
-            Self::run_function_with_2::<F, _, _, _>;
+            Self::run_function_with_2::<F, T0, T1, R>;
 
         // SAFETY: The presence of `self` as an argument attests that it is safe to construct
         // a `Neon` architecture. Additionally, since `Neon` is a `Copy` zero-sized type,
@@ -376,7 +376,7 @@ impl arch::Architecture for Neon {
         F: for<'a, 'b, 'c> FTarget3<Self, R, T0::Of<'a>, T1::Of<'b>, T2::Of<'c>>,
     {
         let f: unsafe fn(Self, T0::Of<'_>, T1::Of<'_>, T2::Of<'_>) -> R =
-            Self::run_function_with_3::<F, _, _, _, _>;
+            Self::run_function_with_3::<F, T0, T1, T2, R>;
 
         // SAFETY: The presence of `self` as an argument attests that it is safe to construct
         // a `Neon` architecture. Additionally, since `Neon` is a `Copy` zero-sized type,

--- a/diskann-wide/src/arch/x86_64/v3/mod.rs
+++ b/diskann-wide/src/arch/x86_64/v3/mod.rs
@@ -432,7 +432,7 @@ impl Architecture for V3 {
         T0: AddLifetime,
         F: for<'a> FTarget1<Self, R, T0::Of<'a>>,
     {
-        let f: unsafe fn(Self, T0::Of<'_>) -> R = Self::run_function_with_1::<F, _, _>;
+        let f: unsafe fn(Self, T0::Of<'_>) -> R = Self::run_function_with_1::<F, T0, R>;
 
         // SAFETY: The presence of `self` as an argument attests that it is safe to construct
         // A `V3` architecture. Additionally, since `V3` is a `Copy` zero-sized type,
@@ -447,7 +447,7 @@ impl Architecture for V3 {
         F: for<'a, 'b> FTarget2<Self, R, T0::Of<'a>, T1::Of<'b>>,
     {
         let f: unsafe fn(Self, T0::Of<'_>, T1::Of<'_>) -> R =
-            Self::run_function_with_2::<F, _, _, _>;
+            Self::run_function_with_2::<F, T0, T1, R>;
 
         // SAFETY: The presence of `self` as an argument attests that it is safe to construct
         // A `V3` architecture. Additionally, since `V3` is a `Copy` zero-sized type,
@@ -463,7 +463,7 @@ impl Architecture for V3 {
         F: for<'a, 'b, 'c> FTarget3<Self, R, T0::Of<'a>, T1::Of<'b>, T2::Of<'c>>,
     {
         let f: unsafe fn(Self, T0::Of<'_>, T1::Of<'_>, T2::Of<'_>) -> R =
-            Self::run_function_with_3::<F, _, _, _, _>;
+            Self::run_function_with_3::<F, T0, T1, T2, R>;
 
         // SAFETY: The presence of `self` as an argument attests that it is safe to construct
         // A `V3` architecture. Additionally, since `V3` is a `Copy` zero-sized type,

--- a/diskann-wide/src/arch/x86_64/v4/mod.rs
+++ b/diskann-wide/src/arch/x86_64/v4/mod.rs
@@ -537,7 +537,7 @@ impl Architecture for V4 {
         T0: AddLifetime,
         F: for<'a> FTarget1<Self, R, T0::Of<'a>>,
     {
-        let f: unsafe fn(Self, T0::Of<'_>) -> R = Self::run_function_with_1::<F, _, _>;
+        let f: unsafe fn(Self, T0::Of<'_>) -> R = Self::run_function_with_1::<F, T0, R>;
 
         // SAFETY: The presence of `self` as an argument attests that it is safe to construct
         // A `V4` architecture. Additionally, since `V4` is a `Copy` zero-sized type,
@@ -552,7 +552,7 @@ impl Architecture for V4 {
         F: for<'a, 'b> FTarget2<Self, R, T0::Of<'a>, T1::Of<'b>>,
     {
         let f: unsafe fn(Self, T0::Of<'_>, T1::Of<'_>) -> R =
-            Self::run_function_with_2::<F, _, _, _>;
+            Self::run_function_with_2::<F, T0, T1, R>;
 
         // SAFETY: The presence of `self` as an argument attests that it is safe to construct
         // A `V4` architecture. Additionally, since `V4` is a `Copy` zero-sized type,
@@ -568,7 +568,7 @@ impl Architecture for V4 {
         F: for<'a, 'b, 'c> FTarget3<Self, R, T0::Of<'a>, T1::Of<'b>, T2::Of<'c>>,
     {
         let f: unsafe fn(Self, T0::Of<'_>, T1::Of<'_>, T2::Of<'_>) -> R =
-            Self::run_function_with_3::<F, _, _, _, _>;
+            Self::run_function_with_3::<F, T0, T1, T2, R>;
 
         // SAFETY: The presence of `self` as an argument attests that it is safe to construct
         // A `V4` architecture. Additionally, since `V4` is a `Copy` zero-sized type,

--- a/diskann-wide/src/test_utils/distribution.rs
+++ b/diskann-wide/src/test_utils/distribution.rs
@@ -99,17 +99,19 @@ macro_rules! finite {
 
                 // Preserve the sign bit and mask out all other values that do not belong to
                 // the kind of floating point number we are generating.
-                value &= <$T>::SIGN_MASK | mask;
-                let exponent = value & <$T>::EXPONENT_MASK;
+                value &= <$T as Layout>::SIGN_MASK | mask;
+                let exponent = value & <$T as Layout>::EXPONENT_MASK;
 
                 // If the all zeros or all ones pattern is not allowed, set it to 0.
-                if !allow_edge_exponent && (exponent == 0 || exponent == <$T>::EXPONENT_MASK) {
+                if !allow_edge_exponent
+                    && (exponent == 0 || exponent == <$T as Layout>::EXPONENT_MASK)
+                {
                     // Clear the exponent bits and set it to the zero value.
-                    value &= !<$T>::EXPONENT_MASK;
-                    value |= <$T>::EXPONENT_ZERO;
+                    value &= !<$T as Layout>::EXPONENT_MASK;
+                    value |= <$T as Layout>::EXPONENT_ZERO;
                 }
 
-                if !allow_zero_mantissa && (value & <$T>::MANTISSA_MASK == 0) {
+                if !allow_zero_mantissa && (value & <$T as Layout>::MANTISSA_MASK == 0) {
                     // Make the mantissa non-zero.
                     value |= 1;
                 }


### PR DESCRIPTION
Relying on inference to deduce higher ranked associated types will not be supported with the next generation trait solver. Fortunately, the fix is to pass the generic parameters explicitly.

The changes to `distribution.rs` are due to a future incompatibility warning on nightly.

The broken compilation can be reproduced with
```
RUSTFLAGS="-Znext-solver=globally" cargo +nightly test --package diskann-wide
``` 

Related issue: https://github.com/rust-lang/rust/issues/160895 (`diskann-wide` is one of the few broken crates)