### PR TITLE
Add Neon inner product U8xU1, U8xU2 and U8xU4 kernels

### DIFF
--- a/diskann-quantization/src/bits/distances.rs
+++ b/diskann-quantization/src/bits/distances.rs
@@ -73,9 +73,9 @@
 //! | `USlice<7>`   | `USlice<7>`   | `MV<u32>` | Fallback  | No            | Uses V3   | Fallback  |
 //! | `USlice<8>`   | `USlice<8>`   | `MV<u32>` | Yes       | Yes           | Yes       | Fallback  |
 //! |               |               |           |           |               |           |           |
-//! | `USlice<8>`   | `USlice<4>`   | `MV<u32>` | Fallback  | Yes           | Uses V3   | Fallback  |
-//! | `USlice<8>`   | `USlice<2>`   | `MV<u32>` | Fallback  | Yes           | Uses V3   | Fallback  |
-//! | `USlice<8>`   | `USlice<1>`   | `MV<u32>` | Fallback  | Yes           | Uses V3   | Fallback  |
+//! | `USlice<8>`   | `USlice<4>`   | `MV<u32>` | Fallback  | Yes           | Uses V3   | Optimized |
+//! | `USlice<8>`   | `USlice<2>`   | `MV<u32>` | Fallback  | Yes           | Uses V3   | Optimized |
+//! | `USlice<8>`   | `USlice<1>`   | `MV<u32>` | Fallback  | Yes           | Uses V3   | Optimized |
 //! |               |               | `       ` |           |               |           |           |
 //! | `TSlice<4>`   | `USlice<1>`   | `MV<u32>` | Optimized | Optimized     | Optimized | Optimized |
 //! |               |               | `       ` |           |               |           |           |
@@ -2202,18 +2202,429 @@ impl Target2<diskann_wide::arch::x86_64::V3, MathematicalResult<u32>, USlice<'_,
 }
 
 #[cfg(target_arch = "aarch64")]
