### PR TITLE
[CI] Verify checksums of binary downloads

### DIFF
--- a/.github/actions/setup-disk-benchmark/action.yml
+++ b/.github/actions/setup-disk-benchmark/action.yml
@@ -14,6 +14,9 @@ inputs:
   archive:
     description: 'Archive filename to download (e.g. wikipedia-100K.tar.gz)'
     required: true
+  sha256:
+    description: 'Expected SHA-256 digest of the dataset archive'
+    required: true
   extract-to:
     description: 'Directory to extract the dataset into'
     required: true
@@ -42,8 +45,13 @@ runs:
     - name: Download ${{ inputs.dataset }} dataset
       shell: bash
       env:
+        ARCHIVE: ${{ inputs.archive }}
         BAB_RELEASE_URL: https://github.com/harsha-simhadri/big-ann-benchmarks/releases/download/v0.4.0
+        EXTRACT_TO: ${{ inputs.extract-to }}
+        SHA256: ${{ inputs.sha256 }}
       run: |
-        mkdir -p ${{ inputs.extract-to }}
-        curl -L -o ${{ inputs.archive }} ${{ env.BAB_RELEASE_URL }}/${{ inputs.archive }}
-        tar xzf ${{ inputs.archive }} -C ${{ inputs.extract-to }}
+        set -euo pipefail
+        mkdir -p "$EXTRACT_TO"
+        curl --fail --location --output "$ARCHIVE" "$BAB_RELEASE_URL/$ARCHIVE"
+        echo "$SHA256  $ARCHIVE" | sha256sum --check
+        tar xzf "$ARCHIVE" -C "$EXTRACT_TO"

--- a/.github/actions/setup-disk-benchmark/action.yml
+++ b/.github/actions/setup-disk-benchmark/action.yml
@@ -52,6 +52,7 @@ runs:
       run: |
         set -euo pipefail
         mkdir -p "$EXTRACT_TO"
-        curl --fail --location --output "$ARCHIVE" "$BAB_RELEASE_URL/$ARCHIVE"
+        curl --proto '=https' --tlsv1.2 --fail --location \
+          --output "$ARCHIVE" "$BAB_RELEASE_URL/$ARCHIVE"
         echo "$SHA256  $ARCHIVE" | sha256sum --check
         tar xzf "$ARCHIVE" -C "$EXTRACT_TO"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,7 +341,8 @@ jobs:
         run: |
           set -euxo pipefail
           SDE_URL="https://downloadmirror.intel.com/915934/${SDE_VERSION}.tar.xz"
-          wget -qO intel-sde.tar.xz "$SDE_URL"
+          curl --proto '=https' --tlsv1.2 --fail --location \
+            --silent --show-error --output intel-sde.tar.xz "$SDE_URL"
           echo "${SDE_SHA256}  intel-sde.tar.xz" | sha256sum --check
           mkdir -p intel-sde
           tar xf intel-sde.tar.xz --strip-components=1 -C intel-sde
@@ -402,7 +403,8 @@ jobs:
         run: |
           set -euxo pipefail
           SDE_URL="https://downloadmirror.intel.com/915934/${SDE_VERSION}.tar.xz"
-          wget -qO intel-sde.tar.xz "$SDE_URL"
+          curl --proto '=https' --tlsv1.2 --fail --location \
+            --silent --show-error --output intel-sde.tar.xz "$SDE_URL"
           echo "${SDE_SHA256}  intel-sde.tar.xz" | sha256sum --check
           mkdir -p intel-sde
           tar xf intel-sde.tar.xz --strip-components=1 -C intel-sde

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,7 +334,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: intel-sde
-          key: intel-${{ env.SDE_VERSION }}
+          key: intel-${{ env.SDE_VERSION }}-${{ env.SDE_SHA256 }}
 
       - name: Download Intel SDE
         if: steps.cache-sde.outputs.cache-hit != 'true'
@@ -396,7 +396,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: intel-sde
-          key: intel-${{ env.SDE_VERSION }}
+          key: intel-${{ env.SDE_VERSION }}-${{ env.SDE_SHA256 }}
 
       - name: Download Intel SDE
         if: steps.cache-sde.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ env:
 
   # Intel SDE version used for baseline and AVX-512 emulation jobs.
   SDE_VERSION: "sde-external-10.8.0-2026-03-15-lin"
