### PR TITLE
Make flat search visitors query-aware

### DIFF
--- a/diskann-benchmark/src/flat/search.rs
+++ b/diskann-benchmark/src/flat/search.rs
@@ -11,9 +11,9 @@
 use std::{io::Write, num::NonZeroUsize, sync::Arc};
 
 use diskann::{
-    flat::{knn_search, DistancesUnordered, SearchStrategy},
+    flat::{knn_search, DistancesUnordered},
     graph::{glue::CopyIds, SearchOutputBuffer},
-    provider::{DataProvider, DefaultContext, HasId, NoopGuard},
+    provider::HasId,
     utils::VectorRepr,
     ANNResult,
 };
@@ -53,27 +53,8 @@ pub(super) fn register_benchmarks(registry: &mut Registry) -> anyhow::Result<()>
 /////////////////
 
 /// A minimal in-memory provider for flat search benchmarks.
-///
-/// Wraps a loaded [`Matrix<T>`] and implements [`DataProvider`] with identity
-/// ID mapping.
 struct InMemProvider<T> {
     data: Arc<Matrix<T>>,
-}
-
-impl<T: VectorRepr> DataProvider for InMemProvider<T> {
-    type Context = DefaultContext;
-    type InternalId = u32;
-    type ExternalId = u32;
-    type Error = diskann::ANNError;
-    type Guard = NoopGuard<u32>;
-
-    fn to_internal_id(&self, _ctx: &DefaultContext, gid: &u32) -> Result<u32, Self::Error> {
-        Ok(*gid)
-    }
-
-    fn to_external_id(&self, _ctx: &DefaultContext, id: u32) -> Result<u32, Self::Error> {
-        Ok(id)
-    }
 }
 
 struct Flat<T> {
@@ -173,7 +154,7 @@ where
         let searcher = Arc::new(Searcher {
             provider,
             queries,
-            strategy: Strategy::new(metric),
+            metric,
         });
 
         for &threads in &input.search.num_threads {
@@ -201,30 +182,19 @@ where
     }
 }
 
-///////////////////////
-// Flat SearchStrategy //
-///////////////////////
-
-/// A [`SearchStrategy`] implementation for [`InMemProvider`] that drives
-/// a full sequential scan over all vectors.
-struct Strategy<T: VectorRepr> {
-    metric: Metric,
-    _phantom: std::marker::PhantomData<T>,
-}
-
-impl<T: VectorRepr> Strategy<T> {
-    fn new(metric: Metric) -> Self {
-        Self {
-            metric,
-            _phantom: std::marker::PhantomData,
-        }
-    }
-}
-
 /// The visitor that iterates over all vectors in the provider.
 struct Visitor<'a, T: VectorRepr> {
     data: &'a Matrix<T>,
     computer: T::QueryDistance,
+}
+
+impl<'a, T: VectorRepr> Visitor<'a, T> {
+    fn new(provider: &'a InMemProvider<T>, query: &[T], metric: Metric) -> Self {
+        Self {
+            data: &provider.data,
+            computer: T::query_distance(query, metric),
+        }
+    }
 }
 
 impl<T: VectorRepr> HasId for Visitor<'_, T> {
@@ -248,23 +218,6 @@ impl<T: VectorRepr> DistancesUnordered for Visitor<'_, T> {
     }
 }
 
-impl<'a, T: VectorRepr> SearchStrategy<'a, InMemProvider<T>, &'a [T]> for Strategy<T> {
-    type Visitor = Visitor<'a, T>;
-    type Error = diskann::error::Infallible;
-
-    fn create_visitor(
-        &'a self,
-        provider: &'a InMemProvider<T>,
-        _context: &'a DefaultContext,
-        query: &'a [T],
-    ) -> Result<Self::Visitor, Self::Error> {
-        Ok(Visitor {
-            data: &provider.data,
-            computer: T::query_distance(query, self.metric),
-        })
-    }
-}
-
 //////////////////////////////////////////
 // benchmark_core::search::Search impl  //
 //////////////////////////////////////////
@@ -273,7 +226,7 @@ impl<'a, T: VectorRepr> SearchStrategy<'a, InMemProvider<T>, &'a [T]> for Strate
 struct Searcher<T: VectorRepr> {
     provider: InMemProvider<T>,
     queries: Matrix<T>,
-    strategy: Strategy<T>,
+    metric: Metric,
 }
 
 /// Search parameters for flat-index benchmarks.
@@ -314,19 +267,10 @@ where
     where
         O: SearchOutputBuffer<u32> + Send,
     {
-        let context = DefaultContext;
         let query = self.queries.row(index);
+        let mut visitor = Visitor::new(&self.provider, query, self.metric);
 
-        let stats = knn_search(
-            &self.provider,
-            parameters.k,
-            &self.strategy,
-            CopyIds,
-            &context,
-            query,
-            buffer,
-        )
-        .await?;
+        let stats = knn_search(&mut visitor, parameters.k, CopyIds, query, buffer).await?;
 
         Ok(Metrics {
             comparisons: stats.cmps,

--- a/diskann-benchmark/src/flat/search.rs
+++ b/diskann-benchmark/src/flat/search.rs
@@ -5,13 +5,13 @@
 
 //! Backend for flat-index (brute-force kNN) benchmarks.
 //!
-//! This exercises [`diskann::flat::FlatIndex::knn_search`] over an in-memory
+//! This exercises [`diskann::flat::knn_search`] over an in-memory
 //! provider, measuring recall and latency.
 
 use std::{io::Write, num::NonZeroUsize, sync::Arc};
 
 use diskann::{
-    flat::{DistancesUnordered, FlatIndex, SearchStrategy},
+    flat::{knn_search, DistancesUnordered, SearchStrategy},
     graph::{glue::CopyIds, SearchOutputBuffer},
     provider::{DataProvider, DefaultContext, HasId, NoopGuard},
     utils::VectorRepr,
@@ -132,10 +132,9 @@ where
         );
         writeln!(output, "  Loaded {} vectors of dimension {}", nrows, ncols)?;
 
-        // Build the provider and wrap in FlatIndex
+        // Build the provider.
         let data = Arc::new(data);
         let provider = InMemProvider { data: data.clone() };
-        let index = FlatIndex::new(provider);
 
         // Load queries and groundtruth
         let queries: Matrix<T> =
@@ -172,7 +171,7 @@ where
         let mut results = Vec::new();
 
         let searcher = Arc::new(Searcher {
-            index,
+            provider,
             queries,
             strategy: Strategy::new(metric),
         });
@@ -223,29 +222,25 @@ impl<T: VectorRepr> Strategy<T> {
 }
 
 /// The visitor that iterates over all vectors in the provider.
-struct Visitor<'a, T> {
+struct Visitor<'a, T: VectorRepr> {
     data: &'a Matrix<T>,
+    computer: T::QueryDistance,
 }
 
 impl<T: VectorRepr> HasId for Visitor<'_, T> {
     type Id = u32;
 }
 
-impl<T: VectorRepr> DistancesUnordered<T::QueryDistance> for Visitor<'_, T> {
-    type ElementRef<'a> = &'a [T];
+impl<T: VectorRepr> DistancesUnordered for Visitor<'_, T> {
     type Error = diskann::error::Infallible;
 
-    fn distances_unordered<F>(
-        &mut self,
-        computer: &T::QueryDistance,
-        mut f: F,
-    ) -> impl SendFuture<Result<(), Self::Error>>
+    fn distances_unordered<F>(&mut self, mut f: F) -> impl SendFuture<Result<(), Self::Error>>
     where
         F: Send + FnMut(Self::Id, f32),
     {
         async move {
             for (i, vector) in self.data.row_iter().enumerate() {
-                let dist = computer.evaluate_similarity(vector);
+                let dist = self.computer.evaluate_similarity(vector);
                 f(i as u32, dist);
             }
             Ok(())
@@ -253,32 +248,20 @@ impl<T: VectorRepr> DistancesUnordered<T::QueryDistance> for Visitor<'_, T> {
     }
 }
 
-impl<T: VectorRepr> SearchStrategy<InMemProvider<T>, &[T]> for Strategy<T> {
-    type ElementRef<'a> = &'a [T];
-    type QueryComputer = T::QueryDistance;
-    type QueryComputerError = diskann::error::Infallible;
-    type Visitor<'a>
-        = Visitor<'a, T>
-    where
-        Self: 'a,
-        InMemProvider<T>: 'a;
+impl<'a, T: VectorRepr> SearchStrategy<'a, InMemProvider<T>, &'a [T]> for Strategy<T> {
+    type Visitor = Visitor<'a, T>;
     type Error = diskann::error::Infallible;
 
-    fn create_visitor<'a>(
+    fn create_visitor(
         &'a self,
         provider: &'a InMemProvider<T>,
         _context: &'a DefaultContext,
-    ) -> Result<Self::Visitor<'a>, Self::Error> {
+        query: &'a [T],
+    ) -> Result<Self::Visitor, Self::Error> {
         Ok(Visitor {
             data: &provider.data,
+            computer: T::query_distance(query, self.metric),
         })
-    }
-
-    fn build_query_computer(
-        &self,
-        query: &[T],
-    ) -> Result<Self::QueryComputer, Self::QueryComputerError> {
-        Ok(T::query_distance(query, self.metric))
     }
 }
 
