### PR TITLE
[Release] Set version to 0.57.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "diskann"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-core"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "diskann",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-runner"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-simd"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "diskann-benchmark-runner",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-bftree"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bf-tree",
  "bytemuck",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-disk"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-inmem"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-label-filter"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-linalg"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "approx",
  "cfg-if",
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-providers"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "approx",
  "arc-swap",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-quantization"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-record"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-tools"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-utils"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-vector"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "approx",
  "bytemuck",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-wide"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ default-members = [
 exclude = ["vectorset"]
 
 [workspace.package]
-version = "0.56.0"                                                                                                                         # Obeying semver
+version = "0.57.0" # Obeying semver
 description = "DiskANN3 is a composable library for bringing scalable, accurate and cost-effective vector indexing to multiple databases."
 authors = ["Microsoft"]
 repository = "https://github.com/microsoft/DiskANN"
@@ -52,24 +52,24 @@ undocumented_unsafe_blocks = "warn"
 
 [workspace.dependencies]
 # Base And Numerics
-diskann-wide = { path = "diskann-wide", version = "0.56.0" }
-diskann-vector = { path = "diskann-vector", version = "0.56.0" }
-diskann-linalg = { path = "diskann-linalg", version = "0.56.0" }
-diskann-utils = { path = "diskann-utils", default-features = false, version = "0.56.0" }
-diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.56.0" }
+diskann-wide = { path = "diskann-wide", version = "0.57.0" }
+diskann-vector = { path = "diskann-vector", version = "0.57.0" }
+diskann-linalg = { path = "diskann-linalg", version = "0.57.0" }
+diskann-utils = { path = "diskann-utils", default-features = false, version = "0.57.0" }
+diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.57.0" }
 # Algorithm
-diskann = { path = "diskann", version = "0.56.0" }
+diskann = { path = "diskann", version = "0.57.0" }
 # Providers
-diskann-providers = { path = "diskann-providers", default-features = false, version = "0.56.0" }
-diskann-inmem = { path = "diskann-inmem", default-features = false, version = "0.56.0" }
-diskann-disk = { path = "diskann-disk", version = "0.56.0" }
-diskann-label-filter = { path = "diskann-label-filter", version = "0.56.0" }
+diskann-providers = { path = "diskann-providers", default-features = false, version = "0.57.0" }
+diskann-inmem = { path = "diskann-inmem", default-features = false, version = "0.57.0" }
+diskann-disk = { path = "diskann-disk", version = "0.57.0" }
+diskann-label-filter = { path = "diskann-label-filter", version = "0.57.0" }
 # Infra
-diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.56.0" }
-diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.56.0" }
-diskann-tools = { path = "diskann-tools", version = "0.56.0" }
-diskann-bftree = { path = "diskann-bftree", version = "0.56.0" }
-diskann-record = { path = "diskann-record", version = "0.56.0" }
+diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.57.0" }
+diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.57.0" }
+diskann-tools = { path = "diskann-tools", version = "0.57.0" }
+diskann-bftree = { path = "diskann-bftree", version = "0.57.0" }
+diskann-record = { path = "diskann-record", version = "0.57.0" }
 
 # External dependencies (shared versions)
 anyhow = "1.0.98"


### PR DESCRIPTION
# Breaking Changes

Flat search visitors are now query-aware (#1359)
* `flat::FlatIndex`  has been removed. The search entry point is now the free function `flat::knn_search`, and the `DistancesUnordered` visitor is constructed per-query rather than reused. The `ElementRef`, `QueryComputer`, and `QueryComputerError` associated types and the visitor GAT have also been removed. `DistancesUnordered` now yields `(id, distance)` pairs directly.

Migration: Callers of the old `FlatIndex`/visitor API should:

1. Drop `FlatIndex` and construct your `DistancesUnordered` visitor directly for the query being searched.
2. Replace calls into the removed wrapper with `flat::knn_search(&mut visitor, k, processor, query, &mut output)`.
3. Remove any `ElementRef`/`QueryComputer` implementation, fuse scanning and distance computation directly in your `DistancesUnordered::distances_unordered` implementation.

# All Changes

* Make `UnalignedSlice` Send and Sync. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/1348
* Bump actions/checkout from 4.4.0 to 7.0.1 in the github-actions group by @dependabot[bot] in https://github.com/microsoft/DiskANN/pull/1344
* Deduplicate virtual start point edges during disk serialization by @partychen in https://github.com/microsoft/DiskANN/pull/1350
* Fix alpha pruning documentation by @xinyuwen2 in https://github.com/microsoft/DiskANN/pull/1351
* Bump the github-actions group with 4 updates by @dependabot[bot] in https://github.com/microsoft/DiskANN/pull/1356
* Add Neon Inner product u4*u4 kernel by @pfoxARM in https://github.com/microsoft/DiskANN/pull/1353
* Strengthen arguments to `robust_prune`. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/1358
* Allow inspection of the paged search accessor. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/1364
* Make flat search visitors query-aware by @partychen in https://github.com/microsoft/DiskANN/pull/1359
* Add Neon inner-product kernel for USlice<2> with spherical wiring by @pfoxARM in https://github.com/microsoft/DiskANN/pull/1363

## New Contributors
* @pfoxARM made their first contribution in https://github.com/microsoft/DiskANN/pull/1353

**Full Changelog**: https://github.com/microsoft/DiskANN/compare/v0.56.0...v0.57.0