### PR TITLE
Bump toolchain to 1.97.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,9 +1288,9 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "iai-callgrind"
-version = "0.14.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c9e864ad001cbbf35a64f7b574998823b8622bb483a25246fa1b0e2b3888686"
+checksum = "0b1e4910d3a9137442723dfb772c32dc10674c4181ca078d2fd227cd5dce9db0"
 dependencies = [
  "bincode",
  "derive_more",
@@ -1300,9 +1300,9 @@ dependencies = [
 
 [[package]]
 name = "iai-callgrind-macros"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9cee6c3bc32b63ff40e5e56190b1276d2bd0e0b319aa6f998864c27865d3b4e"
+checksum = "4d03775318d3f9f01b39ac6612b01464006dc397a654a89dd57df2fd34fb68c3"
 dependencies = [
  "derive_more",
  "proc-macro-error2",
@@ -1315,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "iai-callgrind-runner"
-version = "0.14.2"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82491521e6505b06a824274712a1307904e7cdfdf047735f7dfdb28b5f7a337"
+checksum = "b74c9743c00c3bca4aaffc69c87cae56837796cd362438daf354a3f785788c68"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,7 +87,7 @@ dashmap = "6.1.0"
 futures-util = { version = "0.3.31", default-features = false }
 half = "2.6.0"
 hashbrown = "0.16.0"
-iai-callgrind = "0.14.0"
+iai-callgrind = "0.16.1"
 itertools = "0.13.0"
 num-traits = "0.2.15"
 num_cpus = "1.16.0"

--- a/diskann-benchmark/src/inputs/graph_index.rs
+++ b/diskann-benchmark/src/inputs/graph_index.rs
@@ -617,7 +617,7 @@ impl IndexLoad {
             save_and_load::get_graph_max_observed_degree(&storage_provider, &self.load_path)?;
 
         let metadata =
-            load_metadata_from_file(&storage_provider, &format!("{}.data", &self.load_path))?;
+            load_metadata_from_file(&storage_provider, &format!("{}.data", self.load_path))?;
 
         let distance: diskann_vector::distance::Metric = self.distance.into();
         let config = config::Builder::new(

--- a/diskann-disk/benches/bench_main_iai.rs
+++ b/diskann-disk/benches/bench_main_iai.rs
@@ -5,16 +5,13 @@
 
 use benchmarks_iai::aligned_file_reader_bench_iai::aligned_file_reader_bench_iai;
 use benchmarks_iai::kmeans_bench_iai::kmeans_bench_iai;
-use iai_callgrind::{main, EventKind, LibraryBenchmarkConfig, RegressionConfig};
+use iai_callgrind::{main, Callgrind, EventKind, LibraryBenchmarkConfig};
 
 mod benchmarks_iai;
 
 main!(
     config = LibraryBenchmarkConfig::default()
-        .regression(
-            RegressionConfig::default()
-                .limits([(EventKind::Ir, 5.0), (EventKind::EstimatedCycles, 5.0)])
-        );
+        .tool(Callgrind::default().soft_limits([(EventKind::Ir, 5.0), (EventKind::EstimatedCycles, 5.0)]));
     library_benchmark_groups =
         aligned_file_reader_bench_iai,
         kmeans_bench_iai,

--- a/diskann-label-filter/src/parser/query_parser.rs
+++ b/diskann-label-filter/src/parser/query_parser.rs
@@ -84,10 +84,8 @@ fn parse_query_filter_with_depth(
         if let Some(arr) = obj.get("$and").and_then(|v| v.as_array()) {
             let mut exprs = Vec::new();
             for v in arr {
-                match parse_query_filter_with_depth(v, depth + 1) {
-                    Ok(expr) => exprs.push(expr),
-                    Err(e) => return Err(e),
-                }
+                let expr = parse_query_filter_with_depth(v, depth + 1)?;
+                exprs.push(expr)
             }
             if exprs.is_empty() {
                 return Err(QueryFilterError::ParseFailure(
@@ -100,10 +98,8 @@ fn parse_query_filter_with_depth(
         if let Some(arr) = obj.get("$or").and_then(|v| v.as_array()) {
             let mut exprs = Vec::new();
             for v in arr {
-                match parse_query_filter_with_depth(v, depth + 1) {
-                    Ok(expr) => exprs.push(expr),
-                    Err(e) => return Err(e),
-                }
+                let expr = parse_query_filter_with_depth(v, depth + 1)?;
+                exprs.push(expr)
             }
             if exprs.is_empty() {
                 return Err(QueryFilterError::ParseFailure(

--- a/diskann-quantization/src/minmax/quantizer.rs
+++ b/diskann-quantization/src/minmax/quantizer.rs
@@ -504,9 +504,9 @@ mod minmax_quantizer_tests {
         assert!(
             (reconstruction_error / norm) <= relative_err,
             "Expected vector : {:?} to be reconstructed within error {} but instead got : {:?}, with error {} for dim : {}",
-            &vector,
+            vector,
             relative_err,
-            &reconstructed,
+            reconstructed,
             reconstruction_error / norm,
             dim,
         );
@@ -522,7 +522,7 @@ mod minmax_quantizer_tests {
             "Encoded vector with dim : {dim} is {:?}, got error : {} for vector : {:?}",
             encoded.reborrow(),
             (code_sum - expected_code_sum).abs(),
-            &vector,
+            vector,
         );
         let recon_norm_sq = reconstructed.iter().map(|x| x * x).sum::<f32>();
         assert!((encoded.reborrow().meta().norm_squared - recon_norm_sq).abs() <= 1e-3);

--- a/diskann-tools/src/utils/compute_bitmap.rs
+++ b/diskann-tools/src/utils/compute_bitmap.rs
@@ -79,7 +79,7 @@ impl QueryAccelerator for InvertedIndexAccelerator {
 
     fn universe(&self) -> BitSet {
         let mut result = BitSet::new();
-        for (_, bits) in self.map.iter() {
+        for bits in self.map.values() {
             result.extend(bits);
         }
         result
@@ -121,7 +121,7 @@ impl QueryAccelerator for BTreeAccelerator {
 
     fn universe(&self) -> BitSet {
         let mut result = BitSet::new();
-        for (_, ids) in self.map.iter() {
+        for ids in self.map.values() {
             result.extend(ids.iter().cloned());
         }
         result

--- a/diskann-vector/benches/bench_main_vector_iai.rs
+++ b/diskann-vector/benches/bench_main_vector_iai.rs
@@ -4,16 +4,14 @@
  */
 
 use benchmarks_iai::{contains_bench_iai::*, cosine_iai::*, cosine_normalized_iai::*, l2_iai::*};
-use iai_callgrind::{main, EventKind, LibraryBenchmarkConfig, RegressionConfig};
+use iai_callgrind::{main, Callgrind, EventKind, LibraryBenchmarkConfig};
 mod benchmarks_iai;
 pub(crate) mod utils;
 
 main!(
     config = LibraryBenchmarkConfig::default()
-        .regression(
-            RegressionConfig::default()
-                .limits([(EventKind::Ir, 5.0), (EventKind::EstimatedCycles, 5.0), (EventKind::TotalRW, 5.0), (EventKind::L1hits, 5.0)])
-        );
+        .tool(Callgrind::default().soft_limits([(EventKind::Ir, 5.0), (EventKind::EstimatedCycles, 5.0), (EventKind::TotalRW, 5.0), (EventKind::L1hits, 5.0)]));
+
     library_benchmark_groups =
         benchmark_contains_bench_iai,
         cosine_f16_iai,

--- a/diskann-vector/benches/benchmarks_iai/contains_bench_iai.rs
+++ b/diskann-vector/benches/benchmarks_iai/contains_bench_iai.rs
@@ -3,8 +3,8 @@
  * Licensed under the MIT license.
  */
 use diskann_vector::contains::ContainsSimd;
-use iai_callgrind::black_box;
 use rand::{distr::Uniform, prelude::Distribution, rngs::StdRng, Rng, SeedableRng};
+use std::hint::black_box;
 
 iai_callgrind::library_benchmark_group!(
     name = benchmark_contains_bench_iai;

--- a/diskann-vector/benches/benchmarks_iai/cosine_iai.rs
+++ b/diskann-vector/benches/benchmarks_iai/cosine_iai.rs
@@ -7,9 +7,9 @@ use std::num::NonZeroUsize;
 
 use diskann_vector::{distance::Cosine, DistanceFunction};
 use half::f16;
-use iai_callgrind::black_box;
 use rand::{rngs::StdRng, SeedableRng};
 use rand_distr::{Distribution, Normal, StandardUniform};
+use std::hint::black_box;
 
 use crate::utils::{AlignedDataset, AlignedVector, DatasetArgs, InlineBarrier, Static};
 iai_callgrind::library_benchmark_group!(

--- a/diskann-vector/benches/benchmarks_iai/cosine_normalized_iai.rs
+++ b/diskann-vector/benches/benchmarks_iai/cosine_normalized_iai.rs
@@ -7,9 +7,9 @@ use std::num::NonZeroUsize;
 
 use diskann_vector::distance::CosineNormalized;
 use half::f16;
-use iai_callgrind::black_box;
 use rand::{rngs::StdRng, SeedableRng};
 use rand_distr::{Distribution, Normal};
+use std::hint::black_box;
 
 use crate::utils::{AlignedDataset, AlignedVector, DatasetArgs, InlineBarrier, Static};
 

--- a/diskann-wide/src/test_utils/distribution.rs
+++ b/diskann-wide/src/test_utils/distribution.rs
@@ -103,7 +103,11 @@ macro_rules! finite {
                     // infinity/NaN).
                     //
                     // The mantissa is allowed to be all zeros.
-                    (<$T>::EXPONENT_MASK | <$T>::MANTISSA_MASK, false, true)
+                    (
+                        <$T as Layout>::EXPONENT_MASK | <$T as Layout>::MANTISSA_MASK,
+                        false,
+                        true,
+                    )
                 } else if kind < NORMAL_WEIGHT + SUBNORMAL_WEIGHT {
                     // Generate a subnormal floating point number.
                     //

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.95"
+channel = "1.97.1"
 components = ["rust-src"]


### PR DESCRIPTION
This updates the Rust toolchain to 1.97.1 now that internal Microsoft toolchain are available for the same version.

Aside from the normal few clippy lint changes, this also bumps iai-callgrind to 0.16.1. This was intended to fix a future incompatibility warning, however, but unfortunately did not as the root cause is the unmaintained proc-macro-error2 crate which is still a dependency of iai-callgrind 0.16.1.