### PR TITLE
Enable V0 mangling

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,7 @@
+# V0 becomes the default symbol mangling scheme in Rust 1.97, so this can be removed after upgrading.
+[target.'cfg(all())']
+rustflags = ["-C", "symbol-mangling-version=v0"]
+
 [target.'cfg(target_os = "windows")']
 rustflags = ["-C", "control-flow-guard"]
 


### PR DESCRIPTION
Enable the [V0 mangling scheme](https://doc.rust-lang.org/rustc/symbol-mangling/v0.html) at the workspace level. This is the default in [Rust 1.97](https://blog.rust-lang.org/2026/07/09/Rust-1.97.0/#symbol-mangling-v0-enabled-by-default) and thus this can be reverted when we bump to that toolchain.

The biggest reason to change is that the V0 successfully round-trips generic parameters in function names, making it infinitely easier to inspect assemble for specific methods. The mangled symbols are a bit longer, with an unstripped `cargo build --package diskann-benchmark --release --all-features` increasing in size by 3.2%. That said, I would gladly take the increased binary size for being able to actually find specific functions.