### PR TITLE
Migrate disk PQ flat scan to flat API

### DIFF
--- a/diskann-disk/src/search/pq/mod.rs
+++ b/diskann-disk/src/search/pq/mod.rs
@@ -11,4 +11,3 @@ pub use pq_scratch::PQScratch;
 pub(crate) use crate::storage::quant::pq::PQData;
 
 mod quantizer_preprocess;
-pub use quantizer_preprocess::quantizer_preprocess;

--- a/diskann-disk/src/search/pq/quantizer_preprocess.rs
+++ b/diskann-disk/src/search/pq/quantizer_preprocess.rs
@@ -6,7 +6,6 @@
 use diskann::ANNResult;
 use diskann_vector::distance::Metric;
 
-use diskann_providers::model::compute_pq_distance;
 use diskann_providers::utils::BridgeErr;
 
 use super::{PQData, PQScratch};
@@ -33,11 +32,7 @@ impl PQScratch {
         .bridge_err()?;
 
         match metric {
-            // Prior to the introduction of the `quantizer_preprocess` method, the
-            // disk index was hard-coded to use L2 distance for comparisons.
-            //
-            // We're keeping that behavior here - treating `Cosine` and `CosineNormalized`
-            // as L2 until a more thorough evaluation can be made.
+            // Disk search historically treats cosine metrics as L2 here.
             Metric::L2 | Metric::Cosine | Metric::CosineNormalized => {
                 table.process_into::<diskann_quantization::distances::SquaredL2>(
                     &self.query_scratch,
@@ -54,28 +49,4 @@ impl PQScratch {
 
         Ok(())
     }
-}
-
-/// Preprocesses the query stored in `pq_scratch` and computes PQ distances
-/// for `id_to_calculate_pq_distance`.
-///
-/// The resulting distances are written to `pq_scratch.aligned_dist_scratch`.
-pub fn quantizer_preprocess(
-    pq_scratch: &mut PQScratch,
-    pq_data: &PQData,
-    metric: Metric,
-    id_to_calculate_pq_distance: &[u32],
-) -> ANNResult<()> {
-    pq_scratch.preprocess_query(pq_data, metric)?;
-
-    compute_pq_distance(
-        id_to_calculate_pq_distance,
-        pq_data.get_num_chunks(),
-        &pq_scratch.aligned_pqtable_dist_scratch,
-        pq_data.pq_compressed_data().as_slice(),
-        &mut pq_scratch.aligned_pq_coord_scratch,
-        &mut pq_scratch.aligned_dist_scratch,
-    )?;
-
-    Ok(())
 }

--- a/diskann-disk/src/search/pq/quantizer_preprocess.rs
+++ b/diskann-disk/src/search/pq/quantizer_preprocess.rs
@@ -11,46 +11,63 @@ use diskann_providers::utils::BridgeErr;
 
 use super::{PQData, PQScratch};
 
-/// Preprocesses the query vector for PQ distance calculations.
-/// This function rotates the query vector and prepares the PQ table distances
-/// for efficient computation during search operations.
+impl PQScratch {
+    pub(crate) fn prepare_query(
+        &mut self,
+        pq_data: &PQData,
+        metric: Metric,
+        query: &[f32],
+    ) -> ANNResult<()> {
+        self.set(query)?;
+        self.preprocess_query(pq_data, metric)
+    }
+
+    fn preprocess_query(&mut self, pq_data: &PQData, metric: Metric) -> ANNResult<()> {
+        let table = pq_data.pq_table();
+        let expected_len = table.ncenters() * table.nchunks();
+        let dst = diskann_utils::views::MutMatrixView::try_from(
+            &mut self.aligned_pqtable_dist_scratch[..expected_len],
+            table.nchunks(),
+            table.ncenters(),
+        )
+        .bridge_err()?;
+
+        match metric {
+            // Prior to the introduction of the `quantizer_preprocess` method, the
+            // disk index was hard-coded to use L2 distance for comparisons.
+            //
+            // We're keeping that behavior here - treating `Cosine` and `CosineNormalized`
+            // as L2 until a more thorough evaluation can be made.
+            Metric::L2 | Metric::Cosine | Metric::CosineNormalized => {
+                table.process_into::<diskann_quantization::distances::SquaredL2>(
+                    &self.query_scratch,
+                    dst,
+                );
+            }
+            Metric::InnerProduct => {
+                table.process_into::<diskann_quantization::distances::InnerProduct>(
+                    &self.query_scratch,
+                    dst,
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Preprocesses the query stored in `pq_scratch` and computes PQ distances
+/// for `id_to_calculate_pq_distance`.
+///
+/// The resulting distances are written to `pq_scratch.aligned_dist_scratch`.
 pub fn quantizer_preprocess(
     pq_scratch: &mut PQScratch,
     pq_data: &PQData,
     metric: Metric,
     id_to_calculate_pq_distance: &[u32],
 ) -> ANNResult<()> {
-    let table = pq_data.pq_table();
-    let expected_len = table.ncenters() * table.nchunks();
-    let dst = diskann_utils::views::MutMatrixView::try_from(
-        &mut (*pq_scratch.aligned_pqtable_dist_scratch)[..expected_len],
-        table.nchunks(),
-        table.ncenters(),
-    )
-    .bridge_err()?;
+    pq_scratch.preprocess_query(pq_data, metric)?;
 
-    match metric {
-        // Prior to the introduction of the `quantizer_preprocess` method, the
-        // disk index was hard-coded to use L2 distance for comparisons.
-        //
-        // We're keeping that behavior here - treating `Cosine` and `CosineNormalized`
-        // as L2 until a more thorough evaluation can be made.
-        Metric::L2 | Metric::Cosine | Metric::CosineNormalized => {
-            table.process_into::<diskann_quantization::distances::SquaredL2>(
-                &pq_scratch.query_scratch,
-                dst,
-            );
-        }
-        Metric::InnerProduct => {
-            table.process_into::<diskann_quantization::distances::InnerProduct>(
-                &pq_scratch.query_scratch,
-                dst,
-            );
-        }
-    }
-
-    // Compute the pq distance between query vector to all the vertex in the pq
-    // calculation id scratch.
     compute_pq_distance(
         id_to_calculate_pq_distance,
         pq_data.get_num_chunks(),

--- a/diskann-disk/src/search/pq/quantizer_preprocess.rs
+++ b/diskann-disk/src/search/pq/quantizer_preprocess.rs
@@ -32,7 +32,11 @@ impl PQScratch {
         .bridge_err()?;
 
         match metric {
-            // Disk search historically treats cosine metrics as L2 here.
+            // Prior to moving query preprocessing onto `PQScratch`, the disk index
+            // was hard-coded to use L2 distance for comparisons.
+            //
+            // We're keeping that behavior here - treating `Cosine` and `CosineNormalized`
+            // as L2 until a more thorough evaluation can be made.
             Metric::L2 | Metric::Cosine | Metric::CosineNormalized => {
                 table.process_into::<diskann_quantization::distances::SquaredL2>(
                     &self.query_scratch,

--- a/diskann-disk/src/search/provider/disk_provider.rs
+++ b/diskann-disk/src/search/provider/disk_provider.rs
@@ -670,16 +670,7 @@ where
         _context: &DefaultContext,
         query: &'this [Data::VectorDataType],
     ) -> Result<Self::SearchAccessor, Self::SearchAccessorError> {
-        DiskAccessor::new(
-            provider,
-            self.io_tracker,
-            query,
-            self.vertex_provider_factory,
-            self.scratch_pool,
-            self.cache_indexed_vectors,
-            // Graph filtering is handled by post-processing or `FilteredAccessor`.
-            None,
-        )
+        DiskAccessor::new(provider, query, self)
     }
 }
 
@@ -968,17 +959,13 @@ where
     Data: GraphDataType<VectorIdType = u32>,
     VP: VertexProvider<Data>,
 {
-    fn new<VPF>(
+    fn new<ProviderFactory>(
         provider: &'a DiskProvider<Data>,
-        io_tracker: &'a IOTracker,
         query: &'a [Data::VectorDataType],
-        vertex_provider_factory: &'a VPF,
-        scratch_pool: &'a Arc<ObjectPool<DiskSearchScratch<Data, VP>>>,
-        cache_indexed_vectors: bool,
-        flat_scan_filter: Option<PostprocessFilter<'a>>,
+        strategy: &'a DiskSearchStrategy<'a, Data, ProviderFactory>,
     ) -> ANNResult<Self>
     where
-        VPF: VertexProviderFactory<Data, VertexProviderType = VP>,
+        ProviderFactory: VertexProviderFactory<Data, VertexProviderType = VP>,
     {
         let pq_points = provider.pq_data.pq_compressed_data().nrows();
         if pq_points != provider.num_points {
@@ -990,21 +977,26 @@ where
         }
 
         let scratch = DiskSearchScratch::pooled_for_query(
-            scratch_pool,
+            strategy.scratch_pool,
             provider,
-            io_tracker,
+            strategy.io_tracker,
             query,
-            vertex_provider_factory,
+            strategy.vertex_provider_factory,
         )?;
 
         Ok(Self {
             provider,
-            io_tracker,
+            io_tracker: strategy.io_tracker,
             scratch,
             query,
-            cache_indexed_vectors,
-            flat_scan_filter,
+            cache_indexed_vectors: strategy.cache_indexed_vectors,
+            flat_scan_filter: None,
         })
+    }
+
+    fn with_flat_scan_filter(mut self, filter: Option<PostprocessFilter<'a>>) -> Self {
+        self.flat_scan_filter = filter;
+        self
     }
 
     fn ensure_loaded(&mut self, ids: &[u32]) -> Result<(), ANNError> {
@@ -1225,15 +1217,8 @@ where
             PostprocessStrategy::AcceptAll => None,
             PostprocessStrategy::Apply(filter) => Some(filter),
         };
-        let mut visitor = DiskAccessor::new(
-            self.index.provider(),
-            strategy.io_tracker,
-            query,
-            strategy.vertex_provider_factory,
-            strategy.scratch_pool,
-            strategy.cache_indexed_vectors,
-            flat_scan_filter,
-        )?;
+        let mut visitor = DiskAccessor::new(self.index.provider(), query, strategy)?
+            .with_flat_scan_filter(flat_scan_filter);
         let FlatSearchStats { cmps, result_count } = flat_knn_search(
             &mut visitor,
             k,

--- a/diskann-disk/src/search/provider/disk_provider.rs
+++ b/diskann-disk/src/search/provider/disk_provider.rs
@@ -16,15 +16,18 @@ use std::{
 use crate::data_model::GraphDataType;
 use diskann::{
     error::IntoANNResult,
+    flat::{knn_search as flat_knn_search, DistancesUnordered, SearchStats as FlatSearchStats},
     graph::{
         self,
         ext::labeled::{self, QueryLabelProvider},
-        glue::{self, DefaultPostProcessor, SearchPostProcess, SearchStrategy},
+        glue::{
+            self, DefaultPostProcessor, SearchPostProcess, SearchStrategy as GraphSearchStrategy,
+        },
         search::{AdaptiveL, InlineFilterSearch, Knn},
         search_output_buffer::{self, BufferState, IdDistanceAssociatedData},
         DiskANNIndex,
     },
-    neighbor::{self, Neighbor, NeighborPriorityQueue},
+    neighbor::{self, Neighbor},
     provider::{DataProvider, DefaultContext, HasId, NoopGuard},
     utils::{IntoUsize, VectorRepr},
     ANNError, ANNResult,
@@ -38,11 +41,12 @@ use diskann_providers::{
     storage::{get_compressed_pq_file, get_disk_index_file, get_pq_pivot_file, LoadWith},
 };
 use diskann_utils::{
+    future::SendFuture,
     object_pool::{ObjectPool, PoolOption, TryAsPooled},
     views::Matrix,
 };
 
-use crate::search::pq::{quantizer_preprocess, PQData, PQScratch};
+use crate::search::pq::{PQData, PQScratch};
 use diskann_vector::{distance::Metric, DistanceFunction};
 use tokio::runtime::Runtime;
 use tracing::debug;
@@ -218,15 +222,11 @@ where
 /// `clippy::type_complexity`'s default threshold.
 type PostprocessFilter<'a> = &'a (dyn Fn(&u32) -> bool + Send + Sync);
 
-/// Encodes whether to accept all candidates at rerank time or apply a
-/// specific predicate. Used by `RerankAndFilter` and
-/// `DeterminantDiversityAndFilter` instead of `Option<PostprocessFilter>`
-/// so call sites are self-documenting without relying on comments to
-/// explain what `None` means.
+/// Encodes whether to accept all candidates or apply a specific predicate.
+/// Used during flat scans and by graph-search post-processors.
 #[derive(Clone, Copy)]
 pub enum PostprocessStrategy<'a> {
-    /// Accept every candidate — no predicate is called. Used by `FlatScan`
-    /// (filtered at scan time) and `InlineFilter` (filtered at visit time).
+    /// Accept every candidate — no predicate is called.
     AcceptAll,
     /// Apply the given predicate; non-matching candidates are dropped.
     Apply(PostprocessFilter<'a>),
@@ -240,9 +240,7 @@ where
     // Borrowed from `search_internal` so the strategy can be passed by value
     io_tracker: &'a IOTracker,
     cache_indexed_vectors: bool,
-    /// Consumed only by `default_post_processor()` → `RerankAndFilter`.
-    /// `FlatScan` and `InlineFilter` filter earlier in their pipelines and
-    /// pass `AcceptAll` here to avoid a redundant second pass.
+    /// Applied during flat scans or by the default graph-search post-processor.
     postprocess_filter: PostprocessStrategy<'a>,
 
     /// The vertex provider factory is used to create the vertex provider for each search instance.
@@ -398,7 +396,8 @@ impl<A: Clone + Send, V> search_output_buffer::SearchOutputBuffer<SearchPayload<
 }
 
 fn extend_output<Data, VP, B, I>(
-    accessor: &mut DiskAccessor<'_, Data, VP>,
+    cache_indexed_vectors: bool,
+    scratch: &mut DiskSearchScratch<Data, VP>,
     reranked: I,
     output: &mut B,
 ) -> ANNResult<usize>
@@ -411,7 +410,7 @@ where
         > + Send
         + ?Sized,
 {
-    if !accessor.cache_indexed_vectors {
+    if !cache_indexed_vectors {
         return Ok(output.extend(reranked.into_iter().map(|candidate| {
             let ((id, data), distance) = candidate.as_tuple();
             Neighbor::new((id, data, None), distance)
@@ -424,14 +423,13 @@ where
             break;
         }
         let ((id, data), distance) = candidate.as_tuple();
-        let vector = match accessor
-            .scratch
+        let vector = match scratch
             .distance_cache
             .remove(&id)
             .and_then(|(_, _, vector)| vector)
         {
             Some(vector) => vector,
-            None => Box::from(accessor.scratch.vertex_provider.get_vector(&id)?),
+            None => Box::from(scratch.vertex_provider.get_vector(&id)?),
         };
         count += 1;
         if output
@@ -442,6 +440,63 @@ where
         }
     }
     Ok(count)
+}
+
+fn rerank_and_filter<Data, VP, I, B>(
+    filter: PostprocessStrategy<'_>,
+    provider: &DiskProvider<Data>,
+    scratch: &mut DiskSearchScratch<Data, VP>,
+    query: &[Data::VectorDataType],
+    cache_indexed_vectors: bool,
+    candidates: I,
+    output: &mut B,
+) -> ANNResult<usize>
+where
+    Data: GraphDataType<VectorIdType = u32>,
+    VP: VertexProvider<Data>,
+    I: Iterator<Item = Neighbor<u32>>,
+    B: search_output_buffer::SearchOutputBuffer<
+            SearchPayload<Data::AssociatedDataType, Data::VectorDataType>,
+        > + Send
+        + ?Sized,
+{
+    let mut uncached_ids = Vec::new();
+    let mut reranked: Vec<_> = {
+        let mut process = |id: u32| {
+            if let Some(entry) = scratch.distance_cache.get(&id) {
+                Some(Neighbor::new((id, entry.1), entry.0))
+            } else {
+                uncached_ids.push(id);
+                None
+            }
+        };
+        match filter {
+            PostprocessStrategy::AcceptAll => candidates
+                .map(|candidate| *candidate.id())
+                .filter_map(&mut process)
+                .collect(),
+            PostprocessStrategy::Apply(predicate) => candidates
+                .map(|candidate| *candidate.id())
+                .filter(|id| predicate(id))
+                .filter_map(&mut process)
+                .collect(),
+        }
+    };
+
+    if !uncached_ids.is_empty() {
+        ensure_vertex_loaded(&mut scratch.vertex_provider, &uncached_ids)?;
+        for id in uncached_ids {
+            let vector = scratch.vertex_provider.get_vector(&id)?;
+            let distance = provider
+                .distance_comparer
+                .evaluate_similarity(query, vector);
+            let data = *scratch.vertex_provider.get_associated_data(&id)?;
+            reranked.push(Neighbor::new((id, data), distance));
+        }
+    }
+
+    reranked.sort_unstable_by(neighbor::ord::fast_distance);
+    extend_output(cache_indexed_vectors, scratch, reranked, output)
 }
 
 impl<Data, VP>
@@ -469,45 +524,15 @@ where
             > + Send
             + ?Sized,
     {
-        let provider = accessor.provider;
-
-        let mut uncached_ids = Vec::new();
-        let mut reranked: Vec<_> = {
-            let mut process = |n: u32| {
-                if let Some(entry) = accessor.scratch.distance_cache.get(&n) {
-                    Some(Neighbor::new((n, entry.1), entry.0))
-                } else {
-                    uncached_ids.push(n);
-                    None
-                }
-            };
-            match self.filter {
-                PostprocessStrategy::AcceptAll => candidates
-                    .map(|n| *n.id())
-                    .filter_map(&mut process)
-                    .collect(),
-                PostprocessStrategy::Apply(f) => candidates
-                    .map(|n| *n.id())
-                    .filter(|id| f(id))
-                    .filter_map(&mut process)
-                    .collect(),
-            }
-        };
-        if !uncached_ids.is_empty() {
-            ensure_vertex_loaded(&mut accessor.scratch.vertex_provider, &uncached_ids)?;
-            for n in &uncached_ids {
-                let v = accessor.scratch.vertex_provider.get_vector(n)?;
-                let d = provider.distance_comparer.evaluate_similarity(query, v);
-                let a = accessor.scratch.vertex_provider.get_associated_data(n)?;
-                reranked.push(Neighbor::new((*n, *a), d));
-            }
-        }
-
-        // Sort the full precision distances.
-        reranked.sort_unstable_by(neighbor::ord::fast_distance);
-
-        // Store the reranked results.
-        extend_output(accessor, reranked, output)
+        rerank_and_filter(
+            self.filter,
+            accessor.provider,
+            &mut accessor.scratch,
+            query,
+            accessor.cache_indexed_vectors,
+            candidates,
+            output,
+        )
     }
 }
 
@@ -581,7 +606,8 @@ where
         )?;
 
         extend_output(
-            accessor,
+            accessor.cache_indexed_vectors,
+            &mut accessor.scratch,
             reranked.into_iter().map(|idx| {
                 let id = candidate_ids[idx];
                 let distance = candidate_distances[idx];
@@ -629,7 +655,7 @@ where
 }
 
 impl<'this, Data, ProviderFactory>
-    SearchStrategy<'this, DiskProvider<Data>, &'this [Data::VectorDataType]>
+    GraphSearchStrategy<'this, DiskProvider<Data>, &'this [Data::VectorDataType]>
     for DiskSearchStrategy<'this, Data, ProviderFactory>
 where
     Data: GraphDataType<VectorIdType = u32>,
@@ -651,6 +677,8 @@ where
             self.vertex_provider_factory,
             self.scratch_pool,
             self.cache_indexed_vectors,
+            // Graph filtering is handled by post-processing or `FilteredAccessor`.
+            None,
         )
     }
 }
@@ -734,6 +762,67 @@ where
     }
 }
 
+impl<Data, VP> DiskSearchScratch<Data, VP>
+where
+    Data: GraphDataType<VectorIdType = u32>,
+    VP: VertexProvider<Data>,
+{
+    fn pooled_for_query<VPF>(
+        pool: &Arc<ObjectPool<Self>>,
+        provider: &DiskProvider<Data>,
+        io_tracker: &IOTracker,
+        query: &[Data::VectorDataType],
+        vertex_provider_factory: &VPF,
+    ) -> ANNResult<PoolOption<Self>>
+    where
+        VPF: VertexProviderFactory<Data, VertexProviderType = VP>,
+    {
+        let mut scratch = PoolOption::try_pooled(
+            pool,
+            &DiskSearchScratchArgs {
+                graph_degree: provider.graph_header.max_degree::<Data::VectorDataType>()?,
+                pq_dim: provider.pq_data.get_dim(),
+                num_pq_chunks: provider.pq_data.get_num_chunks(),
+                num_pq_centers: provider.pq_data.get_num_centers(),
+                vertex_factory: vertex_provider_factory,
+                graph_header: &provider.graph_header,
+            },
+        )?;
+
+        let timer = Instant::now();
+        let query = Data::VectorDataType::as_f32(query).into_ann_result()?;
+        scratch
+            .pq_scratch
+            .prepare_query(&provider.pq_data, provider.metric, &query)?;
+        IOTracker::add_time(
+            &io_tracker.preprocess_time_us,
+            timer.elapsed().as_micros() as u64,
+        );
+        Ok(scratch)
+    }
+
+    fn pq_distances<F>(&mut self, pq_data: &PQData, ids: &[u32], mut f: F) -> ANNResult<()>
+    where
+        F: FnMut(u32, f32),
+    {
+        compute_pq_distance(
+            ids,
+            pq_data.get_num_chunks(),
+            &self.pq_scratch.aligned_pqtable_dist_scratch,
+            pq_data.pq_compressed_data().as_slice(),
+            &mut self.pq_scratch.aligned_pq_coord_scratch,
+            &mut self.pq_scratch.aligned_dist_scratch,
+        )?;
+
+        for (id, distance) in
+            std::iter::zip(ids, &self.pq_scratch.aligned_dist_scratch[..ids.len()])
+        {
+            f(*id, *distance);
+        }
+        Ok(())
+    }
+}
+
 pub struct DiskAccessor<'a, Data, VP>
 where
     Data: GraphDataType<VectorIdType = u32>,
@@ -744,6 +833,7 @@ where
     scratch: PoolOption<DiskSearchScratch<Data, VP>>,
     query: &'a [Data::VectorDataType],
     cache_indexed_vectors: bool,
+    flat_scan_filter: Option<PostprocessFilter<'a>>,
 }
 
 impl<Data, VP> DiskAccessor<'_, Data, VP>
@@ -757,22 +847,10 @@ where
     where
         F: FnMut(f32, u32),
     {
-        let pq_scratch = &mut self.scratch.pq_scratch;
-        compute_pq_distance(
-            ids,
-            self.provider.pq_data.get_num_chunks(),
-            &pq_scratch.aligned_pqtable_dist_scratch,
-            self.provider.pq_data.pq_compressed_data().as_slice(),
-            &mut pq_scratch.aligned_pq_coord_scratch,
-            &mut pq_scratch.aligned_dist_scratch,
-        )?;
-
-        for (i, id) in ids.iter().enumerate() {
-            let distance = self.scratch.pq_scratch.aligned_dist_scratch[i];
-            f(distance, *id);
-        }
-
-        Ok(())
+        self.scratch
+            .pq_distances(&self.provider.pq_data, ids, |id, distance| {
+                f(distance, id);
+            })
     }
 }
 
@@ -782,6 +860,47 @@ where
     VP: VertexProvider<Data>,
 {
     type Id = u32;
+}
+
+impl<Data, VP> DistancesUnordered for DiskAccessor<'_, Data, VP>
+where
+    Data: GraphDataType<VectorIdType = u32>,
+    VP: VertexProvider<Data>,
+{
+    type Error = ANNError;
+
+    fn distances_unordered<F>(&mut self, mut f: F) -> impl SendFuture<Result<(), Self::Error>>
+    where
+        F: Send + FnMut(Self::Id, f32),
+    {
+        async move {
+            let batch_size = self.scratch.pq_scratch.max_vectors();
+            if batch_size == 0 {
+                return Err(diskann_error!(
+                    ErrorKind::IndexError,
+                    "pq scratch must support at least one vector",
+                ));
+            }
+
+            let mut ids = Vec::with_capacity(batch_size);
+            let filter = self.flat_scan_filter;
+            let mut remaining = (0..self.provider.num_points as u32)
+                .filter(|id| filter.is_none_or(|filter| filter(id)));
+
+            loop {
+                ids.clear();
+                ids.extend(remaining.by_ref().take(batch_size));
+                if ids.is_empty() {
+                    break;
+                }
+
+                self.scratch
+                    .pq_distances(&self.provider.pq_data, &ids, &mut f)?;
+            }
+
+            Ok(())
+        }
+    }
 }
 
 impl<Data, VP> glue::SearchAccessor for DiskAccessor<'_, Data, VP>
@@ -856,38 +975,27 @@ where
         vertex_provider_factory: &'a VPF,
         scratch_pool: &'a Arc<ObjectPool<DiskSearchScratch<Data, VP>>>,
         cache_indexed_vectors: bool,
+        flat_scan_filter: Option<PostprocessFilter<'a>>,
     ) -> ANNResult<Self>
     where
         VPF: VertexProviderFactory<Data, VertexProviderType = VP>,
     {
-        let mut scratch = PoolOption::try_pooled(
+        let pq_points = provider.pq_data.pq_compressed_data().nrows();
+        if pq_points != provider.num_points {
+            return Err(diskann_error!(
+                ErrorKind::IndexError,
+                "PQ data contains {pq_points} points, expected {}",
+                provider.num_points,
+            ));
+        }
+
+        let scratch = DiskSearchScratch::pooled_for_query(
             scratch_pool,
-            &DiskSearchScratchArgs {
-                graph_degree: provider.graph_header.max_degree::<Data::VectorDataType>()?,
-                pq_dim: provider.pq_data.get_dim(),
-                num_pq_chunks: provider.pq_data.get_num_chunks(),
-                num_pq_centers: provider.pq_data.get_num_centers(),
-                vertex_factory: vertex_provider_factory,
-                graph_header: &provider.graph_header,
-            },
+            provider,
+            io_tracker,
+            query,
+            vertex_provider_factory,
         )?;
-
-        // Decode caller's native vector representation into `f32`; downstream PQ kernels operate purely on `&[f32]`.
-        let f32_query = Data::VectorDataType::as_f32(query).into_ann_result()?;
-        scratch.pq_scratch.set(&f32_query)?;
-        let start_vertex_id = provider.graph_header.metadata().medoid as u32;
-
-        let timer = Instant::now();
-        quantizer_preprocess(
-            &mut scratch.pq_scratch,
-            &provider.pq_data,
-            provider.metric,
-            &[start_vertex_id],
-        )?;
-        IOTracker::add_time(
-            &io_tracker.preprocess_time_us,
-            timer.elapsed().as_micros() as u64,
-        );
 
         Ok(Self {
             provider,
@@ -895,6 +1003,7 @@ where
             scratch,
             query,
             cache_indexed_vectors,
+            flat_scan_filter,
         })
     }
 
@@ -1098,7 +1207,6 @@ where
         &self,
         strategy: &DiskSearchStrategy<'_, Data, ProviderFactory>,
         query: &[Data::VectorDataType],
-        vector_filter: Option<&(dyn Fn(&u32) -> bool + Send + Sync)>,
         neighbors_before_reranking: usize,
         output: &mut OB,
     ) -> ANNResult<graph::index::SearchStats>
@@ -1107,56 +1215,38 @@ where
                 SearchPayload<Data::AssociatedDataType, Data::VectorDataType>,
             > + Send,
     {
-        let provider = self.index.provider();
-        let mut accessor = strategy
-            .search_accessor(provider, &DefaultContext, query)
-            .into_ann_result()?;
-
-        // Derive the batch size from the scratch data structure. Providing too many vectors
-        // will panic.
-        let batch_size = accessor.scratch.pq_scratch.max_vectors();
-
-        // This check should always hold since `graph_degree` comes from
-        // `diskann::graph::Config` and is forced to be non-zero. But this is defensive
-        // against misconfiguration.
-        if batch_size == 0 {
-            return Err(diskann_error!(
+        let k = NonZeroUsize::new(neighbors_before_reranking).ok_or_else(|| {
+            diskann_error!(
                 ErrorKind::IndexError,
-                "pq scratch must support at least one vector",
-            ));
-        }
-
-        let mut id_buffer = Vec::with_capacity(batch_size);
-
-        let mut best = NeighborPriorityQueue::new(neighbors_before_reranking);
-        let mut cmps = 0u32;
-
-        // `None` short-circuits to `true` — no dyn-fn call per node on the
-        // unfiltered (recall-baseline) path.
-        let mut iter =
-            (0..provider.num_points as u32).filter(|id| vector_filter.is_none_or(|f| f(id)));
-        loop {
-            id_buffer.clear();
-            id_buffer.extend(iter.by_ref().take(batch_size));
-
-            if id_buffer.is_empty() {
-                break;
-            }
-
-            accessor.pq_distances(&id_buffer, |dist, id| best.insert(Neighbor::new(id, dist)))?;
-            cmps += id_buffer.len() as u32;
-        }
-
-        let result_count = strategy
-            .default_post_processor()
-            .post_process(&mut accessor, query, best.iter(), output)
-            .await
-            .into_ann_result()?;
+                "flat search list size must be greater than zero",
+            )
+        })?;
+        let flat_scan_filter = match strategy.postprocess_filter {
+            PostprocessStrategy::AcceptAll => None,
+            PostprocessStrategy::Apply(filter) => Some(filter),
+        };
+        let mut visitor = DiskAccessor::new(
+            self.index.provider(),
+            strategy.io_tracker,
+            query,
+            strategy.vertex_provider_factory,
+            strategy.scratch_pool,
+            strategy.cache_indexed_vectors,
+            flat_scan_filter,
+        )?;
+        let FlatSearchStats { cmps, result_count } = flat_knn_search(
+            &mut visitor,
+            k,
+            RerankAndFilter::new(PostprocessStrategy::AcceptAll),
+            query,
+            output,
+        )
+        .await?;
 
         Ok(graph::index::SearchStats {
             cmps,
             hops: 0,
-            result_count: result_count as u32,
+            result_count,
             range_search_second_round: false,
         })
     }
@@ -1386,13 +1476,14 @@ where
             SearchMode::FlatScan { filter } => {
                 let strategy = self.search_strategy(
                     &io_tracker,
-                    PostprocessStrategy::AcceptAll,
+                    filter
+                        .as_deref()
+                        .map_or(PostprocessStrategy::AcceptAll, PostprocessStrategy::Apply),
                     cache_indexed_vectors,
                 );
                 self.runtime.block_on(self.flat_search(
                     &strategy,
                     query,
-                    filter.as_deref(),
                     l,
                     &mut result_output_buffer,
                 ))?
@@ -2740,6 +2831,136 @@ mod disk_provider_tests {
             let source = load_source_data(storage_provider.as_ref(), TEST_DATA_FILE);
             assert_indexed_search_results_match(&result_with_filter_unwrapped, &indexed, &source);
         }
+    }
+
+    #[test]
+    fn unfiltered_flat_scan_matches_baseline() {
+        let storage_provider = Arc::new(VirtualStorageProvider::new_overlay(test_data_root()));
+        let search_engine = create_disk_index_searcher::<GraphDataF32VectorUnitData>(
+            CreateDiskIndexSearcherParams {
+                max_thread_num: 1,
+                pq_pivot_file_path: TEST_PQ_PIVOT_128DIM,
+                pq_compressed_file_path: TEST_PQ_COMPRESSED_128DIM,
+                index_path: TEST_INDEX_128DIM,
+                index_path_prefix: TEST_INDEX_PREFIX_128DIM,
+                ..Default::default()
+            },
+            &storage_provider,
+        );
+
+        let result = search_engine
+            .search(&[0.1; 128], 10, 10, None, SearchMode::flat())
+            .unwrap();
+
+        let expected = [
+            (152, 256101.7),
+            (115, 256400.48),
+            (98, 256451.28),
+            (73, 256572.89),
+            (20, 256623.28),
+            (173, 256636.9),
+            (95, 256661.28),
+            (137, 256673.7),
+            (118, 256675.3),
+            (72, 256709.69),
+        ];
+        assert_eq!(result.results.len(), expected.len());
+        for (index, (actual, (expected_id, expected_distance))) in
+            std::iter::zip(&result.results, expected).enumerate()
+        {
+            assert_eq!(
+                actual.vertex_id, expected_id,
+                "flat baseline ID mismatch at result {index}",
+            );
+            assert!(
+                (actual.distance - expected_distance).abs() <= 0.02,
+                "flat baseline distance mismatch at result {index}: expected \
+                 {expected_distance}, got {}",
+                actual.distance,
+            );
+        }
+
+        assert!(result
+            .results
+            .windows(2)
+            .all(|pair| pair[0].distance <= pair[1].distance));
+        assert_eq!(result.stats.cmps, 256);
+        assert_eq!(result.stats.result_count, 10);
+    }
+
+    #[test]
+    fn flat_filter_runs_once_per_point() {
+        let storage_provider = Arc::new(VirtualStorageProvider::new_overlay(test_data_root()));
+        let search_engine = create_disk_index_searcher::<GraphDataF32VectorUnitData>(
+            CreateDiskIndexSearcherParams {
+                max_thread_num: 1,
+                pq_pivot_file_path: TEST_PQ_PIVOT_128DIM,
+                pq_compressed_file_path: TEST_PQ_COMPRESSED_128DIM,
+                index_path: TEST_INDEX_128DIM,
+                index_path_prefix: TEST_INDEX_PREFIX_128DIM,
+                ..Default::default()
+            },
+            &storage_provider,
+        );
+        let calls = AtomicUsize::new(0);
+
+        let result = search_engine
+            .search(
+                &[0.1; 128],
+                10,
+                10,
+                None,
+                SearchMode::flat_filtered(|id| {
+                    calls.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    id % 64 == 0
+                }),
+            )
+            .unwrap();
+
+        assert_eq!(calls.load(std::sync::atomic::Ordering::Relaxed), 256);
+        assert_eq!(result.stats.cmps, 4);
+        assert_eq!(result.stats.result_count, 4);
+        assert!(result.results.iter().all(|item| item.vertex_id % 64 == 0));
+    }
+
+    #[test]
+    fn graph_and_flat_queries_isolate_pooled_query_state() {
+        let storage_provider = Arc::new(VirtualStorageProvider::new_overlay(test_data_root()));
+        let search_engine = create_disk_index_searcher::<GraphDataF32VectorUnitData>(
+            CreateDiskIndexSearcherParams {
+                max_thread_num: 1,
+                pq_pivot_file_path: TEST_PQ_PIVOT_128DIM,
+                pq_compressed_file_path: TEST_PQ_COMPRESSED_128DIM,
+                index_path: TEST_INDEX_128DIM,
+                index_path_prefix: TEST_INDEX_PREFIX_128DIM,
+                ..Default::default()
+            },
+            &storage_provider,
+        );
+
+        let graph_before = search_engine
+            .search(&[0.1; 128], 10, 10, None, SearchMode::graph())
+            .unwrap();
+        let flat_before = search_engine
+            .search(&[0.9; 128], 10, 10, None, SearchMode::flat())
+            .unwrap();
+        let graph_after = search_engine
+            .search(&[0.1; 128], 10, 10, None, SearchMode::graph())
+            .unwrap();
+        let flat_after = search_engine
+            .search(&[0.9; 128], 10, 10, None, SearchMode::flat())
+            .unwrap();
+
+        let assert_same = |before: &SearchResult<()>, after: &SearchResult<()>| {
+            assert_eq!(before.stats.cmps, after.stats.cmps);
+            assert_eq!(before.results.len(), after.results.len());
+            for (before, after) in std::iter::zip(&before.results, &after.results) {
+                assert_eq!(before.vertex_id, after.vertex_id);
+                assert_eq!(before.distance, after.distance);
+            }
+        };
+        assert_same(&graph_before, &graph_after);
+        assert_same(&flat_before, &flat_after);
     }
 
     // ===========================================================================

--- a/diskann-disk/src/search/provider/disk_provider.rs
+++ b/diskann-disk/src/search/provider/disk_provider.rs
@@ -20,9 +20,7 @@ use diskann::{
     graph::{
         self,
         ext::labeled::{self, QueryLabelProvider},
-        glue::{
-            self, DefaultPostProcessor, SearchPostProcess, SearchStrategy as GraphSearchStrategy,
-        },
+        glue::{self, DefaultPostProcessor, SearchPostProcess, SearchStrategy},
         search::{AdaptiveL, InlineFilterSearch, Knn},
         search_output_buffer::{self, BufferState, IdDistanceAssociatedData},
         DiskANNIndex,
@@ -222,11 +220,15 @@ where
 /// `clippy::type_complexity`'s default threshold.
 type PostprocessFilter<'a> = &'a (dyn Fn(&u32) -> bool + Send + Sync);
 
-/// Encodes whether to accept all candidates at post-processing time or apply a
-/// specific predicate.
+/// Encodes whether to accept all candidates at rerank time or apply a
+/// specific predicate. Used by `RerankAndFilter` and
+/// `DeterminantDiversityAndFilter` instead of `Option<PostprocessFilter>`
+/// so call sites are self-documenting without relying on comments to
+/// explain what `None` means.
 #[derive(Clone, Copy)]
 pub enum PostprocessStrategy<'a> {
-    /// Accept every candidate — no predicate is called.
+    /// Accept every candidate — no predicate is called. Used by `FlatScan`
+    /// (filtered at scan time) and `InlineFilter` (filtered at visit time).
     AcceptAll,
     /// Apply the given predicate; non-matching candidates are dropped.
     Apply(PostprocessFilter<'a>),
@@ -240,7 +242,9 @@ where
     // Borrowed from `search_internal` so the strategy can be passed by value
     io_tracker: &'a IOTracker,
     cache_indexed_vectors: bool,
-    /// Consumed by the default graph-search post-processor.
+    /// Consumed only by `default_post_processor()` → `RerankAndFilter`.
+    /// `FlatScan` and `InlineFilter` filter earlier in their pipelines and
+    /// pass `AcceptAll` here to avoid a redundant second pass.
     postprocess_filter: PostprocessStrategy<'a>,
 
     /// The vertex provider factory is used to create the vertex provider for each search instance.
@@ -468,42 +472,43 @@ where
             + ?Sized,
     {
         let provider = accessor.provider;
+
         let mut uncached_ids = Vec::new();
         let mut reranked: Vec<_> = {
-            let mut process = |id: u32| {
-                if let Some(entry) = accessor.scratch.distance_cache.get(&id) {
-                    Some(Neighbor::new((id, entry.1), entry.0))
+            let mut process = |n: u32| {
+                if let Some(entry) = accessor.scratch.distance_cache.get(&n) {
+                    Some(Neighbor::new((n, entry.1), entry.0))
                 } else {
-                    uncached_ids.push(id);
+                    uncached_ids.push(n);
                     None
                 }
             };
             match self.filter {
                 PostprocessStrategy::AcceptAll => candidates
-                    .map(|candidate| *candidate.id())
+                    .map(|n| *n.id())
                     .filter_map(&mut process)
                     .collect(),
-                PostprocessStrategy::Apply(predicate) => candidates
-                    .map(|candidate| *candidate.id())
-                    .filter(|id| predicate(id))
+                PostprocessStrategy::Apply(f) => candidates
+                    .map(|n| *n.id())
+                    .filter(|id| f(id))
                     .filter_map(&mut process)
                     .collect(),
             }
         };
-
         if !uncached_ids.is_empty() {
             ensure_vertex_loaded(&mut accessor.scratch.vertex_provider, &uncached_ids)?;
-            for id in uncached_ids {
-                let vector = accessor.scratch.vertex_provider.get_vector(&id)?;
-                let distance = provider
-                    .distance_comparer
-                    .evaluate_similarity(query, vector);
-                let data = *accessor.scratch.vertex_provider.get_associated_data(&id)?;
-                reranked.push(Neighbor::new((id, data), distance));
+            for n in &uncached_ids {
+                let v = accessor.scratch.vertex_provider.get_vector(n)?;
+                let d = provider.distance_comparer.evaluate_similarity(query, v);
+                let a = accessor.scratch.vertex_provider.get_associated_data(n)?;
+                reranked.push(Neighbor::new((*n, *a), d));
             }
         }
 
+        // Sort the full precision distances.
         reranked.sort_unstable_by(neighbor::ord::fast_distance);
+
+        // Store the reranked results.
         extend_output(accessor, reranked, output)
     }
 }
@@ -626,7 +631,7 @@ where
 }
 
 impl<'this, Data, ProviderFactory>
-    GraphSearchStrategy<'this, DiskProvider<Data>, &'this [Data::VectorDataType]>
+    SearchStrategy<'this, DiskProvider<Data>, &'this [Data::VectorDataType]>
     for DiskSearchStrategy<'this, Data, ProviderFactory>
 where
     Data: GraphDataType<VectorIdType = u32>,
@@ -762,27 +767,6 @@ where
         );
         Ok(scratch)
     }
-
-    fn pq_distances<F>(&mut self, pq_data: &PQData, ids: &[u32], mut f: F) -> ANNResult<()>
-    where
-        F: FnMut(u32, f32),
-    {
-        compute_pq_distance(
-            ids,
-            pq_data.get_num_chunks(),
-            &self.pq_scratch.aligned_pqtable_dist_scratch,
-            pq_data.pq_compressed_data().as_slice(),
-            &mut self.pq_scratch.aligned_pq_coord_scratch,
-            &mut self.pq_scratch.aligned_dist_scratch,
-        )?;
-
-        for (id, distance) in
-            std::iter::zip(ids, &self.pq_scratch.aligned_dist_scratch[..ids.len()])
-        {
-            f(*id, *distance);
-        }
-        Ok(())
-    }
 }
 
 pub struct DiskAccessor<'a, Data, VP>
@@ -809,10 +793,22 @@ where
     where
         F: FnMut(f32, u32),
     {
-        self.scratch
-            .pq_distances(&self.provider.pq_data, ids, |id, distance| {
-                f(distance, id);
-            })
+        let pq_scratch = &mut self.scratch.pq_scratch;
+        compute_pq_distance(
+            ids,
+            self.provider.pq_data.get_num_chunks(),
+            &pq_scratch.aligned_pqtable_dist_scratch,
+            self.provider.pq_data.pq_compressed_data().as_slice(),
+            &mut pq_scratch.aligned_pq_coord_scratch,
+            &mut pq_scratch.aligned_dist_scratch,
+        )?;
+
+        for (i, id) in ids.iter().enumerate() {
+            let distance = self.scratch.pq_scratch.aligned_dist_scratch[i];
+            f(distance, *id);
+        }
+
+        Ok(())
     }
 }
 
@@ -856,8 +852,7 @@ where
                     break;
                 }
 
-                self.scratch
-                    .pq_distances(&self.provider.pq_data, &ids, &mut f)?;
+                self.pq_distances(&ids, |distance, id| f(id, distance))?;
             }
 
             Ok(())

--- a/diskann-disk/src/search/provider/disk_provider.rs
+++ b/diskann-disk/src/search/provider/disk_provider.rs
@@ -222,8 +222,8 @@ where
 /// `clippy::type_complexity`'s default threshold.
 type PostprocessFilter<'a> = &'a (dyn Fn(&u32) -> bool + Send + Sync);
 
-/// Encodes whether to accept all candidates or apply a specific predicate.
-/// Used during flat scans and by graph-search post-processors.
+/// Encodes whether to accept all candidates at post-processing time or apply a
+/// specific predicate.
 #[derive(Clone, Copy)]
 pub enum PostprocessStrategy<'a> {
     /// Accept every candidate — no predicate is called.
@@ -240,7 +240,7 @@ where
     // Borrowed from `search_internal` so the strategy can be passed by value
     io_tracker: &'a IOTracker,
     cache_indexed_vectors: bool,
-    /// Applied during flat scans or by the default graph-search post-processor.
+    /// Consumed by the default graph-search post-processor.
     postprocess_filter: PostprocessStrategy<'a>,
 
     /// The vertex provider factory is used to create the vertex provider for each search instance.
@@ -396,8 +396,7 @@ impl<A: Clone + Send, V> search_output_buffer::SearchOutputBuffer<SearchPayload<
 }
 
 fn extend_output<Data, VP, B, I>(
-    cache_indexed_vectors: bool,
-    scratch: &mut DiskSearchScratch<Data, VP>,
+    accessor: &mut DiskAccessor<'_, Data, VP>,
     reranked: I,
     output: &mut B,
 ) -> ANNResult<usize>
@@ -410,7 +409,7 @@ where
         > + Send
         + ?Sized,
 {
-    if !cache_indexed_vectors {
+    if !accessor.cache_indexed_vectors {
         return Ok(output.extend(reranked.into_iter().map(|candidate| {
             let ((id, data), distance) = candidate.as_tuple();
             Neighbor::new((id, data, None), distance)
@@ -423,13 +422,14 @@ where
             break;
         }
         let ((id, data), distance) = candidate.as_tuple();
-        let vector = match scratch
+        let vector = match accessor
+            .scratch
             .distance_cache
             .remove(&id)
             .and_then(|(_, _, vector)| vector)
         {
             Some(vector) => vector,
-            None => Box::from(scratch.vertex_provider.get_vector(&id)?),
+            None => Box::from(accessor.scratch.vertex_provider.get_vector(&id)?),
         };
         count += 1;
         if output
@@ -440,63 +440,6 @@ where
         }
     }
     Ok(count)
-}
-
-fn rerank_and_filter<Data, VP, I, B>(
-    filter: PostprocessStrategy<'_>,
-    provider: &DiskProvider<Data>,
-    scratch: &mut DiskSearchScratch<Data, VP>,
-    query: &[Data::VectorDataType],
-    cache_indexed_vectors: bool,
-    candidates: I,
-    output: &mut B,
-) -> ANNResult<usize>
-where
-    Data: GraphDataType<VectorIdType = u32>,
-    VP: VertexProvider<Data>,
-    I: Iterator<Item = Neighbor<u32>>,
-    B: search_output_buffer::SearchOutputBuffer<
-            SearchPayload<Data::AssociatedDataType, Data::VectorDataType>,
-        > + Send
-        + ?Sized,
-{
-    let mut uncached_ids = Vec::new();
-    let mut reranked: Vec<_> = {
-        let mut process = |id: u32| {
-            if let Some(entry) = scratch.distance_cache.get(&id) {
-                Some(Neighbor::new((id, entry.1), entry.0))
-            } else {
-                uncached_ids.push(id);
-                None
-            }
-        };
-        match filter {
-            PostprocessStrategy::AcceptAll => candidates
-                .map(|candidate| *candidate.id())
-                .filter_map(&mut process)
-                .collect(),
-            PostprocessStrategy::Apply(predicate) => candidates
-                .map(|candidate| *candidate.id())
-                .filter(|id| predicate(id))
-                .filter_map(&mut process)
-                .collect(),
-        }
-    };
-
-    if !uncached_ids.is_empty() {
-        ensure_vertex_loaded(&mut scratch.vertex_provider, &uncached_ids)?;
-        for id in uncached_ids {
-            let vector = scratch.vertex_provider.get_vector(&id)?;
-            let distance = provider
-                .distance_comparer
-                .evaluate_similarity(query, vector);
-            let data = *scratch.vertex_provider.get_associated_data(&id)?;
-            reranked.push(Neighbor::new((id, data), distance));
-        }
-    }
-
-    reranked.sort_unstable_by(neighbor::ord::fast_distance);
-    extend_output(cache_indexed_vectors, scratch, reranked, output)
 }
 
 impl<Data, VP>
@@ -524,15 +467,44 @@ where
             > + Send
             + ?Sized,
     {
-        rerank_and_filter(
-            self.filter,
-            accessor.provider,
-            &mut accessor.scratch,
-            query,
-            accessor.cache_indexed_vectors,
-            candidates,
-            output,
-        )
+        let provider = accessor.provider;
+        let mut uncached_ids = Vec::new();
+        let mut reranked: Vec<_> = {
+            let mut process = |id: u32| {
+                if let Some(entry) = accessor.scratch.distance_cache.get(&id) {
+                    Some(Neighbor::new((id, entry.1), entry.0))
+                } else {
+                    uncached_ids.push(id);
+                    None
+                }
+            };
+            match self.filter {
+                PostprocessStrategy::AcceptAll => candidates
+                    .map(|candidate| *candidate.id())
+                    .filter_map(&mut process)
+                    .collect(),
+                PostprocessStrategy::Apply(predicate) => candidates
+                    .map(|candidate| *candidate.id())
+                    .filter(|id| predicate(id))
+                    .filter_map(&mut process)
+                    .collect(),
+            }
+        };
+
+        if !uncached_ids.is_empty() {
+            ensure_vertex_loaded(&mut accessor.scratch.vertex_provider, &uncached_ids)?;
+            for id in uncached_ids {
+                let vector = accessor.scratch.vertex_provider.get_vector(&id)?;
+                let distance = provider
+                    .distance_comparer
+                    .evaluate_similarity(query, vector);
+                let data = *accessor.scratch.vertex_provider.get_associated_data(&id)?;
+                reranked.push(Neighbor::new((id, data), distance));
+            }
+        }
+
+        reranked.sort_unstable_by(neighbor::ord::fast_distance);
+        extend_output(accessor, reranked, output)
     }
 }
 
@@ -606,8 +578,7 @@ where
         )?;
 
         extend_output(
-            accessor.cache_indexed_vectors,
-            &mut accessor.scratch,
+            accessor,
             reranked.into_iter().map(|idx| {
                 let id = candidate_ids[idx];
                 let distance = candidate_distances[idx];
@@ -1199,6 +1170,7 @@ where
         &self,
         strategy: &DiskSearchStrategy<'_, Data, ProviderFactory>,
         query: &[Data::VectorDataType],
+        vector_filter: Option<&(dyn Fn(&u32) -> bool + Send + Sync)>,
         neighbors_before_reranking: usize,
         output: &mut OB,
     ) -> ANNResult<graph::index::SearchStats>
@@ -1213,12 +1185,8 @@ where
                 "flat search list size must be greater than zero",
             )
         })?;
-        let flat_scan_filter = match strategy.postprocess_filter {
-            PostprocessStrategy::AcceptAll => None,
-            PostprocessStrategy::Apply(filter) => Some(filter),
-        };
         let mut visitor = DiskAccessor::new(self.index.provider(), query, strategy)?
-            .with_flat_scan_filter(flat_scan_filter);
+            .with_flat_scan_filter(vector_filter);
         let FlatSearchStats { cmps, result_count } = flat_knn_search(
             &mut visitor,
             k,
@@ -1461,14 +1429,13 @@ where
             SearchMode::FlatScan { filter } => {
                 let strategy = self.search_strategy(
                     &io_tracker,
-                    filter
-                        .as_deref()
-                        .map_or(PostprocessStrategy::AcceptAll, PostprocessStrategy::Apply),
+                    PostprocessStrategy::AcceptAll,
                     cache_indexed_vectors,
                 );
                 self.runtime.block_on(self.flat_search(
                     &strategy,
                     query,
+                    filter.as_deref(),
                     l,
                     &mut result_output_buffer,
                 ))?

--- a/diskann-disk/src/search/provider/disk_provider.rs
+++ b/diskann-disk/src/search/provider/disk_provider.rs
@@ -218,11 +218,11 @@ where
 /// Borrowed predicate used internally by the disk search pipeline.
 /// Spelled out here to keep the field/parameter signatures under
 /// `clippy::type_complexity`'s default threshold.
-type PostprocessFilter<'a> = &'a (dyn Fn(&u32) -> bool + Send + Sync);
+type IdFilter<'a> = &'a (dyn Fn(&u32) -> bool + Send + Sync);
 
 /// Encodes whether to accept all candidates at rerank time or apply a
 /// specific predicate. Used by `RerankAndFilter` and
-/// `DeterminantDiversityAndFilter` instead of `Option<PostprocessFilter>`
+/// `DeterminantDiversityAndFilter` instead of `Option<IdFilter>`
 /// so call sites are self-documenting without relying on comments to
 /// explain what `None` means.
 #[derive(Clone, Copy)]
@@ -231,7 +231,7 @@ pub enum PostprocessStrategy<'a> {
     /// (filtered at scan time) and `InlineFilter` (filtered at visit time).
     AcceptAll,
     /// Apply the given predicate; non-matching candidates are dropped.
-    Apply(PostprocessFilter<'a>),
+    Apply(IdFilter<'a>),
 }
 
 pub struct DiskSearchStrategy<'a, Data, ProviderFactory>
@@ -779,7 +779,7 @@ where
     scratch: PoolOption<DiskSearchScratch<Data, VP>>,
     query: &'a [Data::VectorDataType],
     cache_indexed_vectors: bool,
-    flat_scan_filter: Option<PostprocessFilter<'a>>,
+    flat_scan_filter: Option<IdFilter<'a>>,
 }
 
 impl<Data, VP> DiskAccessor<'_, Data, VP>
@@ -960,7 +960,7 @@ where
         })
     }
 
-    fn with_flat_scan_filter(mut self, filter: Option<PostprocessFilter<'a>>) -> Self {
+    fn with_flat_scan_filter(mut self, filter: Option<IdFilter<'a>>) -> Self {
         self.flat_scan_filter = filter;
         self
     }

--- a/diskann-disk/src/search/provider/disk_provider.rs
+++ b/diskann-disk/src/search/provider/disk_provider.rs
@@ -1587,6 +1587,11 @@ mod disk_provider_tests {
     const TEST_PQ_COMPRESSED: &str =
         "/disk_index_search/disk_index_sift_learn_R4_L50_A1.2_truth_search_pq_compressed.bin";
 
+    // These SIFT squared-L2 distances are around 256_000, where one f32 ULP is
+    // 0.015625. Allow one ULP for architecture-dependent SIMD accumulation;
+    // an absolute tolerance of 1e-4 would require identical f32 results.
+    const SIFT_DISTANCE_ABS_TOLERANCE: f32 = 0.02;
+
     #[test]
     fn test_disk_search_k10_l20_single_or_multi_thread_100dim() {
         let storage_provider = Arc::new(VirtualStorageProvider::new_overlay(test_data_root()));
@@ -2666,19 +2671,14 @@ mod disk_provider_tests {
         #[case] expected_distances: Vec<f32>,
         #[case] check_indexed_vectors: bool,
     ) {
-        // Exact distances can vary slightly depending on the architecture used
-        // to compute distances due to different unrolling strategies and SIMD widthd.
-        //
-        // This parameter allows for a small margin when matching distances.
         let check_distances = |got: &[f32], expected: &[f32]| -> bool {
-            const ABS_TOLERANCE: f32 = 0.02;
             assert_eq!(got.len(), expected.len());
             for (i, (g, e)) in std::iter::zip(got.iter(), expected.iter()).enumerate() {
-                if (g - e).abs() > ABS_TOLERANCE {
+                if (g - e).abs() > SIFT_DISTANCE_ABS_TOLERANCE {
                     panic!(
                         "distances differ at position {} by more than {}\n\n\
                          got: {:?}\nexpected: {:?}",
-                        i, ABS_TOLERANCE, got, expected,
+                        i, SIFT_DISTANCE_ABS_TOLERANCE, got, expected,
                     );
                 }
             }
@@ -2820,7 +2820,7 @@ mod disk_provider_tests {
                 "flat baseline ID mismatch at result {index}",
             );
             assert!(
-                (actual.distance - expected_distance).abs() <= 0.02,
+                (actual.distance - expected_distance).abs() <= SIFT_DISTANCE_ABS_TOLERANCE,
                 "flat baseline distance mismatch at result {index}: expected \
                  {expected_distance}, got {}",
                 actual.distance,


### PR DESCRIPTION
- [x] Does this PR have a descriptive title that could go in our release notes? **Yes.**
- [ ] Does this PR add any new dependencies? **No.**
- [ ] Does this PR modify any existing APIs? **No.** The query-aware flat-search API was introduced separately in #1359; this PR adopts it in `diskann-disk`.
- [x] Is the change to the API backwards compatible? **Yes.** Existing disk search modes and result semantics are preserved.
- [x] Should this result in any changes to our documentation, either updating existing docs or adding new ones? **Yes.** The affected implementation rustdoc is updated.

#### Reference Issues/PRs

Built on the query-aware flat-search API merged in #1359.

#### What does this implement/fix? Briefly explain your changes.

- Replaces the disk-specific manual PQ flat-scan pipeline with the shared flat k-NN API.
- Implements `DistancesUnordered` on `DiskAccessor` to expose complete, batched PQ-distance scanning.
- Initializes query-dependent PQ state after every pooled scratch checkout.
- Preserves scan-time filtering before approximate top-k selection and full-precision reranking afterward.
- Preserves the existing pooled scratch and indexed-vector result behavior across graph and flat search modes.

The disk backend constructs a query-aware `DiskAccessor` and passes it directly to `flat::knn_search`. The generic flat layer now owns top-k selection, comparison accounting, error escalation, and post-processing. `DiskAccessor` continues to own disk-specific PQ preprocessing, batching, filtering, data access, and distance computation.

#### Any other comments?

This PR has been rebased onto `main` after #1359 merged. Its diff is limited to the two `diskann-disk` implementation files.

#### Architecture simplification

Before this change, disk flat search manually coordinated filtering, batching, PQ-distance collection, top-k selection, comparison accounting, and post-processing inside `DiskANNIndex::flat_search`. Graph and flat search already used the same `DiskAccessor` and scratch pool, but the flat algorithm duplicated orchestration now provided by the shared flat API.

```mermaid
flowchart TB
    subgraph Before["Before: disk-specific flat orchestration"]
        direction LR
        F1["FlatScan"] --> M["DiskANNIndex::flat_search"]
        M --> FI["filter IDs"]
        FI --> B["manual batch loop"]
        B --> PQ1["DiskAccessor::pq_distances"]
        PQ1 --> K1["local NeighborPriorityQueue"]
        K1 --> PP1["disk post-processor"]
    end

    subgraph After["After: shared flat orchestration"]
        direction LR
        F2["FlatScan"] --> K2["flat::knn_search"]
        K2 --> DU["DiskAccessor<br/>DistancesUnordered"]
        DU --> PQ2["filtered, batched PQ scan"]
        K2 --> TK["shared top-k · stats · errors"]
        TK --> PP2["RerankAndFilter"]
    end

    G["Graph search"] --> SA["DiskAccessor<br/>SearchAccessor"]
    DU --> S["pooled DiskSearchScratch<br/>per-query PQ preparation"]
    SA --> S
```

`DiskAccessor` now exposes the disk scan through `DistancesUnordered`, allowing `flat::knn_search` to drive the common k-NN workflow while graph traversal continues to use the existing `SearchAccessor` implementation. Both paths preserve their distinct filtering stages and share the same pooled query-state lifecycle.