### PR TITLE
Supporting spherical quantization builds for the disk index

### DIFF
--- a/diskann-benchmark/src/inputs/disk.rs
+++ b/diskann-benchmark/src/inputs/disk.rs
@@ -445,9 +445,11 @@ impl DiskIndexBuild {
                     write_field!(f, "Quantization", format!("sq, nbits {nbits}"))?
                 }
             }
-            QuantizationType::Spherical(nbits) => {
-                write_field!(f, "Quantization", format!("spherical, nbits {nbits}"))?
-            }
+            QuantizationType::Spherical(bits) => write_field!(
+                f,
+                "Quantization",
+                format!("spherical, nbits {}", bits.as_usize())
+            )?,
         }
         write_field!(f, "Save Path", self.save_path)?;
         Ok(())

--- a/diskann-benchmark/src/inputs/disk.rs
+++ b/diskann-benchmark/src/inputs/disk.rs
@@ -445,6 +445,9 @@ impl DiskIndexBuild {
                     write_field!(f, "Quantization", format!("sq, nbits {nbits}"))?
                 }
             }
+            QuantizationType::Spherical(nbits) => {
+                write_field!(f, "Quantization", format!("spherical, nbits {nbits}"))?
+            }
         }
         write_field!(f, "Save Path", self.save_path)?;
         Ok(())

--- a/diskann-disk/src/build/builder/build.rs
+++ b/diskann-disk/src/build/builder/build.rs
@@ -87,7 +87,7 @@ where
             disk_build_param.build_quantization(),
             &index_writer.get_index_path_prefix(),
             &index_configuration,
-            &pq_storage,
+            &index_writer.get_dataset_file(),
             storage_provider,
         )?;
 

--- a/diskann-disk/src/build/builder/core.rs
+++ b/diskann-disk/src/build/builder/core.rs
@@ -17,6 +17,7 @@ use diskann_providers::{
         READ_WRITE_BLOCK_SIZE,
     },
 };
+use diskann_quantization::spherical::DataRef;
 use diskann_utils::io::read_bin;
 use rand::seq::SliceRandom;
 use tracing::info;
@@ -55,6 +56,11 @@ fn estimate_build_index_ram_usage(
         // `+ std::mem::size_of::<f32>()` for f32 compensation metadata for the scalar quantizer.
         QuantizationType::SQ { nbits, .. } => {
             (nbits as u64 * dim).div_ceil(8) + std::mem::size_of::<f32>() as u64
+        }
+        // Spherical quantization currently only supports 1 bit, enforced during validation.
+        QuantizationType::Spherical(nbits) => {
+            debug_assert_eq!(nbits, 1);
+            DataRef::<1>::canonical_bytes(dim.next_power_of_two() as usize) as u64
         }
     };
 