@@ -286,9 +269,9 @@ impl<T: VectorRepr> SearchStrategy<InMemProvider<T>, &[T]> for Strategy<T> {
 // benchmark_core::search::Search impl  //
 //////////////////////////////////////////
 
-/// Wraps a [`FlatIndex`] and queries to implement [`search::Search`].
+/// Wraps a flat-search provider and queries to implement [`search::Search`].
 struct Searcher<T: VectorRepr> {
-    index: FlatIndex<InMemProvider<T>>,
+    provider: InMemProvider<T>,
     queries: Matrix<T>,
     strategy: Strategy<T>,
 }
@@ -334,17 +317,16 @@ where
         let context = DefaultContext;
         let query = self.queries.row(index);
 
-        let stats = self
-            .index
-            .knn_search(
-                parameters.k,
-                &self.strategy,
-                CopyIds,
-                &context,
-                query,
-                buffer,
-            )
-            .await?;
+        let stats = knn_search(
+            &self.provider,
+            parameters.k,
+            &self.strategy,
+            CopyIds,
+            &context,
+            query,
+            buffer,
+        )
+        .await?;
 
         Ok(Metrics {
             comparisons: stats.cmps,

--- a/diskann/src/flat/index.rs
+++ b/diskann/src/flat/index.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-//! Brute-force k-nearest-neighbor search over a [`DataProvider`].
+//! Brute-force k-nearest-neighbor search over a [`DistancesUnordered`] visitor.
 use std::num::NonZeroUsize;
 
 use diskann_utils::future::SendFuture;
@@ -11,10 +11,9 @@ use diskann_utils::future::SendFuture;
 use crate::{
     ANNResult,
     error::{ErrorExt, IntoANNResult},
-    flat::{DistancesUnordered, SearchStrategy},
+    flat::DistancesUnordered,
     graph::{SearchOutputBuffer, glue::SearchPostProcess},
     neighbor::{Neighbor, NeighborPriorityQueue},
-    provider::DataProvider,
 };
 
 /// Statistics collected during a flat search.
@@ -27,43 +26,35 @@ pub struct SearchStats {
     pub result_count: u32,
 }
 
-/// Brute-force k-nearest-neighbor search over a borrowed provider.
+/// Brute-force k-nearest-neighbor search over an initialized visitor.
 ///
-/// Streams every distance produced by the strategy's query-aware visitor, keeps the best `k`
-/// candidates in a [`NeighborPriorityQueue`], then runs `processor` over the survivors
-/// to populate `output`.
+/// Borrows `visitor` for the duration of the search, streams every distance it produces,
+/// keeps the best `k` candidates in a [`NeighborPriorityQueue`], then runs `processor`
+/// over the same visitor and the surviving candidates to populate `output`.
 ///
-/// The provider, strategy, and context are borrowed for the shared lifetime used to
-/// construct the visitor. This permits the visitor to retain references to their search
-/// state until scanning and post-processing are complete.
+/// The visitor remains owned by the caller and becomes available again after the returned
+/// future completes. Whether it supports another scan is determined by its implementation.
 ///
 /// # Errors
 ///
-/// Returns an error if visitor construction, distance scanning, or result
-/// post-processing fails. Distance-scan errors are escalated because a
-/// partial flat scan cannot produce correct k-nearest-neighbor results.
-pub fn knn_search<'a, P, S, T, O, PP, OB>(
-    provider: &'a P,
+/// Returns an error if distance scanning or result post-processing fails. Distance-scan
+/// errors are escalated because a partial flat scan cannot produce correct k-nearest-neighbor
+/// results.
+pub fn knn_search<V, T, O, PP, OB>(
+    visitor: &mut V,
     k: NonZeroUsize,
-    strategy: &'a S,
     processor: PP,
-    context: &'a P::Context,
     query: T,
     output: &mut OB,
 ) -> impl SendFuture<ANNResult<SearchStats>>
 where
-    P: DataProvider,
-    S: SearchStrategy<'a, P, T>,
+    V: DistancesUnordered,
     T: Copy + Send + Sync,
     O: Send,
-    PP: SearchPostProcess<S::Visitor, T, O> + Send + Sync,
+    PP: SearchPostProcess<V, T, O> + Send + Sync,
     OB: SearchOutputBuffer<O> + Send + ?Sized,
 {
     async move {
-        let mut visitor = strategy
-            .create_visitor(provider, context, query)
-            .into_ann_result()?;
-
         let k = k.get();
         let mut queue = NeighborPriorityQueue::new(k);
         let mut cmps: u32 = 0;
@@ -77,7 +68,7 @@ where
             .escalate("flat scan must complete to produce correct k-NN results")?;
 
         let result_count = processor
-            .post_process(&mut visitor, query, queue.iter().take(k), output)
+            .post_process(visitor, query, queue.iter().take(k), output)
             .await
             .into_ann_result()? as u32;
 
@@ -139,15 +130,9 @@ mod tests {
                 let query: Vec<f32> = query.to_vec();
                 let k = *k;
                 set.spawn(async move {
-                    let outcome = KnnOracleRun::run(
-                        &provider,
-                        &flat_provider::Strategy::new(provider.dim()),
-                        &oracle,
-                        &query,
-                        k,
-                    )
-                    .await
-                    .expect("knn_search failed");
+                    let outcome = KnnOracleRun::run(&provider, &oracle, &query, k)
+                        .await
+                        .expect("knn_search failed");
                     (query, k, outcome)
                 });
             }
@@ -180,11 +165,14 @@ mod tests {
     fn transient_scan_error() {
         // The flat scan touches every id, so any transient id is guaranteed to be hit.
         for transient_ids in [&[0u32][..], &[3][..], &[1, 2, 5][..]] {
-            let strategy =
-                flat_provider::Strategy::with_transient(2, transient_ids.iter().copied());
             let (provider, _) = fixture(Grid::Two, 3);
-            let err = KnnOracleRun::run_sync(&provider, &strategy, &CopyIdsOracle, &[1.0, 0.0], 4)
-                .expect_err("transient error during full scan must escalate");
+            let query = &[1.0, 0.0];
+            let visitor =
+                flat_provider::Visitor::flaky(&provider, query, transient_ids.iter().copied())
+                    .unwrap();
+            let err =
+                KnnOracleRun::run_sync_with_visitor(&provider, visitor, &CopyIdsOracle, query, 4)
+                    .expect_err("transient error during full scan must escalate");
 
             let msg = format!("{err}");
             assert!(
@@ -199,10 +187,10 @@ mod tests {
 
     /// Run `knn_search` via the harness, assert it fails, and check the error
     /// message contains `expected_msg`.
-    fn assert_search_error(strategy: &flat_provider::Strategy, query: &[f32], expected_msg: &str) {
+    fn assert_visitor_error(query: &[f32], expected_msg: &str) {
         let (provider, _) = fixture(Grid::Two, 3);
-        let err = KnnOracleRun::run_sync(&provider, strategy, &CopyIdsOracle, query, 4)
-            .expect_err("expected knn_search to fail");
+        let err = flat_provider::Visitor::new(&provider, query)
+            .expect_err("expected visitor construction to fail");
 
         let msg = format!("{err}");
         assert!(
@@ -212,19 +200,7 @@ mod tests {
     }
 
     #[test]
-    fn strategy_constructor_errors() {
-        // Strategy/provider expect dim=2, query has dim=3.
-        assert_search_error(
-            &flat_provider::Strategy::new(2),
-            &[0.0, 0.0, 0.0],
-            "dimension mismatch",
-        );
-
-        // Strategy expects dim=5, provider has dim=2.
-        assert_search_error(
-            &flat_provider::Strategy::new(5),
-            &[0.0, 0.0],
-            "dimension mismatch",
-        );
+    fn visitor_constructor_errors() {
+        assert_visitor_error(&[0.0, 0.0, 0.0], "dimension mismatch");
     }
 }

--- a/diskann/src/flat/index.rs
+++ b/diskann/src/flat/index.rs
@@ -33,6 +33,10 @@ pub struct SearchStats {
 /// candidates in a [`NeighborPriorityQueue`], then runs `processor` over the survivors
 /// to populate `output`.
 ///
+/// The provider, strategy, and context are borrowed for the shared lifetime used to
+/// construct the visitor. This permits the visitor to retain references to their search
+/// state until scanning and post-processing are complete.
+///
 /// # Errors
 ///
 /// Returns an error if visitor construction, distance scanning, or result

--- a/diskann/src/flat/index.rs
+++ b/diskann/src/flat/index.rs
@@ -3,8 +3,7 @@
  * Licensed under the MIT license.
  */
 
-//! [`FlatIndex`] — the index wrapper for a [`DataProvider`]
-//! over which we do flat search.
+//! Brute-force k-nearest-neighbor search over a [`DataProvider`].
 use std::num::NonZeroUsize;
 
 use diskann_utils::future::SendFuture;
@@ -28,74 +27,57 @@ pub struct SearchStats {
     pub result_count: u32,
 }
 
-/// A thin wrapper around a [`DataProvider`] used for flat search.
-#[derive(Debug)]
-pub struct FlatIndex<P: DataProvider> {
-    /// The backing provider.
-    provider: P,
-}
+/// Brute-force k-nearest-neighbor search over a borrowed provider.
+///
+/// Streams every distance produced by the strategy's query-aware visitor, keeps the best `k`
+/// candidates in a [`NeighborPriorityQueue`], then runs `processor` over the survivors
+/// to populate `output`.
+///
+/// # Errors
+///
+/// Returns an error if visitor construction, distance scanning, or result
+/// post-processing fails. Distance-scan errors are escalated because a
+/// partial flat scan cannot produce correct k-nearest-neighbor results.
+pub fn knn_search<'a, P, S, T, O, PP, OB>(
+    provider: &'a P,
+    k: NonZeroUsize,
+    strategy: &'a S,
+    processor: PP,
+    context: &'a P::Context,
+    query: T,
+    output: &mut OB,
+) -> impl SendFuture<ANNResult<SearchStats>>
+where
+    P: DataProvider,
+    S: SearchStrategy<'a, P, T>,
+    T: Copy + Send + Sync,
+    O: Send,
+    PP: SearchPostProcess<S::Visitor, T, O> + Send + Sync,
+    OB: SearchOutputBuffer<O> + Send + ?Sized,
+{
+    async move {
+        let mut visitor = strategy
+            .create_visitor(provider, context, query)
+            .into_ann_result()?;
 
-impl<P: DataProvider> FlatIndex<P> {
-    /// Construct a new [`FlatIndex`] around `provider`.
-    pub fn new(provider: P) -> Self {
-        Self { provider }
-    }
+        let k = k.get();
+        let mut queue = NeighborPriorityQueue::new(k);
+        let mut cmps: u32 = 0;
 
-    /// Borrow the underlying provider.
-    pub fn provider(&self) -> &P {
-        &self.provider
-    }
+        visitor
+            .distances_unordered(|id, dist| {
+                cmps += 1;
+                queue.insert(Neighbor::new(id, dist));
+            })
+            .await
+            .escalate("flat scan must complete to produce correct k-NN results")?;
 
-    /// Brute-force k-nearest-neighbor flat search.
-    ///
-    /// Streams every element produced by the strategy's visitor through the query
-    /// computer, keeps the best `k` candidates in a [`NeighborPriorityQueue`], then runs
-    /// `processor` over the survivors to populate `output`.
-    ///
-    /// The post-processor [`SearchPostProcess::post_process`] outputs the number
-    /// of results that survive, which is returned as `SearchStats::result_count`.
-    pub fn knn_search<S, T, O, PP, OB>(
-        &self,
-        k: NonZeroUsize,
-        strategy: &S,
-        processor: PP,
-        context: &P::Context,
-        query: T,
-        output: &mut OB,
-    ) -> impl SendFuture<ANNResult<SearchStats>>
-    where
-        S: SearchStrategy<P, T>,
-        T: Copy + Send + Sync,
-        O: Send,
-        PP: for<'a> SearchPostProcess<S::Visitor<'a>, T, O> + Send + Sync,
-        OB: SearchOutputBuffer<O> + Send + ?Sized,
-    {
-        async move {
-            let mut visitor = strategy
-                .create_visitor(&self.provider, context)
-                .into_ann_result()?;
+        let result_count = processor
+            .post_process(&mut visitor, query, queue.iter().take(k), output)
+            .await
+            .into_ann_result()? as u32;
 
-            let computer = strategy.build_query_computer(query).into_ann_result()?;
-
-            let k = k.get();
-            let mut queue = NeighborPriorityQueue::new(k);
-            let mut cmps: u32 = 0;
-
-            visitor
-                .distances_unordered(&computer, |id, dist| {
-                    cmps += 1;
-                    queue.insert(Neighbor::new(id, dist));
-                })
-                .await
-                .escalate("flat scan must complete to produce correct k-NN results")?;
-
-            let result_count = processor
-                .post_process(&mut visitor, query, queue.iter().take(k), output)
-                .await
-                .into_ann_result()? as u32;
-
-            Ok(SearchStats { cmps, result_count })
-        }
+        Ok(SearchStats { cmps, result_count })
     }
 }
 
@@ -105,30 +87,27 @@ impl<P: DataProvider> FlatIndex<P> {
 
 #[cfg(test)]
 mod tests {
-    use crate::flat::{
-        FlatIndex,
-        test::{
-            harness::{CopyIdsOracle, EvenIdsOnlyOracle, KnnOracleRun, OracleProcessor},
-            provider::{self as flat_provider},
-        },
+    use crate::flat::test::{
+        harness::{CopyIdsOracle, EvenIdsOnlyOracle, KnnOracleRun, OracleProcessor},
+        provider::{self as flat_provider},
     };
     use crate::graph::test::synthetic::Grid;
 
-    fn fixture(grid: Grid, size: usize) -> (FlatIndex<flat_provider::Provider>, usize) {
+    fn fixture(grid: Grid, size: usize) -> (flat_provider::Provider, usize) {
         let provider = flat_provider::Provider::grid(grid, size).unwrap();
         let len = provider.len();
-        (FlatIndex::new(provider), len)
+        (provider, len)
     }
 
-    /// `knn_search` returns a `Send` future, and a shared `&FlatIndex` can serve
+    /// `knn_search` returns a `Send` future, and a shared provider can serve
     /// many concurrent searches on a multi-threaded runtime, each producing the
     /// correct output independently.
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn multithreaded_knn_search() {
         use std::sync::Arc;
 
-        let (index, len) = fixture(Grid::Two, 4);
-        let index = Arc::new(index);
+        let (provider, len) = fixture(Grid::Two, 4);
+        let provider = Arc::new(provider);
 
         // Mix of corner, axis-aligned, and off-grid queries; k spans 1..=len.
         let cases: &[(&[f32], usize)] = &[
@@ -145,20 +124,20 @@ mod tests {
         /// Spawn every `(query, k)` case under `oracle` onto `set`.
         fn spawn_cases<O>(
             set: &mut tokio::task::JoinSet<(Vec<f32>, usize, KnnOracleRun)>,
-            index: &Arc<FlatIndex<flat_provider::Provider>>,
+            provider: &Arc<flat_provider::Provider>,
             oracle: O,
             cases: &[(&[f32], usize)],
         ) where
             O: OracleProcessor + Copy + Send + Sync + 'static,
         {
             for (query, k) in cases {
-                let index = Arc::clone(index);
+                let provider = Arc::clone(provider);
                 let query: Vec<f32> = query.to_vec();
                 let k = *k;
                 set.spawn(async move {
                     let outcome = KnnOracleRun::run(
-                        &index,
-                        &flat_provider::Strategy::new(index.provider().dim()),
+                        &provider,
+                        &flat_provider::Strategy::new(provider.dim()),
                         &oracle,
                         &query,
                         k,
@@ -171,8 +150,8 @@ mod tests {
         }
 
         let mut set = tokio::task::JoinSet::new();
-        spawn_cases(&mut set, &index, CopyIdsOracle, cases);
-        spawn_cases(&mut set, &index, EvenIdsOnlyOracle, cases);
+        spawn_cases(&mut set, &provider, CopyIdsOracle, cases);
+        spawn_cases(&mut set, &provider, EvenIdsOnlyOracle, cases);
 
         while let Some(joined) = set.join_next().await {
             let (query, k, outcome) = joined.expect("task panicked");
@@ -199,8 +178,8 @@ mod tests {
         for transient_ids in [&[0u32][..], &[3][..], &[1, 2, 5][..]] {
             let strategy =
                 flat_provider::Strategy::with_transient(2, transient_ids.iter().copied());
-            let (index, _) = fixture(Grid::Two, 3);
-            let err = KnnOracleRun::run_sync(&index, &strategy, &CopyIdsOracle, &[1.0, 0.0], 4)
+            let (provider, _) = fixture(Grid::Two, 3);
+            let err = KnnOracleRun::run_sync(&provider, &strategy, &CopyIdsOracle, &[1.0, 0.0], 4)
                 .expect_err("transient error during full scan must escalate");
 
             let msg = format!("{err}");
@@ -217,8 +196,8 @@ mod tests {
     /// Run `knn_search` via the harness, assert it fails, and check the error
     /// message contains `expected_msg`.
     fn assert_search_error(strategy: &flat_provider::Strategy, query: &[f32], expected_msg: &str) {
-        let (index, _) = fixture(Grid::Two, 3);
-        let err = KnnOracleRun::run_sync(&index, strategy, &CopyIdsOracle, query, 4)
+        let (provider, _) = fixture(Grid::Two, 3);
+        let err = KnnOracleRun::run_sync(&provider, strategy, &CopyIdsOracle, query, 4)
             .expect_err("expected knn_search to fail");
 
         let msg = format!("{err}");

--- a/diskann/src/flat/mod.rs
+++ b/diskann/src/flat/mod.rs
@@ -12,13 +12,11 @@
 //!
 //! # Architecture
 //!
-//! The module mirrors the layering used by graph search:
+//! The search algorithm operates directly on an initialized visitor:
 //!
 //! | Graph (random access)                       | Flat (sequential)                          |  Shared?  |
 //! | :------------------------------------       | :----------------------------------------- |:--------- |
-//! | [`crate::provider::DataProvider`]           | [`crate::provider::DataProvider`]          | Yes       |
 //! | [`crate::graph::glue::SearchAccessor`]      | [`DistancesUnordered`]                     | No        |
-//! | [`crate::graph::glue::SearchStrategy`]      | [`SearchStrategy`]                         | No        |
 //! | [`crate::graph::Search`]                    | [`knn_search`]                             | No        |
 //! | [`crate::graph::glue::SearchPostProcess`]   | [`crate::graph::glue::SearchPostProcess`]  | Yes       |
 //!
@@ -26,7 +24,7 @@ pub mod index;
 pub mod strategy;
 
 pub use index::{SearchStats, knn_search};
-pub use strategy::{DistancesUnordered, SearchStrategy};
+pub use strategy::DistancesUnordered;
 
 #[cfg(test)]
 mod test;

--- a/diskann/src/flat/mod.rs
+++ b/diskann/src/flat/mod.rs
@@ -17,16 +17,15 @@
 //! | Graph (random access)                       | Flat (sequential)                          |  Shared?  |
 //! | :------------------------------------       | :----------------------------------------- |:--------- |
 //! | [`crate::provider::DataProvider`]           | [`crate::provider::DataProvider`]          | Yes       |
-//! | [`crate::graph::DiskANNIndex`]              | [`FlatIndex`]                              | No        |
 //! | [`crate::graph::glue::SearchAccessor`]      | [`DistancesUnordered`]                     | No        |
 //! | [`crate::graph::glue::SearchStrategy`]      | [`SearchStrategy`]                         | No        |
-//! | [`crate::graph::Search`]                    | [`FlatIndex::knn_search`]                  | No        |
+//! | [`crate::graph::Search`]                    | [`knn_search`]                             | No        |
 //! | [`crate::graph::glue::SearchPostProcess`]   | [`crate::graph::glue::SearchPostProcess`]  | Yes       |
 //!
 pub mod index;
 pub mod strategy;
 
-pub use index::{FlatIndex, SearchStats};
+pub use index::{SearchStats, knn_search};
 pub use strategy::{DistancesUnordered, SearchStrategy};
 
 #[cfg(test)]

--- a/diskann/src/flat/strategy.rs
+++ b/diskann/src/flat/strategy.rs
@@ -14,40 +14,52 @@ use crate::{
     provider::{DataProvider, HasId},
 };
 
-/// Fused sequential scan-and-score primitive.
+/// A complete, unordered scan of a candidate set.
 ///
-/// Implementations drive an entire scan over the underlying data, scoring each element
-/// and invoking `f` with the resulting `(id, distance)` pair.
+/// Implementations drive the scan rather than exposing elements for the caller to fetch.
+/// For each candidate in the scan, the implementation computes its distance and invokes
+/// the supplied callback with the candidate's `(id, distance)` pair. No ordering of those
+/// callbacks is guaranteed.
+///
+/// A visitor represents one initialized scan. It may retain any state needed while
+/// scanning, and remains available to the search post-processor after the scan completes.
 pub trait DistancesUnordered: HasId + Send + Sync {
-    /// The error type for [`Self::distances_unordered`].
+    /// The error type returned when the visitor cannot complete its scan.
     type Error: ToRanked + Debug + Send + Sync + 'static;
 
-    /// Drive the entire scan, invoking `f` with each `(id, distance)` pair.
+    /// Scan all candidates represented by this visitor and invoke `f` for each result.
     ///
-    /// # Errors
-    ///
-    /// Returns an implementation-defined error if the complete scan cannot be produced.
+    /// The callback may have been invoked before an error is returned. In that case,
+    /// those results form an incomplete scan and must not be treated as exhaustive.
     fn distances_unordered<F>(&mut self, f: F) -> impl SendFuture<Result<(), Self::Error>>
     where
         F: Send + FnMut(Self::Id, f32);
 }
 
-/// Per-call configuration that constructs a query-aware [`DistancesUnordered`] visitor.
+/// Constructs a [`DistancesUnordered`] visitor for one query.
+///
+/// A strategy contains configuration that can be reused across searches. Each call to
+/// [`Self::create_visitor`] combines that configuration with a provider, request context,
+/// and query to initialize an independent visitor. The returned visitor must report
+/// distances for that query when it is scanned.
+///
+/// The lifetime `'a` allows the visitor to borrow any of those inputs for the duration of
+/// the search instead of requiring it to own or copy their data.
 pub trait SearchStrategy<'a, P, T>: Send + Sync
 where
     P: DataProvider,
 {
-    /// The query-aware visitor used to execute the scan.
+    /// The visitor initialized for this search.
     type Visitor: DistancesUnordered<Id = P::InternalId>;
 
     /// The error type for [`Self::create_visitor`].
     type Error: StandardError;
 
-    /// Construct a fresh visitor over `provider` for the given request `context` and `query`.
+    /// Initialize a visitor over `provider` for the given request `context` and `query`.
     ///
     /// # Errors
     ///
-    /// Returns an error when query preprocessing or visitor initialization fails.
+    /// Returns an error if the inputs cannot be used to initialize a visitor.
     fn create_visitor(
         &'a self,
         provider: &'a P,

--- a/diskann/src/flat/strategy.rs
+++ b/diskann/src/flat/strategy.rs
@@ -8,96 +8,58 @@
 use std::fmt::Debug;
 
 use diskann_utils::future::SendFuture;
-use diskann_vector::PreprocessedDistanceFunction;
 
 use crate::{
     error::{StandardError, ToRanked},
     provider::{DataProvider, HasId},
 };
 
-/// Fused iterate-and-score primitive over the elements of a flat index.
+/// Per-query accessor that drives a complete flat scan.
 ///
-/// Implementations drive an entire scan over the underlying data, scoring each element
-/// with the supplied computer `C` and invoking `f` with the resulting `(id, distance)`
-/// pair. The associated [`Self::ElementRef`] is the reference shape on which `C` must
-/// be able to compute distances.
-pub trait DistancesUnordered<C>: HasId + Send + Sync
-where
-    C: for<'a> PreprocessedDistanceFunction<Self::ElementRef<'a>, f32>,
-{
-    /// Lifetime is intentionally unconstrained so it can appear under HRTB without
-    /// inducing a `'static` bound on `Self`.
-    type ElementRef<'a>;
-
+/// The accessor owns the query-specific computation state so implementations can fuse
+/// query preprocessing, data access, batching, filtering, and distance computation.
+pub trait DistancesUnordered: HasId + Send + Sync {
     /// The error type for [`Self::distances_unordered`].
     type Error: ToRanked + Debug + Send + Sync + 'static;
 
-    /// Drive the entire scan, scoring each element with `computer` and invoking `f`
-    /// with the resulting `(id, distance)` pair.
-    fn distances_unordered<F>(
-        &mut self,
-        computer: &C,
-        f: F,
-    ) -> impl SendFuture<Result<(), Self::Error>>
+    /// Drive the entire scan, invoking `f` with each `(id, distance)` pair.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the backend cannot complete the scan.
+    fn distances_unordered<F>(&mut self, f: F) -> impl SendFuture<Result<(), Self::Error>>
     where
         F: Send + FnMut(Self::Id, f32);
 }
 
-/// Per-call configuration that knows how to construct a per-query
-/// [`DistancesUnordered`] visitor for a provider, and the [`Self::QueryComputer`] used
-/// to score each element during the scan.
-pub trait SearchStrategy<P, T>: Send + Sync
+/// Per-call configuration that constructs a query-aware [`DistancesUnordered`] visitor.
+pub trait SearchStrategy<'a, P, T>: Send + Sync
 where
     P: DataProvider,
 {
-    /// The reference element shape on which [`Self::QueryComputer`] computes
-    /// distances.
-    type ElementRef<'a>;
+    /// The query-aware visitor used to execute the scan.
+    type Visitor: DistancesUnordered<Id = P::InternalId>;
 
-    /// The concrete query-computer type.
-    type QueryComputer: for<'a> PreprocessedDistanceFunction<Self::ElementRef<'a>, f32>
-        + Send
-        + Sync
-        + 'static;
-
-    /// The error type for [`Self::build_query_computer`].
-    type QueryComputerError: StandardError;
-
-    /// The visitor type produced by [`Self::create_visitor`].
-    type Visitor<'a>: for<'b> DistancesUnordered<
-            Self::QueryComputer,
-            ElementRef<'b> = Self::ElementRef<'b>,
-            Id = P::InternalId,
-        >
-    where
-        Self: 'a,
-        P: 'a;
-
-    /// The error type for [`Self::create_visitor`].
+    /// An error that can occur while constructing [`Self::Visitor`].
     type Error: StandardError;
 
-    /// Construct a fresh visitor over `provider` for the given request `context`.
-    fn create_visitor<'a>(
+    /// Construct a fresh visitor for `query`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when query preprocessing or visitor initialization fails.
+    fn create_visitor(
         &'a self,
         provider: &'a P,
         context: &'a P::Context,
-    ) -> Result<Self::Visitor<'a>, Self::Error>;
-
-    /// Construct the per-query computer.
-    fn build_query_computer(
-        &self,
         query: T,
-    ) -> Result<Self::QueryComputer, Self::QueryComputerError>;
+    ) -> Result<Self::Visitor, Self::Error>;
 }
 
 #[cfg(test)]
 mod tests {
-    //! Direct [`DistancesUnordered`] impls over a few in-memory fixtures: a
-    //! happy-path scanner over `&[f32]` elements, a scanner whose `ElementRef<'a>`
-    //! is a lifetime-carrying non-reference type, and a scanner that fails
-    //! mid-stream.
-
-    use std::marker::PhantomData;
+    //! Direct [`DistancesUnordered`] impls over in-memory fixtures, including a
+    //! happy-path scanner and one that fails mid-stream.
 
     use diskann_utils::future::SendFuture;
     use diskann_vector::{PreprocessedDistanceFunction, distance::Metric};
@@ -121,27 +83,23 @@ mod tests {
     /// Scans `items` in order, scoring each with the supplied computer.
     struct Scanner {
         items: Vec<(u32, Vec<f32>)>,
+        computer: <f32 as VectorRepr>::QueryDistance,
     }
 
     impl HasId for Scanner {
         type Id = u32;
     }
 
-    impl DistancesUnordered<<f32 as VectorRepr>::QueryDistance> for Scanner {
-        type ElementRef<'a> = &'a [f32];
+    impl DistancesUnordered for Scanner {
         type Error = Infallible;
 
-        fn distances_unordered<F>(
-            &mut self,
-            computer: &<f32 as VectorRepr>::QueryDistance,
-            mut f: F,
-        ) -> impl SendFuture<Result<(), Self::Error>>
+        fn distances_unordered<F>(&mut self, mut f: F) -> impl SendFuture<Result<(), Self::Error>>
         where
             F: Send + FnMut(Self::Id, f32),
         {
             async move {
                 for (id, v) in &self.items {
-                    let dist = computer.evaluate_similarity(v.as_slice());
+                    let dist = self.computer.evaluate_similarity(v.as_slice());
                     f(*id, dist);
                 }
                 Ok(())
@@ -153,23 +111,67 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn distances_unordered_scanner() {
         let query = vec![0.5_f32, 0.9];
-        let computer = f32::query_distance(&query, Metric::L2);
+        let expected_computer = f32::query_distance(&query, Metric::L2);
 
         let expected: Vec<(u32, f32)> = sample_items()
             .into_iter()
-            .map(|(id, v)| (id, computer.evaluate_similarity(v.as_slice())))
+            .map(|(id, v)| (id, expected_computer.evaluate_similarity(v.as_slice())))
             .collect();
 
         let mut scanner = Scanner {
             items: sample_items(),
+            computer: f32::query_distance(&query, Metric::L2),
         };
 
         let mut seen: Vec<(u32, f32)> = Vec::new();
         scanner
-            .distances_unordered(&computer, |id, d| seen.push((id, d)))
+            .distances_unordered(|id, d| seen.push((id, d)))
             .await
             .unwrap();
         assert_eq!(seen, expected);
+    }
+
+    struct BorrowingScanner<'a> {
+        items: &'a [(u32, f32)],
+        query: &'a f32,
+    }
+
+    impl HasId for BorrowingScanner<'_> {
+        type Id = u32;
+    }
+
+    impl DistancesUnordered for BorrowingScanner<'_> {
+        type Error = Infallible;
+
+        fn distances_unordered<F>(&mut self, mut f: F) -> impl SendFuture<Result<(), Self::Error>>
+        where
+            F: Send + FnMut(Self::Id, f32),
+        {
+            async move {
+                for (id, value) in self.items {
+                    f(*id, (*value - *self.query).abs());
+                }
+                Ok(())
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn accessor_can_borrow_query_state() {
+        let items = [(10, 1.0), (11, 4.0)];
+        let query = 2.0;
+        let mut scanner = BorrowingScanner {
+            items: &items,
+            query: &query,
+        };
+        let mut seen = Vec::new();
+
+        scanner
+            .distances_unordered(|id, distance| seen.push((id, distance)))
+            .await
+            .unwrap();
+
+        assert_eq!(seen, [(10, 1.0), (11, 2.0)]);
     }
 
     ///////////////////////////
@@ -189,21 +191,17 @@ mod tests {
     struct Failing {
         items: Vec<(u32, Vec<f32>)>,
         fail_after: usize,
+        computer: <f32 as VectorRepr>::QueryDistance,
     }
 
     impl HasId for Failing {
         type Id = u32;
     }
 
-    impl DistancesUnordered<<f32 as VectorRepr>::QueryDistance> for Failing {
-        type ElementRef<'a> = &'a [f32];
+    impl DistancesUnordered for Failing {
         type Error = Boom;
 
-        fn distances_unordered<F>(
-            &mut self,
-            computer: &<f32 as VectorRepr>::QueryDistance,
-            mut f: F,
-        ) -> impl SendFuture<Result<(), Self::Error>>
+        fn distances_unordered<F>(&mut self, mut f: F) -> impl SendFuture<Result<(), Self::Error>>
         where
             F: Send + FnMut(Self::Id, f32),
         {
@@ -212,7 +210,7 @@ mod tests {
                     if i == self.fail_after {
                         return Err(Boom(*id));
                     }
-                    let dist = computer.evaluate_similarity(v.as_slice());
+                    let dist = self.computer.evaluate_similarity(v.as_slice());
                     f(*id, dist);
                 }
                 Ok(())
@@ -227,14 +225,12 @@ mod tests {
         let mut scanner = Failing {
             items: sample_items(),
             fail_after: 1, // Yield item 0 successfully, fail on item 1.
+            computer: f32::query_distance(&[0.0, 0.0], Metric::L2),
         };
-
-        let query = vec![0.0_f32, 0.0];
-        let computer = f32::query_distance(&query, Metric::L2);
 
         let mut seen: Vec<u32> = Vec::new();
         let err = scanner
-            .distances_unordered(&computer, |id, _d| seen.push(id))
+            .distances_unordered(|id, _d| seen.push(id))
             .await
             .expect_err("Failing scanner must surface its error");
 
@@ -244,107 +240,5 @@ mod tests {
             vec![10],
             "the closure must only see items yielded before the failure",
         );
-    }
-
-    /////////////////////////////////////////////
-    // Lifetime-carrying concrete `ElementRef` //
-    /////////////////////////////////////////////
-
-    struct View<'a> {
-        ptr: *const f32,
-        len: usize,
-        _phantom: PhantomData<&'a [f32]>,
-    }
-
-    // SAFETY: `View<'a>` semantically carries a `&'a [f32]`, which is `Send + Sync`.
-    unsafe impl Send for View<'_> {}
-    unsafe impl Sync for View<'_> {}
-
-    /// Computer that reconstructs a `&[f32]` from a [`View`]'s ptr+len and
-    /// computes inner product against a stored query.
-    struct ViewComputer {
-        query: Vec<f32>,
-    }
-
-    impl<'a> PreprocessedDistanceFunction<View<'a>, f32> for ViewComputer {
-        fn evaluate_similarity(&self, v: View<'a>) -> f32 {
-            // SAFETY: `v.ptr` / `v.len` were produced from a `&'a [f32]` held by the
-            // scanner that owns the backing `Vec`; the phantom lifetime ties this view
-            // to that borrow, so the slice is valid for the duration of this call.
-            let s = unsafe { std::slice::from_raw_parts(v.ptr, v.len) };
-            s.iter().zip(&self.query).map(|(a, b)| a * b).sum()
-        }
-    }
-
-    /// Scans `rows`, yielding a [`View`] tied (via its phantom lifetime) to the
-    /// borrow of the underlying `Vec<f32>`.
-    struct ViewScanner {
-        rows: Vec<(u32, Vec<f32>)>,
-    }
-
-    impl ViewScanner {
-        fn iter<'a>(&self) -> impl Iterator<Item = (u32, View<'a>)> {
-            self.rows.iter().map(|(x, y)| {
-                (
-                    *x,
-                    View {
-                        ptr: y.as_ptr(),
-                        len: y.len(),
-                        _phantom: PhantomData,
-                    },
-                )
-            })
-        }
-    }
-
-    impl HasId for ViewScanner {
-        type Id = u32;
-    }
-
-    impl DistancesUnordered<ViewComputer> for ViewScanner {
-        type ElementRef<'a> = View<'a>;
-        type Error = Infallible;
-
-        fn distances_unordered<F>(
-            &mut self,
-            computer: &ViewComputer,
-            mut f: F,
-        ) -> impl SendFuture<Result<(), Self::Error>>
-        where
-            F: Send + FnMut(Self::Id, f32),
-        {
-            async move {
-                for (id, v) in self.iter() {
-                    f(id, computer.evaluate_similarity(v));
-                }
-                Ok(())
-            }
-        }
-    }
-
-    #[tokio::test]
-    async fn distances_unordered_lifetime_carrying_element_ref() {
-        let mut scanner = ViewScanner {
-            rows: vec![
-                (10, vec![1.0, 0.0]),
-                (11, vec![0.5, 0.5]),
-                (12, vec![0.0, 2.0]),
-            ],
-        };
-        let computer = ViewComputer {
-            query: vec![1.0, 3.0],
-        };
-        let expected: Vec<(u32, f32)> = vec![
-            (10, 1.0 * 1.0 + 0.0 * 3.0),
-            (11, 0.5 * 1.0 + 0.5 * 3.0),
-            (12, 0.0 * 1.0 + 2.0 * 3.0),
-        ];
-
-        let mut seen: Vec<(u32, f32)> = Vec::new();
-        scanner
-            .distances_unordered(&computer, |id, d| seen.push((id, d)))
-            .await
-            .unwrap();
-        assert_eq!(seen, expected);
     }
 }

--- a/diskann/src/flat/strategy.rs
+++ b/diskann/src/flat/strategy.rs
@@ -14,10 +14,10 @@ use crate::{
     provider::{DataProvider, HasId},
 };
 
-/// Per-query accessor that drives a complete flat scan.
+/// Fused sequential scan-and-score primitive.
 ///
-/// The accessor owns the query-specific computation state so implementations can fuse
-/// query preprocessing, data access, batching, filtering, and distance computation.
+/// Implementations drive an entire scan over the underlying data, scoring each element
+/// and invoking `f` with the resulting `(id, distance)` pair.
 pub trait DistancesUnordered: HasId + Send + Sync {
     /// The error type for [`Self::distances_unordered`].
     type Error: ToRanked + Debug + Send + Sync + 'static;
@@ -26,7 +26,7 @@ pub trait DistancesUnordered: HasId + Send + Sync {
     ///
     /// # Errors
     ///
-    /// Returns an error when the backend cannot complete the scan.
+    /// Returns an implementation-defined error if the complete scan cannot be produced.
     fn distances_unordered<F>(&mut self, f: F) -> impl SendFuture<Result<(), Self::Error>>
     where
         F: Send + FnMut(Self::Id, f32);
@@ -40,10 +40,10 @@ where
     /// The query-aware visitor used to execute the scan.
     type Visitor: DistancesUnordered<Id = P::InternalId>;
 
-    /// An error that can occur while constructing [`Self::Visitor`].
+    /// The error type for [`Self::create_visitor`].
     type Error: StandardError;
 
-    /// Construct a fresh visitor for `query`.
+    /// Construct a fresh visitor over `provider` for the given request `context` and `query`.
     ///
     /// # Errors
     ///

--- a/diskann/src/flat/strategy.rs
+++ b/diskann/src/flat/strategy.rs
@@ -3,16 +3,13 @@
  * Licensed under the MIT license.
  */
 
-//! Core flat-search traits: [`DistancesUnordered`] and [`SearchStrategy`].
+//! Core flat-search trait: [`DistancesUnordered`].
 
 use std::fmt::Debug;
 
 use diskann_utils::future::SendFuture;
 
-use crate::{
-    error::{StandardError, ToRanked},
-    provider::{DataProvider, HasId},
-};
+use crate::{error::ToRanked, provider::HasId};
 
 /// A complete, unordered scan of a candidate set.
 ///
@@ -34,38 +31,6 @@ pub trait DistancesUnordered: HasId + Send + Sync {
     fn distances_unordered<F>(&mut self, f: F) -> impl SendFuture<Result<(), Self::Error>>
     where
         F: Send + FnMut(Self::Id, f32);
-}
-
-/// Constructs a [`DistancesUnordered`] visitor for one query.
-///
-/// A strategy contains configuration that can be reused across searches. Each call to
-/// [`Self::create_visitor`] combines that configuration with a provider, request context,
-/// and query to initialize an independent visitor. The returned visitor must report
-/// distances for that query when it is scanned.
-///
-/// The lifetime `'a` allows the visitor to borrow any of those inputs for the duration of
-/// the search instead of requiring it to own or copy their data.
-pub trait SearchStrategy<'a, P, T>: Send + Sync
-where
-    P: DataProvider,
-{
-    /// The visitor initialized for this search.
-    type Visitor: DistancesUnordered<Id = P::InternalId>;
-
-    /// The error type for [`Self::create_visitor`].
-    type Error: StandardError;
-
-    /// Initialize a visitor over `provider` for the given request `context` and `query`.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the inputs cannot be used to initialize a visitor.
-    fn create_visitor(
-        &'a self,
-        provider: &'a P,
-        context: &'a P::Context,
-        query: T,
-    ) -> Result<Self::Visitor, Self::Error>;
 }
 
 #[cfg(test)]

--- a/diskann/src/flat/test/cases/flat_knn_search.rs
+++ b/diskann/src/flat/test/cases/flat_knn_search.rs
@@ -5,7 +5,7 @@
 
 //! Baseline-cached regression sweep for [`crate::flat::knn_search`].
 //!
-//! Bbuilds a fresh index per parameter combination, runs `knn_search` through the
+//! Builds a fresh provider per parameter combination, runs `knn_search` through the
 //! [`crate::flat::test::harness`], snapshots the result + statistics into
 //! [`FlatKnnBaseline`], and compares the entire batch against the JSON committed under
 //! `diskann/test/generated/flat/test/cases/flat_knn_search/`.
@@ -85,7 +85,7 @@ verbose_eq!(FlatKnnBaseline {
     metrics,
 });
 
-/// Run `knn_search` + brute-force oracle against a *shared* `index`, assert the
+/// Run `knn_search` + brute-force oracle against a *shared* provider, assert the
 /// cross-row invariants, and produce the baseline row. The per-row provider metrics
 /// captured into the baseline are the *delta* observed during this row, which keeps
 /// the snapshot independent of how many rows preceded it.

--- a/diskann/src/flat/test/cases/flat_knn_search.rs
+++ b/diskann/src/flat/test/cases/flat_knn_search.rs
@@ -13,7 +13,7 @@
 use crate::{
     flat::test::{
         harness,
-        provider::{self as flat_provider, ElementCounter, Strategy},
+        provider::{self as flat_provider, ElementCounter},
     },
     graph::test::synthetic::Grid,
     test::{
@@ -100,14 +100,8 @@ fn run_row(
     let len = provider.len();
     let metrics_before = provider.metrics();
 
-    let outcome = harness::KnnOracleRun::run_sync(
-        provider,
-        &Strategy::new(provider.dim()),
-        &harness::CopyIdsOracle,
-        query,
-        k,
-    )
-    .unwrap();
+    let outcome =
+        harness::KnnOracleRun::run_sync(provider, &harness::CopyIdsOracle, query, k).unwrap();
     let stats = outcome.stats;
 
     assert_eq!(

--- a/diskann/src/flat/test/cases/flat_knn_search.rs
+++ b/diskann/src/flat/test/cases/flat_knn_search.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-//! Baseline-cached regression sweep for [`crate::flat::FlatIndex::knn_search`].
+//! Baseline-cached regression sweep for [`crate::flat::knn_search`].
 //!
 //! Bbuilds a fresh index per parameter combination, runs `knn_search` through the
 //! [`crate::flat::test::harness`], snapshots the result + statistics into
@@ -11,12 +11,9 @@
 //! `diskann/test/generated/flat/test/cases/flat_knn_search/`.
 
 use crate::{
-    flat::{
-        FlatIndex,
-        test::{
-            harness,
-            provider::{self as flat_provider, ElementCounter, Strategy},
-        },
+    flat::test::{
+        harness,
+        provider::{self as flat_provider, ElementCounter, Strategy},
     },
     graph::test::synthetic::Grid,
     test::{
@@ -34,7 +31,7 @@ fn root() -> TestRoot {
 const KS: [usize; 3] = [1, 4, 10];
 
 /// One row of the baseline JSON: a single `(grid, size, query, k)` execution of
-/// `FlatIndex::knn_search` plus the brute-force ground truth, search stats, and
+/// `knn_search` plus the brute-force ground truth, search stats, and
 /// per-row provider metrics.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct FlatKnnBaseline {
@@ -93,19 +90,19 @@ verbose_eq!(FlatKnnBaseline {
 /// captured into the baseline are the *delta* observed during this row, which keeps
 /// the snapshot independent of how many rows preceded it.
 fn run_row(
-    index: &FlatIndex<flat_provider::Provider>,
+    provider: &flat_provider::Provider,
     grid_dim: usize,
     grid_size: usize,
     query: &[f32],
     k: usize,
     desc: &str,
 ) -> FlatKnnBaseline {
-    let len = index.provider().len();
-    let metrics_before = index.provider().metrics();
+    let len = provider.len();
+    let metrics_before = provider.metrics();
 
     let outcome = harness::KnnOracleRun::run_sync(
-        index,
-        &Strategy::new(index.provider().dim()),
+        provider,
+        &Strategy::new(provider.dim()),
         &harness::CopyIdsOracle,
         query,
         k,
@@ -129,7 +126,7 @@ fn run_row(
         "flat scan top-k distance multiset must agree with brute force",
     );
 
-    let metrics_after = index.provider().metrics();
+    let metrics_after = provider.metrics();
     let metrics = ElementCounter {
         count: metrics_after.count - metrics_before.count,
     };
@@ -159,8 +156,8 @@ fn run_row(
 fn _flat_knn_search(grid: Grid, size: usize, mut parent: TestPath<'_>) {
     let dim: usize = grid.dim().into();
 
-    // Build the provider and index once, mirroring the production pattern where a
-    // single index serves many queries.
+    // Build the provider once, mirroring the production pattern where one provider
+    // serves many queries.
     let provider = flat_provider::Provider::grid(grid, size).unwrap();
     let len = provider.len();
     assert_eq!(
@@ -168,8 +165,6 @@ fn _flat_knn_search(grid: Grid, size: usize, mut parent: TestPath<'_>) {
         size.pow(dim as u32),
         "flat::test::Provider::grid should produce size^dim rows",
     );
-    let index = FlatIndex::new(provider);
-
     let queries: [(Vec<f32>, &str); 2] = [
         (
             vec![-1.0; dim],
@@ -181,12 +176,11 @@ fn _flat_knn_search(grid: Grid, size: usize, mut parent: TestPath<'_>) {
         ),
     ];
 
-    let index_ref = &index;
     let results: Vec<FlatKnnBaseline> = queries
         .iter()
         .flat_map(|(q, desc)| {
             KS.iter()
-                .map(move |&k| run_row(index_ref, dim, size, q, k, desc))
+                .map(|&k| run_row(&provider, dim, size, q, k, desc))
         })
         .collect();
 

--- a/diskann/src/flat/test/harness.rs
+++ b/diskann/src/flat/test/harness.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-//! Reusable execution harness for [`crate::flat::FlatIndex`] tests.
+//! Reusable execution harness for [`crate::flat::knn_search`] tests.
 //!
 //! Use [`KnnOracleRun::run`] to drive `knn_search` under a chosen [`OracleProcessor`]
 //! and pair the result with the oracle's expected post-processed output.
@@ -15,7 +15,7 @@ use diskann_vector::{PreprocessedDistanceFunction, distance::Metric};
 use crate::{
     ANNResult,
     flat::{
-        FlatIndex, SearchStats,
+        SearchStats, knn_search,
         test::provider::{Provider, Strategy, Visitor},
     },
     graph::{
@@ -28,7 +28,7 @@ use crate::{
     utils::VectorRepr,
 };
 
-/// Result of running [`FlatIndex::knn_search`] under the harness alongside the
+/// Result of running [`knn_search`] under the harness alongside the
 /// oracle's expected post-processed output.
 #[derive(Debug, Clone)]
 pub(crate) struct KnnOracleRun {
@@ -46,23 +46,23 @@ pub(crate) struct KnnOracleRun {
 }
 
 impl KnnOracleRun {
-    /// Run [`FlatIndex::knn_search`] once under `oracle`, blocking on a fresh
+    /// Run [`knn_search`] once under `oracle`, blocking on a fresh
     /// single-threaded runtime, and pair the result with the oracle's expected output.
     pub fn run_sync<O: OracleProcessor>(
-        index: &FlatIndex<Provider>,
+        provider: &Provider,
         strategy: &Strategy,
         oracle: &O,
         query: &[f32],
         k: usize,
     ) -> ANNResult<Self> {
-        current_thread_runtime().block_on(Self::run(index, strategy, oracle, query, k))
+        current_thread_runtime().block_on(Self::run(provider, strategy, oracle, query, k))
     }
 
     /// Async variant of [`KnnOracleRun::run_sync`]. Use this from tests that already
     /// have a Tokio runtime (e.g. `#[tokio::test]`) or that need to drive
     /// `knn_search` concurrently across tasks.
     pub async fn run<O: OracleProcessor>(
-        index: &FlatIndex<Provider>,
+        provider: &Provider,
         strategy: &Strategy,
         oracle: &O,
         query: &[f32],
@@ -71,16 +71,16 @@ impl KnnOracleRun {
         let context = crate::flat::test::provider::Context::new();
         let mut buf = vec![Neighbor::<u32>::default(); k];
 
-        let stats = index
-            .knn_search(
-                NonZeroUsize::new(k).expect("flat::test::harness requires k > 0"),
-                strategy,
-                oracle.processor(),
-                &context,
-                query,
-                &mut BackInserter::new(buf.as_mut_slice()),
-            )
-            .await?;
+        let stats = knn_search(
+            provider,
+            NonZeroUsize::new(k).expect("flat::test::harness requires k > 0"),
+            strategy,
+            oracle.processor(),
+            &context,
+            query,
+            &mut BackInserter::new(buf.as_mut_slice()),
+        )
+        .await?;
 
         let mut top_k: Vec<Neighbor<u32>> = buf
             .iter()
@@ -90,8 +90,7 @@ impl KnnOracleRun {
         sort_neighbors(&mut top_k);
         let top_k_distances = top_k.iter().map(|n| *n.distance()).collect();
 
-        let ground_truth =
-            oracle.expected(brute_force_topk(index.provider(), Metric::L2, query, k));
+        let ground_truth = oracle.expected(brute_force_topk(provider, Metric::L2, query, k));
 
         Ok(Self {
             top_k: top_k.into_iter().map(Neighbor::as_tuple).collect(),
@@ -111,7 +110,7 @@ pub(crate) trait OracleProcessor {
     /// The post-processor exercised by the search.
     type Processor: for<'a, 'q> SearchPostProcess<Visitor<'a>, &'q [f32], u32> + Send + Sync;
 
-    /// Construct the processor instance fed to [`FlatIndex::knn_search`].
+    /// Construct the processor instance fed to [`knn_search`].
     fn processor(&self) -> Self::Processor;
 
     /// Transform the brute-force top-`k` neighbors into the output the processor is

--- a/diskann/src/flat/test/harness.rs
+++ b/diskann/src/flat/test/harness.rs
@@ -14,9 +14,10 @@ use diskann_vector::{PreprocessedDistanceFunction, distance::Metric};
 
 use crate::{
     ANNResult,
+    error::IntoANNResult,
     flat::{
         SearchStats, knn_search,
-        test::provider::{Provider, Strategy, Visitor},
+        test::provider::{Provider, Visitor},
     },
     graph::{
         SearchOutputBuffer,
@@ -50,12 +51,28 @@ impl KnnOracleRun {
     /// single-threaded runtime, and pair the result with the oracle's expected output.
     pub fn run_sync<O: OracleProcessor>(
         provider: &Provider,
-        strategy: &Strategy,
         oracle: &O,
         query: &[f32],
         k: usize,
     ) -> ANNResult<Self> {
-        current_thread_runtime().block_on(Self::run(provider, strategy, oracle, query, k))
+        current_thread_runtime().block_on(Self::run(provider, oracle, query, k))
+    }
+
+    /// Run [`knn_search`] with an already initialized visitor.
+    pub fn run_sync_with_visitor<O: OracleProcessor>(
+        provider: &Provider,
+        mut visitor: Visitor<'_>,
+        oracle: &O,
+        query: &[f32],
+        k: usize,
+    ) -> ANNResult<Self> {
+        current_thread_runtime().block_on(Self::run_with_visitor(
+            provider,
+            &mut visitor,
+            oracle,
+            query,
+            k,
+        ))
     }
 
     /// Async variant of [`KnnOracleRun::run_sync`]. Use this from tests that already
@@ -63,20 +80,27 @@ impl KnnOracleRun {
     /// `knn_search` concurrently across tasks.
     pub async fn run<O: OracleProcessor>(
         provider: &Provider,
-        strategy: &Strategy,
         oracle: &O,
         query: &[f32],
         k: usize,
     ) -> ANNResult<Self> {
-        let context = crate::flat::test::provider::Context::new();
+        let mut visitor = Visitor::new(provider, query).into_ann_result()?;
+        Self::run_with_visitor(provider, &mut visitor, oracle, query, k).await
+    }
+
+    async fn run_with_visitor<O: OracleProcessor>(
+        provider: &Provider,
+        visitor: &mut Visitor<'_>,
+        oracle: &O,
+        query: &[f32],
+        k: usize,
+    ) -> ANNResult<Self> {
         let mut buf = vec![Neighbor::<u32>::default(); k];
 
         let stats = knn_search(
-            provider,
+            visitor,
             NonZeroUsize::new(k).expect("flat::test::harness requires k > 0"),
-            strategy,
             oracle.processor(),
-            &context,
             query,
             &mut BackInserter::new(buf.as_mut_slice()),
         )

--- a/diskann/src/flat/test/provider.rs
+++ b/diskann/src/flat/test/provider.rs
@@ -283,25 +283,32 @@ pub struct Visitor<'a> {
     provider: &'a Provider,
     transient_ids: Option<Cow<'a, HashSet<u32>>>,
     get_element: LocalCounter<'a>,
+    computer: <f32 as VectorRepr>::QueryDistance,
 }
 
 impl<'a> Visitor<'a> {
     /// Construct a visitor with no fault injection.
-    pub fn new(provider: &'a Provider) -> Self {
+    pub fn new(provider: &'a Provider, computer: <f32 as VectorRepr>::QueryDistance) -> Self {
         Self {
             provider,
             transient_ids: None,
             get_element: provider.get_element.local(),
+            computer,
         }
     }
 
     /// Construct a visitor that returns a [`TransientGetError`] for any id in
     /// `transient_ids`. Other ids behave normally.
-    pub fn flaky(provider: &'a Provider, transient_ids: Cow<'a, HashSet<u32>>) -> Self {
+    pub fn flaky(
+        provider: &'a Provider,
+        transient_ids: Cow<'a, HashSet<u32>>,
+        computer: <f32 as VectorRepr>::QueryDistance,
+    ) -> Self {
         Self {
             provider,
             transient_ids: Some(transient_ids),
             get_element: provider.get_element.local(),
+            computer,
         }
     }
 }
@@ -319,15 +326,10 @@ impl HasId for Visitor<'_> {
     type Id = u32;
 }
 
-impl DistancesUnordered<<f32 as VectorRepr>::QueryDistance> for Visitor<'_> {
-    type ElementRef<'a> = &'a [f32];
+impl DistancesUnordered for Visitor<'_> {
     type Error = AccessError;
 
-    fn distances_unordered<F>(
-        &mut self,
-        computer: &<f32 as VectorRepr>::QueryDistance,
-        mut f: F,
-    ) -> impl SendFuture<Result<(), Self::Error>>
+    fn distances_unordered<F>(&mut self, mut f: F) -> impl SendFuture<Result<(), Self::Error>>
     where
         F: Send + FnMut(Self::Id, f32),
     {
@@ -340,7 +342,7 @@ impl DistancesUnordered<<f32 as VectorRepr>::QueryDistance> for Visitor<'_> {
                     return Err(AccessError::Transient(TransientGetError::new(id)));
                 }
                 self.get_element.increment();
-                let dist = computer.evaluate_similarity(vector);
+                let dist = self.computer.evaluate_similarity(vector);
                 f(id, dist);
             }
             Ok(())
@@ -352,8 +354,7 @@ impl DistancesUnordered<<f32 as VectorRepr>::QueryDistance> for Visitor<'_> {
 // Strategy //
 //////////////
 
-/// Error from [`Strategy::create_visitor`] or [`Strategy::build_query_computer`]
-/// when dimensions don't match.
+/// Error from [`Strategy::create_visitor`] when dimensions don't match.
 #[derive(Debug, Clone, Error)]
 #[error("dimension mismatch: strategy expects {expected}, got {actual}")]
 pub struct StrategyError {
@@ -390,18 +391,16 @@ impl Strategy {
     }
 }
 
-impl SearchStrategy<Provider, &[f32]> for Strategy {
-    type ElementRef<'a> = &'a [f32];
-    type QueryComputer = <f32 as VectorRepr>::QueryDistance;
-    type QueryComputerError = StrategyError;
-    type Visitor<'a> = Visitor<'a>;
+impl<'a> SearchStrategy<'a, Provider, &'a [f32]> for Strategy {
+    type Visitor = Visitor<'a>;
     type Error = StrategyError;
 
-    fn create_visitor<'a>(
+    fn create_visitor(
         &'a self,
         provider: &'a Provider,
         _context: &'a Context,
-    ) -> Result<Self::Visitor<'a>, Self::Error> {
+        query: &'a [f32],
+    ) -> Result<Self::Visitor, Self::Error> {
         let actual = provider.dim();
         if actual != self.dim {
             return Err(StrategyError {
@@ -409,23 +408,16 @@ impl SearchStrategy<Provider, &[f32]> for Strategy {
                 actual,
             });
         }
-        let visitor = match &self.transient_ids {
-            Some(ids) => Visitor::flaky(provider, Cow::Borrowed(ids)),
-            None => Visitor::new(provider),
-        };
-        Ok(visitor)
-    }
-
-    fn build_query_computer(
-        &self,
-        from: &[f32],
-    ) -> Result<Self::QueryComputer, Self::QueryComputerError> {
-        if from.len() != self.dim {
+        if query.len() != self.dim {
             return Err(StrategyError {
                 expected: self.dim,
-                actual: from.len(),
+                actual: query.len(),
             });
         }
-        Ok(f32::query_distance(from, Metric::L2))
+        let computer = f32::query_distance(query, Metric::L2);
+        Ok(match &self.transient_ids {
+            Some(ids) => Visitor::flaky(provider, Cow::Borrowed(ids), computer),
+            None => Visitor::new(provider, computer),
+        })
     }
 }

--- a/diskann/src/flat/test/provider.rs
+++ b/diskann/src/flat/test/provider.rs
@@ -6,11 +6,9 @@
 //! Self-contained test provider for the flat-search module.
 
 use std::{
-    borrow::Cow,
     collections::HashSet,
     fmt::{self, Debug},
     future::Future,
-    sync::Arc,
 };
 
 use diskann_utils::{future::SendFuture, views::Matrix};
@@ -20,7 +18,7 @@ use thiserror::Error;
 use crate::{
     always_escalate, convert_error,
     error::{RankedError, ToRanked, TransientError},
-    flat::{DistancesUnordered, SearchStrategy},
+    flat::DistancesUnordered,
     graph::test::synthetic::Grid,
     internal::counter::{Counter, LocalCounter},
     provider::{self, ExecutionContext, HasId, NoopGuard},
@@ -123,12 +121,6 @@ crate::test::cmp::verbose_eq!(ElementCounter { count });
 /// the calling task and never spawns.
 #[derive(Debug, Clone, Default)]
 pub struct Context;
-
-impl Context {
-    pub fn new() -> Self {
-        Self
-    }
-}
 
 impl ExecutionContext for Context {
     fn wrap_spawn<F, T>(&self, f: F) -> impl Future<Output = T> + Send + 'static
@@ -281,35 +273,50 @@ impl provider::DataProvider for Provider {
 /// set of ids.
 pub struct Visitor<'a> {
     provider: &'a Provider,
-    transient_ids: Option<Cow<'a, HashSet<u32>>>,
+    transient_ids: Option<HashSet<u32>>,
     get_element: LocalCounter<'a>,
     computer: <f32 as VectorRepr>::QueryDistance,
 }
 
 impl<'a> Visitor<'a> {
     /// Construct a visitor with no fault injection.
-    pub fn new(provider: &'a Provider, computer: <f32 as VectorRepr>::QueryDistance) -> Self {
-        Self {
+    pub fn new(provider: &'a Provider, query: &[f32]) -> Result<Self, VisitorError> {
+        let computer = Self::query_computer(provider, query)?;
+        Ok(Self {
             provider,
             transient_ids: None,
             get_element: provider.get_element.local(),
             computer,
-        }
+        })
     }
 
     /// Construct a visitor that returns a [`TransientGetError`] for any id in
     /// `transient_ids`. Other ids behave normally.
     pub fn flaky(
         provider: &'a Provider,
-        transient_ids: Cow<'a, HashSet<u32>>,
-        computer: <f32 as VectorRepr>::QueryDistance,
-    ) -> Self {
-        Self {
+        query: &[f32],
+        transient_ids: impl IntoIterator<Item = u32>,
+    ) -> Result<Self, VisitorError> {
+        let computer = Self::query_computer(provider, query)?;
+        Ok(Self {
             provider,
-            transient_ids: Some(transient_ids),
+            transient_ids: Some(transient_ids.into_iter().collect()),
             get_element: provider.get_element.local(),
             computer,
+        })
+    }
+
+    fn query_computer(
+        provider: &Provider,
+        query: &[f32],
+    ) -> Result<<f32 as VectorRepr>::QueryDistance, VisitorError> {
+        if query.len() != provider.dim() {
+            return Err(VisitorError {
+                expected: provider.dim(),
+                actual: query.len(),
+            });
         }
+        Ok(f32::query_distance(query, Metric::L2))
     }
 }
 
@@ -350,74 +357,12 @@ impl DistancesUnordered for Visitor<'_> {
     }
 }
 
-//////////////
-// Strategy //
-//////////////
-
-/// Error from [`Strategy::create_visitor`] when dimensions don't match.
+/// Error from visitor construction when dimensions don't match.
 #[derive(Debug, Clone, Error)]
-#[error("dimension mismatch: strategy expects {expected}, got {actual}")]
-pub struct StrategyError {
+#[error("dimension mismatch: provider expects {expected}, got {actual}")]
+pub struct VisitorError {
     pub expected: usize,
     pub actual: usize,
 }
 
-convert_error!(StrategyError);
-
-/// Factory of [`Visitor`]s that validates dimensions and optionally injects
-/// transient errors into the scan.
-#[derive(Clone, Debug)]
-pub struct Strategy {
-    dim: usize,
-    transient_ids: Option<Arc<HashSet<u32>>>,
-}
-
-impl Strategy {
-    /// Construct a strategy expecting vectors of dimension `dim`.
-    pub fn new(dim: usize) -> Self {
-        Self {
-            dim,
-            transient_ids: None,
-        }
-    }
-
-    /// Construct a strategy whose visitors return a transient error on `get_element`
-    /// for every id in `transient_ids`.
-    pub fn with_transient(dim: usize, transient_ids: impl IntoIterator<Item = u32>) -> Self {
-        Self {
-            dim,
-            transient_ids: Some(Arc::new(transient_ids.into_iter().collect())),
-        }
-    }
-}
-
-impl<'a> SearchStrategy<'a, Provider, &'a [f32]> for Strategy {
-    type Visitor = Visitor<'a>;
-    type Error = StrategyError;
-
-    fn create_visitor(
-        &'a self,
-        provider: &'a Provider,
-        _context: &'a Context,
-        query: &'a [f32],
-    ) -> Result<Self::Visitor, Self::Error> {
-        let actual = provider.dim();
-        if actual != self.dim {
-            return Err(StrategyError {
-                expected: self.dim,
-                actual,
-            });
-        }
-        if query.len() != self.dim {
-            return Err(StrategyError {
-                expected: self.dim,
-                actual: query.len(),
-            });
-        }
-        let computer = f32::query_distance(query, Metric::L2);
-        Ok(match &self.transient_ids {
-            Some(ids) => Visitor::flaky(provider, Cow::Borrowed(ids), computer),
-            None => Visitor::new(provider, computer),
-        })
-    }
-}
+convert_error!(VisitorError);


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [x] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [x] Does this PR modify any existing APIs?
- [ ] Is the change to the API backwards compatible?
- [x] Should this result in any changes to our documentation, either updating existing docs or adding new ones?

#### Reference Issues/PRs

Prerequisite API refactor requested during review of #1341.

#### What does this implement/fix? Briefly explain your changes.

Makes flat search visitors query-aware, moves the search algorithm to the free `flat::knn_search` entry point, and removes the unnecessary `FlatIndex` wrapper. It also updates the generic flat tests, test providers, benchmark integration, and API rustdoc for the redesigned public API.

The redesigned interface has several benefits:

- A visitor is constructed for a specific query, so it can own or borrow query preprocessing results and combine them with backend-specific I/O, batching, filtering, and distance-computation state. This is particularly useful for streamed and quantized backends such as the disk PQ scan in #1341.
- `DistancesUnordered` now emits `(id, distance)` pairs directly. Backends can fuse scanning and distance computation instead of exposing every stored element through a common `ElementRef` and external `QueryComputer` abstraction.
- Implementations have a smaller and less brittle type surface. The redesign removes the `ElementRef`, `QueryComputer`, and `QueryComputerError` associated types, the visitor GAT, and their HRTB/lifetime constraints.
- The free `flat::knn_search(&provider, ...)` function borrows the provider directly, removing a stateless ownership wrapper and making shared providers and concurrent searches more natural.
- Responsibilities are clearer: the generic algorithm manages top-k selection and post-processing, while the query-aware visitor owns the backend-specific complete scan.

#### Any other comments?

This intentionally changes the existing public flat-search API and is not backwards compatible. The trade-off is a breaking migration for current callers in exchange for an interface that can naturally represent query-aware, streaming, and quantized backends. #1341 will remain open and be rebased onto `main` after this prerequisite merges.