### PR TITLE
Deduplicate virtual start point edges during disk serialization

### DIFF
--- a/diskann-providers/src/model/graph/provider/async_/simple_neighbor_provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/simple_neighbor_provider.rs
@@ -301,7 +301,7 @@ impl storage::bin::GetAdjacencyList for SimpleNeighborProviderAsync {
 /// Key differences between the formats:
 /// 1. Disk format requires a valid vector ID as start point, while async index uses a
 ///    virtual ID (max_points + 1) that exceeds the valid dataset range
-/// 2. In-memory index appends the virtual start point at the end of adjacency lists
+/// 2. In-memory adjacency lists may contain the virtual start point ID
 /// 3. Disk format expects additional_points = 0, while async index uses additional_points = 1
 ///
 /// This adaptor handles these differences by:
@@ -327,15 +327,26 @@ impl storage::bin::GetAdjacencyList for DiskAdaptor<'_> {
         let mut list = AdjacencyList::new();
         self.provider.get_neighbors_sync(i, &mut list)?;
 
-        // Need to change to a `Vec` because remapping the start point can cause duplicates,
-        // and changing the logic to not have duplicates changes the exact nature of the
-        // graph and breaks integration tests for the disk index builder.
         let mut list: Vec<_> = list.into();
-        for i in list.iter_mut() {
-            if *i == self.inmem_start_point {
-                *i = self.actual_start_point;
+        let node_id = u32::try_from(i).ok();
+        let mut seen_actual_start_point = false;
+        list.retain_mut(|neighbor| {
+            if *neighbor == self.inmem_start_point {
+                *neighbor = self.actual_start_point;
             }
-        }
+
+            if Some(*neighbor) == node_id {
+                return false;
+            }
+
+            if *neighbor != self.actual_start_point {
+                return true;
+            }
+
+            let first = !seen_actual_start_point;
+            seen_actual_start_point = true;
+            first
+        });
 
         Ok(list)
     }
@@ -361,7 +372,7 @@ impl storage::bin::GetAdjacencyList for DiskAdaptor<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::storage::VirtualStorageProvider;
+    use crate::storage::{VirtualStorageProvider, bin::GetAdjacencyList};
 
     use super::*;
 
@@ -389,6 +400,22 @@ mod tests {
             .unwrap();
 
         assert_eq!(new_adj_list, result);
+    }
+
+    #[test]
+    fn disk_adaptor_removes_duplicates_and_self_loops_after_remapping() {
+        let provider = SimpleNeighborProviderAsync::new(4, 1, 4, 1.0);
+        provider.set_neighbors_sync(0, &[4, 2, 1]).unwrap();
+        provider.set_neighbors_sync(1, &[4, 3]).unwrap();
+
+        let adaptor = DiskAdaptor {
+            provider: &provider,
+            inmem_start_point: 4,
+            actual_start_point: 1,
+        };
+
+        assert_eq!(adaptor.get_adjacency_list(0).unwrap(), vec![1, 2]);
+        assert_eq!(adaptor.get_adjacency_list(1).unwrap(), vec![3]);
     }
 
     #[tokio::test]

--- a/diskann-providers/src/model/graph/provider/async_/simple_neighbor_provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/simple_neighbor_provider.rs
@@ -299,10 +299,8 @@ impl storage::bin::GetAdjacencyList for SimpleNeighborProviderAsync {
 /// and the on-disk index format during serialization.
 ///
 /// Key differences between the formats:
-/// 1. Disk format requires a valid vector ID as start point, while async index uses a
-///    virtual ID (max_points + 1) that exceeds the valid dataset range
-/// 2. In-memory adjacency lists may contain the virtual start point ID
-/// 3. Disk format expects additional_points = 0, while async index uses additional_points = 1
+/// 1. The disk format does not support the virtual start point used by the in-memory index.
+/// 2. Disk format expects additional_points = 0, while async index uses additional_points = 1.
 ///
 /// This adaptor handles these differences by:
 /// - Substituting the virtual start point ID with an actual dataset ID when found in adjacency lists
@@ -328,14 +326,14 @@ impl storage::bin::GetAdjacencyList for DiskAdaptor<'_> {
         self.provider.get_neighbors_sync(i, &mut list)?;
 
         let mut list: Vec<_> = list.into();
-        let node_id = u32::try_from(i).ok();
+        let node_id = u32::try_from(i)?;
         let mut seen_actual_start_point = false;
         list.retain_mut(|neighbor| {
             if *neighbor == self.inmem_start_point {
                 *neighbor = self.actual_start_point;
             }
 
-            if Some(*neighbor) == node_id {
+            if *neighbor == node_id {
                 return false;
             }
 

--- a/diskann-providers/src/model/graph/provider/async_/simple_neighbor_provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/simple_neighbor_provider.rs
@@ -300,12 +300,13 @@ impl storage::bin::GetAdjacencyList for SimpleNeighborProviderAsync {
 ///
 /// Key differences between the formats:
 /// 1. The disk format does not support the virtual start point used by the in-memory index.
-/// 2. Disk format expects additional_points = 0, while async index uses additional_points = 1.
+/// 2. The in-memory index stores one virtual start point as an additional point, while the
+///    serialized disk graph omits it after remapping it to the actual medoid.
 ///
 /// This adaptor handles these differences by:
 /// - Substituting the virtual start point ID with an actual dataset ID when found in adjacency lists
 /// - Excluding the virtual point from the total count (subtracting 1 from length)
-/// - Setting additional_points to 0 as required by the disk format specification
+/// - Setting additional_points to 0 because the virtual point is omitted from the serialized graph
 ///
 /// Used with [`storage::bin::save_graph`] to persist an async index in standard DiskANN format.
 struct DiskAdaptor<'a> {

--- a/test_data/disk_index_build/truth_sift_learn_R4_L50_disk.index
+++ b/test_data/disk_index_build/truth_sift_learn_R4_L50_disk.index
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:87f18bab74a8c7724ef49b0f0e03bd8ee4e720de8c134804684c567d3fab9cab
+oid sha256:53fb1b3e2e468099411b9c201cf6fdcc35f31e00113a4c3a2eb0354087188851
 size 155648


### PR DESCRIPTION
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies? No.
- [ ] Does this PR modify any existing APIs? No.
- [x] Is the change to the API backwards compatible? Yes.
- [ ] Should this result in any documentation changes? No.

#### Reference Issues/PRs

N/A

#### What does this implement/fix? Briefly explain your changes.

The in-memory graph uses a virtual start point ID, while the serialized disk graph must replace it with the actual medoid ID.

Previously, this replacement happened after adjacency-list uniqueness had already been established. If a list contained both the virtual start point and the actual medoid, the remapping produced a duplicate medoid edge. On the medoid's own adjacency list, it could also produce a self-loop.

This PR updates `DiskAdaptor` to:

- remap the virtual start point to the actual medoid;
- preserve the original neighbor order;
- retain only the first resulting medoid edge;
- remove self-loops after remapping.

It does not backfill removed entries with arbitrary neighbors, so affected adjacency lists may contain one fewer unique edge.

The regression test covers both a remapping collision and the medoid self-loop case. The expected disk-index fixture is updated for the corrected serialized graph.

#### Any other comments?

The in-memory adjacency list is already unique before serialization, so only the alias introduced by virtual-start-point remapping needs post-remap deduplication. This keeps the change limited to disk serialization and does not alter graph construction or pruning behavior.