### PR TITLE
Fix alpha pruning documentation

### DIFF
--- a/diskann/src/graph/config/mod.rs
+++ b/diskann/src/graph/config/mod.rs
@@ -22,7 +22,7 @@ use crate::utils::IntoUsize;
 ///
 /// A higher occlusion factor means that `j` and `k` are "more similar" than `i` and `k`.
 /// The pruning rules are heuristics established such that using higher values of `alpha`
-/// yields sparser graphs.
+/// makes pruning less aggressive and generally yields denser graphs.
 ///
 /// ```text
 /// i (candidate vector) ----------> k
@@ -51,8 +51,8 @@ use crate::utils::IntoUsize;
 /// entirely as a neighbor candidate (achieved by settings its occlusion factor to
 /// `f32::MAX`.
 ///
-/// When alpha is greater, this requirement is more stringent, so higher alphas lead
-/// to less dense graphs.
+/// When alpha is greater, this requirement is more stringent, so fewer candidates are
+/// removed and the resulting graphs are generally denser.
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum PruneKind {
     TriangleInequality,
@@ -649,7 +649,7 @@ impl Builder {
 
     /// Configure the `alpha` parameter used during pruning.
     ///
-    /// Values closer to 1.0 will yield denser graphs at the cost of increased build time.
+    /// Higher values generally yield denser graphs at the cost of increased build time.
     pub fn alpha(&mut self, alpha: f32) -> &mut Self {
         self.alpha = Some(alpha);
         self


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
- [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?

#### Reference Issues/PRs

#### What does this implement/fix? Briefly explain your changes.
Corrects comments describing alpha during robust pruning. Higher alpha values make pruning less aggressive and generally retain more edges, producing denser graphs.

#### Any other comments?
Documentation-only change; no runtime behavior is modified.
