### PR TITLE
Update Rust install in `publish.yml`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,16 +62,8 @@ jobs:
           lfs: true
           fetch-depth: 0
 
-      - name: Read Rust version from rust-toolchain.toml
-        id: rust-version
-        run: |
-          RUST_VERSION=$(sed -n 's/^channel = "\(.*\)"/\1/p' rust-toolchain.toml)
-          echo "channel=$RUST_VERSION" >> "$GITHUB_OUTPUT"
-
-      - name: Install Rust ${{ steps.rust-version.outputs.channel }}
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ steps.rust-version.outputs.channel }}
+      - name: Install Rust
+        run: rustup show
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
This updates `publish.yml` to install the Rust toolchain in `rust-toolchain.yml` in a manner consistent with our other CI steps, removing the need for `dtolnay/rust-toolchain`.

Fixes one of the issues found in #1322.