-retarget!(
-    diskann_wide::arch::aarch64::Neon,
-    InnerProduct,
-    7,
-    6,
-    5,
-    3,
-    2,
-    (8, 4),
-    (8, 2),
-    (8, 1)
-);
+impl
+    Target2<
+        diskann_wide::arch::aarch64::Neon,
+        MathematicalResult<u32>,
+        USlice<'_, 8>,
+        USlice<'_, 4>,
+    > for InnerProduct
+{
+    #[inline(always)]
+    fn run(
+        self,
+        arch: diskann_wide::arch::aarch64::Neon,
+        x: USlice<'_, 8>,
+        y: USlice<'_, 4>,
+    ) -> MathematicalResult<u32> {
+        // returns number of quantized vectors
+        let len = check_lengths!(x, y)?;
+
+        diskann_wide::alias!(u8s_16 = <diskann_wide::arch::aarch64::Neon>::u8x16);
+        #[allow(non_camel_case_types)]
+        type u8s_8 = diskann_wide::arch::aarch64::u8x8;
+        diskann_wide::alias!(u32s = <diskann_wide::arch::aarch64::Neon>::u32x4);
+
+        let px_u8: *const u8 = x.as_ptr().cast();
+        let py_u8: *const u8 = y.as_ptr().cast();
+
+        let mut i = 0;
+        let mut s: u32 = 0;
+
+        // number of y bytes over the underlying slice
+        let y_bytes = len / 2;
+        if i < y_bytes {
+            let mut s0 = u32s::default(arch);
+
+            #[inline(always)]
+            fn split_and_zip(input: u8s_8, arch: diskann_wide::arch::aarch64::Neon) -> u8s_16 {
+                use diskann_wide::{LoHi, ZipUnzip};
+                let lo = input;
+                let hi = input >> 4;
+                let halves = LoHi::new(lo, hi);
+                let zipped_halves = u8s_16::zip(halves);
+                zipped_halves & u8s_16::splat(arch, 0x0f)
+            }
+
+            while i + 8 <= y_bytes {
+                // SAFETY: `i + 8 <= y_bytes` guarantees 8 readable bytes at `py_u8.add(i)`.
+                let y_vec = split_and_zip(unsafe { u8s_8::load_simd(arch, py_u8.add(i)) }, arch);
+                // SAFETY: `2 * (i + 8) <= 2 * y_bytes == x.bytes()` guarantees a 16-byte load
+                // from `px_u8.add(2 * i)`.
+                let x_vec = unsafe { u8s_16::load_simd(arch, px_u8.add(i * 2)) };
+
+                // compute dot product for lower 4 bits, result is stored as 32x4
+                s0 = s0.dot_simd(x_vec, y_vec);
+
+                // repeat for next 8 byte block of y and 16 byte block of x
+                i += 8;
+            }
+
+            let remaining_bytes = len / 2 - i;
+
+            if remaining_bytes > 0 {
+                // SAFETY: less than 8 bytes remain of y, we infer that less than 16 remain of x.
+                let x_vec =
+                    unsafe { u8s_16::load_simd_first(arch, px_u8.add(i * 2), remaining_bytes * 2) };
+
+                // SAFETY: `remaining_bytes` is exactly the readable tail length from `py_u8.add(i)`.
+                let y_vec = split_and_zip(
+                    unsafe { u8s_8::load_simd_first(arch, py_u8.add(i), remaining_bytes) },
+                    arch,
+                );
+
+                s0 = s0.dot_simd(x_vec, y_vec);
+                i += remaining_bytes;
+            }
+            s = s0.sum_tree();
+        }
+
+        // Convert bytes to nibble indexes.
+        i *= 2;
+
+        // Deal with the remainder the slow way (at most 1 element).
+        debug_assert!(len - i <= 1);
+        if i != len {
+            // SAFETY: `i` is guaranteed to be less than `x.len()`.
+            let ix = unsafe { x.get_unchecked(i) } as u32;
+            // SAFETY: `i` is guaranteed to be less than `y.len()`.
+            let iy = unsafe { y.get_unchecked(i) } as u32;
+            s += (ix * iy) as u32;
+        }
+
+        Ok(MV::new(s))
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+impl
+    Target2<
+        diskann_wide::arch::aarch64::Neon,
+        MathematicalResult<u32>,
+        USlice<'_, 8>,
+        USlice<'_, 2>,
+    > for InnerProduct
+{
+    #[inline(always)]
+    fn run(
+        self,
+        arch: diskann_wide::arch::aarch64::Neon,
+        x: USlice<'_, 8>,
+        y: USlice<'_, 2>,
+    ) -> MathematicalResult<u32> {
+        let len = check_lengths!(x, y)?;
+
+        #[allow(non_camel_case_types)]
+        type u8s_8 = diskann_wide::arch::aarch64::u8x8;
+        diskann_wide::alias!(u8s_16 = <diskann_wide::arch::aarch64::Neon>::u8x16);
+        diskann_wide::alias!(u8s_32 = <diskann_wide::arch::aarch64::Neon>::u8x32);
+        diskann_wide::alias!(u32s = <diskann_wide::arch::aarch64::Neon>::u32x4);
+
+        let px_u8: *const u8 = x.as_ptr().cast();
+        let py_u8: *const u8 = y.as_ptr().cast();
+
+        let mut i = 0;
+        let mut s: u32 = 0;
+
+        #[inline(always)]
+        fn split_and_zip_four_bit(input: u8s_8, arch: diskann_wide::arch::aarch64::Neon) -> u8s_16 {
+            use diskann_wide::{LoHi, ZipUnzip};
+            let lo = input;
+            let hi = input >> 4;
+            let halves = LoHi::new(lo, hi);
+            let zipped_halves = u8s_16::zip(halves);
+            zipped_halves & u8s_16::splat(arch, 0x0f)
+        }
+
+        #[inline(always)]
+        fn split_and_zip_two_bits(
+            input: u8s_8,
+            arch: diskann_wide::arch::aarch64::Neon,
+        ) -> (u8s_16, u8s_16) {
+            use diskann_wide::{LoHi, SplitJoin, ZipUnzip};
+            let four_bit_split = split_and_zip_four_bit(input, arch);
+            let lo = four_bit_split;
+            let hi = four_bit_split >> 2;
+            let zipped = u8s_32::zip(LoHi::new(lo, hi));
+            let LoHi { lo, hi } = zipped.split();
+            let mask = u8s_16::splat(arch, 0x03);
+            (lo & mask, hi & mask)
+        }
+
+        let y_bytes = len / 4; // number of y bytes over the underlying slice
+        if i < y_bytes {
+            let mut s0 = u32s::default(arch);
+            let mut s1 = u32s::default(arch);
+
+            while i + 8 <= y_bytes {
+                // SAFETY: `i + 8 <= y_bytes` guarantees that 8 bytes from `py_u8` are readable at offset `i`.
+                let (y_vec1, y_vec2) =
+                    split_and_zip_two_bits(unsafe { u8s_8::load_simd(arch, py_u8.add(i)) }, arch);
+
+                // SAFETY: `4 * (i + 8) <= 4 * y_bytes == x.bytes()` guarantees the 16-byte
+                // loads at `4 * i` and `4 * i + 16` are in bounds.
+                let x_vec1 = unsafe { u8s_16::load_simd(arch, px_u8.add(4 * i)) };
+                let x_vec2 = unsafe { u8s_16::load_simd(arch, px_u8.add(4 * i + 16)) };
+
+                // compute dot product for lower 4 bits, result is stored as 32x4
+                s0 = s0.dot_simd(x_vec1, y_vec1);
+
+                // compute dot product for upper 4 bits, result is stored as 32x4
+                s1 = s1.dot_simd(x_vec2, y_vec2);
+
+                // repeat for next block
+                i += 8;
+            }
+
+            let remaining_y_bytes = len / 4 - i;
+            let remaining_x_bytes = remaining_y_bytes * 4;
+
+            if remaining_y_bytes > 0 {
+                // SAFETY: `remaining_y_bytes` is the exact readable tail length at `py_u8.add(i)`.
+                let (y_vec1, y_vec2) = split_and_zip_two_bits(
+                    unsafe { u8s_8::load_simd_first(arch, py_u8.add(i), remaining_y_bytes) },
+                    arch,
+                );
+
+                // SAFETY: `remaining_x_bytes == 4 * remaining_y_bytes` is exactly the
+                // in-bounds tail length from `px_u8.add(4 * i)`.
+                let x_first = remaining_x_bytes.min(16);
+                let x_second = remaining_x_bytes.saturating_sub(16);
+
+                let x_vec1 = unsafe { u8s_16::load_simd_first(arch, px_u8.add(i * 4), x_first) };
+                s0 = s0.dot_simd(x_vec1, y_vec1);
+
+                if x_second > 0 {
+                    // SAFETY: `x_second > 0` means bytes remain after the first 16-byte chunk.
+                    let x_vec2 =
+                        unsafe { u8s_16::load_simd_first(arch, px_u8.add(i * 4 + 16), x_second) };
+                    s1 = s1.dot_simd(x_vec2, y_vec2);
+                }
+                i += remaining_y_bytes;
+            }
+            s = (s0 + s1).sum_tree();
+        }
+
+        // converting from y bytes to logical elements.
+        i *= 4;
+
+        // Deal with the remainder the slow way (at most 3 element).
+        debug_assert!(len - i <= 3);
+        if i != len {
+            #[inline(never)]
+            fn fallback(x: USlice<'_, 8>, y: USlice<'_, 2>, from: usize) -> u32 {
+                let mut s: u32 = 0;
+                for i in from..x.len() {
+                    // SAFETY: `i` is in `from..x.len()`, which equals `y.len()`.
+                    let (ix, iy) =
+                        unsafe { (x.get_unchecked(i) as u32, y.get_unchecked(i) as u32) };
+                    s += ix * iy;
+                }
+                s
+            }
+            s += fallback(x, y, i)
+        }
+
+        Ok(MV::new(s))
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+impl
+    Target2<
+        diskann_wide::arch::aarch64::Neon,
+        MathematicalResult<u32>,
+        USlice<'_, 8>,
+        USlice<'_, 1>,
+    > for InnerProduct
+{
+    #[inline(always)]
+    fn run(
+        self,
+        arch: diskann_wide::arch::aarch64::Neon,
+        x: USlice<'_, 8>,
+        y: USlice<'_, 1>,
+    ) -> MathematicalResult<u32> {
+        // returns number of quantized vectors
+        let len = check_lengths!(x, y)?;
+
+        #[allow(non_camel_case_types)]
+        type u8s_8 = diskann_wide::arch::aarch64::u8x8;
+        diskann_wide::alias!(u8s_16 = <diskann_wide::arch::aarch64::Neon>::u8x16);
+        diskann_wide::alias!(u8s_32 = <diskann_wide::arch::aarch64::Neon>::u8x32);
+        diskann_wide::alias!(u32s = <diskann_wide::arch::aarch64::Neon>::u32x4);
+
+        let px_u8: *const u8 = x.as_ptr().cast();
+        let py_u8: *const u8 = y.as_ptr().cast();
+
+        let mut i = 0;
+        let mut s: u32 = 0;
+
+        #[inline(always)]
+        fn split_and_zip_four_bits(
+            input: u8s_8,
+            arch: diskann_wide::arch::aarch64::Neon,
+        ) -> u8s_16 {
+            use diskann_wide::{LoHi, ZipUnzip};
+            let lo = input;
+            let hi = input >> 4;
+            let halves = LoHi::new(lo, hi);
+            let zipped_halves = u8s_16::zip(halves);
+            zipped_halves & u8s_16::splat(arch, 0x0f)
+        }
+
+        #[inline(always)]
+        fn split_and_zip_two_bits(
+            input: u8s_8,
+            arch: diskann_wide::arch::aarch64::Neon,
+        ) -> (u8s_16, u8s_16) {
+            use diskann_wide::{LoHi, SplitJoin, ZipUnzip};
+            let four_bit_split = split_and_zip_four_bits(input, arch);
+            let lo = four_bit_split;
+            let hi = four_bit_split >> 2;
+            let zipped = u8s_32::zip(LoHi::new(lo, hi));
+            let LoHi { lo, hi } = zipped.split();
+            let mask = u8s_16::splat(arch, 0x03);
+            (lo & mask, hi & mask)
+        }
+
+        #[inline(always)]
+        fn split_and_zip_one_bit(
+            input: u8s_8,
+            arch: diskann_wide::arch::aarch64::Neon,
+        ) -> (u8s_16, u8s_16, u8s_16, u8s_16) {
+            use diskann_wide::{LoHi, SplitJoin, ZipUnzip};
+            let (lower_two_bits, upper_two_bits) = split_and_zip_two_bits(input, arch);
+            let vec1_lo = lower_two_bits;
+            let vec1_hi = lower_two_bits >> 1;
+            let vec2_lo = upper_two_bits;
+            let vec2_hi = upper_two_bits >> 1;
+            let vec1_zipped = u8s_32::zip(LoHi::new(vec1_lo, vec1_hi));
+            let vec2_zipped = u8s_32::zip(LoHi::new(vec2_lo, vec2_hi));
+            let LoHi {
+                lo: vec1_lo,
+                hi: vec1_hi,
+            } = vec1_zipped.split();
+            let LoHi {
+                lo: vec2_lo,
+                hi: vec2_hi,
+            } = vec2_zipped.split();
+            let mask = u8s_16::splat(arch, 0x01);
+            (
+                vec1_lo & mask,
+                vec1_hi & mask,
+                vec2_lo & mask,
+                vec2_hi & mask,
+            )
+        }
+
+        let y_bytes = len / 8; // number of y bytes over the underlying slice
+        if i < y_bytes {
+            let mut s0 = u32s::default(arch);
+            let mut s1 = u32s::default(arch);
+            let mut s2 = u32s::default(arch);
+            let mut s3 = u32s::default(arch);
+
+            while i + 8 <= y_bytes {
+                // SAFETY: `i + 8 <= y_bytes` guarantees that 8 bytes from `py_u8` are readable at offset `i`.
+                let (y_vec1, y_vec2, y_vec3, y_vec4) =
+                    split_and_zip_one_bit(unsafe { u8s_8::load_simd(arch, py_u8.add(i)) }, arch);
+
+                // SAFETY: `8 * (i + 8) <= 8 * y_bytes == x.bytes()` guarantees four 16-byte
+                // loads at offsets `8 * i + {0,16,32,48}` are in bounds.
+                let x_vec1 = unsafe { u8s_16::load_simd(arch, px_u8.add(8 * i)) };
+                let x_vec2 = unsafe { u8s_16::load_simd(arch, px_u8.add(8 * i + 16)) };
+                let x_vec3 = unsafe { u8s_16::load_simd(arch, px_u8.add(8 * i + 32)) };
+                let x_vec4 = unsafe { u8s_16::load_simd(arch, px_u8.add(8 * i + 48)) };
+
+                // compute dot product for first 16 logical elements
+                s0 = s0.dot_simd(x_vec1, y_vec1);
+
+                // compute dot product for next 16 logical elements
+                s1 = s1.dot_simd(x_vec2, y_vec2);
+
+                // compute dot product for next 16 logical elements
+                s2 = s2.dot_simd(x_vec3, y_vec3);
+
+                // compute dot product for last 16 logical elements
+                s3 = s3.dot_simd(x_vec4, y_vec4);
+
+                // repeat for next block
+                i += 8;
+            }
+
+            let remaining_y_bytes = len / 8 - i;
+            let remaining_x_bytes = remaining_y_bytes * 8;
+
+            if remaining_y_bytes > 0 {
+                // SAFETY: `remaining_y_bytes` is the exact readable tail length at `py_u8.add(i)`.
+                let (y_vec1, y_vec2, y_vec3, y_vec4) = split_and_zip_one_bit(
+                    unsafe { u8s_8::load_simd_first(arch, py_u8.add(i), remaining_y_bytes) },
+                    arch,
+                );
+
+                // SAFETY: `remaining_x_bytes == 8 * remaining_y_bytes` is exactly the
+                // in-bounds tail length from `px_u8.add(8 * i)`.
+                let x_first = remaining_x_bytes.min(16);
+                let x_second = remaining_x_bytes.saturating_sub(16).min(16);
+                let x_third = remaining_x_bytes.saturating_sub(32).min(16);
+                let x_fourth = remaining_x_bytes.saturating_sub(48).min(16);
+
+                let x_vec1 = unsafe { u8s_16::load_simd_first(arch, px_u8.add(i * 8), x_first) };
+                s0 = s0.dot_simd(x_vec1, y_vec1);
+
+                if x_second > 0 {
+                    // SAFETY: `x_second > 0` means bytes remain after the first 16-byte chunk.
+                    let x_vec2 =
+                        unsafe { u8s_16::load_simd_first(arch, px_u8.add(i * 8 + 16), x_second) };
+                    s1 = s1.dot_simd(x_vec2, y_vec2);
+                }
+
+                if x_third > 0 {
+                    // SAFETY: `x_third > 0` means bytes remain after the first two 16-byte chunks.
+                    let x_vec3 =
+                        unsafe { u8s_16::load_simd_first(arch, px_u8.add(i * 8 + 32), x_third) };
+                    s2 = s2.dot_simd(x_vec3, y_vec3);
+                }
+
+                if x_fourth > 0 {
+                    // SAFETY: `x_fourth > 0` means bytes remain after the first three 16-byte chunks.
+                    let x_vec4 =
+                        unsafe { u8s_16::load_simd_first(arch, px_u8.add(i * 8 + 48), x_fourth) };
+                    s3 = s3.dot_simd(x_vec4, y_vec4);
+                }
+
+                i += remaining_y_bytes;
+            }
+            s = ((s0 + s1) + (s2 + s3)).sum_tree();
+        }
+
+        // converting from y bytes to logical elements.
+        i *= 8;
+
+        // Deal with the remainder the slow way (at most 7 element).
+        debug_assert!(len - i <= 7);
+        if i != len {
+            #[inline(never)]
+            fn fallback(x: USlice<'_, 8>, y: USlice<'_, 1>, from: usize) -> u32 {
+                let mut s: u32 = 0;
+                for i in from..x.len() {
+                    // SAFETY: `i` is in `from..x.len()`, which equals `y.len()`.
+                    let (ix, iy) =
+                        unsafe { (x.get_unchecked(i) as u32, y.get_unchecked(i) as u32) };
+                    s += ix * iy;
+                }
+                s
+            }
+            s += fallback(x, y, i)
+        }
+
+        Ok(MV::new(s))
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+retarget!(diskann_wide::arch::aarch64::Neon, InnerProduct, 7, 6, 5, 3);
 
 //////////////////
 // BitTranspose //
@@ -3058,7 +3469,7 @@ mod tests {
             (Key::new(8, Scalar), Bounds::new(64, 64)),
             (Key::new(8, X86_64_V3), Bounds::new(256, 96)),
             (Key::new(8, X86_64_V4), Bounds::new(256, 96)),
-            (Key::new(8, Neon), Bounds::new(64, 64)),
+            (Key::new(8, Neon), Bounds::new(256, 256)),
         ]
         .into_iter()
         .collect()

--- a/diskann-quantization/src/bits/distances.rs
+++ b/diskann-quantization/src/bits/distances.rs
@@ -2401,7 +2401,7 @@ impl
             let ix = unsafe { x.get_unchecked(i) } as u32;
             // SAFETY: `i` is guaranteed to be less than `y.len()`.
             let iy = unsafe { y.get_unchecked(i) } as u32;
-            s += (ix * iy) as u32;
+            s += ix * iy;
         }
 
         Ok(MV::new(s))
@@ -2476,6 +2476,7 @@ impl
                 // SAFETY: `4 * (i + 8) <= 4 * y_bytes == x.bytes()` guarantees the 16-byte
                 // loads at `4 * i` and `4 * i + 16` are in bounds.
                 let x_vec1 = unsafe { u8s_16::load_simd(arch, px_u8.add(4 * i)) };
+                // SAFETY: same bound as above; this is the second 16-byte chunk in the same valid 32-byte block.
                 let x_vec2 = unsafe { u8s_16::load_simd(arch, px_u8.add(4 * i + 16)) };
 
                 // compute dot product for lower 4 bits, result is stored as 32x4
@@ -2503,6 +2504,7 @@ impl
                 let x_first = remaining_x_bytes.min(16);
                 let x_second = remaining_x_bytes.saturating_sub(16);
 
+                // SAFETY: `x_first <= remaining_x_bytes` and `px_u8.add(4 * i)` points at the tail start.
                 let x_vec1 = unsafe { u8s_16::load_simd_first(arch, px_u8.add(i * 4), x_first) };
                 s0 = s0.dot_simd(x_vec1, y_vec1);
 
@@ -2645,8 +2647,11 @@ impl
                 // SAFETY: `8 * (i + 8) <= 8 * y_bytes == x.bytes()` guarantees four 16-byte
                 // loads at offsets `8 * i + {0,16,32,48}` are in bounds.
                 let x_vec1 = unsafe { u8s_16::load_simd(arch, px_u8.add(8 * i)) };
+                // SAFETY: same bound as above; this is the second 16-byte chunk in the same valid 64-byte block.
                 let x_vec2 = unsafe { u8s_16::load_simd(arch, px_u8.add(8 * i + 16)) };
+                // SAFETY: same bound as above; this is the third 16-byte chunk in the same valid 64-byte block.
                 let x_vec3 = unsafe { u8s_16::load_simd(arch, px_u8.add(8 * i + 32)) };
+                // SAFETY: same bound as above; this is the fourth 16-byte chunk in the same valid 64-byte block.
                 let x_vec4 = unsafe { u8s_16::load_simd(arch, px_u8.add(8 * i + 48)) };
 
                 // compute dot product for first 16 logical elements
@@ -2682,6 +2687,7 @@ impl
                 let x_third = remaining_x_bytes.saturating_sub(32).min(16);
                 let x_fourth = remaining_x_bytes.saturating_sub(48).min(16);
 
+                // SAFETY: `x_first <= remaining_x_bytes` and `px_u8.add(8 * i)` points at the tail start.
                 let x_vec1 = unsafe { u8s_16::load_simd_first(arch, px_u8.add(i * 8), x_first) };
                 s0 = s0.dot_simd(x_vec1, y_vec1);
 

--- a/diskann-quantization/src/bits/distances.rs
+++ b/diskann-quantization/src/bits/distances.rs
@@ -4305,6 +4305,17 @@ mod tests {
                             &mut rng,
                         );
                     }
+                    #[cfg(target_arch = "aarch64")]
+                    if let Some(arch) = diskann_wide::arch::aarch64::Neon::new_checked() {
+                        fuzz_heterogeneous_ip::<$M>(
+                            MAX_DIM,
+                            TRIALS_PER_DIM,
+                            $max_val,
+                            &|x, y| arch.run2(InnerProduct, x, y),
+                            "neon",
+                            &mut rng,
+                        );
+                    }
                 }
 
                 #[test]
@@ -4318,11 +4329,23 @@ mod tests {
                             arch.run2(InnerProduct, x, y)
                         });
                     }
+                    #[cfg(target_arch = "aarch64")]
+                    if let Some(arch) = diskann_wide::arch::aarch64::Neon::new_checked() {
+                        het_test_max_values::<$M>($max_val, "neon", &|x, y| {
+                            arch.run2(InnerProduct, x, y)
+                        });
+                    }
                 }
 
                 #[test]
                 fn known_answers() {
                     het_test_known_answers::<$M>($max_val, &|x, y| InnerProduct::evaluate(x, y));
+                    #[cfg(target_arch = "aarch64")]
+                    if let Some(arch) = diskann_wide::arch::aarch64::Neon::new_checked() {
+                        het_test_known_answers::<$M>($max_val, &|x, y| {
+                            arch.run2(InnerProduct, x, y)
+                        });
+                    }
                 }
 
                 #[test]
