### PR TITLE
Allow inspection of the paged search accessor.

### DIFF
--- a/diskann/src/graph/search/paged.rs
+++ b/diskann/src/graph/search/paged.rs
@@ -42,6 +42,19 @@ where
     DP: DataProvider,
     A: SearchAccessor<Id = DP::InternalId> + 'a,
 {
+    /// Return the contained [`SearchAccessor`].
+    ///
+    /// This method is mainly intended to allow per-page metric reporting from the accessor.
+    pub fn accessor(&mut self) -> &mut A {
+        &mut self.accessor
+    }
+}
+
+impl<'a, DP, A> PagedSearch<'a, DP, A>
+where
+    DP: DataProvider,
+    A: SearchAccessor<Id = DP::InternalId> + 'a,
+{
     /// Returns the next page of at most `k` nearest-neighbor results.
     ///
     /// Results across pages are non-overlapping but not guaranteed to be monotonic with

--- a/diskann/src/graph/search/paged.rs
+++ b/diskann/src/graph/search/paged.rs
@@ -44,7 +44,7 @@ where
 {
     /// Return the contained [`SearchAccessor`].
     ///
-    /// This method is mainly intended to allow per-page metric reporting from the accessor.
+    /// This method is intended to enable per-page metric reporting from the accessor.
     pub fn accessor(&mut self) -> &mut A {
         &mut self.accessor
     }


### PR DESCRIPTION
All the `SearchAccessor` used during `PagedSearch` to be inspected.

This allows users of paged search to implement custom pre- and post-page operations including metric reporting.