@@ -919,6 +925,10 @@ pub(crate) mod disk_index_builder_tests {
 
     #[rstest]
     #[case(QuantizationType::SQ { nbits: 2, standard_deviation: None }, "SQ quantization is only supported for 1 bit")]
+    #[case(
+        QuantizationType::Spherical(2),
+        "Spherical quantization is only supported for 1 bit"
+    )]
     fn test_build_quantization_type_failure_cases(
         #[case] build_quantization_type: QuantizationType,
         #[case] error_message: &str,
@@ -1167,6 +1177,7 @@ mod ram_estimation_tests {
     #[case(QuantizationType::FP)]
     #[case(QuantizationType::PQ { num_chunks: 15 })]
     #[case(QuantizationType::SQ { nbits: 1, standard_deviation: None })]
+    #[case(QuantizationType::Spherical(1))]
     fn test_estimate_build_index_ram_usage(#[case] build_quantization_type: QuantizationType) {
         let num_points = 1000;
         let dim = 128;
@@ -1178,6 +1189,9 @@ mod ram_estimation_tests {
             QuantizationType::PQ { num_chunks } => num_chunks as u64,
             QuantizationType::SQ { nbits, .. } => {
                 (nbits as u64 * dim).div_ceil(8) + std::mem::size_of::<f32>() as u64
+            }
+            QuantizationType::Spherical(_) => {
+                DataRef::<1>::canonical_bytes(dim.next_power_of_two() as usize) as u64
             }
         };
         let mut expected_ram_usage = (num_points as f64)

--- a/diskann-disk/src/build/builder/core.rs
+++ b/diskann-disk/src/build/builder/core.rs
@@ -28,7 +28,7 @@ use crate::{
     storage::{CachedReader, CachedWriter, DiskIndexWriter},
     utils::instrumentation::{BuildMergedVamanaIndexCheckpoint, PerfLogger},
     utils::partition_with_ram_budget,
-    DiskIndexBuildParameters, QuantizationType,
+    DiskIndexBuildParameters, QuantizationType, SphericalBits,
 };
 
 /// Overhead factor for RAM estimation during index build (10% buffer).
@@ -57,10 +57,8 @@ fn estimate_build_index_ram_usage(
         QuantizationType::SQ { nbits, .. } => {
             (nbits as u64 * dim).div_ceil(8) + std::mem::size_of::<f32>() as u64
         }
-        // Spherical quantization currently only supports 1 bit, enforced during validation.
-        QuantizationType::Spherical(nbits) => {
-            debug_assert_eq!(nbits, 1);
-            DataRef::<1>::canonical_bytes(dim.next_power_of_two() as usize) as u64
+        QuantizationType::Spherical(SphericalBits::One) => {
+            DataRef::<1>::canonical_bytes(dim as usize) as u64
         }
     };
 
@@ -925,10 +923,6 @@ pub(crate) mod disk_index_builder_tests {
 
     #[rstest]
     #[case(QuantizationType::SQ { nbits: 2, standard_deviation: None }, "SQ quantization is only supported for 1 bit")]
-    #[case(
-        QuantizationType::Spherical(2),
-        "Spherical quantization is only supported for 1 bit"
-    )]
     fn test_build_quantization_type_failure_cases(
         #[case] build_quantization_type: QuantizationType,
         #[case] error_message: &str,
@@ -1177,7 +1171,7 @@ mod ram_estimation_tests {
     #[case(QuantizationType::FP)]
     #[case(QuantizationType::PQ { num_chunks: 15 })]
     #[case(QuantizationType::SQ { nbits: 1, standard_deviation: None })]
-    #[case(QuantizationType::Spherical(1))]
+    #[case(QuantizationType::Spherical(SphericalBits::One))]
     fn test_estimate_build_index_ram_usage(#[case] build_quantization_type: QuantizationType) {
         let num_points = 1000;
         let dim = 128;
@@ -1190,8 +1184,8 @@ mod ram_estimation_tests {
             QuantizationType::SQ { nbits, .. } => {
                 (nbits as u64 * dim).div_ceil(8) + std::mem::size_of::<f32>() as u64
             }
-            QuantizationType::Spherical(_) => {
-                DataRef::<1>::canonical_bytes(dim.next_power_of_two() as usize) as u64
+            QuantizationType::Spherical(SphericalBits::One) => {
+                DataRef::<1>::canonical_bytes(dim as usize) as u64
             }
         };
         let mut expected_ram_usage = (num_points as f64)

--- a/diskann-disk/src/build/builder/inmem_builder.rs
+++ b/diskann-disk/src/build/builder/inmem_builder.rs
@@ -18,13 +18,18 @@ use diskann_providers::storage::{DynWriteProvider, WriteProviderWrapper};
 use diskann_providers::{
     index::diskann_async,
     model::graph::provider::async_::{
-        common::{FullPrecision, NoDeletes, NoStore, Quantized, SetElementHelper, VectorStore},
+        common::{
+            FullPrecision, NoDeletes, NoStore, Quantized as DefaultQuantized, SetElementHelper,
+            VectorStore,
+        },
         inmem::{
-            DefaultProvider, DefaultProviderParameters, FullPrecisionProvider, SetStartPoints,
+            spherical, DefaultProvider, DefaultProviderParameters, FullPrecisionProvider,
+            SetStartPoints,
         },
     },
     storage::{DiskGraphOnly, SaveWith},
 };
+use diskann_quantization::spherical::iface;
 use diskann_utils::future::{AsyncFriendly, SendFuture};
 
 use super::quantizer::BuildQuantizer;
@@ -153,21 +158,23 @@ where
 // Quant Implementation //
 //////////////////////////
 
-pub(super) struct QuantInMemBuilder<T, Q>
+pub(super) struct QuantInMemBuilder<T, Q, S>
 where
     Q: AsyncFriendly,
 {
     index: DiskANNIndex<DefaultProvider<NoStore, Q>>,
+    strategy: S,
     _vector_data_type: PhantomData<T>,
 }
 
-impl<T, Q> QuantInMemBuilder<T, Q>
+impl<T, Q, S> QuantInMemBuilder<T, Q, S>
 where
     Q: AsyncFriendly,
 {
-    pub fn new(index: DiskANNIndex<DefaultProvider<NoStore, Q>>) -> Self {
+    pub fn new(index: DiskANNIndex<DefaultProvider<NoStore, Q>>, strategy: S) -> Self {
         Self {
             index,
+            strategy,
             _vector_data_type: PhantomData,
         }
     }
@@ -177,11 +184,13 @@ where
     }
 }
 
-impl<T, Q> InmemIndexBuilder<T> for QuantInMemBuilder<T, Q>
+impl<T, Q, S> InmemIndexBuilder<T> for QuantInMemBuilder<T, Q, S>
 where
     T: VectorRepr,
     Q: AsyncFriendly + VectorStore + SetElementHelper<T>,
-    Quantized: for<'a> InsertStrategy<'a, DefaultProvider<NoStore, Q>, &'a [T]>
+    S: Send
+        + Sync
+        + for<'a> InsertStrategy<'a, DefaultProvider<NoStore, Q>, &'a [T]>
         + PruneStrategy<DefaultProvider<NoStore, Q>>,
     DefaultProvider<NoStore, Q>: SaveWith<(u32, u32, DiskGraphOnly), Error = ANNError>,
 {
@@ -206,7 +215,7 @@ where
     ) -> Pin<Box<dyn SendFuture<ANNResult<()>> + 'a>> {
         Box::pin(async move {
             self.index()
-                .insert(&Quantized, &DefaultContext, &id, vector)
+                .insert(&self.strategy, &DefaultContext, &id, vector)
                 .await
         })
     }
@@ -217,7 +226,7 @@ where
     ) -> Pin<Box<dyn SendFuture<ANNResult<()>> + '_>> {
         Box::pin(async move {
             self.index()
-                .prune_range(&Quantized, &DefaultContext, range)
+                .prune_range(&self.strategy, &DefaultContext, range)
                 .await
         })
     }
@@ -255,7 +264,8 @@ where
 ///
 /// Chooses the builder implementation based on the given `BuildQuantizer`.
 /// - `NoQuant` uses a plain index with no quantization.
-/// - `Scalar1Bit` and `PQ` create quantized only indexes backed by `QuantInMemBuilder`.
+/// - `Scalar1Bit`, `Spherical1Bit`, and `PQ` create quantized only indexes backed by
+///   `QuantInMemBuilder`.
 ///
 /// # Parameters
 /// * `config` – Index configuration.
@@ -279,12 +289,24 @@ where
             .map(|index| index as Arc<dyn InmemIndexBuilder<T>>),
         BuildQuantizer::Scalar1Bit(q) => {
             let index = diskann_async::new_quant_only_index(config, params, q.clone(), NoDeletes)?;
-            Ok(Arc::new(QuantInMemBuilder::<T, _>::new(index)))
+            Ok(Arc::new(QuantInMemBuilder::new(index, DefaultQuantized)))
+        }
+        BuildQuantizer::Spherical1Bit(q) => {
+            let quantizer = q
+                .as_ref()
+                .try_clone()
+                .map_err(spherical::AllocatorError::from)?;
+            let plan = iface::Impl::<1>::new(quantizer).map_err(spherical::AllocatorError::from)?;
+            let index = diskann_async::new_quant_only_index(config, params, plan, NoDeletes)?;
+            Ok(Arc::new(QuantInMemBuilder::new(
+                index,
+                spherical::Quantized::build(),
+            )))
         }
         BuildQuantizer::PQ(table) => {
             let index =
                 diskann_async::new_quant_only_index(config, params, table.clone(), NoDeletes)?;
-            Ok(Arc::new(QuantInMemBuilder::<T, _>::new(index)))
+            Ok(Arc::new(QuantInMemBuilder::new(index, DefaultQuantized)))
         }
     }
 }

--- a/diskann-disk/src/build/builder/inmem_builder.rs
+++ b/diskann-disk/src/build/builder/inmem_builder.rs
@@ -292,10 +292,7 @@ where
             Ok(Arc::new(QuantInMemBuilder::new(index, DefaultQuantized)))
         }
         BuildQuantizer::Spherical1Bit(q) => {
-            let quantizer = q
-                .as_ref()
-                .try_clone()
-                .map_err(spherical::AllocatorError::from)?;
+            let quantizer = q.try_clone().map_err(spherical::AllocatorError::from)?;
             let plan = iface::Impl::<1>::new(quantizer).map_err(spherical::AllocatorError::from)?;
             let index = diskann_async::new_quant_only_index(config, params, plan, NoDeletes)?;
             Ok(Arc::new(QuantInMemBuilder::new(

--- a/diskann-disk/src/build/builder/quantizer.rs
+++ b/diskann-disk/src/build/builder/quantizer.rs
@@ -4,7 +4,7 @@
  */
 //! Disk index quantizer implementation.
 use crate::data_model::GraphDataType;
-use diskann::ANNResult;
+use diskann::{ANNError, ANNResult};
 use diskann_providers::storage::{StorageReadProvider, StorageWriteProvider};
 use diskann_providers::{
     index::diskann_async::train_pq,
@@ -13,12 +13,11 @@ use diskann_providers::{
         FixedChunkPQTable, IndexConfiguration, MAX_PQ_TRAINING_SET_SIZE,
     },
     storage::{PQStorage, SQStorage},
-    utils::{create_thread_pool, BridgeErr, PQPathNames},
+    utils::{create_thread_pool, gen_random_slice, BridgeErr, PQPathNames},
 };
 use diskann_quantization::{
     algorithms::transforms::{TargetDim, TransformKind},
     alloc::GlobalAllocator,
-    error::Format,
     scalar::train::ScalarQuantizationParameters,
     spherical::{PreScale, SphericalQuantizer, SupportedMetric},
 };
@@ -44,7 +43,7 @@ impl BuildQuantizer {
         build_quantization_type: &QuantizationType,
         index_path_prefix: &str,
         index_configuration: &IndexConfiguration,
-        pq_storage: &PQStorage,
+        data_path: &str,
         storage_provider: &StorageProvider,
     ) -> ANNResult<Self>
     where
@@ -62,8 +61,9 @@ impl BuildQuantizer {
                     let mut rnd =
                         diskann_providers::utils::create_rnd_provider_from_optional_seed(seed)
                             .create_rnd();
-                    let (train_data, train_size, train_dim) = pq_storage
-                        .get_random_train_data_slice::<Data::VectorDataType, _>(
+                    let (train_data, train_size, train_dim) =
+                        gen_random_slice::<Data::VectorDataType, _>(
+                            data_path,
                             p_val,
                             storage_provider,
                             &mut rnd,
@@ -103,8 +103,9 @@ impl BuildQuantizer {
                 let rng = diskann_providers::utils::create_rnd_provider_from_optional_seed(
                     index_configuration.random_seed,
                 );
-                let (train_data_vector, train_size, train_dim) = pq_storage
-                    .get_random_train_data_slice::<Data::VectorDataType, _>(
+                let (train_data_vector, train_size, train_dim) =
+                    gen_random_slice::<Data::VectorDataType, _>(
+                        data_path,
                         p_val,
                         storage_provider,
                         &mut rng.create_rnd(),
@@ -127,20 +128,21 @@ impl BuildQuantizer {
                 Ok(Self::Scalar1Bit(WithBits::<1>::new(quantizer)))
             }
             QuantizationType::Spherical(SphericalBits::One) => {
+                let metric: SupportedMetric =
+                    index_configuration.dist_metric.try_into().bridge_err()?;
                 let rng = diskann_providers::utils::create_rnd_provider_from_optional_seed(
                     index_configuration.random_seed,
                 );
                 let mut rnd = rng.create_rnd();
-                let (train_data, train_size, train_dim) = pq_storage
-                    .get_random_train_data_slice::<Data::VectorDataType, _>(
+                let (train_data, train_size, train_dim) =
+                    gen_random_slice::<Data::VectorDataType, _>(
+                        data_path,
                         p_val,
                         storage_provider,
                         &mut rnd,
                     )?;
                 let train_data =
                     MatrixView::try_from(&train_data, train_size, train_dim).bridge_err()?;
-                let metric: SupportedMetric =
-                    index_configuration.dist_metric.try_into().bridge_err()?;
                 let quantizer = SphericalQuantizer::train(
                     train_data,
                     TransformKind::DoubleHadamard {
@@ -151,13 +153,7 @@ impl BuildQuantizer {
                     &mut rnd,
                     GlobalAllocator,
                 )
-                .map_err(|err| {
-                    diskann_error!(
-                        ErrorKind::IndexError,
-                        "Failed to train spherical quantizer: {}",
-                        Format(err)
-                    )
-                })?;
+                .map_err(|err| ANNError::new(err).context("Failed to train spherical quantizer"))?;
 
                 Ok(Self::Spherical1Bit(quantizer))
             }

--- a/diskann-disk/src/build/builder/quantizer.rs
+++ b/diskann-disk/src/build/builder/quantizer.rs
@@ -3,8 +3,6 @@
  * Licensed under the MIT license.
  */
 //! Disk index quantizer implementation.
-use std::sync::Arc;
-
 use crate::data_model::GraphDataType;
 use diskann::ANNResult;
 use diskann_providers::storage::{StorageReadProvider, StorageWriteProvider};
@@ -20,6 +18,7 @@ use diskann_providers::{
 use diskann_quantization::{
     algorithms::transforms::{TargetDim, TransformKind},
     alloc::GlobalAllocator,
+    error::Format,
     scalar::train::ScalarQuantizationParameters,
     spherical::{PreScale, SphericalQuantizer, SupportedMetric},
 };
@@ -28,15 +27,14 @@ use tracing::info;
 
 use crate::{
     error::{diskann_error, ErrorKind},
-    QuantizationType,
+    QuantizationType, SphericalBits,
 };
 
 /// Quantizer types used specifically for async disk index building.
-#[derive(Clone)]
 pub enum BuildQuantizer {
     NoQuant(NoStore),
     Scalar1Bit(WithBits<1>),
-    Spherical1Bit(Arc<SphericalQuantizer>),
+    Spherical1Bit(SphericalQuantizer),
     PQ(FixedChunkPQTable),
 }
 
@@ -128,14 +126,7 @@ impl BuildQuantizer {
 
                 Ok(Self::Scalar1Bit(WithBits::<1>::new(quantizer)))
             }
-            QuantizationType::Spherical(nbits) => {
-                if nbits != 1 {
-                    return Err(diskann_error!(
-                        ErrorKind::IndexConfigError("build_quantization_type"),
-                        "Spherical quantization is only supported for 1 bit",
-                    ));
-                }
-
+            QuantizationType::Spherical(SphericalBits::One) => {
                 let rng = diskann_providers::utils::create_rnd_provider_from_optional_seed(
                     index_configuration.random_seed,
                 );
@@ -152,7 +143,7 @@ impl BuildQuantizer {
                     index_configuration.dist_metric.try_into().bridge_err()?;
                 let quantizer = SphericalQuantizer::train(
                     train_data,
-                    TransformKind::PaddingHadamard {
+                    TransformKind::DoubleHadamard {
                         target_dim: TargetDim::Natural,
                     },
                     metric,
@@ -164,11 +155,11 @@ impl BuildQuantizer {
                     diskann_error!(
                         ErrorKind::IndexError,
                         "Failed to train spherical quantizer: {}",
-                        err
+                        Format(err)
                     )
                 })?;
 
-                Ok(Self::Spherical1Bit(Arc::new(quantizer)))
+                Ok(Self::Spherical1Bit(quantizer))
             }
         }
     }

--- a/diskann-disk/src/build/builder/quantizer.rs
+++ b/diskann-disk/src/build/builder/quantizer.rs
@@ -3,6 +3,8 @@
  * Licensed under the MIT license.
  */
 //! Disk index quantizer implementation.
+use std::sync::Arc;
+
 use crate::data_model::GraphDataType;
 use diskann::ANNResult;
 use diskann_providers::storage::{StorageReadProvider, StorageWriteProvider};
@@ -15,7 +17,12 @@ use diskann_providers::{
     storage::{PQStorage, SQStorage},
     utils::{create_thread_pool, BridgeErr, PQPathNames},
 };
-use diskann_quantization::scalar::train::ScalarQuantizationParameters;
+use diskann_quantization::{
+    algorithms::transforms::{TargetDim, TransformKind},
+    alloc::GlobalAllocator,
+    scalar::train::ScalarQuantizationParameters,
+    spherical::{PreScale, SphericalQuantizer, SupportedMetric},
+};
 use diskann_utils::views::MatrixView;
 use tracing::info;
 
@@ -29,6 +36,7 @@ use crate::{
 pub enum BuildQuantizer {
     NoQuant(NoStore),
     Scalar1Bit(WithBits<1>),
+    Spherical1Bit(Arc<SphericalQuantizer>),
     PQ(FixedChunkPQTable),
 }
 
@@ -119,6 +127,48 @@ impl BuildQuantizer {
                 sq_storage.save_quantizer(&quantizer, storage_provider)?;
 
                 Ok(Self::Scalar1Bit(WithBits::<1>::new(quantizer)))
+            }
+            QuantizationType::Spherical(nbits) => {
+                if nbits != 1 {
+                    return Err(diskann_error!(
+                        ErrorKind::IndexConfigError("build_quantization_type"),
+                        "Spherical quantization is only supported for 1 bit",
+                    ));
+                }
+
+                let rng = diskann_providers::utils::create_rnd_provider_from_optional_seed(
+                    index_configuration.random_seed,
+                );
+                let mut rnd = rng.create_rnd();
+                let (train_data, train_size, train_dim) = pq_storage
+                    .get_random_train_data_slice::<Data::VectorDataType, _>(
+                        p_val,
+                        storage_provider,
+                        &mut rnd,
+                    )?;
+                let train_data =
+                    MatrixView::try_from(&train_data, train_size, train_dim).bridge_err()?;
+                let metric: SupportedMetric =
+                    index_configuration.dist_metric.try_into().bridge_err()?;
+                let quantizer = SphericalQuantizer::train(
+                    train_data,
+                    TransformKind::PaddingHadamard {
+                        target_dim: TargetDim::Natural,
+                    },
+                    metric,
+                    PreScale::ReciprocalMeanNorm,
+                    &mut rnd,
+                    GlobalAllocator,
+                )
+                .map_err(|err| {
+                    diskann_error!(
+                        ErrorKind::IndexError,
+                        "Failed to train spherical quantizer: {}",
+                        err
+                    )
+                })?;
+
+                Ok(Self::Spherical1Bit(Arc::new(quantizer)))
             }
         }
     }

--- a/diskann-disk/src/build/builder/tests.rs
+++ b/diskann-disk/src/build/builder/tests.rs
@@ -46,18 +46,29 @@ mod disk_index_build_tests {
         #[values(Metric::InnerProduct, Metric::Cosine)] metric: Metric,
     ) {
         let index_path_prefix = format!(
-            "/disk_index_build/test_spherical_disk_index_build_{:?}",
+            "/disk_index_build/test_spherical_disk_index_build_{:?}_async_SPHERICAL_1",
             metric
         );
-
-        run_test_with_metric(
+        let params = TestParams {
+            l_build: 64,
+            max_degree: 16,
             index_path_prefix,
-            QuantizationType::Spherical(SphericalBits::One),
-            false,
+            data_compression_chunk_vector_count: Some(10),
+            build_quantization_type: QuantizationType::Spherical(SphericalBits::One),
+            metric,
+            ..TestParams::default()
+        };
+        let fixture = IndexBuildFixture::new(new_vfs(), params).unwrap();
+
+        fixture.build::<GraphDataF32VectorUnitData>().unwrap();
+
+        verify_search_result_with_ground_truth::<GraphDataF32VectorUnitData>(
+            &fixture.params,
             8,
             130,
-            metric,
-        );
+            &fixture.storage_provider,
+        )
+        .unwrap();
     }
 
     // Helper function to run the tests with consistent behavior
@@ -116,24 +127,6 @@ mod disk_index_build_tests {
         top_k: usize,
         search_l: u32,
     ) {
-        run_test_with_metric(
-            index_path_prefix,
-            build_quantization_type,
-            use_sharded_build,
-            top_k,
-            search_l,
-            Metric::L2,
-        );
-    }
-
-    fn run_test_with_metric(
-        index_path_prefix: String,
-        build_quantization_type: QuantizationType,
-        use_sharded_build: bool,
-        top_k: usize,
-        search_l: u32,
-        metric: Metric,
-    ) {
         // Use the same parameters from [test_sift_build_and_search] in diskann_index
         let l_build = 64;
         let max_degree = 16;
@@ -149,7 +142,6 @@ mod disk_index_build_tests {
             index_build_ram_gb: get_index_build_ram_gb(use_sharded_build),
             data_compression_chunk_vector_count: Some(10),
             build_quantization_type,
-            metric,
             ..TestParams::default()
         };
 
@@ -157,9 +149,7 @@ mod disk_index_build_tests {
 
         fixture.build::<GraphDataF32VectorUnitData>().unwrap();
 
-        if metric == Metric::L2 {
-            fixture.compare_pq_compressed_files();
-        }
+        fixture.compare_pq_compressed_files();
         verify_search_result_with_ground_truth::<GraphDataF32VectorUnitData>(
             &fixture.params,
             top_k,

--- a/diskann-disk/src/build/builder/tests.rs
+++ b/diskann-disk/src/build/builder/tests.rs
@@ -14,7 +14,7 @@ mod disk_index_build_tests {
         build::builder::core::disk_index_builder_tests::{
             new_vfs, verify_search_result_with_ground_truth, IndexBuildFixture, TestParams,
         },
-        QuantizationType,
+        QuantizationType, SphericalBits,
     };
 
     #[derive(PartialEq)]
@@ -52,7 +52,7 @@ mod disk_index_build_tests {
 
         run_test_with_metric(
             index_path_prefix,
-            QuantizationType::Spherical(1),
+            QuantizationType::Spherical(SphericalBits::One),
             false,
             8,
             130,
@@ -91,7 +91,7 @@ mod disk_index_build_tests {
             BuildType::AsyncSpherical1Bit => {
                 run_test(
                     index_path_prefix,
-                    QuantizationType::Spherical(1),
+                    QuantizationType::Spherical(SphericalBits::One),
                     use_sharded_build,
                     8,   // top_k
                     130, // search_l

--- a/diskann-disk/src/build/builder/tests.rs
+++ b/diskann-disk/src/build/builder/tests.rs
@@ -7,6 +7,7 @@
 #[cfg(test)]
 mod disk_index_build_tests {
     use crate::test_utils::{GraphDataF32VectorUnitData, GraphDataMinMaxVectorUnitData};
+    use diskann_vector::distance::Metric;
     use rstest::rstest;
 
     use crate::{
@@ -20,18 +21,43 @@ mod disk_index_build_tests {
     enum BuildType {
         AsyncFP,
         AsyncSQ1Bit,
+        AsyncSpherical1Bit,
         AsyncPQ,
     }
 
     #[rstest]
     pub fn test_disk_index_builder(
         #[values(false, true)] use_sharded_build: bool,
-        #[values(BuildType::AsyncFP, BuildType::AsyncSQ1Bit, BuildType::AsyncPQ)]
+        #[values(
+            BuildType::AsyncFP,
+            BuildType::AsyncSQ1Bit,
+            BuildType::AsyncSpherical1Bit,
+            BuildType::AsyncPQ
+        )]
         build_type: BuildType,
     ) {
         let index_path_prefix = "/disk_index_build/test_disk_index_build".to_string();
 
         run_disk_index_builder_test(index_path_prefix, use_sharded_build, build_type);
+    }
+
+    #[rstest]
+    fn test_spherical_disk_index_builder_with_metric(
+        #[values(Metric::InnerProduct, Metric::Cosine)] metric: Metric,
+    ) {
+        let index_path_prefix = format!(
+            "/disk_index_build/test_spherical_disk_index_build_{:?}",
+            metric
+        );
+
+        run_test_with_metric(
+            index_path_prefix,
+            QuantizationType::Spherical(1),
+            false,
+            8,
+            130,
+            metric,
+        );
     }
 
     // Helper function to run the tests with consistent behavior
@@ -62,6 +88,15 @@ mod disk_index_build_tests {
                     130, // search_l
                 );
             }
+            BuildType::AsyncSpherical1Bit => {
+                run_test(
+                    index_path_prefix,
+                    QuantizationType::Spherical(1),
+                    use_sharded_build,
+                    8,   // top_k
+                    130, // search_l
+                );
+            }
             BuildType::AsyncPQ => {
                 run_test(
                     index_path_prefix,
@@ -81,6 +116,24 @@ mod disk_index_build_tests {
         top_k: usize,
         search_l: u32,
     ) {
+        run_test_with_metric(
+            index_path_prefix,
+            build_quantization_type,
+            use_sharded_build,
+            top_k,
+            search_l,
+            Metric::L2,
+        );
+    }
+
+    fn run_test_with_metric(
+        index_path_prefix: String,
+        build_quantization_type: QuantizationType,
+        use_sharded_build: bool,
+        top_k: usize,
+        search_l: u32,
+        metric: Metric,
+    ) {
         // Use the same parameters from [test_sift_build_and_search] in diskann_index
         let l_build = 64;
         let max_degree = 16;
@@ -96,6 +149,7 @@ mod disk_index_build_tests {
             index_build_ram_gb: get_index_build_ram_gb(use_sharded_build),
             data_compression_chunk_vector_count: Some(10),
             build_quantization_type,
+            metric,
             ..TestParams::default()
         };
 
@@ -103,7 +157,9 @@ mod disk_index_build_tests {
 
         fixture.build::<GraphDataF32VectorUnitData>().unwrap();
 
-        fixture.compare_pq_compressed_files();
+        if metric == Metric::L2 {
+            fixture.compare_pq_compressed_files();
+        }
         verify_search_result_with_ground_truth::<GraphDataF32VectorUnitData>(
             &fixture.params,
             top_k,

--- a/diskann-disk/src/build/configuration/mod.rs
+++ b/diskann-disk/src/build/configuration/mod.rs
@@ -8,4 +8,4 @@ pub use disk_index_build_parameter::{DiskIndexBuildParameters, MemoryBudget, Num
 pub mod filter_parameter;
 
 pub mod quantization_types;
-pub use quantization_types::QuantizationType;
+pub use quantization_types::{QuantizationType, SphericalBits};

--- a/diskann-disk/src/build/configuration/quantization_types.rs
+++ b/diskann-disk/src/build/configuration/quantization_types.rs
@@ -13,7 +13,7 @@ use serde::{
 use thiserror::Error;
 
 const EXPECTED_QUANTIZATION_TEMPLATE: &str =
-    "Expected 'FP', 'PQ_N', 'SQ_NBITS'(STDDEV=2.0 by default), 'SQ_NBITS_STDDEV', got: ";
+    "Expected 'FP', 'PQ_N', 'SQ_NBITS'(STDDEV=2.0 by default), 'SQ_NBITS_STDDEV', or 'SPHERICAL_NBITS', got: ";
 
 /// - `PQ`: Product Quantization with a specified number of chunks.
 /// - `SQ`: Scalar Quantization with a specified number of bits per dimension and a standard deviation.
@@ -38,6 +38,9 @@ pub enum QuantizationType {
         /// be greater than 1.0.
         standard_deviation: Option<Positive<f64>>,
     },
+
+    /// Spherical quantization bit width. Disk-index builds currently support only 1 bit.
+    Spherical(usize),
 }
 
 #[derive(Debug, Error)]
@@ -146,6 +149,23 @@ impl FromStr for QuantizationType {
                     standard_deviation,
                 })
             }
+            "spherical" => {
+                if parts.len() != 2 {
+                    return Err(QuantizationTypeParseError(format!(
+                        "{} {}",
+                        EXPECTED_QUANTIZATION_TEMPLATE, s
+                    )));
+                }
+                let nbits = parts[1].parse::<usize>().map_err(|_| {
+                    QuantizationTypeParseError(format!("{} {}", EXPECTED_QUANTIZATION_TEMPLATE, s))
+                })?;
+                if nbits == 0 {
+                    return Err(QuantizationTypeParseError(
+                        "The nbits should be more than 0 for Spherical quantization".to_string(),
+                    ));
+                }
+                Ok(QuantizationType::Spherical(nbits))
+            }
             _ => Err(QuantizationTypeParseError(format!(
                 "{} {}",
                 EXPECTED_QUANTIZATION_TEMPLATE, s
@@ -159,6 +179,7 @@ impl Display for QuantizationType {
         match self {
             QuantizationType::PQ { num_chunks } => write!(f, "PQ_{}", num_chunks),
             QuantizationType::FP => write!(f, "FP"),
+            QuantizationType::Spherical(nbits) => write!(f, "SPHERICAL_{}", nbits),
             QuantizationType::SQ {
                 nbits,
                 standard_deviation,
@@ -191,6 +212,8 @@ mod tests {
         nbits: 1,
         standard_deviation: None
     }))]
+    #[case("SPHERICAL_1", Ok(QuantizationType::Spherical(1)))]
+    #[case("spherical_4", Ok(QuantizationType::Spherical(4)))]
     #[case("", Err(()))]
     #[case("FP_1", Err(()))]
     #[case("invalid", Err(()))]
@@ -202,6 +225,9 @@ mod tests {
     #[case("SQ_1_-1", Err(()))]
     #[case("SQ_1_2.0_3", Err(()))]
     #[case("SQ_1_abc", Err(()))]
+    #[case("SPHERICAL", Err(()))]
+    #[case("SPHERICAL_0", Err(()))]
+    #[case("SPHERICAL_abc", Err(()))]
     fn test_parse_quantization_type(
         #[case] input: &str,
         #[case] expected: Result<QuantizationType, ()>,
@@ -224,6 +250,7 @@ mod tests {
     #[rstest]
     #[case(QuantizationType::PQ { num_chunks: 16 }, "PQ_16")]
     #[case(QuantizationType::FP, "FP")]
+    #[case(QuantizationType::Spherical(1), "SPHERICAL_1")]
     #[case(
         QuantizationType::SQ { nbits: 8, standard_deviation: None },
         "SQ_8_None"
@@ -267,6 +294,14 @@ mod tests {
     }
 
     #[test]
+    fn test_serialize_deserialize_quantization_type_spherical() {
+        let quant = QuantizationType::Spherical(1);
+        let serialized = bincode::serialize(&quant).unwrap();
+        let deserialized: QuantizationType = bincode::deserialize(&serialized).unwrap();
+        assert_eq!(quant, deserialized);
+    }
+
+    #[test]
     fn test_roundtrip_serialization() {
         // Note: SQ with None standard_deviation is not included as it formats to "SQ_N_None"
         // which the parser doesn't accept - this is a known limitation of the current implementation
@@ -277,6 +312,7 @@ mod tests {
                 nbits: 8,
                 standard_deviation: Some(Positive::new(1.5).unwrap()),
             },
+            QuantizationType::Spherical(1),
         ];
 
         for quant_type in types {

--- a/diskann-disk/src/build/configuration/quantization_types.rs
+++ b/diskann-disk/src/build/configuration/quantization_types.rs
@@ -17,7 +17,9 @@ const EXPECTED_QUANTIZATION_TEMPLATE: &str =
 
 /// - `PQ`: Product Quantization with a specified number of chunks.
 /// - `SQ`: Scalar Quantization with a specified number of bits per dimension and a standard deviation.
-///   The `Default` implementation returns `FP` (Full Precision).
+/// - `Spherical`: Spherical Quantization with a supported bit width.
+///
+/// The `Default` implementation returns `FP` (Full Precision).
 #[derive(Debug, Copy, Default, PartialEq, Clone)]
 pub enum QuantizationType {
     /// No quantization - uses full precision
@@ -39,13 +41,47 @@ pub enum QuantizationType {
         standard_deviation: Option<Positive<f64>>,
     },
 
-    /// Spherical quantization bit width. Disk-index builds currently support only 1 bit.
-    Spherical(usize),
+    /// Spherical quantization.
+    Spherical(SphericalBits),
 }
 
 #[derive(Debug, Error)]
 #[error("Invalid quantization type: {0:?}")]
 pub struct QuantizationTypeParseError(String);
+
+/// Supported spherical quantization bit widths.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum SphericalBits {
+    One,
+}
+
+impl SphericalBits {
+    pub const fn as_usize(self) -> usize {
+        match self {
+            Self::One => 1,
+        }
+    }
+}
+
+impl FromStr for SphericalBits {
+    type Err = QuantizationTypeParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "1" => Ok(Self::One),
+            _ => Err(QuantizationTypeParseError(format!(
+                "Unsupported spherical quantization bit width: {}",
+                s
+            ))),
+        }
+    }
+}
+
+impl Display for SphericalBits {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_usize().fmt(f)
+    }
+}
 
 impl serde::Serialize for QuantizationType {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
@@ -156,15 +192,7 @@ impl FromStr for QuantizationType {
                         EXPECTED_QUANTIZATION_TEMPLATE, s
                     )));
                 }
-                let nbits = parts[1].parse::<usize>().map_err(|_| {
-                    QuantizationTypeParseError(format!("{} {}", EXPECTED_QUANTIZATION_TEMPLATE, s))
-                })?;
-                if nbits == 0 {
-                    return Err(QuantizationTypeParseError(
-                        "The nbits should be more than 0 for Spherical quantization".to_string(),
-                    ));
-                }
-                Ok(QuantizationType::Spherical(nbits))
+                Ok(QuantizationType::Spherical(parts[1].parse()?))
             }
             _ => Err(QuantizationTypeParseError(format!(
                 "{} {}",
@@ -212,8 +240,7 @@ mod tests {
         nbits: 1,
         standard_deviation: None
     }))]
-    #[case("SPHERICAL_1", Ok(QuantizationType::Spherical(1)))]
-    #[case("spherical_4", Ok(QuantizationType::Spherical(4)))]
+    #[case("SPHERICAL_1", Ok(QuantizationType::Spherical(SphericalBits::One)))]
     #[case("", Err(()))]
     #[case("FP_1", Err(()))]
     #[case("invalid", Err(()))]
@@ -227,6 +254,7 @@ mod tests {
     #[case("SQ_1_abc", Err(()))]
     #[case("SPHERICAL", Err(()))]
     #[case("SPHERICAL_0", Err(()))]
+    #[case("SPHERICAL_2", Err(()))]
     #[case("SPHERICAL_abc", Err(()))]
     fn test_parse_quantization_type(
         #[case] input: &str,
@@ -250,7 +278,7 @@ mod tests {
     #[rstest]
     #[case(QuantizationType::PQ { num_chunks: 16 }, "PQ_16")]
     #[case(QuantizationType::FP, "FP")]
-    #[case(QuantizationType::Spherical(1), "SPHERICAL_1")]
+    #[case(QuantizationType::Spherical(SphericalBits::One), "SPHERICAL_1")]
     #[case(
         QuantizationType::SQ { nbits: 8, standard_deviation: None },
         "SQ_8_None"
@@ -295,7 +323,7 @@ mod tests {
 
     #[test]
     fn test_serialize_deserialize_quantization_type_spherical() {
-        let quant = QuantizationType::Spherical(1);
+        let quant = QuantizationType::Spherical(SphericalBits::One);
         let serialized = bincode::serialize(&quant).unwrap();
         let deserialized: QuantizationType = bincode::deserialize(&serialized).unwrap();
         assert_eq!(quant, deserialized);
@@ -312,7 +340,7 @@ mod tests {
                 nbits: 8,
                 standard_deviation: Some(Positive::new(1.5).unwrap()),
             },
-            QuantizationType::Spherical(1),
+            QuantizationType::Spherical(SphericalBits::One),
         ];
 
         for quant_type in types {

--- a/diskann-disk/src/build/mod.rs
+++ b/diskann-disk/src/build/mod.rs
@@ -14,4 +14,5 @@ pub mod configuration;
 // Re-export key types for convenience
 pub use configuration::{
     disk_index_build_parameter, filter_parameter, DiskIndexBuildParameters, QuantizationType,
+    SphericalBits,
 };

--- a/diskann-disk/src/lib.rs
+++ b/diskann-disk/src/lib.rs
@@ -16,6 +16,7 @@ pub mod error;
 pub mod build;
 pub use build::{
     disk_index_build_parameter, filter_parameter, DiskIndexBuildParameters, QuantizationType,
+    SphericalBits,
 };
 
 pub mod data_model;

--- a/diskann-quantization/src/spherical/quantizer.rs
+++ b/diskann-quantization/src/spherical/quantizer.rs
@@ -82,13 +82,7 @@ where
     A: Allocator,
 {
     fn try_clone(&self) -> Result<Self, AllocatorError> {
-        Ok(Self {
-            shift: self.shift.try_clone()?,
-            transform: self.transform.try_clone()?,
-            metric: self.metric,
-            mean_norm: self.mean_norm,
-            pre_scale: self.pre_scale,
-        })
+        SphericalQuantizer::try_clone(self)
     }
 }
 
@@ -158,7 +152,13 @@ where
 
     /// Return an independently allocated copy of this quantizer.
     pub fn try_clone(&self) -> Result<Self, AllocatorError> {
-        <Self as TryClone>::try_clone(self)
+        Ok(Self {
+            shift: self.shift.try_clone()?,
+            transform: self.transform.try_clone()?,
+            metric: self.metric,
+            mean_norm: self.mean_norm,
+            pre_scale: self.pre_scale,
+        })
     }
 
     /// A lower-level constructor that accepts a centroid, mean norm, and pre-scale directly.

--- a/diskann-quantization/src/spherical/quantizer.rs
+++ b/diskann-quantization/src/spherical/quantizer.rs
@@ -156,6 +156,11 @@ where
         self.shift.allocator()
     }
 
+    /// Return an independently allocated copy of this quantizer.
+    pub fn try_clone(&self) -> Result<Self, AllocatorError> {
+        <Self as TryClone>::try_clone(self)
+    }
+
     /// A lower-level constructor that accepts a centroid, mean norm, and pre-scale directly.
     pub fn generate(
         mut centroid: Poly<[f32], A>,


### PR DESCRIPTION
## Summary

- add spherical quantization as a disk index build option
- train and wire the 1-bit spherical quantizer into one-shot and sharded in-memory builds
- account for spherical vector storage in build RAM estimation
- validate the currently supported 1-bit configuration
- add disk build and search coverage for L2, inner product, and cosine metrics

## Validation

- `cargo test -p diskann-disk` (250 unit tests and 2 doc tests passed)
- `cargo test -p diskann-disk test_spherical_disk_index_builder_with_metric` (2 passed)
- `cargo fmt --all --check`
- `git diff --check`