@@ -4330,6 +4353,12 @@ mod tests {
                     het_test_edge_cases::<$M>($max_val, $block_size, &|x, y| {
                         InnerProduct::evaluate(x, y)
                     });
+                    #[cfg(target_arch = "aarch64")]
+                    if let Some(arch) = diskann_wide::arch::aarch64::Neon::new_checked() {
+                        het_test_edge_cases::<$M>($max_val, $block_size, &|x, y| {
+                            arch.run2(InnerProduct, x, y)
+                        });
+                    }
                 }
             }
         };

--- a/diskann-wide/src/arch/aarch64/double.rs
+++ b/diskann-wide/src/arch/aarch64/double.rs
@@ -8,14 +8,14 @@ use std::arch::aarch64::*;
 use half::f16;
 
 use crate::{
-    LoHi, SplitJoin,
+    LoHi, SplitJoin, ZipUnzip,
     doubled::{self, Doubled},
 };
 
 use super::{
     f16x8, f32x4, i8x16, i16x8, i32x4,
     masks::{mask8x16, mask16x8, mask32x4, mask64x2},
-    u8x16, u32x4, u64x2,
+    u8x8, u8x16, u32x4, u64x2,
 };
 
 // Double Masks
@@ -89,6 +89,37 @@ super::macros::aarch64_zipunzip!(i32x4, vzip1q_s32, vzip2q_s32, vuzp1q_s32, vuzp
 super::macros::aarch64_zipunzip!(u8x16, vzip1q_u8, vzip2q_u8, vuzp1q_u8, vuzp2q_u8);
 super::macros::aarch64_zipunzip!(u32x4, vzip1q_u32, vzip2q_u32, vuzp1q_u32, vuzp2q_u32);
 super::macros::aarch64_zipunzip!(f16x8, vzip1q_u16, vzip2q_u16, vuzp1q_u16, vuzp2q_u16);
+
+impl ZipUnzip for u8x16 {
+    #[inline(always)]
+    fn zip(halves: LoHi<<Self as SplitJoin>::Halved>) -> Self {
+        use crate::SIMDVector;
+        // SAFETY: Caller asserts that these intrinsics match the element types.
+        unsafe {
+            let lo_raw = halves.lo.to_underlying();
+            let hi_raw = halves.hi.to_underlying();
+            <Self as SplitJoin>::join(LoHi::new(
+                u8x8::from_underlying(halves.lo.arch(), vzip1_u8(lo_raw, hi_raw)),
+                u8x8::from_underlying(halves.lo.arch(), vzip2_u8(lo_raw, hi_raw)),
+            ))
+        }
+    }
+
+    #[inline(always)]
+    fn unzip(self) -> LoHi<<Self as SplitJoin>::Halved> {
+        use crate::SIMDVector;
+        // SAFETY: Caller asserts that these intrinsics match the element types.
+        unsafe {
+            let halves = self.split();
+            let lo_raw = halves.lo.to_underlying();
+            let hi_raw = halves.hi.to_underlying();
+            LoHi::new(
+                u8x8::from_underlying(self.arch(), vuzp1_u8(lo_raw, hi_raw)),
+                u8x8::from_underlying(self.arch(), vuzp2_u8(lo_raw, hi_raw)),
+            )
+        }
+    }
+}
 
 //-------------//
 // Conversions //

--- a/diskann-wide/src/arch/aarch64/double.rs
+++ b/diskann-wide/src/arch/aarch64/double.rs
@@ -8,14 +8,14 @@ use std::arch::aarch64::*;
 use half::f16;
 
 use crate::{
-    LoHi, SplitJoin, ZipUnzip,
+    LoHi, SplitJoin,
     doubled::{self, Doubled},
 };
 
 use super::{
     f16x8, f32x4, i8x16, i16x8, i32x4,
     masks::{mask8x16, mask16x8, mask32x4, mask64x2},
-    u8x8, u8x16, u32x4, u64x2,
+    u8x16, u32x4, u64x2,
 };
 
 // Double Masks
@@ -89,37 +89,6 @@ super::macros::aarch64_zipunzip!(i32x4, vzip1q_s32, vzip2q_s32, vuzp1q_s32, vuzp
 super::macros::aarch64_zipunzip!(u8x16, vzip1q_u8, vzip2q_u8, vuzp1q_u8, vuzp2q_u8);
 super::macros::aarch64_zipunzip!(u32x4, vzip1q_u32, vzip2q_u32, vuzp1q_u32, vuzp2q_u32);
 super::macros::aarch64_zipunzip!(f16x8, vzip1q_u16, vzip2q_u16, vuzp1q_u16, vuzp2q_u16);
-
-impl ZipUnzip for u8x16 {
-    #[inline(always)]
-    fn zip(halves: LoHi<<Self as SplitJoin>::Halved>) -> Self {
-        use crate::SIMDVector;
-        // SAFETY: Caller asserts that these intrinsics match the element types.
-        unsafe {
-            let lo_raw = halves.lo.to_underlying();
-            let hi_raw = halves.hi.to_underlying();
-            <Self as SplitJoin>::join(LoHi::new(
-                u8x8::from_underlying(halves.lo.arch(), vzip1_u8(lo_raw, hi_raw)),
-                u8x8::from_underlying(halves.lo.arch(), vzip2_u8(lo_raw, hi_raw)),
-            ))
-        }
-    }
-
-    #[inline(always)]
-    fn unzip(self) -> LoHi<<Self as SplitJoin>::Halved> {
-        use crate::SIMDVector;
-        // SAFETY: Caller asserts that these intrinsics match the element types.
-        unsafe {
-            let halves = self.split();
-            let lo_raw = halves.lo.to_underlying();
-            let hi_raw = halves.hi.to_underlying();
-            LoHi::new(
-                u8x8::from_underlying(self.arch(), vuzp1_u8(lo_raw, hi_raw)),
-                u8x8::from_underlying(self.arch(), vuzp2_u8(lo_raw, hi_raw)),
-            )
-        }
-    }
-}
 
 //-------------//
 // Conversions //

--- a/diskann-wide/src/arch/aarch64/u8x16_.rs
+++ b/diskann-wide/src/arch/aarch64/u8x16_.rs
@@ -4,7 +4,7 @@
  */
 
 use crate::{
-    Emulated,
+    Emulated, LoHi, SplitJoin, ZipUnzip,
     constant::Const,
     helpers,
     traits::{SIMDMask, SIMDMulAdd, SIMDPartialEq, SIMDPartialOrd, SIMDPopcount, SIMDVector},
@@ -62,6 +62,37 @@ macros::aarch64_define_bitops!(
     (u8, i8, vmovq_n_s8),
 );
 
+impl ZipUnzip for u8x16 {
+    #[inline(always)]
+    fn zip(halves: LoHi<<Self as SplitJoin>::Halved>) -> Self {
+        use crate::SIMDVector;
+        // SAFETY: Caller asserts that these intrinsics match the element types.
+        unsafe {
+            let lo_raw = halves.lo.to_underlying();
+            let hi_raw = halves.hi.to_underlying();
+            <Self as SplitJoin>::join(LoHi::new(
+                u8x8::from_underlying(halves.lo.arch(), vzip1_u8(lo_raw, hi_raw)),
+                u8x8::from_underlying(halves.lo.arch(), vzip2_u8(lo_raw, hi_raw)),
+            ))
+        }
+    }
+
+    #[inline(always)]
+    fn unzip(self) -> LoHi<<Self as SplitJoin>::Halved> {
+        use crate::SIMDVector;
+        // SAFETY: Caller asserts that these intrinsics match the element types.
+        unsafe {
+            let halves = self.split();
+            let lo_raw = halves.lo.to_underlying();
+            let hi_raw = halves.hi.to_underlying();
+            LoHi::new(
+                u8x8::from_underlying(self.arch(), vuzp1_u8(lo_raw, hi_raw)),
+                u8x8::from_underlying(self.arch(), vuzp2_u8(lo_raw, hi_raw)),
+            )
+        }
+    }
+}
+
 ///////////
 // Tests //
 ///////////
@@ -99,6 +130,7 @@ mod tests {
     test_utils::ops::test_mul!(u8x16, 0x0f4caa80eceaa523, test_neon());
     test_utils::ops::test_fma!(u8x16, 0xb8f702ba85375041, test_neon());
     test_utils::ops::test_splitjoin!(u8x16 => u8x8, 0xa4d00a4d04293967, test_neon());
+    test_utils::ops::test_zipunzip!(u8x16 => u8x8, 0x041c0a3d046e0211, test_neon());
 
     test_utils::ops::test_cmp!(u8x16, 0x941757bd5cc641a1, test_neon());
 

--- a/diskann-wide/src/lib.rs
+++ b/diskann-wide/src/lib.rs
@@ -195,6 +195,9 @@ pub const ARCH: arch::Current = arch::current();
 ///    ```text
 ///    use of generic parameter from outer item
 ///    ```
+/// 5. `diskann_wide::alias!(f32s = type a::b::f32x4) => type f32s<A> = a::b::f32x4`:
+///    Use a direct path to the type rather than reaching the type as an associated type of
+///    [`Architecture`].
 #[macro_export]
 macro_rules! alias {
     ($var:ident) => {
@@ -210,6 +213,10 @@ macro_rules! alias {
     ($var:ident<$arch:ident> = $type:ident) => {
         #[allow(non_camel_case_types)]
         type $var<$arch> = <$arch as $crate::Architecture>::$type;
+    };
+    ($var:ident = type $type:path) => {
+        #[allow(non_camel_case_types)]
+        type $var = $type;
     };
 }
 


### PR DESCRIPTION
#### What does this implement
Adds inner product 8-bit x 4-bit unsigned vectors using neon
Adds inner product 8-bit x 2-bit unsigned vectors using neon
Adds inner product 8-bit x 1-bit unsigned vectors using neon
Adds Zip and Unzip intrinsics into diskann-wide

