### PR TITLE
[diskann-garnet] Implement `continue_search()`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -603,7 +603,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-garnet"
-version = "5.0.0"
+version = "5.0.1"
 dependencies = [
  "bytemuck",
  "crossbeam",

--- a/diskann-garnet/Cargo.toml
+++ b/diskann-garnet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diskann-garnet"
-version = "5.0.0"
+version = "5.0.1"
 edition = "2024"
 authors.workspace = true
 license.workspace = true

--- a/diskann-garnet/diskann-garnet.nuspec
+++ b/diskann-garnet/diskann-garnet.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>diskann-garnet</id>
-    <version>5.0.0</version>
+    <version>5.0.1</version>
     <readme>docs/README.md</readme>
     <authors>Microsoft</authors>
     <projectUrl>https://github.com/microsoft/DiskANN</projectUrl>

--- a/diskann-garnet/docs/ffi-design.rs
+++ b/diskann-garnet/docs/ffi-design.rs
@@ -239,8 +239,8 @@ extern "C" fn set_attribute(
 /// `max_filtering_effort` bounding the extra work spent satisfying the filter. Attribute data
 /// is evaluated through the `filter_callback` supplied to `create_index`.
 ///
-/// Returns the number of results, or -1 on error. Continuations are not implemented, so the
-/// `continuation` parameter is currently ignored.
+/// Returns the number of results, or -1 on error. If the supplied output buffers cannot hold all
+/// results, `overflow` is set to an opaque pointer that can be passed to `overflow_results`.
 #[unsafe(no_mangle)]
 extern "C" fn search_vector(
     context: u64,
@@ -257,7 +257,7 @@ extern "C" fn search_vector(
     output_distances: *mut f32,
     output_distances_len: usize,
     beam_width: u32,
-    continuation: *mut c_void,
+    overflow: *mut *mut c_void,
 ) -> i32;
 
 /// Find similar vectors, takes parameters of VSIM (https://redis.io/docs/latest/commands/vsim/) and maps to a reasonable interpretation.
@@ -280,25 +280,23 @@ extern "C" fn search_element(
     output_distances: *mut f32,
     output_distances_len: usize,
     beam_width: u32,
-    continuation: *mut c_void,
+    overflow: *mut *mut c_void,
 ) -> i32;
 
-/// Continues fetching results if not all were available after a call to search_xxx
+/// Fetches overflow results that did not fit after a call to search_xxx.
 ///
 /// Returns the number of results placed in output_xxx, or -1 on error, and sets
-/// new_continuation to non-zero if even more results are available.
-///
-/// NOTE: This is not implemented and always returns -1.
+/// `new_overflow` to non-null if even more results are available.
 #[unsafe(no_mangle)]
-extern "C" fn continue_search(
+extern "C" fn overflow_results(
     context: u64,
     index_ptr: *const c_void,
-    continuation: *mut c_void,
+    overflow: *mut c_void,
     output_ids: *mut u8,
     output_ids_len: usize,
     output_distances: *mut f32,
     output_distances_len: usize,
-    new_continuation: *mut c_void,
+    new_overflow: *mut *mut c_void,
 ) -> i32;
 
 /// Remove vector from index.
@@ -367,8 +365,8 @@ extern "C" fn random_members(
 /// For implementing VLINKS (https://redis.io/docs/latest/commands/vlinks/). Output buffers are
 /// filled as they are for search_xxx.
 ///
-/// Returns the number of neighbors written, or -1 on error. Continuations are not implemented,
-/// so the `continuation` parameter is currently ignored.
+/// Returns the number of neighbors written, or -1 on error. If the supplied output buffers cannot
+/// hold all results, `overflow` is set to an opaque pointer that can be passed to `overflow_results`.
 #[unsafe(no_mangle)]
 extern "C" fn search_neighbors(
     context: u64,
@@ -379,5 +377,5 @@ extern "C" fn search_neighbors(
     output_ids_len: usize,
     output_distances: *mut f32,
     output_distances_len: usize,
-    continuation: *mut c_void,
+    overflow: *mut *mut c_void,
 ) -> i32;

--- a/diskann-garnet/src/dyn_index.rs
+++ b/diskann-garnet/src/dyn_index.rs
@@ -71,6 +71,9 @@ pub(crate) trait DynIndex: Send + Sync {
     /// Return an approximate count of vectors in the index
     fn approximate_count(&self) -> u64;
 
+    /// Return the maximum degree of the index graph
+    fn max_degree(&self) -> usize;
+
     /// Set a start point if one doesn't already exist.
     /// If there is already a start point, this is a no-op.
     fn maybe_set_start_point(&self, context: &Context, data: &[u8]) -> ANNResult<()>;
@@ -101,6 +104,11 @@ pub(crate) trait DynIndex: Send + Sync {
 
     /// Returns the neighbors of and distances from the target vector
     fn neighbors(&self, context: &Context, id: &GarnetId) -> ANNResult<Vec<Neighbor<GarnetId>>>;
+
+    /// Log a message to Garnet. The context term can be used to scope the log
+    /// message to an area (e.g. `Term::Quantized` for quantization related
+    /// messages).
+    fn log(&self, context: &Context, msg: &str);
 }
 
 impl<T: VectorRepr> DynIndex for DiskANNIndex<GarnetProvider<T>> {
@@ -194,6 +202,10 @@ impl<T: VectorRepr> DynIndex for DiskANNIndex<GarnetProvider<T>> {
         self.inner.provider().max_internal_id() as u64
     }
 
+    fn max_degree(&self) -> usize {
+        self.inner.provider().max_degree()
+    }
+
     fn maybe_set_start_point(&self, context: &Context, data: &[u8]) -> ANNResult<()> {
         self.inner
             .provider()
@@ -235,5 +247,9 @@ impl<T: VectorRepr> DynIndex for DiskANNIndex<GarnetProvider<T>> {
 
     fn neighbors(&self, context: &Context, id: &GarnetId) -> ANNResult<Vec<Neighbor<GarnetId>>> {
         self.inner.provider().neighbors(context, id)
+    }
+
+    fn log(&self, context: &Context, msg: &str) {
+        self.inner.provider().log(context, msg);
     }
 }

--- a/diskann-garnet/src/ffi_recall_tests.rs
+++ b/diskann-garnet/src/ffi_recall_tests.rs
@@ -10,8 +10,8 @@ mod tests {
     use diskann_vector::distance::{Cosine, Metric, SquaredL2};
 
     use crate::{
-        VectorQuantType, create_index, drop_index, garnet::Context, insert, search_vector,
-        test_utils::Store,
+        Overflow, VectorQuantType, create_index, drop_index, garnet::Context, insert,
+        search_vector, test_utils::Store,
     };
 
     /// Helper to insert a vector with a string external ID and FP32 data.
@@ -197,13 +197,13 @@ mod tests {
         let delta = 2.0_f32;
         let search_exploration_factor = 200_u32;
         let max_filtering_effort = 0_usize;
-        let continuation = ptr::null_mut();
 
         for vec in vectors {
             let query_bytes: &[u8] = bytemuck::cast_slice(vec);
             let max_id_size = mem::size_of::<u32>() + max_id_len;
             let mut output_id_buffer = vec![0u8; k * max_id_size];
             let mut output_dists = vec![0f32; k];
+            let mut overflow = ptr::null_mut();
 
             let count = unsafe {
                 search_vector(
@@ -221,7 +221,7 @@ mod tests {
                     output_dists.as_mut_ptr(),
                     output_dists.len(),
                     1,
-                    continuation,
+                    &mut overflow,
                 )
             };
             assert!(count >= 0, "search failed");
@@ -238,6 +238,10 @@ mod tests {
             );
             total_matches += matches;
             total_expected += expected_ids.len();
+
+            if !overflow.is_null() {
+                unsafe { drop(Overflow::from_ptr(overflow)) };
+            }
         }
 
         unsafe { drop_index(ctx.get(), index_ptr) };

--- a/diskann-garnet/src/ffi_tests.rs
+++ b/diskann-garnet/src/ffi_tests.rs
@@ -10,8 +10,8 @@ mod tests {
     use rand::{Rng, seq::SliceRandom};
 
     use crate::{
-        Index, InsertResult, VectorQuantType, backfill_quant_vectors, build_quant_table, card,
-        check_external_id_valid, check_internal_id_valid, create_index, drop_index,
+        Index, InsertResult, Overflow, VectorQuantType, backfill_quant_vectors, build_quant_table,
+        card, check_external_id_valid, check_internal_id_valid, create_index, drop_index,
         garnet::{Context, Term},
         insert,
         quantization::{GarnetQuantizer, Spherical1Bit},
@@ -465,6 +465,7 @@ mod tests {
         let qv = &[0.0f32, 0.0];
         let mut output_id_buffer = vec![0u8; 2 * (mem::size_of::<u64>() + mem::size_of::<u32>())];
         let mut output_dists = vec![0f32; 2];
+        let mut overflow = ptr::null_mut();
 
         let count = unsafe {
             search_vector(
@@ -482,11 +483,12 @@ mod tests {
                 output_dists.as_mut_ptr(),
                 output_dists.len(),
                 1,
-                ptr::null_mut(),
+                &mut overflow,
             )
         };
 
         assert_eq!(count, 2);
+        assert!(overflow.is_null());
 
         let mut output_ids = vec![];
         let mut offset = 0;
@@ -573,6 +575,7 @@ mod tests {
 
         let mut output_id_buffer = vec![0u8; 2 * (mem::size_of::<u64>() + mem::size_of::<u32>())];
         let mut output_dists = vec![0f32; 2];
+        let mut overflow = ptr::null_mut();
 
         let count = unsafe {
             crate::search_element(
@@ -590,11 +593,12 @@ mod tests {
                 output_dists.as_mut_ptr(),
                 output_dists.len(),
                 1,
-                ptr::null_mut(),
+                &mut overflow,
             )
         };
 
         assert_eq!(count, 2);
+        assert!(overflow.is_null());
 
         let mut output_ids = vec![];
         let mut offset = 0;
@@ -634,13 +638,55 @@ mod tests {
     }
 
     #[test]
-    fn continue_search() {
+    fn search_element_writes_overflow_output() {
+        let store = Store::new();
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
+        let id = 1u32;
+        assert_eq!(
+            insert_f32_vector(&ctx, index_ptr, id, &[0.0, 1.0]),
+            InsertResult::Success
+        );
+
+        let mut output_ids: [u8; 0] = [];
+        let mut output_distances: [f32; 1] = [0f32];
+        let mut overflow = ptr::null_mut();
+        let count = unsafe {
+            crate::search_element(
+                ctx.get(),
+                index_ptr,
+                bytemuck::bytes_of(&id).as_ptr(),
+                mem::size_of::<u32>(),
+                1.0,
+                10,
+                ptr::null(),
+                0,
+                0,
+                output_ids.as_mut_ptr(),
+                output_ids.len(),
+                output_distances.as_mut_ptr(),
+                output_distances.len(),
+                1,
+                &mut overflow,
+            )
+        };
+
+        assert_eq!(count, 0);
+        assert!(!overflow.is_null());
+
+        unsafe {
+            drop(Overflow::from_ptr(overflow));
+            drop_index(ctx.get(), index_ptr);
+        }
+    }
+
+    #[test]
+    fn overflow_results() {
         let store = Store::new();
         let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
         let mut output_id_buffer = vec![0u8; 2 * (mem::size_of::<u64>() + mem::size_of::<u32>())];
         let mut output_dists = vec![0f32; 2];
         let res = unsafe {
-            crate::continue_search(
+            crate::overflow_results(
                 ctx.get(),
                 index_ptr,
                 ptr::null_mut(),
@@ -694,6 +740,7 @@ mod tests {
             Some(b) => (b.as_ptr(), b.len()),
             None => (ptr::null(), 0),
         };
+        let mut overflow = ptr::null_mut();
 
         let count = unsafe {
             search_vector(
@@ -711,9 +758,13 @@ mod tests {
                 output_dists.as_mut_ptr(),
                 output_dists.len(),
                 1,
-                ptr::null_mut(),
+                &mut overflow,
             )
         };
+
+        if !overflow.is_null() {
+            unsafe { drop(Overflow::from_ptr(overflow)) };
+        }
 
         assert!(count >= 0, "search failed with {count}");
         let count = count as usize;
@@ -734,6 +785,49 @@ mod tests {
 
         output_dists.truncate(count);
         (ids, output_dists)
+    }
+
+    #[test]
+    fn search_vector_writes_overflow_output() {
+        let store = Store::new();
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
+        let vector = [0.0f32, 1.0];
+        assert_eq!(
+            insert_f32_vector(&ctx, index_ptr, 1, &vector),
+            InsertResult::Success
+        );
+
+        let query_bytes = bytemuck::cast_slice(&vector);
+        let mut output_ids: [u8; 0] = [];
+        let mut output_distances: [f32; 1] = [0f32];
+        let mut overflow = ptr::null_mut();
+        let count = unsafe {
+            search_vector(
+                ctx.get(),
+                index_ptr,
+                query_bytes.as_ptr(),
+                vector.len(),
+                1.0,
+                10,
+                ptr::null(),
+                0,
+                0,
+                output_ids.as_mut_ptr(),
+                output_ids.len(),
+                output_distances.as_mut_ptr(),
+                output_distances.len(),
+                1,
+                &mut overflow,
+            )
+        };
+
+        assert_eq!(count, 0);
+        assert!(!overflow.is_null());
+
+        unsafe {
+            drop(Overflow::from_ptr(overflow));
+            drop_index(ctx.get(), index_ptr);
+        }
     }
 
     #[test]

--- a/diskann-garnet/src/lib.rs
+++ b/diskann-garnet/src/lib.rs
@@ -117,27 +117,42 @@ pub enum VectorQuantType {
 
 /// Helper struct to manage the FFI buffers for handling search results
 ///
-/// NOTE: The ids will be 4-byte length prefixed, and external IDs are arbitrary length
-/// byte strings.
+/// If the supplied ID buffer from Garnet isn't large enough, `overflow_ids` and
+/// `overflow_dists` will allocate enough space to store the remaining entries
+/// so they can be fetched by Garnet later.
+///
+/// Having overflow allocations means we don't allocate extra until actually
+/// needed. Short result sets can happen without allocation.
+///
+/// NOTE: The ids will be 4-byte length prefixed, and external IDs are arbitrary
+/// length byte strings.
 struct SearchResults<'a> {
+    k: usize,
     ids: &'a mut [u8],
     dists: &'a mut [f32],
     index: usize,
     id_index: usize,
+    overflow_ids: Vec<u8>,
+    overflow_dists: Vec<f32>,
 }
 
 impl SearchResults<'_> {
     /// Construct from the raw pointers
-    fn new(ids: *mut u8, ids_len: usize, dists: *mut f32, dists_len: usize) -> Self {
+    fn new(k: usize, ids: *mut u8, ids_len: usize, dists: *mut f32, dists_len: usize) -> Self {
         let ids = unsafe { slice::from_raw_parts_mut(ids, ids_len) };
         let dists = unsafe { slice::from_raw_parts_mut(dists, dists_len) };
         let index = 0;
         let id_index = 0;
+        let overflow_ids = Vec::new();
+        let overflow_dists = Vec::new();
         Self {
+            k,
             ids,
             dists,
             index,
             id_index,
+            overflow_ids,
+            overflow_dists,
         }
     }
 
@@ -146,20 +161,43 @@ impl SearchResults<'_> {
     fn push_id(&mut self, id: GarnetId) -> diskann::graph::BufferState {
         self.push(Neighbor::new(id, 0.0))
     }
+
+    fn overflowing(&self) -> bool {
+        !self.overflow_ids.is_empty()
+    }
+
+    fn into_overflows(self) -> (Vec<u8>, Vec<f32>) {
+        (self.overflow_ids, self.overflow_dists)
+    }
+
+    fn is_full(&self) -> bool {
+        self.index + self.overflow_dists.len() >= self.k
+    }
 }
 
 impl SearchOutputBuffer<GarnetId> for SearchResults<'_> {
     fn size_hint(&self) -> Option<usize> {
-        Some(self.dists.len() - self.index)
+        Some(self.k - self.index - self.overflow_dists.len())
     }
 
     fn push(&mut self, neighbor: Neighbor<GarnetId>) -> diskann::graph::BufferState {
         let (id, distance) = neighbor.as_tuple();
 
-        if self.index >= self.dists.len()
+        if self.is_full() {
+            return diskann::graph::BufferState::Full;
+        } else if self.overflowing()
+            || self.index >= self.dists.len()
             || self.id_index + mem::size_of::<u32>() + id.len() > self.ids.len()
         {
-            return diskann::graph::BufferState::Full;
+            self.overflow_ids
+                .extend_from_slice(id.as_prefixed_key_bytes());
+            self.overflow_dists.push(distance);
+
+            if self.is_full() {
+                return diskann::graph::BufferState::Full;
+            } else {
+                return diskann::graph::BufferState::Available;
+            }
         }
 
         let id_len = id.len() as u32;
@@ -172,7 +210,7 @@ impl SearchOutputBuffer<GarnetId> for SearchResults<'_> {
         self.index += 1;
         self.id_index += id.len();
 
-        if self.index >= self.dists.len() || self.id_index >= self.ids.len() {
+        if self.is_full() {
             diskann::graph::BufferState::Full
         } else {
             diskann::graph::BufferState::Available
@@ -674,7 +712,117 @@ pub unsafe extern "C" fn set_attribute(
     true
 }
 
+/// Search result overflow container.
+///
+/// This will be boxed and a pointer given to Garnet in order to signal that more results than
+/// fit in the provided buffer are available. Garnet will hand this back along with new
+/// results buffers to access additional results. `drain()` is used to fill those buffers and
+/// update the `Overflow`.
+pub struct Overflow {
+    index: usize,
+    id_index: usize,
+    id_buffer: Vec<u8>,
+    dist_buffer: Vec<f32>,
+}
+
+impl Overflow {
+    /// Construct a new `Box<Overflow>` from the overflow buffers
+    pub fn new(id_buffer: Vec<u8>, dist_buffer: Vec<f32>) -> Box<Self> {
+        let index = 0;
+        let id_index = 0;
+        Box::new(Self {
+            index,
+            id_index,
+            id_buffer,
+            dist_buffer,
+        })
+    }
+
+    /// Turn a raw pointer back into `Box<Overflow>`
+    ///
+    /// # SAFETY
+    ///
+    /// This must only be called once on the pointer.
+    pub unsafe fn from_ptr(ptr: *mut c_void) -> Box<Self> {
+        unsafe { Box::from_raw(ptr as *mut Overflow) }
+    }
+
+    /// Turn a `Box<Overflow>` into a raw pointer, leaking the memory.
+    ///
+    /// To free the memory, `from_ptr()` must be used to turn it back into a Box which can then
+    /// be dropped normally.
+    pub fn into_ptr(self: Box<Self>) -> *mut c_void {
+        Box::into_raw(self) as *mut c_void
+    }
+
+    /// Drains the overflow buffers into the provided `ids` and `dists` buffers.
+    ///
+    /// Returns the amount drained.
+    pub fn drain(&mut self, ids: &mut [u8], dists: &mut [f32]) -> usize {
+        let mut index = 0;
+        let mut id_index = 0;
+
+        // Scan `id_buffer` until we reach the first id that doesn't fit because one of the
+        // buffers is full.
+        let mut count = 0;
+        let prefix_len = mem::size_of::<u32>();
+        while index < dists.len()
+            && id_index < ids.len()
+            && self.index < self.dist_buffer.len()
+            && self.id_index < self.id_buffer.len()
+        {
+            // Read length prefix
+            if id_index + prefix_len > ids.len() {
+                break;
+            }
+            let mut len = 0u32;
+            bytemuck::bytes_of_mut(&mut len)
+                .copy_from_slice(&self.id_buffer[self.id_index..self.id_index + prefix_len]);
+
+            // We check there is room before advancing the indices
+            if id_index + prefix_len + len as usize > ids.len() {
+                break;
+            }
+
+            // Copy length prefix
+            ids[id_index..id_index + prefix_len]
+                .copy_from_slice(&self.id_buffer[self.id_index..self.id_index + prefix_len]);
+
+            id_index += prefix_len;
+            self.id_index += prefix_len;
+
+            // Copy ID
+
+            ids[id_index..id_index + len as usize]
+                .copy_from_slice(&self.id_buffer[self.id_index..self.id_index + len as usize]);
+
+            id_index += len as usize;
+            self.id_index += len as usize;
+
+            // Copy the distance
+            dists[index] = self.dist_buffer[self.index];
+            index += 1;
+            self.index += 1;
+
+            count += 1;
+        }
+
+        count
+    }
+
+    /// Determines whether the overflow is finished
+    pub fn is_empty(&self) -> bool {
+        self.index >= self.dist_buffer.len()
+    }
+}
+
 /// Search the closest vectors to the given query vector.
+///
+/// The k value for the search is implied by `output_distances_len`. The output
+/// distances buffer will be correctly sized for k, but because IDs are variable
+/// length, the output_ids buffer may be too small. If that happens, an overflow
+/// will be returned so that Garnet can use `overflow_results` to fetch the
+/// remaining results.
 ///
 /// # Safety
 ///
@@ -695,7 +843,7 @@ pub unsafe extern "C" fn search_vector(
     output_distances: *mut f32,
     output_distances_len: usize,
     beam_width: u32,
-    _continuation: *mut c_void,
+    overflow: *mut *mut c_void,
 ) -> i32 {
     let index = unsafe { &*index_ptr.cast::<Index>() };
 
@@ -708,6 +856,7 @@ pub unsafe extern "C" fn search_vector(
     let ctx = Context::new(ctx);
 
     let mut output = SearchResults::new(
+        output_distances_len,
         output_ids,
         output_ids_len,
         output_distances,
@@ -743,7 +892,22 @@ pub unsafe extern "C" fn search_vector(
         if stats.result_count > i32::MAX as u32 {
             -1
         } else {
-            stats.result_count as i32
+            let count = output.current_len();
+
+            if overflow.is_null() {
+                index.inner.log(&ctx, "overflow argument was null");
+                return -1;
+            }
+
+            if output.overflowing() {
+                let (id_buffer, dist_buffer) = output.into_overflows();
+                let cont = Overflow::new(id_buffer, dist_buffer);
+                unsafe { overflow.write(cont.into_ptr()) };
+            } else {
+                unsafe { overflow.write(ptr::null_mut()) };
+            }
+
+            count as i32
         }
     } else {
         -1
@@ -751,6 +915,8 @@ pub unsafe extern "C" fn search_vector(
 }
 
 /// Search the closest vectors to the given existing vector in the index.
+///
+/// This is a thin wrapper around `search_vector`, so see its documentation for more details.
 ///
 /// # Safety
 ///
@@ -771,7 +937,7 @@ pub unsafe extern "C" fn search_element(
     output_distances: *mut f32,
     output_distances_len: usize,
     beam_width: u32,
-    _continuation: *mut c_void,
+    overflow: *mut *mut c_void,
 ) -> i32 {
     let index = unsafe { &*index_ptr.cast::<Index>() };
     let id_bytes = unsafe { slice::from_raw_parts(id_data, id_len) };
@@ -779,6 +945,7 @@ pub unsafe extern "C" fn search_element(
     let ctx = Context::new(ctx);
 
     let mut output = SearchResults::new(
+        output_distances_len,
         output_ids,
         output_ids_len,
         output_distances,
@@ -817,7 +984,22 @@ pub unsafe extern "C" fn search_element(
         if stats.result_count > i32::MAX as u32 {
             -1
         } else {
-            stats.result_count as i32
+            let count = output.current_len();
+
+            if overflow.is_null() {
+                index.inner.log(&ctx, "overflow argument was null");
+                return -1;
+            }
+
+            if output.overflowing() {
+                let (id_buffer, dist_buffer) = output.into_overflows();
+                let cont = Overflow::new(id_buffer, dist_buffer);
+                unsafe { overflow.write(cont.into_ptr()) };
+            } else {
+                unsafe { overflow.write(ptr::null_mut()) };
+            }
+
+            count as i32
         }
     } else {
         -1
@@ -826,25 +1008,52 @@ pub unsafe extern "C" fn search_element(
 
 /// Continue getting results for a previously executed search.
 ///
-/// NOTE: This is currently unimplemented.
-///
 /// Positive return values are the count of vectors returned. `-1` will be returned on errors.
+/// If further overflow is needed, `new_overflow` will be set to a new overflow pointer.
 ///
 /// # Safety
 ///
 /// FFI
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn continue_search(
-    _context: u64,
-    _index_ptr: *const c_void,
-    _continuation: *mut c_void,
-    _output_ids: *mut u8,
-    _output_ids_len: usize,
-    _output_distances: *mut f32,
-    _output_distances_len: usize,
-    _new_continuation: *mut c_void,
+pub unsafe extern "C" fn overflow_results(
+    ctx: u64,
+    index_ptr: *const c_void,
+    overflow: *mut c_void,
+    output_ids: *mut u8,
+    output_ids_len: usize,
+    output_distances: *mut f32,
+    output_distances_len: usize,
+    new_overflow: *mut *mut c_void,
 ) -> i32 {
-    -1
+    let index = unsafe { &*index_ptr.cast::<Index>() };
+    let ctx = Context::new(ctx);
+
+    if overflow.is_null() {
+        index.inner.log(&ctx, "overflow argument was null");
+        if !new_overflow.is_null() {
+            unsafe { new_overflow.write(ptr::null_mut()) };
+        }
+        return -1;
+    }
+
+    if new_overflow.is_null() {
+        index.inner.log(&ctx, "new_overflow argument was null");
+        return -1;
+    }
+
+    let output_ids = unsafe { slice::from_raw_parts_mut(output_ids, output_ids_len) };
+    let output_distances =
+        unsafe { slice::from_raw_parts_mut(output_distances, output_distances_len) };
+    let mut overflow = unsafe { Overflow::from_ptr(overflow) };
+    let count = overflow.drain(output_ids, output_distances);
+
+    if !overflow.is_empty() {
+        unsafe { new_overflow.write(overflow.into_ptr()) };
+    } else {
+        unsafe { new_overflow.write(ptr::null_mut()) };
+    }
+
+    count as i32
 }
 
 /// Remove a vector from the index.
@@ -957,6 +1166,7 @@ pub unsafe extern "C" fn random_members(
     // Dummy buffer for distances
     let mut output_distances = vec![0f32; output_ids_len / 5];
     let mut output = SearchResults::new(
+        count as usize,
         output_ids,
         output_ids_len,
         output_distances.as_mut_ptr(),
@@ -986,7 +1196,7 @@ pub unsafe extern "C" fn search_neighbors(
     output_ids_len: usize,
     output_distances: *mut f32,
     output_distances_len: usize,
-    _continuation: *mut c_void,
+    overflow: *mut *mut c_void,
 ) -> i32 {
     let index = unsafe { &*index_ptr.cast::<Index>() };
     let ctx = Context::new(ctx);
@@ -994,6 +1204,7 @@ pub unsafe extern "C" fn search_neighbors(
     let id = GarnetId::from(id_bytes);
 
     let mut output = SearchResults::new(
+        index.inner.max_degree(),
         output_ids,
         output_ids_len,
         output_distances,
@@ -1006,7 +1217,21 @@ pub unsafe extern "C" fn search_neighbors(
 
     output.extend(neighbors);
 
-    output.current_len() as i32
+    if overflow.is_null() {
+        index.inner.log(&ctx, "overflow argument was null");
+        return -1;
+    }
+
+    let count = output.current_len();
+    if output.overflowing() {
+        let (id_buffer, dist_buffer) = output.into_overflows();
+        let cont = Overflow::new(id_buffer, dist_buffer);
+        unsafe { overflow.write(cont.into_ptr()) };
+    } else {
+        unsafe { overflow.write(ptr::null_mut()) };
+    }
+
+    count as i32
 }
 
 #[cfg(test)]
@@ -1042,7 +1267,7 @@ mod tests {
         let dists_buffer = dists.as_mut_ptr();
         let dists_len = dists.len();
 
-        let mut sr = SearchResults::new(ids_buffer, ids_len, dists_buffer, dists_len);
+        let mut sr = SearchResults::new(5, ids_buffer, ids_len, dists_buffer, dists_len);
 
         assert_eq!(sr.size_hint(), Some(5));
 
@@ -1084,6 +1309,93 @@ mod tests {
             )),
             BufferState::Full
         );
+    }
+
+    #[test]
+    fn overflow_results() {
+        let store = Store::new();
+        let mut quant_needed = false;
+        let index_ptr = unsafe {
+            super::create_index(
+                0,
+                2,
+                0,
+                VectorQuantType::NoQuant,
+                Metric::L2.into(),
+                10,
+                8,
+                store.callbacks().read_callback(),
+                store.callbacks().write_callback(),
+                store.callbacks().delete_callback(),
+                store.callbacks().rmw_callback(),
+                store.callbacks().filter_callback(),
+                store.callbacks().log_callback(),
+                &mut quant_needed,
+            )
+        };
+        assert!(!index_ptr.is_null());
+
+        let first_id = b"first";
+        let second_id = b"second";
+        let mut overflow_ids = Vec::new();
+        overflow_ids.extend_from_slice(bytemuck::bytes_of(&(first_id.len() as u32)));
+        overflow_ids.extend_from_slice(first_id);
+        overflow_ids.extend_from_slice(bytemuck::bytes_of(&(second_id.len() as u32)));
+        overflow_ids.extend_from_slice(second_id);
+
+        let overflow = super::Overflow::new(overflow_ids, vec![1.25, 2.5]).into_ptr();
+        let mut next_overflow = ptr::null_mut();
+        let mut output_ids = vec![0u8; mem::size_of::<u32>() + first_id.len()];
+        let mut output_distances = [0.0f32; 1];
+
+        let count = unsafe {
+            super::overflow_results(
+                0,
+                index_ptr,
+                overflow,
+                output_ids.as_mut_ptr(),
+                output_ids.len(),
+                output_distances.as_mut_ptr(),
+                output_distances.len(),
+                &mut next_overflow,
+            )
+        };
+
+        assert_eq!(count, 1);
+        assert_eq!(
+            output_ids[..mem::size_of::<u32>()],
+            (first_id.len() as u32).to_le_bytes()
+        );
+        assert_eq!(&output_ids[mem::size_of::<u32>()..], first_id);
+        assert_eq!(output_distances, [1.25]);
+        assert!(!next_overflow.is_null());
+
+        let mut final_overflow = ptr::null_mut();
+        let mut output_ids = vec![0u8; mem::size_of::<u32>() + second_id.len()];
+        let mut output_distances = [0.0f32; 1];
+        let count = unsafe {
+            super::overflow_results(
+                0,
+                index_ptr,
+                next_overflow,
+                output_ids.as_mut_ptr(),
+                output_ids.len(),
+                output_distances.as_mut_ptr(),
+                output_distances.len(),
+                &mut final_overflow,
+            )
+        };
+
+        assert_eq!(count, 1);
+        assert_eq!(
+            output_ids[..mem::size_of::<u32>()],
+            (second_id.len() as u32).to_le_bytes()
+        );
+        assert_eq!(&output_ids[mem::size_of::<u32>()..], second_id);
+        assert_eq!(output_distances, [2.5]);
+        assert!(final_overflow.is_null());
+
+        unsafe { drop_index(0, index_ptr) };
     }
 
     fn check_create_index(quant_type: VectorQuantType) {
@@ -1497,6 +1809,7 @@ mod tests {
         let bad_id = GarnetId::from(bytemuck::bytes_of(&250u32));
 
         // check the good case
+        let mut overflow = ptr::null_mut();
         let count = unsafe {
             super::search_neighbors(
                 ctx.get(),
@@ -1507,11 +1820,12 @@ mod tests {
                 output_ids.len() * mem::size_of::<u32>(),
                 output_dists.as_mut_ptr(),
                 output_dists.len(),
-                ptr::null_mut(),
+                &mut overflow,
             )
         };
 
         assert!(count > 0 && count <= 8, "count = {count}");
+        assert!(overflow.is_null());
 
         for i in 0..count as usize {
             assert_eq!(output_ids[i * 2], 4);
@@ -1519,6 +1833,7 @@ mod tests {
             assert!(output_dists[i] < f32::MAX);
         }
 
+        let mut overflow = ptr::null_mut();
         let count = unsafe {
             super::search_neighbors(
                 ctx.get(),
@@ -1529,10 +1844,11 @@ mod tests {
                 output_ids.len() * mem::size_of::<u32>(),
                 output_dists.as_mut_ptr(),
                 output_dists.len(),
-                ptr::null_mut(),
+                &mut overflow,
             )
         };
 
         assert!(count < 0);
+        assert!(overflow.is_null());
     }
 }

--- a/diskann-garnet/src/provider.rs
+++ b/diskann-garnet/src/provider.rs
@@ -487,6 +487,10 @@ impl<T: VectorRepr> GarnetProvider<T> {
         self.fsm.max_id()
     }
 
+    pub(crate) fn max_degree(&self) -> usize {
+        self.max_degree
+    }
+
     /// Train the quantizer.
     ///
     /// This should only be called when at least `quantizer.required_vectors()` vectors exist in
@@ -790,6 +794,11 @@ impl<T: VectorRepr> GarnetProvider<T> {
         }
 
         Ok(result)
+    }
+
+    /// Log a message to Garnet.
+    pub(crate) fn log(&self, context: &Context, msg: &str) {
+        self.callbacks.log(context, msg);
     }
 
     /// Returns the quantizer associated with the index.
@@ -2152,6 +2161,7 @@ mod tests {
         let mut output_ids = vec![0u8; mem::size_of::<u32>() * 2 * 10];
         let mut output_dists = vec![0f32; 10];
         let mut output = SearchResults::new(
+            10,
             output_ids.as_mut_ptr(),
             output_ids.len(),
             output_dists.as_mut_ptr(),
@@ -2343,6 +2353,7 @@ mod tests {
         let mut output_ids = vec![0u8; mem::size_of::<u32>() * 2 * 10];
         let mut output_dists = vec![0f32; 10];
         let mut output = SearchResults::new(
+            10,
             output_ids.as_mut_ptr(),
             output_ids.len(),
             output_dists.as_mut_ptr(),


### PR DESCRIPTION
Implements `continue_search()` in the Garnet FFI.

The buffers for ids that Garnet passes may be insufficient since external IDs are user-provided byte strings of arbitrary length. The distances buffer will always be correctly sized. In the case the id buffer is too small, a `Continuation` is boxed and returned, which can be used by potentially repeated calls to `continue_search()` to retrieve the rest of the results.

This set up is used all the `search_X` FFI methods. It is not used in `random_members()` since due to how other things are handled with that it can just use multiple calls to get more random members if needed.