+  SDE_SHA256: "50b320cd226acef7a491f5b321fc1be3c3c7984f9e27a456e64894b5b0979dd3"
 
 defaults:
   run:
@@ -341,6 +342,7 @@ jobs:
           set -euxo pipefail
           SDE_URL="https://downloadmirror.intel.com/915934/${SDE_VERSION}.tar.xz"
           wget -qO intel-sde.tar.xz "$SDE_URL"
+          echo "${SDE_SHA256}  intel-sde.tar.xz" | sha256sum --check
           mkdir -p intel-sde
           tar xf intel-sde.tar.xz --strip-components=1 -C intel-sde
           rm intel-sde.tar.xz
@@ -401,6 +403,7 @@ jobs:
           set -euxo pipefail
           SDE_URL="https://downloadmirror.intel.com/915934/${SDE_VERSION}.tar.xz"
           wget -qO intel-sde.tar.xz "$SDE_URL"
+          echo "${SDE_SHA256}  intel-sde.tar.xz" | sha256sum --check
           mkdir -p intel-sde
           tar xf intel-sde.tar.xz --strip-components=1 -C intel-sde
           rm intel-sde.tar.xz

--- a/.github/workflows/disk-benchmarks-aa.yml
+++ b/.github/workflows/disk-benchmarks-aa.yml
@@ -46,9 +46,11 @@ jobs:
           - dataset: wikipedia-100K
             config: wikipedia-100K-disk-index.json
             archive: wikipedia-100K.tar.gz
+            sha256: 5b312d186773c549e6132483b148a22b2421140f1a8d9fcd6230c4e019405027
           - dataset: openai-100K
             config: openai-100K-disk-index.json
             archive: openai-100K.tar.gz
+            sha256: b6887d9a31e9ce035665e3df385db37866116a7b7effc1cbaded239956fec113
 
     steps:
       # Kept inline because this must run before checkout, but local action.yml
@@ -77,6 +79,7 @@ jobs:
         with:
           dataset: ${{ matrix.dataset }}
           archive: ${{ matrix.archive }}
+          sha256: ${{ matrix.sha256 }}
           extract-to: diskann_rust/target/tmp
 
       # A/A: build once, run twice (identical code — only detecting environment noise)

--- a/.github/workflows/disk-benchmarks.yml
+++ b/.github/workflows/disk-benchmarks.yml
@@ -31,6 +31,7 @@ on:
       - 'diskann-label-filter/**'
       - 'diskann-benchmark/**'
       - 'diskann-benchmark-runner/**'
+      - '.github/actions/setup-disk-benchmark/**'
       - '.github/workflows/disk-benchmarks.yml'
 
 # Cancel in-progress runs when a new run is triggered
@@ -66,10 +67,12 @@ jobs:
           - dataset: wikipedia-100K
             config: wikipedia-100K-disk-index.json
             archive: wikipedia-100K.tar.gz
+            sha256: 5b312d186773c549e6132483b148a22b2421140f1a8d9fcd6230c4e019405027
             data_dir: wikipedia_cohere
           - dataset: openai-100K
             config: openai-100K-disk-index.json
             archive: openai-100K.tar.gz
+            sha256: b6887d9a31e9ce035665e3df385db37866116a7b7effc1cbaded239956fec113
             data_dir: OpenAIArXiv
 
     steps:
@@ -105,6 +108,7 @@ jobs:
         with:
           dataset: ${{ matrix.dataset }}
           archive: ${{ matrix.archive }}
+          sha256: ${{ matrix.sha256 }}
           extract-to: diskann_rust/target/tmp
 
       - name: Copy dataset to baseline


### PR DESCRIPTION
Validate the checksums of binary artifacts downloaded in CI. There is one more that I'm aware of in [setup-disk-benchmark](https://github.com/microsoft/DiskANN/blob/2882c7591abc621351622fcafa9918a16a79d4da/.github/actions/setup-disk-benchmark/action.yml#L26-L30) that is tracked in #1324.