### PR TITLE
[diskann-utils] Simplify `StridedView`.

### DIFF
--- a/diskann-benchmark-core/src/recall.rs
+++ b/diskann-benchmark-core/src/recall.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use diskann_utils::{
-    strided::{self, Strided},
+    strided::Strided,
     views::{Matrix, MatrixView},
 };
 use thiserror::Error;
@@ -145,7 +145,7 @@ pub enum GroundTruthMode {
 /// than `recall_k` candidates.
 pub fn knn<T>(
     groundtruth: &dyn Rows<T>,
-    groundtruth_distances: Option<strided::Ref<'_, f32>>,
+    groundtruth_distances: Option<Strided<'_, f32>>,
     results: &dyn Rows<T>,
     recall_k: usize,
     recall_n: usize,

--- a/diskann-benchmark-core/src/recall.rs
+++ b/diskann-benchmark-core/src/recall.rs
@@ -9,7 +9,7 @@ use std::{
 };
 
 use diskann_utils::{
-    strided::StridedView,
+    strided::{self, Strided},
     views::{Matrix, MatrixView},
 };
 use thiserror::Error;
@@ -145,7 +145,7 @@ pub enum GroundTruthMode {
 /// than `recall_k` candidates.
 pub fn knn<T>(
     groundtruth: &dyn Rows<T>,
-    groundtruth_distances: Option<StridedView<'_, f32>>,
+    groundtruth_distances: Option<strided::Ref<'_, f32>>,
     results: &dyn Rows<T>,
     recall_k: usize,
     recall_n: usize,
@@ -189,7 +189,7 @@ where
 
         for i in 0..nrows {
             let gt_row = groundtruth.row(i);
-            let distances_row = distances.row(i);
+            let distances_row = distances.row_or_panic(i);
             if gt_row.len() != distances_row.len() {
                 return Err(ComputeRecallError::GroundTruthDistanceMismatch(
                     distances_row.len(),
@@ -239,7 +239,7 @@ where
         // If we have distances, then continue to append distances as long as the distance
         // value is constant
         if let Some(distances) = groundtruth_distances {
-            let distances_row = distances.row(i);
+            let distances_row = distances.row_or_panic(i);
 
             // we've already checked that `results` and `distances` have at lesat
             // `recall_k >= this_recall_k` entries, so it's safe to access `distances_row[this_recall_k - 1]`

--- a/diskann-providers/src/model/pq/strided.rs
+++ b/diskann-providers/src/model/pq/strided.rs
@@ -4,7 +4,7 @@
  */
 
 use diskann::ANNError;
-use diskann_utils::{strided};
+use diskann_utils::strided;
 
 use crate::utils::Bridge;
 
@@ -32,7 +32,7 @@ mod tests {
         let x = vec![u8::default(); nrows * ncols];
 
         // Provided the incorrect dimensions.
-        let err = strided::Ref::try_from_data(&x, nrows, ncols + 1, ncols + 1)
+        let err = strided::Strided::try_from_data(&x, nrows, ncols + 1, ncols + 1)
             .bridge_err()
             .unwrap_err();
         let message = format!("{}", err);

--- a/diskann-providers/src/model/pq/strided.rs
+++ b/diskann-providers/src/model/pq/strided.rs
@@ -4,14 +4,14 @@
  */
 
 use diskann::ANNError;
-use diskann_utils::{strided, views};
+use diskann_utils::{strided};
 
 use crate::utils::Bridge;
 
-impl<T: views::DenseData> From<Bridge<strided::TryFromError<T>>> for ANNError {
+impl From<Bridge<strided::TryFromError>> for ANNError {
     #[track_caller]
-    fn from(value: Bridge<strided::TryFromError<T>>) -> Self {
-        ANNError::new(value.into_inner().as_static())
+    fn from(value: Bridge<strided::TryFromError>) -> Self {
+        ANNError::new(value.into_inner())
     }
 }
 
@@ -32,7 +32,7 @@ mod tests {
         let x = vec![u8::default(); nrows * ncols];
 
         // Provided the incorrect dimensions.
-        let err = strided::StridedView::try_from(&x, nrows, ncols + 1, ncols + 1)
+        let err = strided::Ref::try_from_data(&x, nrows, ncols + 1, ncols + 1)
             .bridge_err()
             .unwrap_err();
         let message = format!("{}", err);

--- a/diskann-quantization/src/algorithms/kmeans/lloyds.rs
+++ b/diskann-quantization/src/algorithms/kmeans/lloyds.rs
@@ -8,7 +8,7 @@ use diskann_wide::{SIMDMask, SIMDMulAdd, SIMDPartialOrd, SIMDSelect, SIMDSumTree
 use super::common::square_norm;
 use crate::multi_vector::{BlockTransposed, BlockTransposedRef};
 use diskann_utils::{
-    strided::StridedView,
+    strided::{self, Strided},
     views::{Matrix, MatrixView, MutMatrixView},
 };
 
@@ -342,10 +342,10 @@ fn update((d0, i0): (f32s, u32s), (d1, i1): (f32s, u32s)) -> (f32s, u32s) {
 // Update Step //
 /////////////////
 
-fn update_centroids(mut centers: MutMatrixView<'_, f32>, data: StridedView<'_, f32>, map: &[u32]) {
+fn update_centroids(mut centers: MutMatrixView<'_, f32>, data: strided::Ref<'_, f32>, map: &[u32]) {
     let mut sums = Matrix::<f64>::new(0.0, centers.nrows(), centers.ncols());
     let mut counts: Vec<u32> = vec![0; centers.nrows()];
-    data.row_iter().zip(map.iter()).for_each(|(row, &center)| {
+    data.rows().zip(map.iter()).for_each(|(row, &center)| {
         counts[center as usize] += 1;
         let sum = sums.row_mut(center as usize);
         std::iter::zip(sum.iter_mut(), row.iter()).for_each(|(s, r)| {
@@ -370,7 +370,7 @@ fn update_centroids(mut centers: MutMatrixView<'_, f32>, data: StridedView<'_, f
 ////////////
 
 pub(crate) fn lloyds_inner(
-    data: StridedView<'_, f32>,
+    data: strided::Ref<'_, f32>,
     square_norms: &[f32],
     transpose: BlockTransposedRef<'_, f32, 16>,
     mut centers: MutMatrixView<'_, f32>,

--- a/diskann-quantization/src/algorithms/kmeans/lloyds.rs
+++ b/diskann-quantization/src/algorithms/kmeans/lloyds.rs
@@ -8,7 +8,7 @@ use diskann_wide::{SIMDMask, SIMDMulAdd, SIMDPartialOrd, SIMDSelect, SIMDSumTree
 use super::common::square_norm;
 use crate::multi_vector::{BlockTransposed, BlockTransposedRef};
 use diskann_utils::{
-    strided::{self, Strided},
+    strided::Strided,
     views::{Matrix, MatrixView, MutMatrixView},
 };
 
@@ -342,7 +342,7 @@ fn update((d0, i0): (f32s, u32s), (d1, i1): (f32s, u32s)) -> (f32s, u32s) {
 // Update Step //
 /////////////////
 
-fn update_centroids(mut centers: MutMatrixView<'_, f32>, data: strided::Ref<'_, f32>, map: &[u32]) {
+fn update_centroids(mut centers: MutMatrixView<'_, f32>, data: Strided<'_, f32>, map: &[u32]) {
     let mut sums = Matrix::<f64>::new(0.0, centers.nrows(), centers.ncols());
     let mut counts: Vec<u32> = vec![0; centers.nrows()];
     data.rows().zip(map.iter()).for_each(|(row, &center)| {
@@ -370,7 +370,7 @@ fn update_centroids(mut centers: MutMatrixView<'_, f32>, data: strided::Ref<'_, 
 ////////////
 
 pub(crate) fn lloyds_inner(
-    data: strided::Ref<'_, f32>,
+    data: Strided<'_, f32>,
     square_norms: &[f32],
     transpose: BlockTransposedRef<'_, f32, 16>,
     mut centers: MutMatrixView<'_, f32>,

--- a/diskann-quantization/src/algorithms/kmeans/plusplus.rs
+++ b/diskann-quantization/src/algorithms/kmeans/plusplus.rs
@@ -6,7 +6,7 @@
 use std::{collections::HashSet, fmt};
 
 use diskann_utils::{
-    strided::StridedView,
+    strided::{self, Strided},
     views::{MatrixView, MutMatrixView},
 };
 use diskann_wide::{SIMDMulAdd, SIMDPartialOrd, SIMDSelect, SIMDVector};
@@ -380,7 +380,7 @@ impl KMeansPlusPlusError {
 
 pub(crate) fn kmeans_plusplus_into_inner<const N: usize>(
     mut points: MutMatrixView<'_, f32>,
-    data: StridedView<'_, f32>,
+    data: strided::Ref<'_, f32>,
     transpose: BlockTransposedRef<'_, f32, N>,
     norms: &[f32],
     rng: &mut dyn RngCore,
@@ -423,7 +423,7 @@ where
     // Pick the first point randomly.
     let mut previous_square_norm = {
         let i = all_rows.sample(rng);
-        points.row_mut(0).copy_from_slice(data.row(i));
+        points.row_mut(0).copy_from_slice(data.row_or_panic(i));
         picked.insert(i);
         norms[i]
     };
@@ -451,7 +451,9 @@ where
                     if rolling_sum >= threshold && (*d > 0.0) && !picked.contains(&i) {
                         // This point is the winner.
                         // Copy it over and update our scratch variables.
-                        points.row_mut(current).clone_from_slice(data.row(i));
+                        points
+                            .row_mut(current)
+                            .clone_from_slice(data.row_or_panic(i));
                         picked.insert(i);
                         previous_square_norm = norms[i];
                         selected = current + 1;

--- a/diskann-quantization/src/algorithms/kmeans/plusplus.rs
+++ b/diskann-quantization/src/algorithms/kmeans/plusplus.rs
@@ -6,7 +6,7 @@
 use std::{collections::HashSet, fmt};
 
 use diskann_utils::{
-    strided::{self, Strided},
+    strided::Strided,
     views::{MatrixView, MutMatrixView},
 };
 use diskann_wide::{SIMDMulAdd, SIMDPartialOrd, SIMDSelect, SIMDVector};
@@ -380,7 +380,7 @@ impl KMeansPlusPlusError {
 
 pub(crate) fn kmeans_plusplus_into_inner<const N: usize>(
     mut points: MutMatrixView<'_, f32>,
-    data: strided::Ref<'_, f32>,
+    data: Strided<'_, f32>,
     transpose: BlockTransposedRef<'_, f32, N>,
     norms: &[f32],
     rng: &mut dyn RngCore,

--- a/diskann-quantization/src/multi_vector/block_transposed.rs
+++ b/diskann-quantization/src/multi_vector/block_transposed.rs
@@ -81,7 +81,7 @@ use std::{alloc::Layout, marker::PhantomData, ptr::NonNull};
 
 use diskann_utils::{
     Reborrow, ReborrowMut,
-    strided::{self, Strided},
+    strided::Strided,
     views::{MatrixView, MutMatrixView},
 };
 
@@ -1142,7 +1142,7 @@ impl<T: Copy + Default, const GROUP: usize, const PACK: usize> BlockTransposed<T
         })
     }
 
-    /// Construct a block-transposed matrix by copying data from a [`strided::Ref`].
+    /// Construct a block-transposed matrix by copying data from a [`Strided`].
     ///
     /// Each source element at `(row, col)` is placed at the correct offset in the
     /// block-transposed layout. Padding positions (both partial-block rows and
@@ -1151,9 +1151,9 @@ impl<T: Copy + Default, const GROUP: usize, const PACK: usize> BlockTransposed<T
     ///
     /// The loop iterates in physical (block-transposed) order — block, column-group,
     /// row-within-block, pack-lane — so that writes to the backing allocation are
-    /// sequential. Source reads stride across rows of the [`strided::Ref`], which is
+    /// sequential. Source reads stride across rows of the [`Strided`], which is
     /// acceptable because read-side prefetch is more effective than write-side.
-    pub fn from_strided(v: strided::Ref<'_, T>) -> Self {
+    pub fn from_strided(v: Strided<'_, T>) -> Self {
         let nrows = v.nrows();
         let ncols = v.ncols();
         let mut mat = Self::new(nrows, ncols);
@@ -2136,8 +2136,6 @@ mod tests {
 
     #[test]
     fn test_from_strided_nonunit_stride() {
-        use diskann_utils::strided;
-
         const GROUP: usize = 4;
         const PACK: usize = 2;
         let nrows = 5;
@@ -2152,7 +2150,7 @@ mod tests {
             }
         }
 
-        let strided = strided::Ref::try_from_data(&flat, nrows, ncols, cstride)
+        let strided = Strided::try_from_data(&flat, nrows, ncols, cstride)
             .expect("should construct strided view");
         let transpose = BlockTransposed::<f32, GROUP, PACK>::from_strided(strided);
 

--- a/diskann-quantization/src/multi_vector/block_transposed.rs
+++ b/diskann-quantization/src/multi_vector/block_transposed.rs
@@ -81,7 +81,7 @@ use std::{alloc::Layout, marker::PhantomData, ptr::NonNull};
 
 use diskann_utils::{
     Reborrow, ReborrowMut,
-    strided::StridedView,
+    strided::{self, Strided},
     views::{MatrixView, MutMatrixView},
 };
 
@@ -1142,7 +1142,7 @@ impl<T: Copy + Default, const GROUP: usize, const PACK: usize> BlockTransposed<T
         })
     }
 
-    /// Construct a block-transposed matrix by copying data from a [`StridedView`].
+    /// Construct a block-transposed matrix by copying data from a [`strided::Ref`].
     ///
     /// Each source element at `(row, col)` is placed at the correct offset in the
     /// block-transposed layout. Padding positions (both partial-block rows and
@@ -1151,9 +1151,9 @@ impl<T: Copy + Default, const GROUP: usize, const PACK: usize> BlockTransposed<T
     ///
     /// The loop iterates in physical (block-transposed) order — block, column-group,
     /// row-within-block, pack-lane — so that writes to the backing allocation are
-    /// sequential. Source reads stride across rows of the [`StridedView`], which is
+    /// sequential. Source reads stride across rows of the [`strided::Ref`], which is
     /// acceptable because read-side prefetch is more effective than write-side.
-    pub fn from_strided(v: StridedView<'_, T>) -> Self {
+    pub fn from_strided(v: strided::Ref<'_, T>) -> Self {
         let nrows = v.nrows();
         let ncols = v.ncols();
         let mut mat = Self::new(nrows, ncols);
@@ -1175,7 +1175,7 @@ impl<T: Copy + Default, const GROUP: usize, const PACK: usize> BlockTransposed<T
                     let row = row_base + rib;
                     if row < nrows {
                         // SAFETY: row < nrows is checked by the enclosing `if` condition.
-                        let src_row = unsafe { v.get_row_unchecked(row) };
+                        let src_row = unsafe { v.row_unchecked(row) };
                         for p in 0..PACK {
                             let col = col_base + p;
                             if col < ncols {
@@ -2136,7 +2136,7 @@ mod tests {
 
     #[test]
     fn test_from_strided_nonunit_stride() {
-        use diskann_utils::strided::StridedView;
+        use diskann_utils::strided;
 
         const GROUP: usize = 4;
         const PACK: usize = 2;
@@ -2152,7 +2152,7 @@ mod tests {
             }
         }
 
-        let strided = StridedView::try_shrink_from(&flat, nrows, ncols, cstride)
+        let strided = strided::Ref::try_from_data(&flat, nrows, ncols, cstride)
             .expect("should construct strided view");
         let transpose = BlockTransposed::<f32, GROUP, PACK>::from_strided(strided);
 

--- a/diskann-quantization/src/product/tables/transposed/pivots.rs
+++ b/diskann-quantization/src/product/tables/transposed/pivots.rs
@@ -5,7 +5,7 @@
 
 use std::fmt;
 
-use diskann_utils::strided;
+use diskann_utils::strided::{self, Strided};
 use diskann_wide::{SIMDMask, SIMDMulAdd, SIMDPartialOrd, SIMDSelect, SIMDVector};
 
 use crate::{
@@ -21,9 +21,9 @@ diskann_wide::alias!(u32s = u32x8);
 /// Error types returned by Chunk construction.
 #[derive(Debug, Clone)]
 pub enum ChunkConstructionError {
-    /// A `StridedView` was provided with a dimension of zero.
+    /// A `strided::Ref` was provided with a dimension of zero.
     DimensionCannotBeZero,
-    /// A `StridedView` was provided with a length of zero.
+    /// A `strided::Ref` was provided with a length of zero.
     LengthCannotBeZero,
 }
 
@@ -220,7 +220,7 @@ impl Chunk {
     ///
     /// 1. `data.ncols() == 0`
     /// 2. `data.nrows() == 0`
-    pub(super) fn new(data: strided::StridedView<'_, f32>) -> Result<Self, ChunkConstructionError> {
+    pub(super) fn new(data: strided::Ref<'_, f32>) -> Result<Self, ChunkConstructionError> {
         // Error handling.
         if data.ncols() == 0 {
             return Err(ChunkConstructionError::DimensionCannotBeZero);
@@ -229,7 +229,7 @@ impl Chunk {
             return Err(ChunkConstructionError::LengthCannotBeZero);
         }
 
-        let square_norms = data.row_iter().map(kmeans::square_norm).collect();
+        let square_norms = data.rows().map(kmeans::square_norm).collect();
         let data = BlockTransposed::<f32, 16>::from_strided(data);
         Ok(Self { data, square_norms })
     }
@@ -346,9 +346,9 @@ impl Chunk {
     ///
     /// This method is generally more efficient to call.
     ///
-    /// **IMPORTANT**: The provided `StridedView` must have a length of `Self::batchsize()`.
+    /// **IMPORTANT**: The provided `strided::Ref` must have a length of `Self::batchsize()`.
     ///
-    /// Providing a `StridedView` as an argument allows the compiler to infer that each
+    /// Providing a `strided::Ref` as an argument allows the compiler to infer that each
     /// row in `x` has a strided offset from the base, allowing for better code generation.
     ///
     /// If the distances between a row in `x` and all centers is not finite, return
@@ -385,7 +385,7 @@ impl Chunk {
     /// inner products.
     pub(super) fn find_closest_batch<T>(
         &self,
-        x: strided::StridedView<'_, T>,
+        x: strided::Ref<'_, T>,
     ) -> [CompressionResult; Self::batchsize()]
     where
         T: Copy + Into<f32>,
@@ -394,7 +394,7 @@ impl Chunk {
         assert_eq!(
             x.nrows(),
             Self::batchsize(),
-            "argument StridedView must have a length of {}",
+            "argument strided::Ref must have a length of {}",
             Self::batchsize()
         );
 
@@ -437,7 +437,7 @@ impl Chunk {
             debug_assert!(k < x.ncols());
 
             // SAFETY:
-            // * `StridedView` indexing: We have checked in Assertion 1 that it is safe
+            // * `strided::Ref` indexing: We have checked in Assertion 1 that it is safe
             //   to index `x` at indices `0, 1, 2, and 3`.
             // * Inner slice indexing: It is the caller's responsibility to ensure that
             //   `k < x.dim()` so that indexing the slices return by `x.get_unchecked` are
@@ -449,19 +449,19 @@ impl Chunk {
                 (
                     f32s::splat(
                         diskann_wide::ARCH,
-                        <T as Into<f32>>::into(*x.get_row_unchecked(0).get_unchecked(k)),
+                        <T as Into<f32>>::into(*x.row_unchecked(0).get_unchecked(k)),
                     ),
                     f32s::splat(
                         diskann_wide::ARCH,
-                        <T as Into<f32>>::into(*x.get_row_unchecked(1).get_unchecked(k)),
+                        <T as Into<f32>>::into(*x.row_unchecked(1).get_unchecked(k)),
                     ),
                     f32s::splat(
                         diskann_wide::ARCH,
-                        <T as Into<f32>>::into(*x.get_row_unchecked(2).get_unchecked(k)),
+                        <T as Into<f32>>::into(*x.row_unchecked(2).get_unchecked(k)),
                     ),
                     f32s::splat(
                         diskann_wide::ARCH,
-                        <T as Into<f32>>::into(*x.get_row_unchecked(3).get_unchecked(k)),
+                        <T as Into<f32>>::into(*x.row_unchecked(3).get_unchecked(k)),
                     ),
                 )
             }
@@ -1198,19 +1198,14 @@ mod tests {
             let query_batch =
                 flatten(&[copy_query(0), copy_query(1), copy_query(2), copy_query(3)]);
 
-            let view = strided::StridedView::try_from(
-                query_batch.as_slice(),
-                Chunk::batchsize(),
-                dim,
-                dim,
-            )
-            .unwrap();
+            let view =
+                strided::Ref::try_from_data(query_batch.as_slice(), Chunk::batchsize(), dim, dim)
+                    .unwrap();
 
             // Make sure that the query batch was constructed correctly.
             assert_eq!(view.nrows(), Chunk::batchsize());
             assert_eq!(view.ncols(), dim);
-            for k in 0..view.nrows() {
-                let row = view.row(k);
+            for (k, row) in view.rows().enumerate() {
                 if k == j {
                     assert_eq!(
                         row, query,
@@ -1261,13 +1256,9 @@ mod tests {
                 maybe_broadcast(3, values[3]),
             ]);
 
-            let view = strided::StridedView::try_from(
-                query_batch.as_slice(),
-                Chunk::batchsize(),
-                dim,
-                dim,
-            )
-            .unwrap();
+            let view =
+                strided::Ref::try_from_data(query_batch.as_slice(), Chunk::batchsize(), dim, dim)
+                    .unwrap();
 
             let closest = chunk.find_closest_batch(view);
             // Lane `j` should not be okay. All other lanes should return the correct
@@ -1299,7 +1290,7 @@ mod tests {
         let mut data_aggregate = create_test_pattern(dim, total);
 
         let data = flatten(&data_aggregate);
-        let sliced = strided::StridedView::try_from(data.as_slice(), total, dim, dim).unwrap();
+        let sliced = strided::Ref::try_from_data(data.as_slice(), total, dim, dim).unwrap();
         let chunk = Chunk::new(sliced).unwrap();
 
         assert_eq!(chunk.num_centers(), total);
@@ -1309,7 +1300,7 @@ mod tests {
         for row in 0..sliced.nrows() {
             for col in 0..sliced.ncols() {
                 assert_eq!(
-                    sliced[(row, col)],
+                    *sliced.element_or_panic(row, col),
                     chunk.get(row, col),
                     "failed on row {} and col {}",
                     row,
@@ -1383,7 +1374,7 @@ mod tests {
         let last = data_aggregate.last().unwrap().clone();
         data_aggregate[0].clone_from(&last);
         let data = flatten(&data_aggregate);
-        let sliced = strided::StridedView::try_from(data.as_slice(), total, dim, dim).unwrap();
+        let sliced = strided::Ref::try_from_data(data.as_slice(), total, dim, dim).unwrap();
         let chunk = Chunk::new(sliced).unwrap();
 
         assert_eq!(chunk.num_centers(), total);
@@ -1447,7 +1438,7 @@ mod tests {
     #[test]
     fn test_chunk_construction_error() {
         // No dimensions
-        let chunk = Chunk::new(strided::StridedView::try_from(&[], 3, 0, 0).unwrap());
+        let chunk = Chunk::new(strided::Ref::try_from_data(&[], 3, 0, 0).unwrap());
         let err = chunk.unwrap_err();
         assert!(
             err.to_string()
@@ -1455,7 +1446,7 @@ mod tests {
         );
 
         // No length
-        let chunk = Chunk::new(strided::StridedView::try_from(&[], 0, 10, 10).unwrap());
+        let chunk = Chunk::new(strided::Ref::try_from_data(&[], 0, 10, 10).unwrap());
         let err = chunk.unwrap_err();
         assert!(
             err.to_string()
@@ -1470,7 +1461,7 @@ mod tests {
         let dim = 10;
         let total = 13;
         let data = flatten(&create_test_pattern(dim, total));
-        let sliced = strided::StridedView::try_from(data.as_slice(), total, dim, dim).unwrap();
+        let sliced = strided::Ref::try_from_data(data.as_slice(), total, dim, dim).unwrap();
         let chunk = Chunk::new(sliced).unwrap();
 
         let query: Vec<f32> = vec![0.0; total];
@@ -1486,12 +1477,12 @@ mod tests {
         let dim = 10;
         let total = 13;
         let data = flatten(&create_test_pattern(dim, total));
-        let sliced = strided::StridedView::try_from(data.as_slice(), total, dim, dim).unwrap();
+        let sliced = strided::Ref::try_from_data(data.as_slice(), total, dim, dim).unwrap();
         let chunk = Chunk::new(sliced).unwrap();
 
         let query: Vec<f32> = vec![0.0; 4 * total];
         let query_view =
-            strided::StridedView::try_from(query.as_slice(), Chunk::batchsize(), total, total)
+            strided::Ref::try_from_data(query.as_slice(), Chunk::batchsize(), total, total)
                 .unwrap();
 
         // PANICS
@@ -1500,17 +1491,17 @@ mod tests {
 
     // Make sure `find_closest_batch` panics for an incorrect length
     #[test]
-    #[should_panic(expected = "argument StridedView must have a length of")]
+    #[should_panic(expected = "argument strided::Ref must have a length of")]
     fn test_find_closest_batch_panics_on_non_batch_length() {
         let dim = 10;
         let total = 13;
         let data = flatten(&create_test_pattern(dim, total));
-        let sliced = strided::StridedView::try_from(data.as_slice(), total, dim, dim).unwrap();
+        let sliced = strided::Ref::try_from_data(data.as_slice(), total, dim, dim).unwrap();
         let chunk = Chunk::new(sliced).unwrap();
 
         let query: Vec<f32> = vec![0.0; (Chunk::batchsize() + 1) * dim];
         let query_view =
-            strided::StridedView::try_from(query.as_slice(), Chunk::batchsize() + 1, dim, dim)
+            strided::Ref::try_from_data(query.as_slice(), Chunk::batchsize() + 1, dim, dim)
                 .unwrap();
 
         // PANICS

--- a/diskann-quantization/src/product/tables/transposed/pivots.rs
+++ b/diskann-quantization/src/product/tables/transposed/pivots.rs
@@ -5,7 +5,7 @@
 
 use std::fmt;
 
-use diskann_utils::strided::{self, Strided};
+use diskann_utils::strided::Strided;
 use diskann_wide::{SIMDMask, SIMDMulAdd, SIMDPartialOrd, SIMDSelect, SIMDVector};
 
 use crate::{
@@ -21,9 +21,9 @@ diskann_wide::alias!(u32s = u32x8);
 /// Error types returned by Chunk construction.
 #[derive(Debug, Clone)]
 pub enum ChunkConstructionError {
-    /// A `strided::Ref` was provided with a dimension of zero.
+    /// A `Strided` was provided with a dimension of zero.
     DimensionCannotBeZero,
-    /// A `strided::Ref` was provided with a length of zero.
+    /// A `Strided` was provided with a length of zero.
     LengthCannotBeZero,
 }
 
@@ -220,7 +220,7 @@ impl Chunk {
     ///
     /// 1. `data.ncols() == 0`
     /// 2. `data.nrows() == 0`
-    pub(super) fn new(data: strided::Ref<'_, f32>) -> Result<Self, ChunkConstructionError> {
+    pub(super) fn new(data: Strided<'_, f32>) -> Result<Self, ChunkConstructionError> {
         // Error handling.
         if data.ncols() == 0 {
             return Err(ChunkConstructionError::DimensionCannotBeZero);
@@ -346,9 +346,9 @@ impl Chunk {
     ///
     /// This method is generally more efficient to call.
     ///
-    /// **IMPORTANT**: The provided `strided::Ref` must have a length of `Self::batchsize()`.
+    /// **IMPORTANT**: The provided `Strided` must have a length of `Self::batchsize()`.
     ///
-    /// Providing a `strided::Ref` as an argument allows the compiler to infer that each
+    /// Providing a `Strided` as an argument allows the compiler to infer that each
     /// row in `x` has a strided offset from the base, allowing for better code generation.
     ///
     /// If the distances between a row in `x` and all centers is not finite, return
@@ -385,7 +385,7 @@ impl Chunk {
     /// inner products.
     pub(super) fn find_closest_batch<T>(
         &self,
-        x: strided::Ref<'_, T>,
+        x: Strided<'_, T>,
     ) -> [CompressionResult; Self::batchsize()]
     where
         T: Copy + Into<f32>,
@@ -394,7 +394,7 @@ impl Chunk {
         assert_eq!(
             x.nrows(),
             Self::batchsize(),
-            "argument strided::Ref must have a length of {}",
+            "argument Strided must have a length of {}",
             Self::batchsize()
         );
 
@@ -437,7 +437,7 @@ impl Chunk {
             debug_assert!(k < x.ncols());
 
             // SAFETY:
-            // * `strided::Ref` indexing: We have checked in Assertion 1 that it is safe
+            // * `Strided` indexing: We have checked in Assertion 1 that it is safe
             //   to index `x` at indices `0, 1, 2, and 3`.
             // * Inner slice indexing: It is the caller's responsibility to ensure that
             //   `k < x.dim()` so that indexing the slices return by `x.get_unchecked` are
@@ -1198,9 +1198,8 @@ mod tests {
             let query_batch =
                 flatten(&[copy_query(0), copy_query(1), copy_query(2), copy_query(3)]);
 
-            let view =
-                strided::Ref::try_from_data(query_batch.as_slice(), Chunk::batchsize(), dim, dim)
-                    .unwrap();
+            let view = Strided::try_from_data(query_batch.as_slice(), Chunk::batchsize(), dim, dim)
+                .unwrap();
 
             // Make sure that the query batch was constructed correctly.
             assert_eq!(view.nrows(), Chunk::batchsize());
@@ -1256,9 +1255,8 @@ mod tests {
                 maybe_broadcast(3, values[3]),
             ]);
 
-            let view =
-                strided::Ref::try_from_data(query_batch.as_slice(), Chunk::batchsize(), dim, dim)
-                    .unwrap();
+            let view = Strided::try_from_data(query_batch.as_slice(), Chunk::batchsize(), dim, dim)
+                .unwrap();
 
             let closest = chunk.find_closest_batch(view);
             // Lane `j` should not be okay. All other lanes should return the correct
@@ -1290,7 +1288,7 @@ mod tests {
         let mut data_aggregate = create_test_pattern(dim, total);
 
         let data = flatten(&data_aggregate);
-        let sliced = strided::Ref::try_from_data(data.as_slice(), total, dim, dim).unwrap();
+        let sliced = Strided::try_from_data(data.as_slice(), total, dim, dim).unwrap();
         let chunk = Chunk::new(sliced).unwrap();
 
         assert_eq!(chunk.num_centers(), total);
@@ -1374,7 +1372,7 @@ mod tests {
         let last = data_aggregate.last().unwrap().clone();
         data_aggregate[0].clone_from(&last);
         let data = flatten(&data_aggregate);
-        let sliced = strided::Ref::try_from_data(data.as_slice(), total, dim, dim).unwrap();
+        let sliced = Strided::try_from_data(data.as_slice(), total, dim, dim).unwrap();
         let chunk = Chunk::new(sliced).unwrap();
 
         assert_eq!(chunk.num_centers(), total);
@@ -1438,7 +1436,7 @@ mod tests {
     #[test]
     fn test_chunk_construction_error() {
         // No dimensions
-        let chunk = Chunk::new(strided::Ref::try_from_data(&[], 3, 0, 0).unwrap());
+        let chunk = Chunk::new(Strided::try_from_data(&[], 3, 0, 0).unwrap());
         let err = chunk.unwrap_err();
         assert!(
             err.to_string()
@@ -1446,7 +1444,7 @@ mod tests {
         );
 
         // No length
-        let chunk = Chunk::new(strided::Ref::try_from_data(&[], 0, 10, 10).unwrap());
+        let chunk = Chunk::new(Strided::try_from_data(&[], 0, 10, 10).unwrap());
         let err = chunk.unwrap_err();
         assert!(
             err.to_string()
@@ -1461,7 +1459,7 @@ mod tests {
         let dim = 10;
         let total = 13;
         let data = flatten(&create_test_pattern(dim, total));
-        let sliced = strided::Ref::try_from_data(data.as_slice(), total, dim, dim).unwrap();
+        let sliced = Strided::try_from_data(data.as_slice(), total, dim, dim).unwrap();
         let chunk = Chunk::new(sliced).unwrap();
 
         let query: Vec<f32> = vec![0.0; total];
@@ -1477,13 +1475,12 @@ mod tests {
         let dim = 10;
         let total = 13;
         let data = flatten(&create_test_pattern(dim, total));
-        let sliced = strided::Ref::try_from_data(data.as_slice(), total, dim, dim).unwrap();
+        let sliced = Strided::try_from_data(data.as_slice(), total, dim, dim).unwrap();
         let chunk = Chunk::new(sliced).unwrap();
 
         let query: Vec<f32> = vec![0.0; 4 * total];
         let query_view =
-            strided::Ref::try_from_data(query.as_slice(), Chunk::batchsize(), total, total)
-                .unwrap();
+            Strided::try_from_data(query.as_slice(), Chunk::batchsize(), total, total).unwrap();
 
         // PANICS
         chunk.find_closest_batch(query_view);
@@ -1491,18 +1488,17 @@ mod tests {
 
     // Make sure `find_closest_batch` panics for an incorrect length
     #[test]
-    #[should_panic(expected = "argument strided::Ref must have a length of")]
+    #[should_panic(expected = "argument Strided must have a length of")]
     fn test_find_closest_batch_panics_on_non_batch_length() {
         let dim = 10;
         let total = 13;
         let data = flatten(&create_test_pattern(dim, total));
-        let sliced = strided::Ref::try_from_data(data.as_slice(), total, dim, dim).unwrap();
+        let sliced = Strided::try_from_data(data.as_slice(), total, dim, dim).unwrap();
         let chunk = Chunk::new(sliced).unwrap();
 
         let query: Vec<f32> = vec![0.0; (Chunk::batchsize() + 1) * dim];
         let query_view =
-            strided::Ref::try_from_data(query.as_slice(), Chunk::batchsize() + 1, dim, dim)
-                .unwrap();
+            Strided::try_from_data(query.as_slice(), Chunk::batchsize() + 1, dim, dim).unwrap();
 
         // PANICS
         chunk.find_closest_batch(query_view);

--- a/diskann-quantization/src/product/tables/transposed/table.rs
+++ b/diskann-quantization/src/product/tables/transposed/table.rs
@@ -12,7 +12,7 @@ use crate::{
     views::{ChunkOffsets, ChunkOffsetsView},
 };
 use diskann_utils::{
-    strided,
+    strided::Strided,
     views::{self, MatrixView, MutMatrixView},
 };
 use thiserror::Error;
@@ -89,7 +89,7 @@ impl TransposedTable {
             .map(|i| {
                 let range = offsets.at(i);
                 largest = largest.max(range.len());
-                let view = strided::Ref::try_from_data(
+                let view = Strided::try_from_data(
                     &(pivots.as_slice()[range.start..]),
                     pivots.nrows(),
                     range.len(),

--- a/diskann-quantization/src/product/tables/transposed/table.rs
+++ b/diskann-quantization/src/product/tables/transposed/table.rs
@@ -89,7 +89,7 @@ impl TransposedTable {
             .map(|i| {
                 let range = offsets.at(i);
                 largest = largest.max(range.len());
-                let view = strided::StridedView::try_shrink_from(
+                let view = strided::Ref::try_from_data(
                     &(pivots.as_slice()[range.start..]),
                     pivots.nrows(),
                     range.len(),

--- a/diskann-quantization/src/product/train.rs
+++ b/diskann-quantization/src/product/train.rs
@@ -4,7 +4,7 @@
  */
 
 use diskann_utils::{
-    strided::{self, Strided},
+    strided::Strided,
     views::{self, Matrix},
 };
 #[cfg(feature = "rayon")]
@@ -153,7 +153,7 @@ impl TrainQuantizer for LightPQTrainingParameters {
                 // the remaining tasks to exit early.
                 exit_if_canceled()?;
 
-                let view = strided::Ref::try_from_data(
+                let view = Strided::try_from_data(
                     &(data.as_slice()[range.start..]),
                     data.nrows(),
                     range.len(),

--- a/diskann-quantization/src/product/train.rs
+++ b/diskann-quantization/src/product/train.rs
@@ -4,7 +4,7 @@
  */
 
 use diskann_utils::{
-    strided::StridedView,
+    strided::{self, Strided},
     views::{self, Matrix},
 };
 #[cfg(feature = "rayon")]
@@ -153,7 +153,7 @@ impl TrainQuantizer for LightPQTrainingParameters {
                 // the remaining tasks to exit early.
                 exit_if_canceled()?;
 
-                let view = StridedView::try_shrink_from(
+                let view = strided::Ref::try_from_data(
                     &(data.as_slice()[range.start..]),
                     data.nrows(),
                     range.len(),
@@ -163,11 +163,11 @@ impl TrainQuantizer for LightPQTrainingParameters {
                     chunk: i,
                     of: schema.len(),
                     dim: range.len(),
-                    kind: PQTrainingErrorKind::InternalError(Box::new(err.as_static())),
+                    kind: PQTrainingErrorKind::InternalError(Box::new(err)),
                 })?;
 
                 // Allocate scratch data structures.
-                let norms: Vec<f32> = view.row_iter().map(square_norm).collect();
+                let norms: Vec<f32> = view.rows().map(square_norm).collect();
                 let transpose = BlockTransposed::<f32, 16>::from_strided(view);
                 let mut centers = Matrix::new(0.0, trainer.ncenters, range.len());
 

--- a/diskann-utils/src/internal.rs
+++ b/diskann-utils/src/internal.rs
@@ -4,6 +4,6 @@
  */
 
 pub(crate) fn slice_to_nonnull<T>(s: &[T]) -> std::ptr::NonNull<T> {
-    // SAFETY: sliced are guaranteed to have non-null base pointers.
+    // SAFETY: slices are guaranteed to have non-null base pointers.
     unsafe { std::ptr::NonNull::new_unchecked(s.as_ptr().cast_mut()) }
 }

--- a/diskann-utils/src/internal.rs
+++ b/diskann-utils/src/internal.rs
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+pub(crate) fn slice_to_nonnull<T>(s: &[T]) -> std::ptr::NonNull<T> {
+    // SAFETY: sliced are guaranteed to have non-null base pointers.
+    unsafe { std::ptr::NonNull::new_unchecked(s.as_ptr().cast_mut()) }
+}

--- a/diskann-utils/src/lib.rs
+++ b/diskann-utils/src/lib.rs
@@ -24,6 +24,8 @@ pub mod views;
 mod lazystring;
 pub use lazystring::LazyString;
 
+mod internal;
+
 #[cfg(feature = "testing")]
 #[doc(hidden)]
 pub fn workspace_root() -> std::path::PathBuf {

--- a/diskann-utils/src/strided.rs
+++ b/diskann-utils/src/strided.rs
@@ -214,7 +214,7 @@ impl<'a, T> Strided<'a, T> {
     pub fn as_slice(&self) -> &[T] {
         let layout = self.layout();
 
-        // SAFETY: Constructors verify that the backing memory has a length as least
+        // SAFETY: Constructors verify that the backing memory has a length at least
         // `layout.linear_length()`.
         unsafe { std::slice::from_raw_parts(self.as_ptr(), layout.linear_length()) }
     }
@@ -325,7 +325,7 @@ impl<'a, T> Strided<'a, T> {
     }
 }
 
-/// Errors for [`Strided::new`].
+/// Errors for [`Strided::try_from_data`].
 #[derive(Debug, Error)]
 pub enum TryFromError {
     #[error(transparent)]

--- a/diskann-utils/src/strided.rs
+++ b/diskann-utils/src/strided.rs
@@ -5,11 +5,17 @@
 
 use std::{
     fmt,
+    marker::PhantomData,
+    num::NonZeroUsize,
     ops::{Index, IndexMut},
+    ptr::NonNull,
 };
 use thiserror::Error;
 
-use crate::views::{self, DenseData, MutDenseData};
+use crate::{
+    views::{self, DenseData, MutDenseData},
+    Reborrow, ReborrowMut,
+};
 
 /// A row-major strided matrix.
 ///
@@ -36,484 +42,991 @@ use crate::views::{self, DenseData, MutDenseData};
 /// compression as it provides a convenient abstraction for working with columnar subsets
 /// of dense data in-place.
 #[derive(Debug, Clone, Copy)]
-pub struct StridedBase<T>
-where
-    T: DenseData,
-{
-    data: T,
-    nrows: usize,
-    ncols: usize,
-    // The stride along the columns. This must be greater than or equal to `ncols`.
-    cstride: usize,
-}
-
-/// Return the linear length of a slice underlying a `StridedBase` with the given parameters.
-pub fn linear_length(nrows: usize, ncols: usize, cstride: usize) -> usize {
-    (nrows.max(1) - 1) * cstride + nrows.min(1) * ncols
-}
-
-#[derive(Debug, Error)]
-#[non_exhaustive]
-#[error(
-    "tried to construct a strided matrix with {nrows} rows and {ncols} cols and \
-     column stride {cstride} over a slice of length {} (expected {})",
-     len,
-     linear_length(self.nrows, self.ncols, self.cstride)
-)]
-pub struct TryFromErrorLight {
-    len: usize,
+pub struct Layout {
     nrows: usize,
     ncols: usize,
     cstride: usize,
 }
 
-#[derive(Error)]
-#[non_exhaustive]
-#[error(
-    "tried to construct a strided matrix with {nrows} rows and {ncols} cols and \
-     column stride {cstride} over a slice of length {} (expected {})",
-     data.as_slice().len(),
-     linear_length(self.nrows, self.ncols, self.cstride)
-)]
-pub struct TryFromError<T: views::DenseData> {
-    data: T,
-    nrows: usize,
-    ncols: usize,
-    cstride: usize,
-}
-
-// Manually implement `fmt::Debug` so we don't require `T::Debug`.
-impl<T: DenseData> fmt::Debug for TryFromError<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TryFromError")
-            .field("data_len", &self.data.as_slice().len())
-            .field("nrows", &self.nrows)
-            .field("ncols", &self.ncols)
-            .field("cstride", &self.cstride)
-            .finish()
-    }
-}
-
-impl<T: views::DenseData> TryFromError<T> {
-    /// Consume the error and return the base data.
-    pub fn into_inner(self) -> T {
-        self.data
+impl Layout {
+    pub fn new(nrows: usize, ncols: usize, cstride: usize) -> Result<Self, LayoutError> {
+        LayoutError::check(nrows, ncols, cstride)?;
+        Ok(Self {
+            nrows,
+            ncols,
+            cstride,
+        })
     }
 
-    /// Drop the data portion of the error and return an equivalent error that is guaranteed
-    /// to be `'static`.
-    pub fn as_static(&self) -> TryFromErrorLight {
-        TryFromErrorLight {
-            len: self.data.as_slice().len(),
-            nrows: self.nrows,
-            ncols: self.ncols,
-            cstride: self.cstride,
-        }
-    }
-}
-
-impl<'a, T> StridedBase<&'a [T]> {
-    /// Construct a strided view over data slice, shrinking the slice as needed.
-    ///
-    /// Returns an error if `data` is shorter than the value returned by `linear_length`.
-    ///
-    /// # Panics
-    ///
-    /// * Panics if `cstride < ncols`.
-    pub fn try_shrink_from(
-        data: &'a [T],
-        nrows: usize,
-        ncols: usize,
-        cstride: usize,
-    ) -> Result<Self, TryFromError<&'a [T]>> {
-        assert!(
-            cstride >= ncols,
-            "cstride must be greater than or equal to ncols"
-        );
-        let required_length = linear_length(nrows, ncols, cstride);
-        match data.get(..required_length) {
-            Some(data) => Ok(Self {
-                data,
-                nrows,
-                ncols,
-                cstride,
-            }),
-            None => Err(TryFromError {
-                data,
-                nrows,
-                ncols,
-                cstride,
-            }),
-        }
-    }
-}
-
-impl<'a, T> StridedBase<&'a mut [T]> {
-    /// Construct a strided view over data slice, shrinking the slice as needed.
-    ///
-    /// Returns an error if `data` is shorter than the value returned by `linear_length`.
-    ///
-    /// # Panics
-    ///
-    /// * Panics if `cstride < ncols`.
-    pub fn try_shrink_from_mut(
-        data: &'a mut [T],
-        nrows: usize,
-        ncols: usize,
-        cstride: usize,
-    ) -> Result<Self, TryFromError<&'a mut [T]>> {
-        assert!(
-            cstride >= ncols,
-            "cstride must be greater than or equal to ncols"
-        );
-        let required_length = linear_length(nrows, ncols, cstride);
-        if data.as_slice().len() >= required_length {
-            Ok(Self {
-                data: &mut data[..required_length],
-                nrows,
-                ncols,
-                cstride,
-            })
-        } else {
-            Err(TryFromError {
-                data,
-                nrows,
-                ncols,
-                cstride,
-            })
-        }
-    }
-}
-
-impl<T> StridedBase<T>
-where
-    T: DenseData,
-{
-    /// Construct a strided view over data slice, shrinking the slice as needed.
-    ///
-    /// Returns an error if `data` is not equal to the expected length as determined
-    /// by `linear_length`.
-    ///
-    /// # Panics
-    ///
-    /// * Panics if `cstride < ncols`.
-    pub fn try_from(
-        data: T,
-        nrows: usize,
-        ncols: usize,
-        cstride: usize,
-    ) -> Result<Self, TryFromError<T>> {
-        assert!(
-            cstride >= ncols,
-            "cstride must be greater than or equal to ncols"
-        );
-        // This computation needs to be set up such that:
-        // 1. When `nrows == 0`, the expected length is 0.
-        // 2. We make a tight upper-bound on the expected length for the last row.
-        let required_length = linear_length(nrows, ncols, cstride);
-        if data.as_slice().len() == required_length {
-            Ok(Self {
-                data,
-                nrows,
-                ncols,
-                cstride,
-            })
-        } else {
-            Err(TryFromError {
-                data,
-                nrows,
-                ncols,
-                cstride,
-            })
-        }
+    pub fn new_for<T>(nrows: usize, ncols: usize, cstride: usize) -> Result<Self, LayoutError> {
+        LayoutError::check_for::<T>(nrows, ncols, cstride)?;
+        Ok(Self {
+            nrows,
+            ncols,
+            cstride,
+        })
     }
 
-    /// Return the number of columns in the matrix.
-    pub fn ncols(&self) -> usize {
-        self.ncols
-    }
-
-    /// Return the number of rows in the matrix.
     pub fn nrows(&self) -> usize {
         self.nrows
     }
 
-    /// Return the count of elements between the start of each row.
+    pub fn ncols(&self) -> usize {
+        self.ncols
+    }
+
     pub fn cstride(&self) -> usize {
         self.cstride
     }
 
-    /// Return the underlying data as a slice.
-    ///
-    /// # Note
-    ///
-    /// The underlying representation for a strided matrix is not necessarily dense.
-    pub fn as_slice(&self) -> &[T::Elem] {
-        self.data.as_slice()
+    pub fn linear_length(&self) -> usize {
+        self.nrows.saturating_sub(1) * self.cstride + self.nrows.min(1) * self.ncols
     }
+}
 
-    /// Return the underlying data as a slice.
-    ///
-    /// # Note
-    ///
-    /// The underlying representation for a strided matrix is not necessarily dense.
-    pub fn as_mut_slice(&mut self) -> &mut [T::Elem]
-    where
-        T: MutDenseData,
-    {
-        self.data.as_mut_slice()
-    }
+fn __linear_length(nrows: usize, ncols: usize, cstride: usize) -> Option<usize> {
+    nrows
+        .saturating_sub(1)
+        .checked_mul(cstride)
+        .and_then(|main| main.checked_add(nrows.min(1) * ncols))
+}
 
-    /// Return row `row` as a slice.
-    ///
-    /// # Panic
-    ///
-    /// Panics if `row >= self.nrows()`.
-    pub fn row(&self, row: usize) -> &[T::Elem] {
-        assert!(
-            row < self.nrows(),
-            "tried to access row {row} of a matrix with {} rows",
-            self.nrows()
-        );
+#[derive(Debug)]
+pub struct LayoutError(LayoutErrorInner);
 
-        // SAFETY: `row` is in-bounds.
-        unsafe { self.get_row_unchecked(row) }
-    }
-
-    /// Returns the requested row without boundschecking.
-    ///
-    /// # Safety
-    ///
-    /// The following conditions must hold to avoid undefined behavior:
-    /// * `row < self.nrows()`.
-    pub unsafe fn get_row_unchecked(&self, row: usize) -> &[T::Elem] {
-        debug_assert!(row < self.nrows);
-        let cstride = self.cstride;
-        let ncols = self.ncols;
-        let start = row * cstride;
-
-        debug_assert!(start + ncols <= self.as_slice().len());
-        // SAFETY: The idempotency requirement of `as_slice` and our audited constructors
-        // mean that `self.as_slice()` has a length of `self.nrows * self.ncols`.
-        //
-        // Therefore, this access is in-bounds.
-        unsafe { self.as_slice().get_unchecked(start..start + ncols) }
-    }
-
-    /// Return row `row` as a mutable slice.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `row >= self.nrows()`.
-    pub fn row_mut(&mut self, row: usize) -> &mut [T::Elem]
-    where
-        T: MutDenseData,
-    {
-        assert!(
-            row < self.nrows(),
-            "tried to access row {row} of a matrix with {} rows",
-            self.nrows()
-        );
-
-        // SAFETY: `row` is in-bounds.
-        unsafe { self.get_row_unchecked_mut(row) }
-    }
-
-    /// Returns the requested row without boundschecking.
-    ///
-    /// # Safety
-    ///
-    /// The following conditions must hold to avoid undefined behavior:
-    /// * `row < self.nrows()`.
-    pub unsafe fn get_row_unchecked_mut(&mut self, row: usize) -> &mut [T::Elem]
-    where
-        T: MutDenseData,
-    {
-        debug_assert!(row < self.nrows);
-        let cstride = self.cstride;
-        let ncols = self.ncols;
-        let start = row * cstride;
-
-        debug_assert!(start + ncols <= self.as_slice().len());
-        // SAFETY: The idempotency requirement of `as_mut_slice` and our audited constructors
-        // mean that `self.as_mut_slice()` has a length of `self.nrows * self.ncols`.
-        //
-        // Therefore, this access is in-bounds.
-        unsafe {
-            self.data
-                .as_mut_slice()
-                .get_unchecked_mut(start..start + ncols)
+impl LayoutError {
+    fn check(nrows: usize, ncols: usize, cstride: usize) -> Result<usize, Self> {
+        if cstride < ncols {
+            Err(Self(LayoutErrorInner::InvalidStride { ncols, cstride }))
+        } else {
+            __linear_length(nrows, ncols, cstride).ok_or(Self(LayoutErrorInner::Overflow {
+                nrows,
+                cstride,
+                elsize: None,
+            }))
         }
     }
 
-    /// Return a iterator over all rows in the matrix.
-    ///
-    /// Rows are yielded sequentially beginning with row 0.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `self.ncols() == 0` (because the implementation does not work correctly
-    /// in this case and it's too corner-case to bother fixing). This restriction may
-    /// be lifted in the future.
-    pub fn row_iter(&self) -> impl Iterator<Item = &[T::Elem]> {
-        assert!(self.ncols() != 0);
-        let ncols = self.ncols;
+    fn check_for<T>(nrows: usize, ncols: usize, cstride: usize) -> Result<(), Self> {
+        let len = Self::check(nrows, ncols, cstride)?;
 
-        self.data
-            .as_slice()
+        let elsize = std::mem::size_of::<T>();
+        if let Some(bytes) = len.checked_mul(elsize) {
+            if bytes <= isize::MAX as usize {
+                return Ok(());
+            }
+        }
+
+        Err(Self(LayoutErrorInner::Overflow {
+            nrows,
+            cstride,
+            elsize: NonZeroUsize::new(elsize),
+        }))
+    }
+}
+
+impl fmt::Display for LayoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::error::Error for LayoutError {}
+
+#[derive(Debug)]
+enum LayoutErrorInner {
+    InvalidStride {
+        ncols: usize,
+        cstride: usize,
+    },
+    Overflow {
+        nrows: usize,
+        cstride: usize,
+        elsize: Option<NonZeroUsize>,
+    },
+}
+
+impl fmt::Display for LayoutErrorInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidStride { ncols, cstride } => write!(
+                f,
+                "column strice {} must be greater than or equal to number of columns {}",
+                cstride, ncols
+            ),
+
+            Self::Overflow {
+                nrows,
+                cstride,
+                elsize,
+            } => match elsize {
+                None => write!(
+                    f,
+                    "a {}x{} strided matrix has a length exceeding usize::MAX",
+                    nrows, cstride
+                ),
+
+                Some(elsize) => write!(
+                    f,
+                    "a {}x{} strided matrix with elements of size {} exceeds isize::MAX bytes",
+                    nrows, cstride, elsize,
+                ),
+            },
+        }
+    }
+}
+
+pub unsafe trait Strided {
+    type Element;
+
+    fn as_nonnull(&self) -> NonNull<Self::Element>;
+    fn layout(&self) -> Layout;
+
+    //----------//
+    // Provided //
+    //----------//
+
+    fn as_ptr(&self) -> *const Self::Element {
+        self.as_nonnull().as_ptr().cast_const()
+    }
+
+    fn ncols(&self) -> usize {
+        self.layout().ncols()
+    }
+
+    fn nrows(&self) -> usize {
+        self.layout().nrows()
+    }
+
+    fn cstride(&self) -> usize {
+        self.layout().cstride()
+    }
+
+    fn as_slice(&self) -> &[Self::Element] {
+        let layout = self.layout();
+        unsafe { std::slice::from_raw_parts(self.as_ptr(), layout.linear_length()) }
+    }
+
+    // Element Access
+
+    unsafe fn element_unchecked(&self, row: usize, col: usize) -> &Self::Element {
+        let layout = self.layout();
+        debug_assert!(row < layout.nrows());
+        debug_assert!(col < layout.ncols());
+
+        unsafe { &*self.as_ptr().add(layout.cstride() * row + col) }
+    }
+
+    fn element(&self, row: usize, col: usize) -> Option<&Self::Element> {
+        if row < self.nrows() && col < self.ncols() {
+            Some(unsafe { self.element_unchecked(row, col) })
+        } else {
+            None
+        }
+    }
+
+    fn element_or_panic(&self, row: usize, col: usize) -> &Self::Element {
+        assert!(row < self.nrows());
+        assert!(col < self.ncols());
+
+        unsafe { self.element_unchecked(row, col) }
+    }
+
+    // Row Access
+
+    unsafe fn row_unchecked(&self, row: usize) -> &[Self::Element] {
+        let layout = self.layout();
+        debug_assert!(row < layout.nrows());
+
+        unsafe {
+            std::slice::from_raw_parts(self.as_ptr().add(layout.cstride() * row), layout.ncols())
+        }
+    }
+
+    fn row(&self, row: usize) -> Option<&[Self::Element]> {
+        if row < self.nrows() {
+            Some(unsafe { self.row_unchecked(row) })
+        } else {
+            None
+        }
+    }
+
+    fn row_or_panic(&self, row: usize) -> &[Self::Element] {
+        assert!(row < self.nrows());
+        unsafe { self.row_unchecked(row) }
+    }
+
+    fn rows(&self) -> impl Iterator<Item = &[Self::Element]> {
+        assert!(self.ncols() != 0);
+
+        let ncols = self.ncols();
+        self.as_slice()
             .chunks(self.cstride())
             .map(move |i| &i[..ncols])
     }
 
-    /// Return a mutable iterator over all rows in the matrix.
-    ///
-    /// Rows are yielded sequentially beginning with row 0.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `self.ncols() == 0` (because the implementation does not work correctly
-    /// in this case and it's too corner-case to bother fixing). This restriction may
-    /// be lifted in the future.
-    pub fn row_iter_mut(&mut self) -> impl Iterator<Item = &mut [T::Elem]>
-    where
-        T: MutDenseData,
-    {
+    // Reborrow
+
+    fn as_view(&self) -> Ref<'_, Self::Element> {
+        Ref {
+            ptr: self.as_nonnull(),
+            layout: self.layout(),
+            _lifetime: PhantomData,
+        }
+    }
+}
+
+pub unsafe trait StridedMut: Strided {
+    //----------//
+    // Provided //
+    //----------//
+
+    fn as_mut_ptr(&self) -> *mut Self::Element {
+        self.as_nonnull().as_ptr()
+    }
+
+    fn as_mut_slice(&mut self) -> &mut [Self::Element] {
+        unsafe { std::slice::from_raw_parts_mut(self.as_mut_ptr(), self.layout().linear_length()) }
+    }
+
+    // Element Access
+
+    unsafe fn element_mut_unchecked(&mut self, row: usize, col: usize) -> &mut Self::Element {
+        let layout = self.layout();
+        debug_assert!(row < layout.nrows());
+        debug_assert!(col < layout.ncols());
+
+        unsafe { &mut *self.as_mut_ptr().add(layout.cstride() * row + col) }
+    }
+
+    fn element_mut(&mut self, row: usize, col: usize) -> Option<&mut Self::Element> {
+        if row < self.nrows() && col < self.ncols() {
+            Some(unsafe { self.element_mut_unchecked(row, col) })
+        } else {
+            None
+        }
+    }
+
+    fn element_mut_or_panic(&mut self, row: usize, col: usize) -> &mut Self::Element {
+        assert!(row < self.nrows());
+        assert!(col < self.ncols());
+
+        unsafe { self.element_mut_unchecked(row, col) }
+    }
+
+    // Row Access
+
+    unsafe fn row_mut_unchecked(&mut self, row: usize) -> &mut [Self::Element] {
+        let layout = self.layout();
+        debug_assert!(row < layout.nrows());
+
+        unsafe {
+            std::slice::from_raw_parts_mut(
+                self.as_mut_ptr().add(layout.cstride() * row),
+                layout.ncols(),
+            )
+        }
+    }
+
+    fn row_mut(&mut self, row: usize) -> Option<&mut [Self::Element]> {
+        if row < self.nrows() {
+            Some(unsafe { self.row_mut_unchecked(row) })
+        } else {
+            None
+        }
+    }
+
+    fn row_mut_or_panic(&mut self, row: usize) -> &mut [Self::Element] {
+        assert!(row < self.nrows());
+        unsafe { self.row_mut_unchecked(row) }
+    }
+
+    fn rows_mut(&mut self) -> impl Iterator<Item = &mut [Self::Element]> {
         assert!(self.ncols() != 0);
 
         let ncols = self.ncols();
         let cstride = self.cstride();
-        self.data
-            .as_mut_slice()
+        self.as_mut_slice()
             .chunks_mut(cstride)
             .map(move |i| &mut i[..ncols])
     }
 
-    /// Return a pointer to the base of the matrix.
-    pub fn as_ptr(&self) -> *const T::Elem {
-        self.as_slice().as_ptr()
-    }
+    // Reborrow
 
-    /// Return a pointer to the base of the matrix.
-    pub fn as_mut_ptr(&mut self) -> *mut T::Elem
-    where
-        T: MutDenseData,
-    {
-        self.as_mut_slice().as_mut_ptr()
-    }
-
-    /// Returns a reference to an element without boundschecking.
-    ///
-    /// # Safety
-    ///
-    /// The following conditions must hold to avoid undefined behavior:
-    /// * `row < self.nrows()`.
-    /// * `col < self.ncols()`.
-    pub unsafe fn get_unchecked(&self, row: usize, col: usize) -> &T::Elem {
-        debug_assert!(row < self.nrows);
-        debug_assert!(col < self.ncols);
-        self.as_slice().get_unchecked(row * self.cstride + col)
-    }
-
-    /// Returns a mutable reference to an element without boundschecking.
-    ///
-    /// # Safety
-    ///
-    /// The following conditions must hold to avoid undefined behavior:
-    /// * `row < self.nrows()`.
-    /// * `col < self.ncols()`.
-    pub unsafe fn get_unchecked_mut(&mut self, row: usize, col: usize) -> &mut T::Elem
-    where
-        T: MutDenseData,
-    {
-        let cstride = self.cstride;
-        debug_assert!(row < self.nrows);
-        debug_assert!(col < self.ncols);
-        self.as_mut_slice().get_unchecked_mut(row * cstride + col)
-    }
-
-    /// Return a view over the matrix.
-    pub fn as_view(&self) -> StridedView<'_, T::Elem> {
-        StridedView {
-            data: self.as_slice(),
-            nrows: self.nrows,
-            ncols: self.ncols,
-            cstride: self.cstride,
+    fn as_mut_view(&mut self) -> Mut<'_, Self::Element> {
+        Mut {
+            ptr: self.as_nonnull(),
+            layout: self.layout(),
+            _lifetime: PhantomData,
         }
     }
 }
 
-pub type StridedView<'a, T> = StridedBase<&'a [T]>;
-pub type MutStridedView<'a, T> = StridedBase<&'a mut [T]>;
-
-/// Return a reference to the item at entry `(row, col)` in the matrix.
-///
-/// # Panics
-///
-/// Panics if `row >= self.nrows()` or `col >= self.ncols()`.
-impl<T> Index<(usize, usize)> for StridedBase<T>
-where
-    T: DenseData,
-{
-    type Output = T::Elem;
-
-    fn index(&self, (row, col): (usize, usize)) -> &Self::Output {
-        assert!(
-            row < self.nrows(),
-            "row {row} is out of bounds (max: {})",
-            self.nrows()
-        );
-        assert!(
-            col < self.ncols(),
-            "col {col} is out of bounds (max: {})",
-            self.ncols()
-        );
-        // SAFETY: We have checked that `row` and `col` are in-bounds.
-        unsafe { self.get_unchecked(row, col) }
-    }
+#[derive(Debug, Error)]
+pub enum TryFromError {
+    #[error(transparent)]
+    LayoutError(LayoutError),
+    #[error(
+        "argument of length {} is shorter than the expected length {}",
+        got,
+        expected
+    )]
+    InvalidLength { got: usize, expected: usize },
 }
 
-/// Return a mutable reference to the item at entry `(row, col)` in the matrix.
-///
-/// # Panics
-///
-/// Panics if `row >= self.nrows()` or `col >= self.ncols()`.
-impl<T> IndexMut<(usize, usize)> for StridedBase<T>
-where
-    T: MutDenseData,
-{
-    fn index_mut(&mut self, (row, col): (usize, usize)) -> &mut Self::Output {
-        assert!(
-            row < self.nrows(),
-            "row {row} is out of bounds (max: {})",
-            self.nrows()
-        );
-        assert!(
-            col < self.ncols(),
-            "col {col} is out of bounds (max: {})",
-            self.ncols()
-        );
-        // SAFETY: We have checked that `row` and `col` are in-bounds.
-        unsafe { self.get_unchecked_mut(row, col) }
-    }
+/////////
+// Ref //
+/////////
+
+#[derive(Debug)]
+pub struct Ref<'a, T> {
+    ptr: NonNull<T>,
+    layout: Layout,
+    _lifetime: PhantomData<&'a [T]>,
 }
 
-impl<T, U> From<views::MatrixBase<T>> for StridedBase<U>
-where
-    T: DenseData,
-    U: DenseData,
-    T: Into<U>,
-{
-    fn from(matrix: views::MatrixBase<T>) -> Self {
-        let nrows = matrix.nrows();
-        let ncols = matrix.ncols();
-        Self {
-            data: matrix.into_inner().into(),
-            nrows,
-            ncols,
-            cstride: ncols,
+impl<'a, T> Ref<'a, T> {
+    pub fn try_from_data(
+        data: &'a [T],
+        nrows: usize,
+        ncols: usize,
+        cstride: usize,
+    ) -> Result<Self, TryFromError> {
+        let layout =
+            Layout::new_for::<T>(nrows, ncols, cstride).map_err(TryFromError::LayoutError)?;
+        let expected = layout.linear_length();
+        if data.len() < expected {
+            Err(TryFromError::InvalidLength {
+                got: data.len(),
+                expected,
+            })
+        } else {
+            Ok(Self {
+                ptr: unsafe { NonNull::new_unchecked(data.as_ptr().cast_mut()) },
+                layout,
+                _lifetime: PhantomData,
+            })
         }
     }
 }
+
+impl<'a, T> From<views::MatrixView<'a, T>> for Ref<'a, T> {
+    fn from(matrix: views::MatrixView<'a, T>) -> Self {
+        // FIXME: `views::MatrixView` doesn't quite ensure that `nrows * ncols` doesn't
+        // overflow. So for now, we need to be pessimistic.
+        //
+        // This will be fixed when `MatrixView` gets the same treatment.
+        Self::try_from_data(
+            matrix.into_inner(),
+            matrix.nrows(),
+            matrix.ncols(),
+            matrix.ncols(),
+        )
+        .expect("this will be made infallible in the future")
+    }
+}
+
+unsafe impl<T> Send for Ref<'_, T> where T: Sync {}
+unsafe impl<T> Sync for Ref<'_, T> where T: Sync {}
+
+impl<T> Clone for Ref<'_, T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> Copy for Ref<'_, T> {}
+
+impl<'a, T> Reborrow<'a> for Ref<'_, T> {
+    type Target = Ref<'a, T>;
+    fn reborrow(&'a self) -> Self::Target {
+        *self
+    }
+}
+
+unsafe impl<T> Strided for Ref<'_, T> {
+    type Element = T;
+
+    fn as_nonnull(&self) -> NonNull<T> {
+        self.ptr
+    }
+
+    fn layout(&self) -> Layout {
+        self.layout
+    }
+}
+
+/////////
+// Mut //
+/////////
+
+#[derive(Debug)]
+pub struct Mut<'a, T> {
+    ptr: NonNull<T>,
+    layout: Layout,
+    _lifetime: PhantomData<&'a mut [T]>,
+}
+
+impl<'a, T> Mut<'a, T> {
+    pub fn try_from_data(
+        data: &'a mut [T],
+        nrows: usize,
+        ncols: usize,
+        cstride: usize,
+    ) -> Result<Self, TryFromError> {
+        let layout =
+            Layout::new_for::<T>(nrows, ncols, cstride).map_err(TryFromError::LayoutError)?;
+        let expected = layout.linear_length();
+        if data.len() < expected {
+            Err(TryFromError::InvalidLength {
+                got: data.len(),
+                expected,
+            })
+        } else {
+            Ok(Self {
+                ptr: unsafe { NonNull::new_unchecked(data.as_ptr().cast_mut()) },
+                layout,
+                _lifetime: PhantomData,
+            })
+        }
+    }
+}
+
+impl<'a, T> From<views::MutMatrixView<'a, T>> for Mut<'a, T> {
+    fn from(matrix: views::MutMatrixView<'a, T>) -> Self {
+        let (nrows, ncols) = (matrix.nrows(), matrix.ncols());
+
+        // FIXME: `views::MatrixView` doesn't quite ensure that `nrows * ncols` doesn't
+        // overflow. So for now, we need to be pessimistic.
+        //
+        // This will be fixed when `MatrixView` gets the same treatment.
+        Self::try_from_data(matrix.into_inner(), nrows, ncols, ncols)
+            .expect("this will be made infallible in the future")
+    }
+}
+
+unsafe impl<T> Send for Mut<'_, T> where T: Send {}
+unsafe impl<T> Sync for Mut<'_, T> where T: Sync {}
+
+impl<'a, T> Reborrow<'a> for Mut<'_, T> {
+    type Target = Ref<'a, T>;
+    fn reborrow(&'a self) -> Self::Target {
+        Ref {
+            ptr: self.ptr,
+            layout: self.layout,
+            _lifetime: PhantomData,
+        }
+    }
+}
+
+impl<'a, T> ReborrowMut<'a> for Mut<'_, T> {
+    type Target = Mut<'a, T>;
+    fn reborrow_mut(&'a mut self) -> Self::Target {
+        Mut {
+            ptr: self.ptr,
+            layout: self.layout,
+            _lifetime: PhantomData,
+        }
+    }
+}
+
+unsafe impl<T> Strided for Mut<'_, T> {
+    type Element = T;
+
+    fn as_nonnull(&self) -> NonNull<T> {
+        self.ptr
+    }
+
+    fn layout(&self) -> Layout {
+        self.layout
+    }
+}
+
+unsafe impl<T> StridedMut for Mut<'_, T> {}
+
+// /////////
+// // OLD //
+// /////////
+//
+// #[derive(Debug, Clone, Copy)]
+// pub struct StridedBase<T>
+// where
+//     T: DenseData,
+// {
+//     data: T,
+//     nrows: usize,
+//     ncols: usize,
+//     // The stride along the columns. This must be greater than or equal to `ncols`.
+//     cstride: usize,
+// }
+//
+// /// Return the linear length of a slice underlying a `StridedBase` with the given parameters.
+// pub fn linear_length(nrows: usize, ncols: usize, cstride: usize) -> usize {
+//     (nrows.max(1) - 1) * cstride + nrows.min(1) * ncols
+// }
+//
+// #[derive(Debug, Error)]
+// #[non_exhaustive]
+// #[error(
+//     "tried to construct a strided matrix with {nrows} rows and {ncols} cols and \
+//      column stride {cstride} over a slice of length {} (expected {})",
+//      len,
+//      linear_length(self.nrows, self.ncols, self.cstride)
+// )]
+// pub struct TryFromErrorLight {
+//     len: usize,
+//     nrows: usize,
+//     ncols: usize,
+//     cstride: usize,
+// }
+//
+// #[derive(Error)]
+// #[non_exhaustive]
+// #[error(
+//     "tried to construct a strided matrix with {nrows} rows and {ncols} cols and \
+//      column stride {cstride} over a slice of length {} (expected {})",
+//      data.as_slice().len(),
+//      linear_length(self.nrows, self.ncols, self.cstride)
+// )]
+// pub struct TryFromError<T: views::DenseData> {
+//     data: T,
+//     nrows: usize,
+//     ncols: usize,
+//     cstride: usize,
+// }
+//
+// // Manually implement `fmt::Debug` so we don't require `T::Debug`.
+// impl<T: DenseData> fmt::Debug for TryFromError<T> {
+//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//         f.debug_struct("TryFromError")
+//             .field("data_len", &self.data.as_slice().len())
+//             .field("nrows", &self.nrows)
+//             .field("ncols", &self.ncols)
+//             .field("cstride", &self.cstride)
+//             .finish()
+//     }
+// }
+//
+// impl<T: views::DenseData> TryFromError<T> {
+//     /// Consume the error and return the base data.
+//     pub fn into_inner(self) -> T {
+//         self.data
+//     }
+//
+//     /// Drop the data portion of the error and return an equivalent error that is guaranteed
+//     /// to be `'static`.
+//     pub fn as_static(&self) -> TryFromErrorLight {
+//         TryFromErrorLight {
+//             len: self.data.as_slice().len(),
+//             nrows: self.nrows,
+//             ncols: self.ncols,
+//             cstride: self.cstride,
+//         }
+//     }
+// }
+//
+// impl<'a, T> StridedBase<&'a [T]> {
+//     /// Construct a strided view over data slice, shrinking the slice as needed.
+//     ///
+//     /// Returns an error if `data` is shorter than the value returned by `linear_length`.
+//     ///
+//     /// # Panics
+//     ///
+//     /// * Panics if `cstride < ncols`.
+//     pub fn try_shrink_from(
+//         data: &'a [T],
+//         nrows: usize,
+//         ncols: usize,
+//         cstride: usize,
+//     ) -> Result<Self, TryFromError<&'a [T]>> {
+//         assert!(
+//             cstride >= ncols,
+//             "cstride must be greater than or equal to ncols"
+//         );
+//         let required_length = linear_length(nrows, ncols, cstride);
+//         match data.get(..required_length) {
+//             Some(data) => Ok(Self {
+//                 data,
+//                 nrows,
+//                 ncols,
+//                 cstride,
+//             }),
+//             None => Err(TryFromError {
+//                 data,
+//                 nrows,
+//                 ncols,
+//                 cstride,
+//             }),
+//         }
+//     }
+// }
+//
+// impl<'a, T> StridedBase<&'a mut [T]> {
+//     /// Construct a strided view over data slice, shrinking the slice as needed.
+//     ///
+//     /// Returns an error if `data` is shorter than the value returned by `linear_length`.
+//     ///
+//     /// # Panics
+//     ///
+//     /// * Panics if `cstride < ncols`.
+//     pub fn try_shrink_from_mut(
+//         data: &'a mut [T],
+//         nrows: usize,
+//         ncols: usize,
+//         cstride: usize,
+//     ) -> Result<Self, TryFromError<&'a mut [T]>> {
+//         assert!(
+//             cstride >= ncols,
+//             "cstride must be greater than or equal to ncols"
+//         );
+//         let required_length = linear_length(nrows, ncols, cstride);
+//         if data.as_slice().len() >= required_length {
+//             Ok(Self {
+//                 data: &mut data[..required_length],
+//                 nrows,
+//                 ncols,
+//                 cstride,
+//             })
+//         } else {
+//             Err(TryFromError {
+//                 data,
+//                 nrows,
+//                 ncols,
+//                 cstride,
+//             })
+//         }
+//     }
+// }
+//
+// impl<T> StridedBase<T>
+// where
+//     T: DenseData,
+// {
+//     /// Construct a strided view over data slice, shrinking the slice as needed.
+//     ///
+//     /// Returns an error if `data` is not equal to the expected length as determined
+//     /// by `linear_length`.
+//     ///
+//     /// # Panics
+//     ///
+//     /// * Panics if `cstride < ncols`.
+//     pub fn try_from(
+//         data: T,
+//         nrows: usize,
+//         ncols: usize,
+//         cstride: usize,
+//     ) -> Result<Self, TryFromError<T>> {
+//         assert!(
+//             cstride >= ncols,
+//             "cstride must be greater than or equal to ncols"
+//         );
+//         // This computation needs to be set up such that:
+//         // 1. When `nrows == 0`, the expected length is 0.
+//         // 2. We make a tight upper-bound on the expected length for the last row.
+//         let required_length = linear_length(nrows, ncols, cstride);
+//         if data.as_slice().len() == required_length {
+//             Ok(Self {
+//                 data,
+//                 nrows,
+//                 ncols,
+//                 cstride,
+//             })
+//         } else {
+//             Err(TryFromError {
+//                 data,
+//                 nrows,
+//                 ncols,
+//                 cstride,
+//             })
+//         }
+//     }
+//
+//     /// Return the number of columns in the matrix.
+//     pub fn ncols(&self) -> usize {
+//         self.ncols
+//     }
+//
+//     /// Return the number of rows in the matrix.
+//     pub fn nrows(&self) -> usize {
+//         self.nrows
+//     }
+//
+//     /// Return the count of elements between the start of each row.
+//     pub fn cstride(&self) -> usize {
+//         self.cstride
+//     }
+//
+//     /// Return the underlying data as a slice.
+//     ///
+//     /// # Note
+//     ///
+//     /// The underlying representation for a strided matrix is not necessarily dense.
+//     pub fn as_slice(&self) -> &[T::Elem] {
+//         self.data.as_slice()
+//     }
+//
+//     /// Return the underlying data as a slice.
+//     ///
+//     /// # Note
+//     ///
+//     /// The underlying representation for a strided matrix is not necessarily dense.
+//     pub fn as_mut_slice(&mut self) -> &mut [T::Elem]
+//     where
+//         T: MutDenseData,
+//     {
+//         self.data.as_mut_slice()
+//     }
+//
+//     /// Return row `row` as a slice.
+//     ///
+//     /// # Panic
+//     ///
+//     /// Panics if `row >= self.nrows()`.
+//     pub fn row(&self, row: usize) -> &[T::Elem] {
+//         assert!(
+//             row < self.nrows(),
+//             "tried to access row {row} of a matrix with {} rows",
+//             self.nrows()
+//         );
+//
+//         // SAFETY: `row` is in-bounds.
+//         unsafe { self.get_row_unchecked(row) }
+//     }
+//
+//     /// Returns the requested row without boundschecking.
+//     ///
+//     /// # Safety
+//     ///
+//     /// The following conditions must hold to avoid undefined behavior:
+//     /// * `row < self.nrows()`.
+//     pub unsafe fn get_row_unchecked(&self, row: usize) -> &[T::Elem] {
+//         debug_assert!(row < self.nrows);
+//         let cstride = self.cstride;
+//         let ncols = self.ncols;
+//         let start = row * cstride;
+//
+//         debug_assert!(start + ncols <= self.as_slice().len());
+//         // SAFETY: The idempotency requirement of `as_slice` and our audited constructors
+//         // mean that `self.as_slice()` has a length of `self.nrows * self.ncols`.
+//         //
+//         // Therefore, this access is in-bounds.
+//         unsafe { self.as_slice().get_unchecked(start..start + ncols) }
+//     }
+//
+//     /// Return row `row` as a mutable slice.
+//     ///
+//     /// # Panics
+//     ///
+//     /// Panics if `row >= self.nrows()`.
+//     pub fn row_mut(&mut self, row: usize) -> &mut [T::Elem]
+//     where
+//         T: MutDenseData,
+//     {
+//         assert!(
+//             row < self.nrows(),
+//             "tried to access row {row} of a matrix with {} rows",
+//             self.nrows()
+//         );
+//
+//         // SAFETY: `row` is in-bounds.
+//         unsafe { self.get_row_unchecked_mut(row) }
+//     }
+//
+//     /// Returns the requested row without boundschecking.
+//     ///
+//     /// # Safety
+//     ///
+//     /// The following conditions must hold to avoid undefined behavior:
+//     /// * `row < self.nrows()`.
+//     pub unsafe fn get_row_unchecked_mut(&mut self, row: usize) -> &mut [T::Elem]
+//     where
+//         T: MutDenseData,
+//     {
+//         debug_assert!(row < self.nrows);
+//         let cstride = self.cstride;
+//         let ncols = self.ncols;
+//         let start = row * cstride;
+//
+//         debug_assert!(start + ncols <= self.as_slice().len());
+//         // SAFETY: The idempotency requirement of `as_mut_slice` and our audited constructors
+//         // mean that `self.as_mut_slice()` has a length of `self.nrows * self.ncols`.
+//         //
+//         // Therefore, this access is in-bounds.
+//         unsafe {
+//             self.data
+//                 .as_mut_slice()
+//                 .get_unchecked_mut(start..start + ncols)
+//         }
+//     }
+//
+//     /// Return a iterator over all rows in the matrix.
+//     ///
+//     /// Rows are yielded sequentially beginning with row 0.
+//     ///
+//     /// # Panics
+//     ///
+//     /// Panics if `self.ncols() == 0` (because the implementation does not work correctly
+//     /// in this case and it's too corner-case to bother fixing). This restriction may
+//     /// be lifted in the future.
+//     pub fn row_iter(&self) -> impl Iterator<Item = &[T::Elem]> {
+//         assert!(self.ncols() != 0);
+//         let ncols = self.ncols;
+//
+//         self.data
+//             .as_slice()
+//             .chunks(self.cstride())
+//             .map(move |i| &i[..ncols])
+//     }
+//
+//     /// Return a mutable iterator over all rows in the matrix.
+//     ///
+//     /// Rows are yielded sequentially beginning with row 0.
+//     ///
+//     /// # Panics
+//     ///
+//     /// Panics if `self.ncols() == 0` (because the implementation does not work correctly
+//     /// in this case and it's too corner-case to bother fixing). This restriction may
+//     /// be lifted in the future.
+//     pub fn row_iter_mut(&mut self) -> impl Iterator<Item = &mut [T::Elem]>
+//     where
+//         T: MutDenseData,
+//     {
+//         assert!(self.ncols() != 0);
+//
+//         let ncols = self.ncols();
+//         let cstride = self.cstride();
+//         self.data
+//             .as_mut_slice()
+//             .chunks_mut(cstride)
+//             .map(move |i| &mut i[..ncols])
+//     }
+//
+//     /// Return a pointer to the base of the matrix.
+//     pub fn as_ptr(&self) -> *const T::Elem {
+//         self.as_slice().as_ptr()
+//     }
+//
+//     /// Return a pointer to the base of the matrix.
+//     pub fn as_mut_ptr(&mut self) -> *mut T::Elem
+//     where
+//         T: MutDenseData,
+//     {
+//         self.as_mut_slice().as_mut_ptr()
+//     }
+//
+//     /// Returns a reference to an element without boundschecking.
+//     ///
+//     /// # Safety
+//     ///
+//     /// The following conditions must hold to avoid undefined behavior:
+//     /// * `row < self.nrows()`.
+//     /// * `col < self.ncols()`.
+//     pub unsafe fn get_unchecked(&self, row: usize, col: usize) -> &T::Elem {
+//         debug_assert!(row < self.nrows);
+//         debug_assert!(col < self.ncols);
+//         self.as_slice().get_unchecked(row * self.cstride + col)
+//     }
+//
+//     /// Returns a mutable reference to an element without boundschecking.
+//     ///
+//     /// # Safety
+//     ///
+//     /// The following conditions must hold to avoid undefined behavior:
+//     /// * `row < self.nrows()`.
+//     /// * `col < self.ncols()`.
+//     pub unsafe fn get_unchecked_mut(&mut self, row: usize, col: usize) -> &mut T::Elem
+//     where
+//         T: MutDenseData,
+//     {
+//         let cstride = self.cstride;
+//         debug_assert!(row < self.nrows);
+//         debug_assert!(col < self.ncols);
+//         self.as_mut_slice().get_unchecked_mut(row * cstride + col)
+//     }
+//
+//     /// Return a view over the matrix.
+//     pub fn as_view(&self) -> StridedView<'_, T::Elem> {
+//         StridedView {
+//             data: self.as_slice(),
+//             nrows: self.nrows,
+//             ncols: self.ncols,
+//             cstride: self.cstride,
+//         }
+//     }
+// }
+//
+// pub type StridedView<'a, T> = StridedBase<&'a [T]>;
+// pub type MutStridedView<'a, T> = StridedBase<&'a mut [T]>;
+//
+// /// Return a reference to the item at entry `(row, col)` in the matrix.
+// ///
+// /// # Panics
+// ///
+// /// Panics if `row >= self.nrows()` or `col >= self.ncols()`.
+// impl<T> Index<(usize, usize)> for StridedBase<T>
+// where
+//     T: DenseData,
+// {
+//     type Output = T::Elem;
+//
+//     fn index(&self, (row, col): (usize, usize)) -> &Self::Output {
+//         assert!(
+//             row < self.nrows(),
+//             "row {row} is out of bounds (max: {})",
+//             self.nrows()
+//         );
+//         assert!(
+//             col < self.ncols(),
+//             "col {col} is out of bounds (max: {})",
+//             self.ncols()
+//         );
+//         // SAFETY: We have checked that `row` and `col` are in-bounds.
+//         unsafe { self.get_unchecked(row, col) }
+//     }
+// }
+//
+// /// Return a mutable reference to the item at entry `(row, col)` in the matrix.
+// ///
+// /// # Panics
+// ///
+// /// Panics if `row >= self.nrows()` or `col >= self.ncols()`.
+// impl<T> IndexMut<(usize, usize)> for StridedBase<T>
+// where
+//     T: MutDenseData,
+// {
+//     fn index_mut(&mut self, (row, col): (usize, usize)) -> &mut Self::Output {
+//         assert!(
+//             row < self.nrows(),
+//             "row {row} is out of bounds (max: {})",
+//             self.nrows()
+//         );
+//         assert!(
+//             col < self.ncols(),
+//             "col {col} is out of bounds (max: {})",
+//             self.ncols()
+//         );
+//         // SAFETY: We have checked that `row` and `col` are in-bounds.
+//         unsafe { self.get_unchecked_mut(row, col) }
+//     }
+// }
+//
+// impl<T, U> From<views::MatrixBase<T>> for StridedBase<U>
+// where
+//     T: DenseData,
+//     U: DenseData,
+//     T: Into<U>,
+// {
+//     fn from(matrix: views::MatrixBase<T>) -> Self {
+//         let nrows = matrix.nrows();
+//         let ncols = matrix.ncols();
+//         Self {
+//             data: matrix.into_inner().into(),
+//             nrows,
+//             ncols,
+//             cstride: ncols,
+//         }
+//     }
+// }
 
 #[cfg(test)]
 mod tests {
@@ -522,28 +1035,31 @@ mod tests {
     #[test]
     fn test_linear_length() {
         // If the number of rows is zero - the output should always be zero.
-        assert_eq!(linear_length(0, 1, 1), 0);
-        assert_eq!(linear_length(0, 2, 2), 0);
-        assert_eq!(linear_length(0, 2, 3), 0);
-        assert_eq!(linear_length(0, 2, 4), 0);
+        assert_eq!(__linear_length(0, 1, 1).unwrap(), 0);
+        assert_eq!(__linear_length(0, 2, 2).unwrap(), 0);
+        assert_eq!(__linear_length(0, 2, 3).unwrap(), 0);
+        assert_eq!(__linear_length(0, 2, 4).unwrap(), 0);
 
         // If `cstride == ncols`, then the computation should be trivial.
         for row in 1..10 {
             for col in 1..10 {
-                assert_eq!(linear_length(row, col, col), row * col);
+                assert_eq!(__linear_length(row, col, col).unwrap(), row * col);
             }
         }
 
         // If there is only one row, then `cstride` should be ignored.
-        assert_eq!(linear_length(1, 5, 10), 5);
-        assert_eq!(linear_length(1, 7, 99), 7);
+        assert_eq!(__linear_length(1, 5, 10).unwrap(), 5);
+        assert_eq!(__linear_length(1, 7, 99).unwrap(), 7);
 
         // Otherwise, the computation is a block of `nrows - 1` chunks of `cstride` and then
         // `ncols`. Yes - this runs a bunch of computations.
         for row in 2..10 {
             for col in 0..10 {
                 for cstride in col..12 {
-                    assert_eq!(linear_length(row, col, cstride), (row - 1) * cstride + col);
+                    assert_eq!(
+                        __linear_length(row, col, cstride).unwrap(),
+                        (row - 1) * cstride + col
+                    );
                 }
             }
         }
@@ -551,44 +1067,47 @@ mod tests {
 
     fn assert_is_static<T: 'static>(_x: &T) {}
 
-    #[test]
-    fn try_from_error_misc() {
-        let x = TryFromError::<&[f32]> {
-            data: &[],
-            nrows: 1,
-            ncols: 2,
-            cstride: 3,
-        };
+    // #[test]
+    // fn try_from_error_misc() {
+    //     let x = TryFromError::<&[f32]> {
+    //         data: &[],
+    //         nrows: 1,
+    //         ncols: 2,
+    //         cstride: 3,
+    //     };
 
-        let display = format!("{}", x);
-        let debug = format!("{:?}", x);
-        println!("debug = {}", debug);
-        assert!(debug.contains("TryFromError"));
-        assert!(debug.contains("data_len: 0"));
-        assert!(debug.contains("nrows: 1"));
-        assert!(debug.contains("ncols: 2"));
-        assert!(debug.contains("cstride: 3"));
+    //     let display = format!("{}", x);
+    //     let debug = format!("{:?}", x);
+    //     println!("debug = {}", debug);
+    //     assert!(debug.contains("TryFromError"));
+    //     assert!(debug.contains("data_len: 0"));
+    //     assert!(debug.contains("nrows: 1"));
+    //     assert!(debug.contains("ncols: 2"));
+    //     assert!(debug.contains("cstride: 3"));
 
-        let x = x.as_static();
-        assert_is_static(&x);
-        assert_eq!(
-            display,
-            format!("{}", x),
-            "static version of the error must hav ethe same message"
-        );
-    }
+    //     let x = x.as_static();
+    //     assert_is_static(&x);
+    //     assert_eq!(
+    //         display,
+    //         format!("{}", x),
+    //         "static version of the error must hav ethe same message"
+    //     );
+    // }
 
-    fn expected_error(len: usize, nrows: usize, ncols: usize, cstride: usize) -> String {
-        format!(
-            "tried to construct a strided matrix with {nrows} rows and {ncols} cols and \
-             column stride {cstride} over a slice of length {} (expected {})",
-            len,
-            linear_length(nrows, ncols, cstride)
-        )
-    }
+    // fn expected_error(len: usize, nrows: usize, ncols: usize, cstride: usize) -> String {
+    //     format!(
+    //         "tried to construct a strided matrix with {nrows} rows and {ncols} cols and \
+    //          column stride {cstride} over a slice of length {} (expected {})",
+    //         len,
+    //         linear_length(nrows, ncols, cstride)
+    //     )
+    // }
 
     // Test that the contents of `dut` match those in the dense 2d matrix.
-    fn test_indexing(dut: StridedView<'_, usize>, expected: views::MatrixView<'_, usize>) {
+    fn test_indexing<T>(dut: &T, expected: views::MatrixView<'_, usize>)
+    where
+        T: Strided<Element = usize>,
+    {
         assert_eq!(dut.nrows(), expected.nrows());
         assert_eq!(dut.ncols(), expected.ncols());
 
@@ -603,7 +1122,7 @@ mod tests {
         for row in 0..dut.nrows() {
             for col in 0..dut.ncols() {
                 assert_eq!(
-                    dut[(row, col)],
+                    *dut.element(row, col).unwrap(),
                     expected[(row, col)],
                     "failed on (row, col) = ({}, {})",
                     row,
@@ -614,11 +1133,16 @@ mod tests {
 
         // Compare via row.
         for row in 0..dut.nrows() {
-            assert_eq!(dut.row(row), expected.row(row), "failed on row {}", row);
+            assert_eq!(
+                dut.row(row).unwrap(),
+                expected.row(row),
+                "failed on row {}",
+                row
+            );
         }
 
         // Compare via row iterators.
-        assert!(dut.row_iter().eq(expected.row_iter()));
+        assert!(dut.rows().eq(expected.row_iter()));
     }
 
     // Create a base Matrix with the following pattern:
@@ -647,16 +1171,16 @@ mod tests {
 
         // First - test a dense StridedView over the entire matrix.
         let ptr = m.as_ptr();
-        let v = StridedView::try_from(m.as_slice(), m.nrows(), m.ncols(), m.ncols()).unwrap();
+        let v = Ref::try_from_data(m.as_slice(), m.nrows(), m.ncols(), m.ncols()).unwrap();
         assert_eq!(v.as_ptr(), ptr, "base pointer was not preserved");
 
         assert_eq!(v.nrows(), m.nrows());
         assert_eq!(v.ncols(), m.ncols());
         assert_eq!(v.cstride(), m.ncols());
-        test_indexing(v, m.as_view());
+        test_indexing(&v, m.as_view());
 
         // Now - create a truly strided view over the first two columns.
-        let v = StridedView::try_from(
+        let v = Ref::try_from_data(
             &(m.as_slice()[..(4 * m.ncols() + 2)]),
             m.nrows(),
             2,
@@ -672,17 +1196,17 @@ mod tests {
                 expected[(row, col)] = m[(row, col)];
             }
         }
-        test_indexing(v, expected.as_view());
+        test_indexing(&v, expected.as_view());
 
         // Create a strided view over the last two columns.
-        let v = StridedView::try_from(&(m.as_slice()[1..]), m.nrows(), 2, m.ncols()).unwrap();
+        let v = Ref::try_from_data(&(m.as_slice()[1..]), m.nrows(), 2, m.ncols()).unwrap();
         let mut expected = views::Matrix::new(0, 5, 2);
         for row in 0..expected.nrows() {
             for col in 0..expected.ncols() {
                 expected[(row, col)] = m[(row, col + 1)];
             }
         }
-        test_indexing(v, expected.as_view());
+        test_indexing(&v, expected.as_view());
     }
 
     #[test]
@@ -700,8 +1224,7 @@ mod tests {
             let nrows = src.nrows();
             let cstride = dst.ncols();
             let mut dst_view =
-                MutStridedView::try_shrink_from_mut(dst.as_mut_slice(), nrows, ncols, cstride)
-                    .unwrap();
+                Mut::try_from_data(dst.as_mut_slice(), nrows, ncols, cstride).unwrap();
 
             assert_eq!(dst_view.as_ptr(), ptr);
             assert_eq!(dst_view.as_mut_ptr().cast_const(), ptr);
@@ -712,12 +1235,12 @@ mod tests {
             // Initialize using linear indexing.
             for row in 0..dst_view.nrows() {
                 for col in 0..dst_view.ncols() {
-                    dst_view[(row, col)] = src[(row, col)]
+                    *dst_view.element_mut(row, col).unwrap() = src[(row, col)]
                 }
             }
 
             // Check equality.
-            test_indexing(dst_view.as_view(), src.as_view());
+            test_indexing(&dst_view, src.as_view());
         }
 
         // Initialize using row-wise indexing.
@@ -730,8 +1253,7 @@ mod tests {
             let nrows = src.nrows();
             let cstride = dst.ncols();
             let mut dst_view =
-                MutStridedView::try_shrink_from_mut(dst.as_mut_slice(), nrows, ncols, cstride)
-                    .unwrap();
+                Mut::try_from_data(dst.as_mut_slice(), nrows, ncols, cstride).unwrap();
 
             assert_eq!(dst_view.as_ptr(), ptr);
             assert_eq!(dst_view.as_mut_ptr().cast_const(), ptr);
@@ -741,11 +1263,11 @@ mod tests {
 
             // Initialize by looping over rows.
             for row in 0..dst_view.nrows() {
-                dst_view.row_mut(row).copy_from_slice(src.row(row))
+                dst_view.row_mut(row).unwrap().copy_from_slice(src.row(row))
             }
 
             // Check equality.
-            test_indexing(dst_view.as_view(), src.as_view());
+            test_indexing(&dst_view, src.as_view());
         }
 
         // Initialize using row-iterator indexing.
@@ -759,13 +1281,8 @@ mod tests {
             let ncols = src.ncols();
             let nrows = src.nrows();
             let cstride = dst.ncols();
-            let mut dst_view = MutStridedView::try_shrink_from_mut(
-                &mut dst.as_mut_slice()[2..],
-                nrows,
-                ncols,
-                cstride,
-            )
-            .unwrap();
+            let mut dst_view =
+                Mut::try_from_data(&mut dst.as_mut_slice()[2..], nrows, ncols, cstride).unwrap();
 
             assert_eq!(dst_view.as_ptr(), ptr);
             assert_eq!(dst_view.as_mut_ptr().cast_const(), ptr);
@@ -774,12 +1291,12 @@ mod tests {
             assert_eq!(dst_view.cstride(), cstride);
 
             // Initialize using row iterators.
-            for (d, s) in std::iter::zip(dst_view.row_iter_mut(), src.row_iter()) {
+            for (d, s) in std::iter::zip(dst_view.rows_mut(), src.row_iter()) {
                 d.copy_from_slice(s)
             }
 
             // Check equality.
-            test_indexing(dst_view.as_view(), src.as_view());
+            test_indexing(&dst_view, src.as_view());
         }
     }
 
@@ -787,28 +1304,28 @@ mod tests {
     fn matrix_conversion() {
         let m = create_test_matrix(3, 4);
         let ptr = m.as_ptr();
-        let v: StridedView<_> = m.as_view().into();
+        let v: Ref<_> = m.as_view().into();
         assert_eq!(v.as_ptr(), ptr);
-        test_indexing(v, m.as_view());
+        test_indexing(&v, m.as_view());
     }
 
     #[test]
     fn test_zero_sized() {
         let m = create_test_matrix(5, 5);
-        let v = StridedView::try_shrink_from(m.as_slice(), 0, 4, 5).unwrap();
+        let v = Ref::try_from_data(m.as_slice(), 0, 4, 5).unwrap();
 
         assert_eq!(v.nrows(), 0);
         assert_eq!(v.ncols(), 4);
         assert_eq!(v.cstride(), 5);
 
-        let v = StridedView::try_shrink_from(m.as_slice(), 5, 0, 5).unwrap();
+        let v = Ref::try_from_data(m.as_slice(), 5, 0, 5).unwrap();
         assert_eq!(v.nrows(), 5);
         assert_eq!(v.ncols(), 0);
         assert_eq!(v.cstride(), 5);
 
         for row in 0..v.nrows() {
             let empty: &[usize] = &[];
-            assert_eq!(v.row(row), empty);
+            assert_eq!(v.row(row).unwrap(), empty);
         }
     }
 
@@ -816,16 +1333,16 @@ mod tests {
     #[should_panic]
     fn test_row_iter_panics() {
         let m = create_test_matrix(5, 5);
-        let v = StridedView::try_shrink_from(m.as_slice(), 5, 0, 5).unwrap();
-        let _ = v.row_iter();
+        let v = Ref::try_from_data(m.as_slice(), 5, 0, 5).unwrap();
+        let _ = v.rows();
     }
 
     #[test]
     #[should_panic]
     fn test_row_iter_mut_panics() {
         let mut m = create_test_matrix(5, 5);
-        let mut v = MutStridedView::try_shrink_from_mut(m.as_mut_slice(), 5, 0, 5).unwrap();
-        let _ = v.row_iter_mut();
+        let mut v = Mut::try_from_data(m.as_mut_slice(), 5, 0, 5).unwrap();
+        let _ = v.rows_mut();
     }
 
     #[test]
@@ -834,29 +1351,29 @@ mod tests {
         let m = views::Matrix::<usize>::new(0, 10, 10);
         let nrows = m.nrows();
         let ncols = m.ncols();
-        let s = StridedView::try_shrink_from(m.as_slice(), nrows, ncols, ncols).unwrap();
+        let s = Ref::try_from_data(m.as_slice(), nrows, ncols, ncols).unwrap();
         assert_eq!(s.as_slice(), m.as_slice());
 
         // Giving a slice that is too large is okay.
-        let s = StridedView::try_shrink_from(m.as_slice(), nrows, 5, ncols).unwrap();
+        let s = Ref::try_from_data(m.as_slice(), nrows, 5, ncols).unwrap();
         assert_eq!(s.as_ptr(), m.as_ptr());
 
         // Too small is a problem.
-        let s = StridedView::try_shrink_from(m.as_slice(), nrows, ncols, ncols + 1);
+        let s = Ref::try_from_data(m.as_slice(), nrows, ncols, ncols + 1);
         assert!(s.is_err());
         let err = s.unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            expected_error(m.as_slice().len(), nrows, ncols, ncols + 1)
-        );
-        assert_eq!(err.into_inner(), m.as_slice());
+        // assert_eq!(
+        //     err.to_string(),
+        //     expected_error(m.as_slice().len(), nrows, ncols, ncols + 1)
+        // );
+        // assert_eq!(err.into_inner(), m.as_slice());
     }
 
     #[test]
     #[should_panic(expected = "cstride must be greater than or equal to ncols")]
     fn test_try_shink_from_panics() {
         let m = views::Matrix::<usize>::new(0, 4, 4);
-        let _ = StridedView::try_shrink_from(m.as_slice(), 2, 2, 1);
+        let _ = Ref::try_from_data(m.as_slice(), 2, 2, 1).unwrap();
     }
 
     #[test]
@@ -869,112 +1386,112 @@ mod tests {
         let ptr = m.as_ptr();
         let len = m.as_slice().len();
 
-        let s = MutStridedView::try_shrink_from_mut(m.as_mut_slice(), nrows, ncols, ncols).unwrap();
+        let s = Mut::try_from_data(m.as_mut_slice(), nrows, ncols, ncols).unwrap();
         assert_eq!(s.as_ptr(), ptr);
         assert_eq!(s.as_slice().len(), len);
 
         // Giving a slice that is too large is okay.
-        let s = MutStridedView::try_shrink_from_mut(m.as_mut_slice(), nrows, 5, ncols).unwrap();
+        let s = Mut::try_from_data(m.as_mut_slice(), nrows, 5, ncols).unwrap();
         assert_eq!(s.as_ptr(), ptr);
 
         // Too small is a problem.
-        let s = MutStridedView::try_shrink_from_mut(m.as_mut_slice(), nrows, ncols, ncols + 1);
-        assert!(s.is_err());
-        let err = s.unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            expected_error(len, nrows, ncols, ncols + 1)
-        );
+        let s = Mut::try_from_data(m.as_mut_slice(), nrows, ncols, ncols + 1);
+        // assert!(s.is_err());
+        // let err = s.unwrap_err();
+        // assert_eq!(
+        //     err.to_string(),
+        //     expected_error(len, nrows, ncols, ncols + 1)
+        // );
     }
 
     #[test]
     #[should_panic(expected = "cstride must be greater than or equal to ncols")]
     fn test_try_shink_from_mut_panics() {
         let mut m = views::Matrix::<usize>::new(0, 4, 4);
-        let _ = MutStridedView::try_shrink_from_mut(m.as_mut_slice(), 2, 2, 1);
+        let _ = Mut::try_from_data(m.as_mut_slice(), 2, 2, 1);
     }
 
-    #[test]
-    fn test_try_from() {
-        // Exact is okay.
-        let m = views::Matrix::<usize>::new(0, 10, 10);
-        let nrows = m.nrows();
-        let ncols = m.ncols();
-        let s = StridedView::try_from(m.as_slice(), nrows, ncols, ncols).unwrap();
-        assert_eq!(s.as_slice(), m.as_slice());
+    // #[test]
+    // fn test_try_from() {
+    //     // Exact is okay.
+    //     let m = views::Matrix::<usize>::new(0, 10, 10);
+    //     let nrows = m.nrows();
+    //     let ncols = m.ncols();
+    //     let s = StridedView::try_from(m.as_slice(), nrows, ncols, ncols).unwrap();
+    //     assert_eq!(s.as_slice(), m.as_slice());
 
-        // Giving a slice that is too large is a problem.
-        let s = StridedView::try_from(m.as_slice(), nrows, 5, ncols);
-        assert!(s.is_err());
-        let err = s.unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            expected_error(m.as_slice().len(), nrows, 5, ncols)
-        );
+    //     // Giving a slice that is too large is a problem.
+    //     let s = StridedView::try_from(m.as_slice(), nrows, 5, ncols);
+    //     assert!(s.is_err());
+    //     let err = s.unwrap_err();
+    //     assert_eq!(
+    //         err.to_string(),
+    //         expected_error(m.as_slice().len(), nrows, 5, ncols)
+    //     );
 
-        // Too small is a problem.
-        let s = StridedView::try_from(m.as_slice(), nrows, ncols, ncols + 1);
-        assert!(s.is_err());
-        let err = s.unwrap_err();
-        assert_eq!(
-            err.to_string(),
-            expected_error(m.as_slice().len(), nrows, ncols, ncols + 1)
-        );
-        assert_eq!(err.into_inner(), m.as_slice());
-    }
+    //     // Too small is a problem.
+    //     let s = StridedView::try_from(m.as_slice(), nrows, ncols, ncols + 1);
+    //     assert!(s.is_err());
+    //     let err = s.unwrap_err();
+    //     assert_eq!(
+    //         err.to_string(),
+    //         expected_error(m.as_slice().len(), nrows, ncols, ncols + 1)
+    //     );
+    //     assert_eq!(err.into_inner(), m.as_slice());
+    // }
 
-    #[test]
-    #[should_panic(expected = "cstride must be greater than or equal to ncols")]
-    fn test_try_frompanics() {
-        let mut m = views::Matrix::<usize>::new(0, 4, 4);
-        let _ = MutStridedView::try_from(m.as_mut_slice(), 2, 2, 1);
-    }
+    // #[test]
+    // #[should_panic(expected = "cstride must be greater than or equal to ncols")]
+    // fn test_try_frompanics() {
+    //     let mut m = views::Matrix::<usize>::new(0, 4, 4);
+    //     let _ = MutStridedView::try_from(m.as_mut_slice(), 2, 2, 1);
+    // }
 
-    #[test]
-    #[should_panic(expected = "tried to access row 3 of a matrix with 3 rows")]
-    fn test_get_row_panics() {
-        let m = views::Matrix::<usize>::new(0, 3, 7);
-        let v: StridedView<_> = m.as_view().into();
-        v.row(3);
-    }
+    // #[test]
+    // #[should_panic(expected = "tried to access row 3 of a matrix with 3 rows")]
+    // fn test_get_row_panics() {
+    //     let m = views::Matrix::<usize>::new(0, 3, 7);
+    //     let v: StridedView<_> = m.as_view().into();
+    //     v.row(3);
+    // }
 
-    #[test]
-    #[should_panic(expected = "tried to access row 3 of a matrix with 3 rows")]
-    fn test_get_row_mut_panics() {
-        let mut m = views::Matrix::<usize>::new(0, 3, 7);
-        let mut v: MutStridedView<_> = m.as_mut_view().into();
-        v.row_mut(3);
-    }
+    // #[test]
+    // #[should_panic(expected = "tried to access row 3 of a matrix with 3 rows")]
+    // fn test_get_row_mut_panics() {
+    //     let mut m = views::Matrix::<usize>::new(0, 3, 7);
+    //     let mut v: MutStridedView<_> = m.as_mut_view().into();
+    //     v.row_mut(3);
+    // }
 
-    #[test]
-    #[should_panic(expected = "row 3 is out of bounds (max: 3)")]
-    fn test_index_panics_row() {
-        let m = views::Matrix::<usize>::new(0, 3, 7);
-        let v: StridedView<_> = m.as_view().into();
-        let _ = v[(3, 2)];
-    }
+    // #[test]
+    // #[should_panic(expected = "row 3 is out of bounds (max: 3)")]
+    // fn test_index_panics_row() {
+    //     let m = views::Matrix::<usize>::new(0, 3, 7);
+    //     let v: StridedView<_> = m.as_view().into();
+    //     let _ = v[(3, 2)];
+    // }
 
-    #[test]
-    #[should_panic(expected = "col 7 is out of bounds (max: 7)")]
-    fn test_index_panics_col() {
-        let m = views::Matrix::<usize>::new(0, 3, 7);
-        let v: StridedView<_> = m.as_view().into();
-        let _ = v[(2, 7)];
-    }
+    // #[test]
+    // #[should_panic(expected = "col 7 is out of bounds (max: 7)")]
+    // fn test_index_panics_col() {
+    //     let m = views::Matrix::<usize>::new(0, 3, 7);
+    //     let v: StridedView<_> = m.as_view().into();
+    //     let _ = v[(2, 7)];
+    // }
 
-    #[test]
-    #[should_panic(expected = "row 3 is out of bounds (max: 3)")]
-    fn test_index_mut_panics_row() {
-        let mut m = views::Matrix::<usize>::new(0, 3, 7);
-        let mut v: MutStridedView<_> = m.as_mut_view().into();
-        v[(3, 2)] = 1;
-    }
+    // #[test]
+    // #[should_panic(expected = "row 3 is out of bounds (max: 3)")]
+    // fn test_index_mut_panics_row() {
+    //     let mut m = views::Matrix::<usize>::new(0, 3, 7);
+    //     let mut v: MutStridedView<_> = m.as_mut_view().into();
+    //     v[(3, 2)] = 1;
+    // }
 
-    #[test]
-    #[should_panic(expected = "col 7 is out of bounds (max: 7)")]
-    fn test_index_mut_panics_col() {
-        let mut m = views::Matrix::<usize>::new(0, 3, 7);
-        let mut v: MutStridedView<_> = m.as_mut_view().into();
-        v[(2, 7)] = 1;
-    }
+    // #[test]
+    // #[should_panic(expected = "col 7 is out of bounds (max: 7)")]
+    // fn test_index_mut_panics_col() {
+    //     let mut m = views::Matrix::<usize>::new(0, 3, 7);
+    //     let mut v: MutStridedView<_> = m.as_mut_view().into();
+    //     v[(2, 7)] = 1;
+    // }
 }

--- a/diskann-utils/src/strided.rs
+++ b/diskann-utils/src/strided.rs
@@ -3,19 +3,121 @@
  * Licensed under the MIT license.
  */
 
-use std::{
-    fmt,
-    marker::PhantomData,
-    num::NonZeroUsize,
-    ops::{Index, IndexMut},
-    ptr::NonNull,
-};
+use std::{fmt, marker::PhantomData, ptr::NonNull};
 use thiserror::Error;
 
 use crate::{
-    views::{self, DenseData, MutDenseData},
-    Reborrow, ReborrowMut,
+    internal,
+    views::{self},
+    Reborrow,
 };
+
+/// The layout for [`Strided`].
+///
+/// This struct ensures that the [`Self::cstride`] is greater than [`Self::ncols`] and that
+/// the linear length of the representation does not overflow `usize::MAX`.
+///
+/// The linear length of [`Strided]` is given by the forumula
+/// ```text
+/// self.nrows.saturating_sub(1) * self.cstride + self.nrows.min(1) * self.ncols
+/// ```
+/// This allows the last row to occupy less than a full stride.
+#[derive(Debug, Clone, Copy)]
+pub struct Layout {
+    nrows: usize,
+    ncols: usize,
+    cstride: usize,
+}
+
+impl Layout {
+    /// Construct a new [`Layout`].
+    ///
+    /// Errors if:
+    ///
+    /// * `ncols < cstride`.
+    /// * The computation of the linear length overflows `usize::MAX`.
+    pub fn new(nrows: usize, ncols: usize, cstride: usize) -> Result<Self, LayoutError> {
+        LayoutError::check(nrows, ncols, cstride)?;
+        Ok(Self {
+            nrows,
+            ncols,
+            cstride,
+        })
+    }
+
+    /// Return the number of rows.
+    pub fn nrows(&self) -> usize {
+        self.nrows
+    }
+
+    /// Return the number of columns.
+    pub fn ncols(&self) -> usize {
+        self.ncols
+    }
+
+    /// Return the stride between subsequent rows.
+    pub fn cstride(&self) -> usize {
+        self.cstride
+    }
+
+    /// Return the linear length of the [`Strided`] described by this [`Layout`].
+    pub fn linear_length(&self) -> usize {
+        self.nrows.saturating_sub(1) * self.cstride + self.nrows.min(1) * self.ncols
+    }
+}
+
+fn linear_length(nrows: usize, ncols: usize, cstride: usize) -> Option<usize> {
+    nrows
+        .saturating_sub(1)
+        .checked_mul(cstride)
+        .and_then(|main| main.checked_add(nrows.min(1) * ncols))
+}
+
+/// Errors for [`Layout::new`].
+#[derive(Debug)]
+pub struct LayoutError(LayoutErrorInner);
+
+impl LayoutError {
+    fn check(nrows: usize, ncols: usize, cstride: usize) -> Result<usize, Self> {
+        if cstride < ncols {
+            Err(Self(LayoutErrorInner::InvalidStride { ncols, cstride }))
+        } else {
+            linear_length(nrows, ncols, cstride)
+                .ok_or(Self(LayoutErrorInner::Overflow { nrows, cstride }))
+        }
+    }
+}
+
+impl fmt::Display for LayoutError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl std::error::Error for LayoutError {}
+
+#[derive(Debug)]
+enum LayoutErrorInner {
+    InvalidStride { ncols: usize, cstride: usize },
+    Overflow { nrows: usize, cstride: usize },
+}
+
+impl fmt::Display for LayoutErrorInner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidStride { ncols, cstride } => write!(
+                f,
+                "column stride {} must be greater than or equal to number of columns {}",
+                cstride, ncols
+            ),
+            Self::Overflow { nrows, cstride } => write!(
+                f,
+                "a {}x{} strided matrix has a length exceeding usize::MAX",
+                nrows, cstride
+            ),
+        }
+    }
+}
 
 /// A row-major strided matrix.
 ///
@@ -41,327 +143,188 @@ use crate::{
 /// This abstraction is useful when performing PQ related operations such as training or
 /// compression as it provides a convenient abstraction for working with columnar subsets
 /// of dense data in-place.
-#[derive(Debug, Clone, Copy)]
-pub struct Layout {
-    nrows: usize,
-    ncols: usize,
-    cstride: usize,
-}
-
-impl Layout {
-    pub fn new(nrows: usize, ncols: usize, cstride: usize) -> Result<Self, LayoutError> {
-        LayoutError::check(nrows, ncols, cstride)?;
-        Ok(Self {
-            nrows,
-            ncols,
-            cstride,
-        })
-    }
-
-    pub fn new_for<T>(nrows: usize, ncols: usize, cstride: usize) -> Result<Self, LayoutError> {
-        LayoutError::check_for::<T>(nrows, ncols, cstride)?;
-        Ok(Self {
-            nrows,
-            ncols,
-            cstride,
-        })
-    }
-
-    pub fn nrows(&self) -> usize {
-        self.nrows
-    }
-
-    pub fn ncols(&self) -> usize {
-        self.ncols
-    }
-
-    pub fn cstride(&self) -> usize {
-        self.cstride
-    }
-
-    pub fn linear_length(&self) -> usize {
-        self.nrows.saturating_sub(1) * self.cstride + self.nrows.min(1) * self.ncols
-    }
-}
-
-fn __linear_length(nrows: usize, ncols: usize, cstride: usize) -> Option<usize> {
-    nrows
-        .saturating_sub(1)
-        .checked_mul(cstride)
-        .and_then(|main| main.checked_add(nrows.min(1) * ncols))
-}
-
 #[derive(Debug)]
-pub struct LayoutError(LayoutErrorInner);
-
-impl LayoutError {
-    fn check(nrows: usize, ncols: usize, cstride: usize) -> Result<usize, Self> {
-        if cstride < ncols {
-            Err(Self(LayoutErrorInner::InvalidStride { ncols, cstride }))
-        } else {
-            __linear_length(nrows, ncols, cstride).ok_or(Self(LayoutErrorInner::Overflow {
-                nrows,
-                cstride,
-                elsize: None,
-            }))
-        }
-    }
-
-    fn check_for<T>(nrows: usize, ncols: usize, cstride: usize) -> Result<(), Self> {
-        let len = Self::check(nrows, ncols, cstride)?;
-
-        let elsize = std::mem::size_of::<T>();
-        if let Some(bytes) = len.checked_mul(elsize) {
-            if bytes <= isize::MAX as usize {
-                return Ok(());
-            }
-        }
-
-        Err(Self(LayoutErrorInner::Overflow {
-            nrows,
-            cstride,
-            elsize: NonZeroUsize::new(elsize),
-        }))
-    }
+pub struct Strided<'a, T> {
+    ptr: NonNull<T>,
+    layout: Layout,
+    _lifetime: PhantomData<&'a [T]>,
 }
 
-impl fmt::Display for LayoutError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl std::error::Error for LayoutError {}
-
-#[derive(Debug)]
-enum LayoutErrorInner {
-    InvalidStride {
+impl<'a, T> Strided<'a, T> {
+    /// Construct a strided view over data slice, shrinking the slice as needed.
+    ///
+    /// Returns an error if the layout is invalid or `data` is not at least
+    /// [`Layout::linear_length`].
+    pub fn try_from_data(
+        data: &'a [T],
+        nrows: usize,
         ncols: usize,
         cstride: usize,
-    },
-    Overflow {
-        nrows: usize,
-        cstride: usize,
-        elsize: Option<NonZeroUsize>,
-    },
-}
-
-impl fmt::Display for LayoutErrorInner {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidStride { ncols, cstride } => write!(
-                f,
-                "column strice {} must be greater than or equal to number of columns {}",
-                cstride, ncols
-            ),
-
-            Self::Overflow {
-                nrows,
-                cstride,
-                elsize,
-            } => match elsize {
-                None => write!(
-                    f,
-                    "a {}x{} strided matrix has a length exceeding usize::MAX",
-                    nrows, cstride
-                ),
-
-                Some(elsize) => write!(
-                    f,
-                    "a {}x{} strided matrix with elements of size {} exceeds isize::MAX bytes",
-                    nrows, cstride, elsize,
-                ),
-            },
+    ) -> Result<Self, TryFromError> {
+        let layout = Layout::new(nrows, ncols, cstride).map_err(TryFromError::LayoutError)?;
+        let expected = layout.linear_length();
+        if data.len() < expected {
+            Err(TryFromError::InvalidLength {
+                got: data.len(),
+                expected,
+            })
+        } else {
+            Ok(Self {
+                ptr: internal::slice_to_nonnull(data),
+                layout,
+                _lifetime: PhantomData,
+            })
         }
     }
-}
 
-pub unsafe trait Strided {
-    type Element;
+    fn as_nonnull(&self) -> NonNull<T> {
+        self.ptr
+    }
 
-    fn as_nonnull(&self) -> NonNull<Self::Element>;
-    fn layout(&self) -> Layout;
+    /// Return the [`Layout`] for the matrix.
+    pub fn layout(&self) -> Layout {
+        self.layout
+    }
 
-    //----------//
-    // Provided //
-    //----------//
-
-    fn as_ptr(&self) -> *const Self::Element {
+    pub fn as_ptr(&self) -> *const T {
         self.as_nonnull().as_ptr().cast_const()
     }
 
-    fn ncols(&self) -> usize {
+    /// Return the number of columns in the matrix.
+    pub fn ncols(&self) -> usize {
         self.layout().ncols()
     }
 
-    fn nrows(&self) -> usize {
+    /// Return the number of rows in the matrix.
+    pub fn nrows(&self) -> usize {
         self.layout().nrows()
     }
 
-    fn cstride(&self) -> usize {
+    /// Return the count of elements between the start of each row.
+    pub fn cstride(&self) -> usize {
         self.layout().cstride()
     }
 
-    fn as_slice(&self) -> &[Self::Element] {
+    /// Return the underlying data as a slice.
+    ///
+    /// # Note
+    ///
+    /// The underlying representation for a strided matrix is not necessarily dense.
+    pub fn as_slice(&self) -> &[T] {
         let layout = self.layout();
+
+        // SAFETY: Constructors verify that the backing memory has a length as least
+        // `layout.linear_length()`.
         unsafe { std::slice::from_raw_parts(self.as_ptr(), layout.linear_length()) }
     }
 
     // Element Access
 
-    unsafe fn element_unchecked(&self, row: usize, col: usize) -> &Self::Element {
+    /// Return the specified element.
+    ///
+    /// # Safety
+    ///
+    /// * `row < self.nrows()`.
+    /// * `col < self.ncols()`.
+    pub unsafe fn element_unchecked(&self, row: usize, col: usize) -> &T {
         let layout = self.layout();
         debug_assert!(row < layout.nrows());
         debug_assert!(col < layout.ncols());
 
+        // SAFETY: Constructors verify that the backing memory has a length of at least
+        // `layout.linear_length`. Since `row` and `col` are in-bounds, the pointer offset
+        // is valid and it is safe to return a reference.
         unsafe { &*self.as_ptr().add(layout.cstride() * row + col) }
     }
 
-    fn element(&self, row: usize, col: usize) -> Option<&Self::Element> {
+    /// Return the specified element if `row < self.nrows()` and `col < self.ncols()`.
+    pub fn element(&self, row: usize, col: usize) -> Option<&T> {
         if row < self.nrows() && col < self.ncols() {
+            // SAFETY: `row` and `col` are in-bounds.
             Some(unsafe { self.element_unchecked(row, col) })
         } else {
             None
         }
     }
 
-    fn element_or_panic(&self, row: usize, col: usize) -> &Self::Element {
-        assert!(row < self.nrows());
-        assert!(col < self.ncols());
+    /// Return the specified element.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `row >= self.nrows()` or `col >= self.ncols()`.
+    pub fn element_or_panic(&self, row: usize, col: usize) -> &T {
+        assert!(
+            row < self.nrows(),
+            "row {} is out of bounds for a matrix with {} rows",
+            row,
+            self.nrows()
+        );
+        assert!(
+            col < self.ncols(),
+            "col {} is out of bounds for a matrix with {} cols",
+            col,
+            self.ncols()
+        );
 
+        // SAFETY: `row` and `col` are in-bounds.
         unsafe { self.element_unchecked(row, col) }
     }
 
     // Row Access
 
-    unsafe fn row_unchecked(&self, row: usize) -> &[Self::Element] {
+    /// Returns the requested row without boundschecking.
+    ///
+    /// # Safety
+    ///
+    /// Caller must ensure `row < self.nrows()`.
+    pub unsafe fn row_unchecked(&self, row: usize) -> &[T] {
         let layout = self.layout();
         debug_assert!(row < layout.nrows());
 
+        // SAFETY: Constructors verify that the backing memory has a length of at least
+        // `layout.linear_length`. Since `row` is in-bounds, the pointer offset
+        // is valid and it is safe to form a slice of length `layout.ncols()`.
         unsafe {
             std::slice::from_raw_parts(self.as_ptr().add(layout.cstride() * row), layout.ncols())
         }
     }
 
-    fn row(&self, row: usize) -> Option<&[Self::Element]> {
+    /// Return the requested row if `row < self.nrows()`.
+    pub fn row(&self, row: usize) -> Option<&[T]> {
         if row < self.nrows() {
+            // SAFETY: `row` is in-bounds.
             Some(unsafe { self.row_unchecked(row) })
         } else {
             None
         }
     }
 
-    fn row_or_panic(&self, row: usize) -> &[Self::Element] {
-        assert!(row < self.nrows());
+    /// Return row `row` as a slice.
+    ///
+    /// # Panic
+    ///
+    /// Panics if `row >= self.nrows()`.
+    pub fn row_or_panic(&self, row: usize) -> &[T] {
+        assert!(
+            row < self.nrows(),
+            "row {} is out of bounds for a matrix with {} rows",
+            row,
+            self.nrows()
+        );
+
+        // SAFETY: `row` is in-bounds.
         unsafe { self.row_unchecked(row) }
     }
 
-    fn rows(&self) -> impl Iterator<Item = &[Self::Element]> {
-        assert!(self.ncols() != 0);
-
-        let ncols = self.ncols();
-        self.as_slice()
-            .chunks(self.cstride())
-            .map(move |i| &i[..ncols])
-    }
-
-    // Reborrow
-
-    fn as_view(&self) -> Ref<'_, Self::Element> {
-        Ref {
-            ptr: self.as_nonnull(),
-            layout: self.layout(),
-            _lifetime: PhantomData,
-        }
+    /// Return a iterator over all rows in the matrix.
+    ///
+    /// Rows are yielded sequentially beginning with row 0.
+    pub fn rows(&self) -> Rows<'_, T> {
+        Rows::new(*self)
     }
 }
 
-pub unsafe trait StridedMut: Strided {
-    //----------//
-    // Provided //
-    //----------//
-
-    fn as_mut_ptr(&self) -> *mut Self::Element {
-        self.as_nonnull().as_ptr()
-    }
-
-    fn as_mut_slice(&mut self) -> &mut [Self::Element] {
-        unsafe { std::slice::from_raw_parts_mut(self.as_mut_ptr(), self.layout().linear_length()) }
-    }
-
-    // Element Access
-
-    unsafe fn element_mut_unchecked(&mut self, row: usize, col: usize) -> &mut Self::Element {
-        let layout = self.layout();
-        debug_assert!(row < layout.nrows());
-        debug_assert!(col < layout.ncols());
-
-        unsafe { &mut *self.as_mut_ptr().add(layout.cstride() * row + col) }
-    }
-
-    fn element_mut(&mut self, row: usize, col: usize) -> Option<&mut Self::Element> {
-        if row < self.nrows() && col < self.ncols() {
-            Some(unsafe { self.element_mut_unchecked(row, col) })
-        } else {
-            None
-        }
-    }
-
-    fn element_mut_or_panic(&mut self, row: usize, col: usize) -> &mut Self::Element {
-        assert!(row < self.nrows());
-        assert!(col < self.ncols());
-
-        unsafe { self.element_mut_unchecked(row, col) }
-    }
-
-    // Row Access
-
-    unsafe fn row_mut_unchecked(&mut self, row: usize) -> &mut [Self::Element] {
-        let layout = self.layout();
-        debug_assert!(row < layout.nrows());
-
-        unsafe {
-            std::slice::from_raw_parts_mut(
-                self.as_mut_ptr().add(layout.cstride() * row),
-                layout.ncols(),
-            )
-        }
-    }
-
-    fn row_mut(&mut self, row: usize) -> Option<&mut [Self::Element]> {
-        if row < self.nrows() {
-            Some(unsafe { self.row_mut_unchecked(row) })
-        } else {
-            None
-        }
-    }
-
-    fn row_mut_or_panic(&mut self, row: usize) -> &mut [Self::Element] {
-        assert!(row < self.nrows());
-        unsafe { self.row_mut_unchecked(row) }
-    }
-
-    fn rows_mut(&mut self) -> impl Iterator<Item = &mut [Self::Element]> {
-        assert!(self.ncols() != 0);
-
-        let ncols = self.ncols();
-        let cstride = self.cstride();
-        self.as_mut_slice()
-            .chunks_mut(cstride)
-            .map(move |i| &mut i[..ncols])
-    }
-
-    // Reborrow
-
-    fn as_mut_view(&mut self) -> Mut<'_, Self::Element> {
-        Mut {
-            ptr: self.as_nonnull(),
-            layout: self.layout(),
-            _lifetime: PhantomData,
-        }
-    }
-}
-
+/// Errors for [`Strided::new`].
 #[derive(Debug, Error)]
 pub enum TryFromError {
     #[error(transparent)]
@@ -374,43 +337,7 @@ pub enum TryFromError {
     InvalidLength { got: usize, expected: usize },
 }
 
-/////////
-// Ref //
-/////////
-
-#[derive(Debug)]
-pub struct Ref<'a, T> {
-    ptr: NonNull<T>,
-    layout: Layout,
-    _lifetime: PhantomData<&'a [T]>,
-}
-
-impl<'a, T> Ref<'a, T> {
-    pub fn try_from_data(
-        data: &'a [T],
-        nrows: usize,
-        ncols: usize,
-        cstride: usize,
-    ) -> Result<Self, TryFromError> {
-        let layout =
-            Layout::new_for::<T>(nrows, ncols, cstride).map_err(TryFromError::LayoutError)?;
-        let expected = layout.linear_length();
-        if data.len() < expected {
-            Err(TryFromError::InvalidLength {
-                got: data.len(),
-                expected,
-            })
-        } else {
-            Ok(Self {
-                ptr: unsafe { NonNull::new_unchecked(data.as_ptr().cast_mut()) },
-                layout,
-                _lifetime: PhantomData,
-            })
-        }
-    }
-}
-
-impl<'a, T> From<views::MatrixView<'a, T>> for Ref<'a, T> {
+impl<'a, T> From<views::MatrixView<'a, T>> for Strided<'a, T> {
     fn from(matrix: views::MatrixView<'a, T>) -> Self {
         // FIXME: `views::MatrixView` doesn't quite ensure that `nrows * ncols` doesn't
         // overflow. So for now, we need to be pessimistic.
@@ -426,607 +353,87 @@ impl<'a, T> From<views::MatrixView<'a, T>> for Ref<'a, T> {
     }
 }
 
-unsafe impl<T> Send for Ref<'_, T> where T: Sync {}
-unsafe impl<T> Sync for Ref<'_, T> where T: Sync {}
+// SAFETY: `Strided` only exposes shared access to its `T` elements (via `&T`/`&[T]`), so
+// sharing or transferring a `Strided<T>` across threads is sound whenever `T: Sync`.
+unsafe impl<T> Send for Strided<'_, T> where T: Sync {}
+// SAFETY: See above.
+unsafe impl<T> Sync for Strided<'_, T> where T: Sync {}
 
-impl<T> Clone for Ref<'_, T> {
+impl<T> Clone for Strided<'_, T> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<T> Copy for Ref<'_, T> {}
+impl<T> Copy for Strided<'_, T> {}
 
-impl<'a, T> Reborrow<'a> for Ref<'_, T> {
-    type Target = Ref<'a, T>;
+impl<'a, T> Reborrow<'a> for Strided<'_, T> {
+    type Target = Strided<'a, T>;
     fn reborrow(&'a self) -> Self::Target {
         *self
     }
 }
 
-unsafe impl<T> Strided for Ref<'_, T> {
-    type Element = T;
-
-    fn as_nonnull(&self) -> NonNull<T> {
-        self.ptr
-    }
-
-    fn layout(&self) -> Layout {
-        self.layout
-    }
-}
-
-/////////
-// Mut //
-/////////
-
+/// Iterator for [`Strided::rows`].
 #[derive(Debug)]
-pub struct Mut<'a, T> {
+pub struct Rows<'a, T> {
     ptr: NonNull<T>,
-    layout: Layout,
-    _lifetime: PhantomData<&'a mut [T]>,
+    remaining: usize,
+    ncols: usize,
+    cstride: usize,
+    _lifetime: PhantomData<&'a T>,
 }
 
-impl<'a, T> Mut<'a, T> {
-    pub fn try_from_data(
-        data: &'a mut [T],
-        nrows: usize,
-        ncols: usize,
-        cstride: usize,
-    ) -> Result<Self, TryFromError> {
-        let layout =
-            Layout::new_for::<T>(nrows, ncols, cstride).map_err(TryFromError::LayoutError)?;
-        let expected = layout.linear_length();
-        if data.len() < expected {
-            Err(TryFromError::InvalidLength {
-                got: data.len(),
-                expected,
-            })
-        } else {
-            Ok(Self {
-                ptr: unsafe { NonNull::new_unchecked(data.as_ptr().cast_mut()) },
-                layout,
-                _lifetime: PhantomData,
-            })
-        }
-    }
-}
-
-impl<'a, T> From<views::MutMatrixView<'a, T>> for Mut<'a, T> {
-    fn from(matrix: views::MutMatrixView<'a, T>) -> Self {
-        let (nrows, ncols) = (matrix.nrows(), matrix.ncols());
-
-        // FIXME: `views::MatrixView` doesn't quite ensure that `nrows * ncols` doesn't
-        // overflow. So for now, we need to be pessimistic.
-        //
-        // This will be fixed when `MatrixView` gets the same treatment.
-        Self::try_from_data(matrix.into_inner(), nrows, ncols, ncols)
-            .expect("this will be made infallible in the future")
-    }
-}
-
-unsafe impl<T> Send for Mut<'_, T> where T: Send {}
-unsafe impl<T> Sync for Mut<'_, T> where T: Sync {}
-
-impl<'a, T> Reborrow<'a> for Mut<'_, T> {
-    type Target = Ref<'a, T>;
-    fn reborrow(&'a self) -> Self::Target {
-        Ref {
-            ptr: self.ptr,
-            layout: self.layout,
+impl<'a, T> Rows<'a, T> {
+    fn new(strided: Strided<'a, T>) -> Self {
+        let layout = strided.layout();
+        Self {
+            ptr: strided.as_nonnull(),
+            remaining: layout.nrows(),
+            ncols: layout.ncols(),
+            cstride: layout.cstride(),
             _lifetime: PhantomData,
         }
     }
 }
 
-impl<'a, T> ReborrowMut<'a> for Mut<'_, T> {
-    type Target = Mut<'a, T>;
-    fn reborrow_mut(&'a mut self) -> Self::Target {
-        Mut {
-            ptr: self.ptr,
-            layout: self.layout,
-            _lifetime: PhantomData,
-        }
+// SAFETY: `Rows` only yields shared `&[T]` slices borrowed from a `Strided`, so sharing or
+// transferring a `Rows<T>` across threads is sound whenever `T: Sync`.
+unsafe impl<T> Send for Rows<'_, T> where T: Sync {}
+// SAFETY: See above.
+unsafe impl<T> Sync for Rows<'_, T> where T: Sync {}
+
+impl<'a, T> Iterator for Rows<'a, T> {
+    type Item = &'a [T];
+    fn next(&mut self) -> Option<&'a [T]> {
+        self.remaining.checked_sub(1).map(|remaining| {
+            // SAFETY: The originating `Strided` guarantees `self.remaining` rows of
+            // `self.ncols` elements each are readable starting from `self.ptr`, so the
+            // current row is valid for `self.ncols` elements.
+            let item =
+                unsafe { std::slice::from_raw_parts(self.ptr.as_ptr().cast_const(), self.ncols) };
+            self.remaining = remaining;
+            if remaining != 0 {
+                // SAFETY: There is at least one more row remaining, so advancing by
+                // `self.cstride` stays within (or one-past-the-end of) the originating
+                // allocation, per `Layout::linear_length`.
+                self.ptr = unsafe { self.ptr.add(self.cstride) };
+            }
+            item
+        })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
     }
 }
 
-unsafe impl<T> Strided for Mut<'_, T> {
-    type Element = T;
+impl<T> ExactSizeIterator for Rows<'_, T> {}
+impl<T> std::iter::FusedIterator for Rows<'_, T> {}
 
-    fn as_nonnull(&self) -> NonNull<T> {
-        self.ptr
-    }
-
-    fn layout(&self) -> Layout {
-        self.layout
-    }
-}
-
-unsafe impl<T> StridedMut for Mut<'_, T> {}
-
-// /////////
-// // OLD //
-// /////////
-//
-// #[derive(Debug, Clone, Copy)]
-// pub struct StridedBase<T>
-// where
-//     T: DenseData,
-// {
-//     data: T,
-//     nrows: usize,
-//     ncols: usize,
-//     // The stride along the columns. This must be greater than or equal to `ncols`.
-//     cstride: usize,
-// }
-//
-// /// Return the linear length of a slice underlying a `StridedBase` with the given parameters.
-// pub fn linear_length(nrows: usize, ncols: usize, cstride: usize) -> usize {
-//     (nrows.max(1) - 1) * cstride + nrows.min(1) * ncols
-// }
-//
-// #[derive(Debug, Error)]
-// #[non_exhaustive]
-// #[error(
-//     "tried to construct a strided matrix with {nrows} rows and {ncols} cols and \
-//      column stride {cstride} over a slice of length {} (expected {})",
-//      len,
-//      linear_length(self.nrows, self.ncols, self.cstride)
-// )]
-// pub struct TryFromErrorLight {
-//     len: usize,
-//     nrows: usize,
-//     ncols: usize,
-//     cstride: usize,
-// }
-//
-// #[derive(Error)]
-// #[non_exhaustive]
-// #[error(
-//     "tried to construct a strided matrix with {nrows} rows and {ncols} cols and \
-//      column stride {cstride} over a slice of length {} (expected {})",
-//      data.as_slice().len(),
-//      linear_length(self.nrows, self.ncols, self.cstride)
-// )]
-// pub struct TryFromError<T: views::DenseData> {
-//     data: T,
-//     nrows: usize,
-//     ncols: usize,
-//     cstride: usize,
-// }
-//
-// // Manually implement `fmt::Debug` so we don't require `T::Debug`.
-// impl<T: DenseData> fmt::Debug for TryFromError<T> {
-//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-//         f.debug_struct("TryFromError")
-//             .field("data_len", &self.data.as_slice().len())
-//             .field("nrows", &self.nrows)
-//             .field("ncols", &self.ncols)
-//             .field("cstride", &self.cstride)
-//             .finish()
-//     }
-// }
-//
-// impl<T: views::DenseData> TryFromError<T> {
-//     /// Consume the error and return the base data.
-//     pub fn into_inner(self) -> T {
-//         self.data
-//     }
-//
-//     /// Drop the data portion of the error and return an equivalent error that is guaranteed
-//     /// to be `'static`.
-//     pub fn as_static(&self) -> TryFromErrorLight {
-//         TryFromErrorLight {
-//             len: self.data.as_slice().len(),
-//             nrows: self.nrows,
-//             ncols: self.ncols,
-//             cstride: self.cstride,
-//         }
-//     }
-// }
-//
-// impl<'a, T> StridedBase<&'a [T]> {
-//     /// Construct a strided view over data slice, shrinking the slice as needed.
-//     ///
-//     /// Returns an error if `data` is shorter than the value returned by `linear_length`.
-//     ///
-//     /// # Panics
-//     ///
-//     /// * Panics if `cstride < ncols`.
-//     pub fn try_shrink_from(
-//         data: &'a [T],
-//         nrows: usize,
-//         ncols: usize,
-//         cstride: usize,
-//     ) -> Result<Self, TryFromError<&'a [T]>> {
-//         assert!(
-//             cstride >= ncols,
-//             "cstride must be greater than or equal to ncols"
-//         );
-//         let required_length = linear_length(nrows, ncols, cstride);
-//         match data.get(..required_length) {
-//             Some(data) => Ok(Self {
-//                 data,
-//                 nrows,
-//                 ncols,
-//                 cstride,
-//             }),
-//             None => Err(TryFromError {
-//                 data,
-//                 nrows,
-//                 ncols,
-//                 cstride,
-//             }),
-//         }
-//     }
-// }
-//
-// impl<'a, T> StridedBase<&'a mut [T]> {
-//     /// Construct a strided view over data slice, shrinking the slice as needed.
-//     ///
-//     /// Returns an error if `data` is shorter than the value returned by `linear_length`.
-//     ///
-//     /// # Panics
-//     ///
-//     /// * Panics if `cstride < ncols`.
-//     pub fn try_shrink_from_mut(
-//         data: &'a mut [T],
-//         nrows: usize,
-//         ncols: usize,
-//         cstride: usize,
-//     ) -> Result<Self, TryFromError<&'a mut [T]>> {
-//         assert!(
-//             cstride >= ncols,
-//             "cstride must be greater than or equal to ncols"
-//         );
-//         let required_length = linear_length(nrows, ncols, cstride);
-//         if data.as_slice().len() >= required_length {
-//             Ok(Self {
-//                 data: &mut data[..required_length],
-//                 nrows,
-//                 ncols,
-//                 cstride,
-//             })
-//         } else {
-//             Err(TryFromError {
-//                 data,
-//                 nrows,
-//                 ncols,
-//                 cstride,
-//             })
-//         }
-//     }
-// }
-//
-// impl<T> StridedBase<T>
-// where
-//     T: DenseData,
-// {
-//     /// Construct a strided view over data slice, shrinking the slice as needed.
-//     ///
-//     /// Returns an error if `data` is not equal to the expected length as determined
-//     /// by `linear_length`.
-//     ///
-//     /// # Panics
-//     ///
-//     /// * Panics if `cstride < ncols`.
-//     pub fn try_from(
-//         data: T,
-//         nrows: usize,
-//         ncols: usize,
-//         cstride: usize,
-//     ) -> Result<Self, TryFromError<T>> {
-//         assert!(
-//             cstride >= ncols,
-//             "cstride must be greater than or equal to ncols"
-//         );
-//         // This computation needs to be set up such that:
-//         // 1. When `nrows == 0`, the expected length is 0.
-//         // 2. We make a tight upper-bound on the expected length for the last row.
-//         let required_length = linear_length(nrows, ncols, cstride);
-//         if data.as_slice().len() == required_length {
-//             Ok(Self {
-//                 data,
-//                 nrows,
-//                 ncols,
-//                 cstride,
-//             })
-//         } else {
-//             Err(TryFromError {
-//                 data,
-//                 nrows,
-//                 ncols,
-//                 cstride,
-//             })
-//         }
-//     }
-//
-//     /// Return the number of columns in the matrix.
-//     pub fn ncols(&self) -> usize {
-//         self.ncols
-//     }
-//
-//     /// Return the number of rows in the matrix.
-//     pub fn nrows(&self) -> usize {
-//         self.nrows
-//     }
-//
-//     /// Return the count of elements between the start of each row.
-//     pub fn cstride(&self) -> usize {
-//         self.cstride
-//     }
-//
-//     /// Return the underlying data as a slice.
-//     ///
-//     /// # Note
-//     ///
-//     /// The underlying representation for a strided matrix is not necessarily dense.
-//     pub fn as_slice(&self) -> &[T::Elem] {
-//         self.data.as_slice()
-//     }
-//
-//     /// Return the underlying data as a slice.
-//     ///
-//     /// # Note
-//     ///
-//     /// The underlying representation for a strided matrix is not necessarily dense.
-//     pub fn as_mut_slice(&mut self) -> &mut [T::Elem]
-//     where
-//         T: MutDenseData,
-//     {
-//         self.data.as_mut_slice()
-//     }
-//
-//     /// Return row `row` as a slice.
-//     ///
-//     /// # Panic
-//     ///
-//     /// Panics if `row >= self.nrows()`.
-//     pub fn row(&self, row: usize) -> &[T::Elem] {
-//         assert!(
-//             row < self.nrows(),
-//             "tried to access row {row} of a matrix with {} rows",
-//             self.nrows()
-//         );
-//
-//         // SAFETY: `row` is in-bounds.
-//         unsafe { self.get_row_unchecked(row) }
-//     }
-//
-//     /// Returns the requested row without boundschecking.
-//     ///
-//     /// # Safety
-//     ///
-//     /// The following conditions must hold to avoid undefined behavior:
-//     /// * `row < self.nrows()`.
-//     pub unsafe fn get_row_unchecked(&self, row: usize) -> &[T::Elem] {
-//         debug_assert!(row < self.nrows);
-//         let cstride = self.cstride;
-//         let ncols = self.ncols;
-//         let start = row * cstride;
-//
-//         debug_assert!(start + ncols <= self.as_slice().len());
-//         // SAFETY: The idempotency requirement of `as_slice` and our audited constructors
-//         // mean that `self.as_slice()` has a length of `self.nrows * self.ncols`.
-//         //
-//         // Therefore, this access is in-bounds.
-//         unsafe { self.as_slice().get_unchecked(start..start + ncols) }
-//     }
-//
-//     /// Return row `row` as a mutable slice.
-//     ///
-//     /// # Panics
-//     ///
-//     /// Panics if `row >= self.nrows()`.
-//     pub fn row_mut(&mut self, row: usize) -> &mut [T::Elem]
-//     where
-//         T: MutDenseData,
-//     {
-//         assert!(
-//             row < self.nrows(),
-//             "tried to access row {row} of a matrix with {} rows",
-//             self.nrows()
-//         );
-//
-//         // SAFETY: `row` is in-bounds.
-//         unsafe { self.get_row_unchecked_mut(row) }
-//     }
-//
-//     /// Returns the requested row without boundschecking.
-//     ///
-//     /// # Safety
-//     ///
-//     /// The following conditions must hold to avoid undefined behavior:
-//     /// * `row < self.nrows()`.
-//     pub unsafe fn get_row_unchecked_mut(&mut self, row: usize) -> &mut [T::Elem]
-//     where
-//         T: MutDenseData,
-//     {
-//         debug_assert!(row < self.nrows);
-//         let cstride = self.cstride;
-//         let ncols = self.ncols;
-//         let start = row * cstride;
-//
-//         debug_assert!(start + ncols <= self.as_slice().len());
-//         // SAFETY: The idempotency requirement of `as_mut_slice` and our audited constructors
-//         // mean that `self.as_mut_slice()` has a length of `self.nrows * self.ncols`.
-//         //
-//         // Therefore, this access is in-bounds.
-//         unsafe {
-//             self.data
-//                 .as_mut_slice()
-//                 .get_unchecked_mut(start..start + ncols)
-//         }
-//     }
-//
-//     /// Return a iterator over all rows in the matrix.
-//     ///
-//     /// Rows are yielded sequentially beginning with row 0.
-//     ///
-//     /// # Panics
-//     ///
-//     /// Panics if `self.ncols() == 0` (because the implementation does not work correctly
-//     /// in this case and it's too corner-case to bother fixing). This restriction may
-//     /// be lifted in the future.
-//     pub fn row_iter(&self) -> impl Iterator<Item = &[T::Elem]> {
-//         assert!(self.ncols() != 0);
-//         let ncols = self.ncols;
-//
-//         self.data
-//             .as_slice()
-//             .chunks(self.cstride())
-//             .map(move |i| &i[..ncols])
-//     }
-//
-//     /// Return a mutable iterator over all rows in the matrix.
-//     ///
-//     /// Rows are yielded sequentially beginning with row 0.
-//     ///
-//     /// # Panics
-//     ///
-//     /// Panics if `self.ncols() == 0` (because the implementation does not work correctly
-//     /// in this case and it's too corner-case to bother fixing). This restriction may
-//     /// be lifted in the future.
-//     pub fn row_iter_mut(&mut self) -> impl Iterator<Item = &mut [T::Elem]>
-//     where
-//         T: MutDenseData,
-//     {
-//         assert!(self.ncols() != 0);
-//
-//         let ncols = self.ncols();
-//         let cstride = self.cstride();
-//         self.data
-//             .as_mut_slice()
-//             .chunks_mut(cstride)
-//             .map(move |i| &mut i[..ncols])
-//     }
-//
-//     /// Return a pointer to the base of the matrix.
-//     pub fn as_ptr(&self) -> *const T::Elem {
-//         self.as_slice().as_ptr()
-//     }
-//
-//     /// Return a pointer to the base of the matrix.
-//     pub fn as_mut_ptr(&mut self) -> *mut T::Elem
-//     where
-//         T: MutDenseData,
-//     {
-//         self.as_mut_slice().as_mut_ptr()
-//     }
-//
-//     /// Returns a reference to an element without boundschecking.
-//     ///
-//     /// # Safety
-//     ///
-//     /// The following conditions must hold to avoid undefined behavior:
-//     /// * `row < self.nrows()`.
-//     /// * `col < self.ncols()`.
-//     pub unsafe fn get_unchecked(&self, row: usize, col: usize) -> &T::Elem {
-//         debug_assert!(row < self.nrows);
-//         debug_assert!(col < self.ncols);
-//         self.as_slice().get_unchecked(row * self.cstride + col)
-//     }
-//
-//     /// Returns a mutable reference to an element without boundschecking.
-//     ///
-//     /// # Safety
-//     ///
-//     /// The following conditions must hold to avoid undefined behavior:
-//     /// * `row < self.nrows()`.
-//     /// * `col < self.ncols()`.
-//     pub unsafe fn get_unchecked_mut(&mut self, row: usize, col: usize) -> &mut T::Elem
-//     where
-//         T: MutDenseData,
-//     {
-//         let cstride = self.cstride;
-//         debug_assert!(row < self.nrows);
-//         debug_assert!(col < self.ncols);
-//         self.as_mut_slice().get_unchecked_mut(row * cstride + col)
-//     }
-//
-//     /// Return a view over the matrix.
-//     pub fn as_view(&self) -> StridedView<'_, T::Elem> {
-//         StridedView {
-//             data: self.as_slice(),
-//             nrows: self.nrows,
-//             ncols: self.ncols,
-//             cstride: self.cstride,
-//         }
-//     }
-// }
-//
-// pub type StridedView<'a, T> = StridedBase<&'a [T]>;
-// pub type MutStridedView<'a, T> = StridedBase<&'a mut [T]>;
-//
-// /// Return a reference to the item at entry `(row, col)` in the matrix.
-// ///
-// /// # Panics
-// ///
-// /// Panics if `row >= self.nrows()` or `col >= self.ncols()`.
-// impl<T> Index<(usize, usize)> for StridedBase<T>
-// where
-//     T: DenseData,
-// {
-//     type Output = T::Elem;
-//
-//     fn index(&self, (row, col): (usize, usize)) -> &Self::Output {
-//         assert!(
-//             row < self.nrows(),
-//             "row {row} is out of bounds (max: {})",
-//             self.nrows()
-//         );
-//         assert!(
-//             col < self.ncols(),
-//             "col {col} is out of bounds (max: {})",
-//             self.ncols()
-//         );
-//         // SAFETY: We have checked that `row` and `col` are in-bounds.
-//         unsafe { self.get_unchecked(row, col) }
-//     }
-// }
-//
-// /// Return a mutable reference to the item at entry `(row, col)` in the matrix.
-// ///
-// /// # Panics
-// ///
-// /// Panics if `row >= self.nrows()` or `col >= self.ncols()`.
-// impl<T> IndexMut<(usize, usize)> for StridedBase<T>
-// where
-//     T: MutDenseData,
-// {
-//     fn index_mut(&mut self, (row, col): (usize, usize)) -> &mut Self::Output {
-//         assert!(
-//             row < self.nrows(),
-//             "row {row} is out of bounds (max: {})",
-//             self.nrows()
-//         );
-//         assert!(
-//             col < self.ncols(),
-//             "col {col} is out of bounds (max: {})",
-//             self.ncols()
-//         );
-//         // SAFETY: We have checked that `row` and `col` are in-bounds.
-//         unsafe { self.get_unchecked_mut(row, col) }
-//     }
-// }
-//
-// impl<T, U> From<views::MatrixBase<T>> for StridedBase<U>
-// where
-//     T: DenseData,
-//     U: DenseData,
-//     T: Into<U>,
-// {
-//     fn from(matrix: views::MatrixBase<T>) -> Self {
-//         let nrows = matrix.nrows();
-//         let ncols = matrix.ncols();
-//         Self {
-//             data: matrix.into_inner().into(),
-//             nrows,
-//             ncols,
-//             cstride: ncols,
-//         }
-//     }
-// }
+///////////
+// Tests //
+///////////
 
 #[cfg(test)]
 mod tests {
@@ -1035,21 +442,21 @@ mod tests {
     #[test]
     fn test_linear_length() {
         // If the number of rows is zero - the output should always be zero.
-        assert_eq!(__linear_length(0, 1, 1).unwrap(), 0);
-        assert_eq!(__linear_length(0, 2, 2).unwrap(), 0);
-        assert_eq!(__linear_length(0, 2, 3).unwrap(), 0);
-        assert_eq!(__linear_length(0, 2, 4).unwrap(), 0);
+        assert_eq!(linear_length(0, 1, 1).unwrap(), 0);
+        assert_eq!(linear_length(0, 2, 2).unwrap(), 0);
+        assert_eq!(linear_length(0, 2, 3).unwrap(), 0);
+        assert_eq!(linear_length(0, 2, 4).unwrap(), 0);
 
         // If `cstride == ncols`, then the computation should be trivial.
         for row in 1..10 {
             for col in 1..10 {
-                assert_eq!(__linear_length(row, col, col).unwrap(), row * col);
+                assert_eq!(linear_length(row, col, col).unwrap(), row * col);
             }
         }
 
         // If there is only one row, then `cstride` should be ignored.
-        assert_eq!(__linear_length(1, 5, 10).unwrap(), 5);
-        assert_eq!(__linear_length(1, 7, 99).unwrap(), 7);
+        assert_eq!(linear_length(1, 5, 10).unwrap(), 5);
+        assert_eq!(linear_length(1, 7, 99).unwrap(), 7);
 
         // Otherwise, the computation is a block of `nrows - 1` chunks of `cstride` and then
         // `ncols`. Yes - this runs a bunch of computations.
@@ -1057,7 +464,7 @@ mod tests {
             for col in 0..10 {
                 for cstride in col..12 {
                     assert_eq!(
-                        __linear_length(row, col, cstride).unwrap(),
+                        linear_length(row, col, cstride).unwrap(),
                         (row - 1) * cstride + col
                     );
                 }
@@ -1065,49 +472,163 @@ mod tests {
         }
     }
 
-    fn assert_is_static<T: 'static>(_x: &T) {}
+    #[test]
+    fn test_layout_new() {
+        // Valid layouts.
+        let layout = Layout::new(3, 4, 4).unwrap();
+        assert_eq!(layout.nrows(), 3);
+        assert_eq!(layout.ncols(), 4);
+        assert_eq!(layout.cstride(), 4);
+        assert_eq!(layout.linear_length(), 12);
 
-    // #[test]
-    // fn try_from_error_misc() {
-    //     let x = TryFromError::<&[f32]> {
-    //         data: &[],
-    //         nrows: 1,
-    //         ncols: 2,
-    //         cstride: 3,
-    //     };
+        let layout = Layout::new(3, 4, 6).unwrap();
+        assert_eq!(layout.linear_length(), 2 * 6 + 4);
 
-    //     let display = format!("{}", x);
-    //     let debug = format!("{:?}", x);
-    //     println!("debug = {}", debug);
-    //     assert!(debug.contains("TryFromError"));
-    //     assert!(debug.contains("data_len: 0"));
-    //     assert!(debug.contains("nrows: 1"));
-    //     assert!(debug.contains("ncols: 2"));
-    //     assert!(debug.contains("cstride: 3"));
+        // `cstride == ncols` is fine, even at zero.
+        assert!(Layout::new(0, 0, 0).is_ok());
 
-    //     let x = x.as_static();
-    //     assert_is_static(&x);
-    //     assert_eq!(
-    //         display,
-    //         format!("{}", x),
-    //         "static version of the error must hav ethe same message"
-    //     );
-    // }
+        // Invalid stride: `cstride < ncols`.
+        let err = Layout::new(3, 4, 3).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "column stride 3 must be greater than or equal to number of columns 4"
+        );
 
-    // fn expected_error(len: usize, nrows: usize, ncols: usize, cstride: usize) -> String {
-    //     format!(
-    //         "tried to construct a strided matrix with {nrows} rows and {ncols} cols and \
-    //          column stride {cstride} over a slice of length {} (expected {})",
-    //         len,
-    //         linear_length(nrows, ncols, cstride)
-    //     )
-    // }
+        // Overflow: linear length exceeds `usize::MAX`.
+        let err = Layout::new(usize::MAX, usize::MAX, usize::MAX).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "a {}x{} strided matrix has a length exceeding usize::MAX",
+                usize::MAX,
+                usize::MAX
+            )
+        );
+    }
+
+    #[test]
+    fn test_try_from_data_errors() {
+        let m = views::Matrix::<usize>::new(0, 10, 10);
+        let nrows = m.nrows();
+        let ncols = m.ncols();
+
+        // An invalid layout (`cstride < ncols`) is reported as a `LayoutError`, not a panic.
+        let err = Strided::try_from_data(m.as_slice(), 2, 2, 1).unwrap_err();
+        assert_eq!(
+            err.to_string(),
+            "column stride 1 must be greater than or equal to number of columns 2"
+        );
+
+        // A slice shorter than `Layout::linear_length` is reported as `InvalidLength`.
+        let err = Strided::try_from_data(m.as_slice(), nrows, ncols, ncols + 1).unwrap_err();
+        let expected_len = Layout::new(nrows, ncols, ncols + 1).unwrap().linear_length();
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "argument of length {} is shorter than the expected length {}",
+                m.as_slice().len(),
+                expected_len
+            )
+        );
+    }
+
+    #[test]
+    fn test_element_and_row_out_of_bounds() {
+        let m = create_test_matrix(3, 4);
+        let v = Strided::try_from_data(m.as_slice(), m.nrows(), m.ncols(), m.ncols()).unwrap();
+
+        // In-bounds accesses succeed.
+        assert!(v.element(2, 3).is_some());
+        assert!(v.row(2).is_some());
+
+        // Out-of-bounds row and/or col return `None` rather than panicking.
+        assert!(v.element(3, 0).is_none(), "row out-of-bounds");
+        assert!(v.element(0, 4).is_none(), "col out-of-bounds");
+        assert!(v.element(3, 4).is_none(), "both out-of-bounds");
+        assert!(v.row(3).is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "row 3 is out of bounds for a matrix with 3 rows")]
+    fn test_element_or_panic_panics_on_row() {
+        let m = create_test_matrix(3, 4);
+        let v = Strided::try_from_data(m.as_slice(), m.nrows(), m.ncols(), m.ncols()).unwrap();
+        v.element_or_panic(3, 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "col 4 is out of bounds for a matrix with 4 cols")]
+    fn test_element_or_panic_panics_on_col() {
+        let m = create_test_matrix(3, 4);
+        let v = Strided::try_from_data(m.as_slice(), m.nrows(), m.ncols(), m.ncols()).unwrap();
+        v.element_or_panic(0, 4);
+    }
+
+    #[test]
+    #[should_panic(expected = "row 3 is out of bounds for a matrix with 3 rows")]
+    fn test_row_or_panic_panics() {
+        let m = create_test_matrix(3, 4);
+        let v = Strided::try_from_data(m.as_slice(), m.nrows(), m.ncols(), m.ncols()).unwrap();
+        v.row_or_panic(3);
+    }
+
+    #[test]
+    fn test_clone_copy_reborrow() {
+        let m = create_test_matrix(3, 4);
+        let v = Strided::try_from_data(m.as_slice(), m.nrows(), m.ncols(), m.ncols()).unwrap();
+
+        // `Copy`/`Clone` produce an independent handle to the same data.
+        let copied = v;
+        let cloned = v.clone();
+        assert_eq!(v.as_ptr(), copied.as_ptr());
+        assert_eq!(v.as_ptr(), cloned.as_ptr());
+
+        // `Reborrow` should yield an equivalent view.
+        let reborrowed = v.reborrow();
+        assert_eq!(reborrowed.as_ptr(), v.as_ptr());
+        assert_eq!(reborrowed.nrows(), v.nrows());
+        assert_eq!(reborrowed.ncols(), v.ncols());
+    }
+
+    #[test]
+    fn test_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<Strided<'_, u8>>();
+        assert_send_sync::<Rows<'_, u8>>();
+    }
+
+    #[test]
+    fn test_rows_iterator_properties() {
+        let m = create_test_matrix(4, 3);
+        let v = Strided::try_from_data(m.as_slice(), m.nrows(), m.ncols(), m.ncols()).unwrap();
+
+        let mut rows = v.rows();
+        assert_eq!(rows.len(), 4);
+        assert_eq!(rows.size_hint(), (4, Some(4)));
+
+        for expected_row in 0..4 {
+            let row = rows.next().unwrap();
+            assert_eq!(row, m.row(expected_row));
+        }
+
+        // Exhausted iterators keep returning `None` (`FusedIterator`).
+        assert_eq!(rows.next(), None);
+        assert_eq!(rows.next(), None);
+        assert_eq!(rows.len(), 0);
+    }
+
+    #[test]
+    fn test_rows_iterator_zero_rows() {
+        let m = create_test_matrix(5, 5);
+        let v = Strided::try_from_data(m.as_slice(), 0, 4, 5).unwrap();
+
+        let mut rows = v.rows();
+        assert_eq!(rows.len(), 0);
+        assert_eq!(rows.next(), None);
+    }
 
     // Test that the contents of `dut` match those in the dense 2d matrix.
-    fn test_indexing<T>(dut: &T, expected: views::MatrixView<'_, usize>)
-    where
-        T: Strided<Element = usize>,
-    {
+    fn test_indexing(dut: Strided<'_, usize>, expected: views::MatrixView<'_, usize>) {
         assert_eq!(dut.nrows(), expected.nrows());
         assert_eq!(dut.ncols(), expected.ncols());
 
@@ -1121,9 +642,19 @@ mod tests {
         // Compare via linear indexing.
         for row in 0..dut.nrows() {
             for col in 0..dut.ncols() {
+                let e = expected[(row, col)];
+
+                assert_eq!(
+                    *dut.element_or_panic(row, col),
+                    e,
+                    "failed on (row, col) = ({}, {})",
+                    row,
+                    col
+                );
+
                 assert_eq!(
                     *dut.element(row, col).unwrap(),
-                    expected[(row, col)],
+                    e,
                     "failed on (row, col) = ({}, {})",
                     row,
                     col
@@ -1133,6 +664,13 @@ mod tests {
 
         // Compare via row.
         for row in 0..dut.nrows() {
+            assert_eq!(
+                dut.row_or_panic(row),
+                expected.row(row),
+                "failed on row {}",
+                row
+            );
+
             assert_eq!(
                 dut.row(row).unwrap(),
                 expected.row(row),
@@ -1171,16 +709,16 @@ mod tests {
 
         // First - test a dense StridedView over the entire matrix.
         let ptr = m.as_ptr();
-        let v = Ref::try_from_data(m.as_slice(), m.nrows(), m.ncols(), m.ncols()).unwrap();
+        let v = Strided::try_from_data(m.as_slice(), m.nrows(), m.ncols(), m.ncols()).unwrap();
         assert_eq!(v.as_ptr(), ptr, "base pointer was not preserved");
 
         assert_eq!(v.nrows(), m.nrows());
         assert_eq!(v.ncols(), m.ncols());
         assert_eq!(v.cstride(), m.ncols());
-        test_indexing(&v, m.as_view());
+        test_indexing(v, m.as_view());
 
         // Now - create a truly strided view over the first two columns.
-        let v = Ref::try_from_data(
+        let v = Strided::try_from_data(
             &(m.as_slice()[..(4 * m.ncols() + 2)]),
             m.nrows(),
             2,
@@ -1196,129 +734,38 @@ mod tests {
                 expected[(row, col)] = m[(row, col)];
             }
         }
-        test_indexing(&v, expected.as_view());
+        test_indexing(v, expected.as_view());
 
         // Create a strided view over the last two columns.
-        let v = Ref::try_from_data(&(m.as_slice()[1..]), m.nrows(), 2, m.ncols()).unwrap();
+        let v = Strided::try_from_data(&(m.as_slice()[1..]), m.nrows(), 2, m.ncols()).unwrap();
         let mut expected = views::Matrix::new(0, 5, 2);
         for row in 0..expected.nrows() {
             for col in 0..expected.ncols() {
                 expected[(row, col)] = m[(row, col + 1)];
             }
         }
-        test_indexing(&v, expected.as_view());
-    }
-
-    #[test]
-    fn test_mutable_indexing() {
-        // The source matrix.
-        let src = create_test_matrix(5, 4);
-
-        // Initialize using 2d indexing.
-        {
-            let mut dst = views::Matrix::<usize>::new(0, 5, 10);
-
-            let ptr = dst.as_ptr();
-
-            let ncols = src.ncols();
-            let nrows = src.nrows();
-            let cstride = dst.ncols();
-            let mut dst_view =
-                Mut::try_from_data(dst.as_mut_slice(), nrows, ncols, cstride).unwrap();
-
-            assert_eq!(dst_view.as_ptr(), ptr);
-            assert_eq!(dst_view.as_mut_ptr().cast_const(), ptr);
-            assert_eq!(dst_view.nrows(), nrows);
-            assert_eq!(dst_view.ncols(), ncols);
-            assert_eq!(dst_view.cstride(), cstride);
-
-            // Initialize using linear indexing.
-            for row in 0..dst_view.nrows() {
-                for col in 0..dst_view.ncols() {
-                    *dst_view.element_mut(row, col).unwrap() = src[(row, col)]
-                }
-            }
-
-            // Check equality.
-            test_indexing(&dst_view, src.as_view());
-        }
-
-        // Initialize using row-wise indexing.
-        {
-            let mut dst = views::Matrix::<usize>::new(0, 5, 10);
-
-            let ptr = dst.as_ptr();
-
-            let ncols = src.ncols();
-            let nrows = src.nrows();
-            let cstride = dst.ncols();
-            let mut dst_view =
-                Mut::try_from_data(dst.as_mut_slice(), nrows, ncols, cstride).unwrap();
-
-            assert_eq!(dst_view.as_ptr(), ptr);
-            assert_eq!(dst_view.as_mut_ptr().cast_const(), ptr);
-            assert_eq!(dst_view.nrows(), nrows);
-            assert_eq!(dst_view.ncols(), ncols);
-            assert_eq!(dst_view.cstride(), cstride);
-
-            // Initialize by looping over rows.
-            for row in 0..dst_view.nrows() {
-                dst_view.row_mut(row).unwrap().copy_from_slice(src.row(row))
-            }
-
-            // Check equality.
-            test_indexing(&dst_view, src.as_view());
-        }
-
-        // Initialize using row-iterator indexing.
-        {
-            let mut dst = views::Matrix::<usize>::new(0, 5, 10);
-
-            let offset = 2;
-            // SAFETY: The underlying allocation is valid for much more than 2 elements.
-            let ptr = unsafe { dst.as_ptr().add(offset) };
-
-            let ncols = src.ncols();
-            let nrows = src.nrows();
-            let cstride = dst.ncols();
-            let mut dst_view =
-                Mut::try_from_data(&mut dst.as_mut_slice()[2..], nrows, ncols, cstride).unwrap();
-
-            assert_eq!(dst_view.as_ptr(), ptr);
-            assert_eq!(dst_view.as_mut_ptr().cast_const(), ptr);
-            assert_eq!(dst_view.nrows(), nrows);
-            assert_eq!(dst_view.ncols(), ncols);
-            assert_eq!(dst_view.cstride(), cstride);
-
-            // Initialize using row iterators.
-            for (d, s) in std::iter::zip(dst_view.rows_mut(), src.row_iter()) {
-                d.copy_from_slice(s)
-            }
-
-            // Check equality.
-            test_indexing(&dst_view, src.as_view());
-        }
+        test_indexing(v, expected.as_view());
     }
 
     #[test]
     fn matrix_conversion() {
         let m = create_test_matrix(3, 4);
         let ptr = m.as_ptr();
-        let v: Ref<_> = m.as_view().into();
+        let v: Strided<_> = m.as_view().into();
         assert_eq!(v.as_ptr(), ptr);
-        test_indexing(&v, m.as_view());
+        test_indexing(v, m.as_view());
     }
 
     #[test]
     fn test_zero_sized() {
         let m = create_test_matrix(5, 5);
-        let v = Ref::try_from_data(m.as_slice(), 0, 4, 5).unwrap();
+        let v = Strided::try_from_data(m.as_slice(), 0, 4, 5).unwrap();
 
         assert_eq!(v.nrows(), 0);
         assert_eq!(v.ncols(), 4);
         assert_eq!(v.cstride(), 5);
 
-        let v = Ref::try_from_data(m.as_slice(), 5, 0, 5).unwrap();
+        let v = Strided::try_from_data(m.as_slice(), 5, 0, 5).unwrap();
         assert_eq!(v.nrows(), 5);
         assert_eq!(v.ncols(), 0);
         assert_eq!(v.cstride(), 5);
@@ -1330,36 +777,20 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-    fn test_row_iter_panics() {
-        let m = create_test_matrix(5, 5);
-        let v = Ref::try_from_data(m.as_slice(), 5, 0, 5).unwrap();
-        let _ = v.rows();
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_row_iter_mut_panics() {
-        let mut m = create_test_matrix(5, 5);
-        let mut v = Mut::try_from_data(m.as_mut_slice(), 5, 0, 5).unwrap();
-        let _ = v.rows_mut();
-    }
-
-    #[test]
     fn test_try_shrink_from() {
         // Exact is okay.
         let m = views::Matrix::<usize>::new(0, 10, 10);
         let nrows = m.nrows();
         let ncols = m.ncols();
-        let s = Ref::try_from_data(m.as_slice(), nrows, ncols, ncols).unwrap();
+        let s = Strided::try_from_data(m.as_slice(), nrows, ncols, ncols).unwrap();
         assert_eq!(s.as_slice(), m.as_slice());
 
         // Giving a slice that is too large is okay.
-        let s = Ref::try_from_data(m.as_slice(), nrows, 5, ncols).unwrap();
+        let s = Strided::try_from_data(m.as_slice(), nrows, 5, ncols).unwrap();
         assert_eq!(s.as_ptr(), m.as_ptr());
 
         // Too small is a problem.
-        let s = Ref::try_from_data(m.as_slice(), nrows, ncols, ncols + 1);
+        let s = Strided::try_from_data(m.as_slice(), nrows, ncols, ncols + 1);
         assert!(s.is_err());
         let err = s.unwrap_err();
         // assert_eq!(
@@ -1373,42 +804,7 @@ mod tests {
     #[should_panic(expected = "cstride must be greater than or equal to ncols")]
     fn test_try_shink_from_panics() {
         let m = views::Matrix::<usize>::new(0, 4, 4);
-        let _ = Ref::try_from_data(m.as_slice(), 2, 2, 1).unwrap();
-    }
-
-    #[test]
-    fn test_try_shrink_from_mut() {
-        // Exact is okay.
-        let mut m = views::Matrix::<usize>::new(0, 10, 10);
-
-        let nrows = m.nrows();
-        let ncols = m.ncols();
-        let ptr = m.as_ptr();
-        let len = m.as_slice().len();
-
-        let s = Mut::try_from_data(m.as_mut_slice(), nrows, ncols, ncols).unwrap();
-        assert_eq!(s.as_ptr(), ptr);
-        assert_eq!(s.as_slice().len(), len);
-
-        // Giving a slice that is too large is okay.
-        let s = Mut::try_from_data(m.as_mut_slice(), nrows, 5, ncols).unwrap();
-        assert_eq!(s.as_ptr(), ptr);
-
-        // Too small is a problem.
-        let s = Mut::try_from_data(m.as_mut_slice(), nrows, ncols, ncols + 1);
-        // assert!(s.is_err());
-        // let err = s.unwrap_err();
-        // assert_eq!(
-        //     err.to_string(),
-        //     expected_error(len, nrows, ncols, ncols + 1)
-        // );
-    }
-
-    #[test]
-    #[should_panic(expected = "cstride must be greater than or equal to ncols")]
-    fn test_try_shink_from_mut_panics() {
-        let mut m = views::Matrix::<usize>::new(0, 4, 4);
-        let _ = Mut::try_from_data(m.as_mut_slice(), 2, 2, 1);
+        let _ = Strided::try_from_data(m.as_slice(), 2, 2, 1).unwrap();
     }
 
     // #[test]

--- a/diskann-utils/src/strided.rs
+++ b/diskann-utils/src/strided.rs
@@ -34,7 +34,7 @@ impl Layout {
     ///
     /// Errors if:
     ///
-    /// * `ncols < cstride`.
+    /// * `cstride < ncols`.
     /// * The computation of the linear length overflows `usize::MAX`.
     pub fn new(nrows: usize, ncols: usize, cstride: usize) -> Result<Self, LayoutError> {
         LayoutError::check(nrows, ncols, cstride)?;
@@ -137,7 +137,7 @@ impl fmt::Display for LayoutErrorInner {
 ///            +-------------+
 ///                  ^
 ///                  |
-///             StridedView
+///               Strided
 /// ```
 ///
 /// This abstraction is useful when performing PQ related operations such as training or
@@ -186,6 +186,7 @@ impl<'a, T> Strided<'a, T> {
         self.layout
     }
 
+    /// Return a pointer to the base of the matrix.
     pub fn as_ptr(&self) -> *const T {
         self.as_nonnull().as_ptr().cast_const()
     }
@@ -470,6 +471,11 @@ mod tests {
                 }
             }
         }
+
+        // Check OOB detection.
+        assert!(linear_length(usize::MAX, 2, 2).is_none());
+        assert!(linear_length(2, usize::MAX, 2).is_none());
+        assert!(linear_length(2, 2, usize::MAX).is_none());
     }
 
     #[test]
@@ -521,14 +527,10 @@ mod tests {
 
         // A slice shorter than `Layout::linear_length` is reported as `InvalidLength`.
         let err = Strided::try_from_data(m.as_slice(), nrows, ncols, ncols + 1).unwrap_err();
-        let expected_len = Layout::new(nrows, ncols, ncols + 1).unwrap().linear_length();
+
         assert_eq!(
             err.to_string(),
-            format!(
-                "argument of length {} is shorter than the expected length {}",
-                m.as_slice().len(),
-                expected_len
-            )
+            "argument of length 100 is shorter than the expected length 109",
         );
     }
 
@@ -579,7 +581,7 @@ mod tests {
 
         // `Copy`/`Clone` produce an independent handle to the same data.
         let copied = v;
-        let cloned = v.clone();
+        let cloned = Clone::clone(&v);
         assert_eq!(v.as_ptr(), copied.as_ptr());
         assert_eq!(v.as_ptr(), cloned.as_ptr());
 
@@ -600,7 +602,8 @@ mod tests {
     #[test]
     fn test_rows_iterator_properties() {
         let m = create_test_matrix(4, 3);
-        let v = Strided::try_from_data(m.as_slice(), m.nrows(), m.ncols(), m.ncols()).unwrap();
+        let v = Strided::try_from_data(&m.as_slice()[1..], m.nrows(), m.ncols() - 1, m.ncols())
+            .unwrap();
 
         let mut rows = v.rows();
         assert_eq!(rows.len(), 4);
@@ -608,7 +611,7 @@ mod tests {
 
         for expected_row in 0..4 {
             let row = rows.next().unwrap();
-            assert_eq!(row, m.row(expected_row));
+            assert_eq!(row, &m.row(expected_row)[1..]);
         }
 
         // Exhausted iterators keep returning `None` (`FusedIterator`).
@@ -625,6 +628,42 @@ mod tests {
         let mut rows = v.rows();
         assert_eq!(rows.len(), 0);
         assert_eq!(rows.next(), None);
+    }
+
+    #[test]
+    fn test_rows_iterator_zero_cols() {
+        let m = create_test_matrix(5, 5);
+        let v = Strided::try_from_data(m.as_slice(), 5, 0, 5).unwrap();
+
+        let rows = v.rows();
+        assert_eq!(rows.len(), 5);
+        assert_eq!(rows.size_hint(), (5, Some(5)));
+
+        let mut count = 0;
+        for r in rows {
+            assert!(r.is_empty());
+            count += 1;
+        }
+
+        assert_eq!(count, 5);
+    }
+
+    #[test]
+    fn test_rows_iterator_zero_cstride() {
+        let m = create_test_matrix(5, 5);
+        let v = Strided::try_from_data(m.as_slice(), 5, 0, 0).unwrap();
+
+        let rows = v.rows();
+        assert_eq!(rows.len(), 5);
+        assert_eq!(rows.size_hint(), (5, Some(5)));
+
+        let mut count = 0;
+        for r in rows {
+            assert!(r.is_empty());
+            count += 1;
+        }
+
+        assert_eq!(count, 5);
     }
 
     // Test that the contents of `dut` match those in the dense 2d matrix.
@@ -707,7 +746,7 @@ mod tests {
     fn test_basic_indexing() {
         let m = create_test_matrix(5, 3);
 
-        // First - test a dense StridedView over the entire matrix.
+        // First - test a dense Strided view over the entire matrix.
         let ptr = m.as_ptr();
         let v = Strided::try_from_data(m.as_slice(), m.nrows(), m.ncols(), m.ncols()).unwrap();
         assert_eq!(v.as_ptr(), ptr, "base pointer was not preserved");
@@ -789,105 +828,17 @@ mod tests {
         let s = Strided::try_from_data(m.as_slice(), nrows, 5, ncols).unwrap();
         assert_eq!(s.as_ptr(), m.as_ptr());
 
-        // Too small is a problem.
+        // Too small is a problem, and is reported as an `Err`, not a panic.
         let s = Strided::try_from_data(m.as_slice(), nrows, ncols, ncols + 1);
         assert!(s.is_err());
-        let err = s.unwrap_err();
-        // assert_eq!(
-        //     err.to_string(),
-        //     expected_error(m.as_slice().len(), nrows, ncols, ncols + 1)
-        // );
-        // assert_eq!(err.into_inner(), m.as_slice());
     }
 
     #[test]
-    #[should_panic(expected = "cstride must be greater than or equal to ncols")]
-    fn test_try_shink_from_panics() {
+    fn test_invalid_stride_is_an_error_not_a_panic() {
+        // Constructing a `Strided` with an invalid layout (`cstride < ncols`) returns an
+        // `Err` rather than panicking - only unwrapping the result panics.
         let m = views::Matrix::<usize>::new(0, 4, 4);
-        let _ = Strided::try_from_data(m.as_slice(), 2, 2, 1).unwrap();
+        let err = Strided::try_from_data(m.as_slice(), 2, 2, 1).unwrap_err();
+        assert!(matches!(err, TryFromError::LayoutError(_)));
     }
-
-    // #[test]
-    // fn test_try_from() {
-    //     // Exact is okay.
-    //     let m = views::Matrix::<usize>::new(0, 10, 10);
-    //     let nrows = m.nrows();
-    //     let ncols = m.ncols();
-    //     let s = StridedView::try_from(m.as_slice(), nrows, ncols, ncols).unwrap();
-    //     assert_eq!(s.as_slice(), m.as_slice());
-
-    //     // Giving a slice that is too large is a problem.
-    //     let s = StridedView::try_from(m.as_slice(), nrows, 5, ncols);
-    //     assert!(s.is_err());
-    //     let err = s.unwrap_err();
-    //     assert_eq!(
-    //         err.to_string(),
-    //         expected_error(m.as_slice().len(), nrows, 5, ncols)
-    //     );
-
-    //     // Too small is a problem.
-    //     let s = StridedView::try_from(m.as_slice(), nrows, ncols, ncols + 1);
-    //     assert!(s.is_err());
-    //     let err = s.unwrap_err();
-    //     assert_eq!(
-    //         err.to_string(),
-    //         expected_error(m.as_slice().len(), nrows, ncols, ncols + 1)
-    //     );
-    //     assert_eq!(err.into_inner(), m.as_slice());
-    // }
-
-    // #[test]
-    // #[should_panic(expected = "cstride must be greater than or equal to ncols")]
-    // fn test_try_frompanics() {
-    //     let mut m = views::Matrix::<usize>::new(0, 4, 4);
-    //     let _ = MutStridedView::try_from(m.as_mut_slice(), 2, 2, 1);
-    // }
-
-    // #[test]
-    // #[should_panic(expected = "tried to access row 3 of a matrix with 3 rows")]
-    // fn test_get_row_panics() {
-    //     let m = views::Matrix::<usize>::new(0, 3, 7);
-    //     let v: StridedView<_> = m.as_view().into();
-    //     v.row(3);
-    // }
-
-    // #[test]
-    // #[should_panic(expected = "tried to access row 3 of a matrix with 3 rows")]
-    // fn test_get_row_mut_panics() {
-    //     let mut m = views::Matrix::<usize>::new(0, 3, 7);
-    //     let mut v: MutStridedView<_> = m.as_mut_view().into();
-    //     v.row_mut(3);
-    // }
-
-    // #[test]
-    // #[should_panic(expected = "row 3 is out of bounds (max: 3)")]
-    // fn test_index_panics_row() {
-    //     let m = views::Matrix::<usize>::new(0, 3, 7);
-    //     let v: StridedView<_> = m.as_view().into();
-    //     let _ = v[(3, 2)];
-    // }
-
-    // #[test]
-    // #[should_panic(expected = "col 7 is out of bounds (max: 7)")]
-    // fn test_index_panics_col() {
-    //     let m = views::Matrix::<usize>::new(0, 3, 7);
-    //     let v: StridedView<_> = m.as_view().into();
-    //     let _ = v[(2, 7)];
-    // }
-
-    // #[test]
-    // #[should_panic(expected = "row 3 is out of bounds (max: 3)")]
-    // fn test_index_mut_panics_row() {
-    //     let mut m = views::Matrix::<usize>::new(0, 3, 7);
-    //     let mut v: MutStridedView<_> = m.as_mut_view().into();
-    //     v[(3, 2)] = 1;
-    // }
-
-    // #[test]
-    // #[should_panic(expected = "col 7 is out of bounds (max: 7)")]
-    // fn test_index_mut_panics_col() {
-    //     let mut m = views::Matrix::<usize>::new(0, 3, 7);
-    //     let mut v: MutStridedView<_> = m.as_mut_view().into();
-    //     v[(2, 7)] = 1;
-    // }
 }

--- a/diskann-utils/src/strided.rs
+++ b/diskann-utils/src/strided.rs
@@ -14,10 +14,10 @@ use crate::{
 
 /// The layout for [`Strided`].
 ///
-/// This struct ensures that the [`Self::cstride`] is greater than [`Self::ncols`] and that
-/// the linear length of the representation does not overflow `usize::MAX`.
+/// This struct ensures that the [`Self::cstride`] is greater than or equal to[`Self::ncols`]
+/// and that the linear length of the representation does not overflow `usize::MAX`.
 ///
-/// The linear length of [`Strided]` is given by the forumula
+/// The linear length of [`Strided`] is given by the forumula
 /// ```text
 /// self.nrows.saturating_sub(1) * self.cstride + self.nrows.min(1) * self.ncols
 /// ```
@@ -126,18 +126,18 @@ impl fmt::Display for LayoutErrorInner {
 ///
 /// ```text
 ///            |<------ cstride ----->|
-///            |<-- ncols -->|
-///            +-------------+
-/// slice 0 -> | a0 a1 a2 a3 | a4 a5 a6     ^
-/// slice 1 -> | b0 b1 b2 b3 | b4 b5 b6     |
-/// slice 2 -> | c0 c1 c2 c3 | c4 c5 c6   nrows
-/// slice 3 -> | d0 d1 d2 d3 | d4 d5 d6     |
-/// slice 4 -> | e0 e1 e2 e3 | e4 e5 e6     |
-/// slicf 5 -> | f0 f1 f2 f3 | f4 f5 f6     v
-///            +-------------+
-///                  ^
-///                  |
-///               Strided
+///                     |<-- ncols -->|
+///                     +-------------+
+/// slice 0 -> a0 a1 a2 | a3 a4 a5 a6 |    ^
+/// slice 1 -> b0 b1 b2 | b3 b4 b4 b5 |    |
+/// slice 2 -> c0 c1 c2 | c3 c4 c5 c6 |  nrows
+/// slice 3 -> d0 d1 d2 | d3 d4 d5 d6 |    |
+/// slice 4 -> e0 e1 e2 | e3 e4 e5 e6 |    |
+/// slice 5 -> f0 f1 f2 | f3 f4 f5 f6 |    v
+///                     +-------------+
+///                           ^
+///                           |
+///                        Strided
 /// ```
 ///
 /// This abstraction is useful when performing PQ related operations such as training or


### PR DESCRIPTION
We apparently don't need owned or mutable `StridedViews`. This struct was getting in the way of simplifying the `Matrix` type, so I decided to do the following:

1. Collapse everything into a single `Strided<'a, T>` struct.
2. Ensure that the layout for a `Strided` is well formed.
3. Shrink the memory representation from 40 bytes to 32 bytes.
4. Implement a custom `Rows` iterator so we no longer panic if the column-stride is zero.

Note that currently, `From<MatrixView<'a, T>>` can panic. This is because `MatrixView` and friends don't actually guarantee that `nrows * ncols` does not overflow `usize::MAX`. I have another PR in the pipeline to fix that, but ran into a chicken and egg problem with `Strided` preventing that PR from making progress.