### PR TITLE
Graph-IVF: add LIRE splits with local-scatter merges

### DIFF
--- a/diskann-graphivf/ONLINE.md
+++ b/diskann-graphivf/ONLINE.md
@@ -36,13 +36,13 @@ partition state, [`search.rs`](src/online/search.rs) implements live queries,
 - **Search = route then scan.** A query navigates the centroid graph to its
   `nlist` nearest centroids, reads those lists from disk, and exhaustively scores
   the query against their members.
-- **Online build = stream, route, split/dissolve.** Points stream in and out:
+- **Online build = stream, route, LIRE split/merge.** Points stream in and out:
   each insert is routed to its nearest centroid and appended; each delete removes
   the point from its list. When a cluster overflows `split_threshold` it is
   **split** and its neighbourhood locally **reassigned**. When one falls below
-   `merge_threshold` it is **dissolved** (recorded as a merge) — retired from the
-   centroid graph and its members scattered onto survivors. The centroid count
-   grows with splits and contracts with dissolves; it is not fixed up front.
+   `merge_threshold` it is **merged** — retired from the centroid graph and its
+   members globally rerouted for NPA. The centroid count grows with splits and
+   contracts with merges; it is not fixed up front.
 
 ```mermaid
 flowchart LR
@@ -71,7 +71,7 @@ flowchart LR
   `f32` copy for clustering (row `pid` = point `pid`). It then "streams" points
   by feeding row indices to `insert_batch`; there is no per-insert disk I/O. This
   is not an out-of-core builder, so budget memory for both representations.
-- **Clustering is always squared-L2.** Routing, 2-means splits, and reassignment
+- **Clustering is always squared-L2.** Routing, balanced splits, and reassignment
   all run in full-precision `f32` under squared-L2. The configured
   [`Metric`](src/params.rs) controls search-time routing/scoring after load. For
   cosine-style or normalized inner-product data, the caller must pre-normalize
@@ -225,17 +225,25 @@ partition. For a single streamed point `pid`:
    the affected region. An error after commit starts poisons the clusterer; see
    [State ownership and failure semantics](#3d-state-ownership-and-failure-semantics).
 
-This is the semantics of `batch_size: 1`. Inserts can cause splits but never
-dissolves; deletes can cause dissolves but never splits. Larger batches retain
-that rule while planning all splits together — see
+This is the semantics of `batch_size: 1`. Inserts trigger split-reassign; deletes
+can trigger LIRE merges whose final NPA routes may cascade into splits. Larger
+batches plan all initial splits together — see
 [Batched inserts](#3b-batched-inserts).
 
 
-### 3. Split a cluster (split-and-reassign)
+### 3. LIRE split and reassignment
 
-One admitted parent `c` becomes two children and its local neighborhood is
-re-optimized. The operation has a read-only prepare phase and a mutating commit
-phase.
+Online maintenance follows SPFresh's Lightweight Incremental RE-balancing
+(LIRE) protocol. One admitted parent `c` becomes two capacity-bounded children;
+the two necessary conditions from SPFresh §3.3 select only vectors that can
+possibly violate nearest-partition assignment (NPA), and a final global centroid
+route removes the false positives.
+
+The algorithmic reference is SPFresh §3.2–§3.4
+([SOSP'23 paper](https://arxiv.org/abs/2410.14452)). This in-memory Graph-IVF
+adaptation implements balanced split, both necessary conditions, final NPA
+checks, merge, and cascade convergence. It does not implement SPFresh's
+asynchronous Local Rebuilder, version map, replicas, or SSD Block Controller.
 
 **Prepare, without changing live state:**
 
@@ -244,31 +252,29 @@ phase.
 2. **Select neighbor clusters.** Search from `c`'s centroid and take the
    `reassign_neighbors` (`s`) nearest **live** centroids, excluding `c`. The
    search uses a list at least `max(reassign_l, s + 1)`.
-3. **Fit children.** Run Lloyd 2-means (`two_means_iters`, seeded from two
-   distinct members), producing two child vectors (L2-normalized if
-   `normalize_centroids`).
+3. **Fit balanced children.** Run a capacity-constrained binary fit. Points stay
+   on their geometrically nearer child unless that child would exceed the split
+   capacity, in which case the weakest-preference points move across. Recompute
+   both child centroids after each constrained assignment.
+4. **Filter possible NPA violations.** For a parent member `v`, retain it for a
+   global check only when the old centroid is no farther than both children
+   (LIRE Equation 1). For a neighbor member, retain it only when at least one
+   child is no farther than the old centroid (Equation 2).
 
 **Commit the prepared plan:**
 
-4. **Publish the structural change.** Reserve two fresh ids, insert both child
+5. **Publish the structural change.** Reserve two fresh ids, insert both child
    vertices into the centroid graph, and delete `c` from that graph. Only after
    all graph operations succeed does the private
    [`CentroidRegistry`](src/online/state.rs) publish the child vectors and retire
    `c` in its table. Retired ids are never reused.
-5. **Reassign the neighborhood.** Form
-   - *candidate centroids* = selected neighbors ∪ {child₁, child₂}
-   - *candidate points* = `c`'s members ∪ all points of the neighbor clusters
-
-   Detach those points through the private
-   [`IvfPartition`](src/online/state.rs), then attach each to its nearest
-   candidate by exact squared-L2, rebuilding both the lists and reverse map.
-   Distances are computed as
-   `‖p‖² − 2p·c + ‖c‖²` over a `tile × |candidates|` GEMM rather than a scalar
-   loop per point, which is what makes a large `reassign_neighbors` affordable;
-   points stream through a fixed-size tile so the gathered working set stays
-   bounded regardless of region size. Every member of the retired cluster
-   necessarily moves (its old id is not a candidate); a neighbor point counts as
-   "reassigned" only if it lands on a different centroid than before.
+6. **Final NPA check.** Route only the filtered candidates against the current
+   global centroid set. Parent members that failed Equation 1 go directly to
+   their nearer child. Move a filtered vector only when its newly routed centroid
+   differs from its current assignment.
+7. **Cascade to equilibrium.** Reassignment may overflow another posting. Split
+   every newly overfull posting admitted by the live/id budgets and repeat until
+   all live postings are at or below `split_threshold`.
 
 Each split is a net **+1** to the live-cluster count (−1 retired, +2 children).
 
@@ -277,18 +283,19 @@ flowchart TD
     S0["cluster c exceeds split_threshold"]
    S1["prepare: snapshot current + incoming members"]
    S2["prepare: graph search from c's centroid<br/>→ s nearest live centroids"]
-   S3["prepare: 2-means<br/>→ child1, child2"]
+    S3["prepare: balanced binary fit<br/>→ child1, child2"]
+    S35["LIRE Eq. 1 / Eq. 2<br/>filter possible NPA violations"]
    S4["commit: graph inserts children,<br/>then deletes c"]
    S45["commit: publish table update<br/>after graph success"]
-    S5["candidate centroids = s neighbors + 2 children<br/>candidate points = c's members + neighbor lists"]
-    S6["reassign each candidate point to its<br/>nearest candidate centroid, exact L2"]
-    S7["rebuild affected lists<br/>live cluster count +1"]
-      S0 --> S1 --> S2 --> S3 --> S4 --> S45 --> S5 --> S6 --> S7
+    S5["route filtered vectors against<br/>the global centroid set"]
+    S6["move only true NPA violations"]
+    S7["cascade any new overflow<br/>until threshold equilibrium"]
+      S0 --> S1 --> S2 --> S3 --> S35 --> S4 --> S45 --> S5 --> S6 --> S7
 ```
 
-Only `c` and the `reassign_neighbors` clusters selected by graph search are
-touched; the rest of the partition is unchanged, keeping each split's cost
-**local**.
+Only `c` and the `reassign_neighbors` clusters are examined by the necessary
+conditions. Vectors proven safe stay in place, so the expensive global NPA route
+is paid only by the local boundary subset.
 
 ### 3b. Batched inserts
 
@@ -310,20 +317,14 @@ lifecycle:
 2. **Project and prepare each parent.** Compute post-insert sizes without
    appending anything. Every admitted overflow is a parent `c₁ … c_l`; its
    snapshot includes both current and incoming members. Each snapshot `Xᵢ` is
-   bisected by its **own** 2-means — two seeds drawn from `Xᵢ`,
-   `two_means_iters` Lloyd iterations, and centroid normalization when
-   requested — exactly as in the serial path above. Neighbor searches also run
-   here against the old graph. Parents never see one another, so a cluster
-   splits identically however many others overflowed alongside it.
+   bisected by its own capacity-constrained binary fit. Neighbor searches and
+   LIRE Equation 1/2 filters also run here against the old graph.
 3. **Publish.** Attach all routed points, insert all `2l` child graph vertices,
    and retire the `l` parent vertices. The centroid table changes only after the
    graph operations succeed.
-4. **Reassign per region.** Each parent's region is then reassigned in turn,
-   exactly as in step 3.5: the candidates are the parent's own two children plus
-   the `reassign_neighbors` nearest live centroids selected *before* the
-   mutation, and the candidate points are the parent's members plus everything
-   those neighbors hold. A neighbor that was itself a parent of this batch has
-   been retired and drops out — its region is covered by its own turn.
+4. **LIRE reassign.** Apply Equations 1 and 2 per parent, deduplicate the union
+   of possible violations across the batch, route that subset globally, and move
+   only true NPA violations. Then process cascade splits to equilibrium.
 
 Admission control still applies per batch: a split costs two ids and adds one
 live cluster, so when a batch would breach `max_clusters` or the id budget the
@@ -337,10 +338,10 @@ parent is bisected and its region reassigned exactly as it would be on its own.
 Telemetry coarsens to match — one `SplitEvent` per split parent still, but every
 event from one batch shares that batch's `insert_index` and `live_after`.
 
-The speedup is almost entirely routing: that phase is embarrassingly parallel
-once the graph is frozen, while splitting stays serial per parent.
+Batch routing remains embarrassingly parallel once the graph is frozen; local
+balanced fits run per parent and LIRE globally routes only filtered vectors.
 
-### 3c. Delete a point (remove, maybe dissolve)
+### 3c. Delete a point (remove, maybe merge)
 
 `delete_batch(pids)` also prepares all fallible work before mutation:
 
@@ -350,32 +351,29 @@ once the graph is frozen, while splitting stays serial per parent.
 2. **Project and admit victims.** Subtract each group's delete count from its
    list size without removing anything. Clusters projected below
    `merge_threshold` are considered emptiest-first, subject to the
-   `min_clusters` floor. `merge_threshold = 0` (the default) disables dissolves.
-3. **Prepare landing sites.** Snapshot each admitted victim's remaining members
-   (excluding this batch's deleted points). While the graph is still unchanged,
-   search from each victim centroid for up to `reassign_neighbors` survivors,
-   explicitly excluding **every** victim in the batch. If approximate navigation
-   returns too few survivors, an exact live-centroid scan completes the set.
-   No point, list, centroid table entry, or graph vertex has changed yet.
-4. **Commit removal and dissolves.** Filter each touched list once, resetting the
+   `min_clusters` floor. `merge_threshold = 0` (the default) disables merges.
+3. **Prepare LIRE merges.** Snapshot each admitted victim's remaining members.
+   Select the nearest surviving posting whose current plus already-planned merge
+   load remains at or below `split_threshold`; skip a victim when no compatible
+   target exists. Neighbor posting vectors require no check: deleting a centroid
+   cannot invalidate a vector already assigned to another live centroid.
+4. **Commit removal and merges.** Filter each touched list once, resetting the
    deleted points to `UNASSIGNED`. Then retire the whole victim batch from the
-   centroid graph and table. Finally detach each victim's remaining members and
-   place them onto its preselected surviving candidates with the same tiled GEMM
-   used by split reassignment.
+   centroid graph and table. Detach each victim's remaining members and route
+   them against the post-retirement global centroid set for the final NPA check.
 
-Candidate search therefore happens **before** retirement, but placement happens
-**after** every victim is retired. Explicit batch-wide victim exclusion makes
-the precomputed landing sites valid even when mutually adjacent clusters are
-dissolved together.
+Capacity-compatible target selection happens **before** retirement, but final
+NPA routing happens **after** every victim is retired. Batch-wide victim
+exclusion prevents one victim from selecting another victim as its merge target.
 
 A merge is a net **−1** to the live-cluster count, fits no new centroid, and
 consumes **no centroid id** — merges are free against the id budget
 (see [§4](#4-id-budget--termination)).
 
-**The cascade rule:** `insert_batch` never merges; `delete_batch` never splits.
-A survivor that absorbs a dissolved cluster's members may end up over
-`split_threshold` — it waits for the next insert routed to it. This makes
-split/merge cascades structurally impossible rather than bounded by a counter.
+**The cascade rule:** insert-driven and merge-reassignment overflows both run
+split-reassign to threshold equilibrium. LIRE's convergence argument applies:
+each split retires one centroid and publishes two, so live-centroid count grows
+by one and remains bounded by the finite vector/id budgets.
 
 The `min_clusters` floor prevents the partition from collapsing entirely: merges
 are admitted emptiest-first until the live count would fall below `min_clusters`.
@@ -388,7 +386,7 @@ for merging.
 Two private types own the cross-structure invariants:
 
 - [`CentroidRegistry`](src/online/state.rs) owns both the id-indexed centroid
-   table and mutable centroid graph. Splits and dissolves cannot update one
+   table and mutable centroid graph. Splits and merges cannot update one
    representation through a separate call site. Table publication is infallible
    and occurs only after the corresponding graph operations succeed.
 - [`IvfPartition`](src/online/state.rs) owns both inverted lists and the reverse
@@ -532,9 +530,9 @@ Online build ([`OnlineParams`](src/params.rs)):
 | `min_clusters` | Live-cluster floor: merges stop before taking the count below this (clamped to `≥ 1` internally). |
 | `max_clusters` | Optional hard cap on live clusters (`None` = data-driven growth). |
 | `centroid_capacity` | Total id budget (live + retired); size to `≈ 2×` expected final clusters. |
-| `reassign_neighbors` | Neighbor clusters pooled with split children, and maximum survivor landing sites per dissolve (`≥ 1`); a candidate count, so it applies under either routing mode. |
-| `two_means_iters` | Lloyd iterations for split k-means (two children per admitted parent; internally at least one). |
-| `routing` | How the clusterer finds nearest centroids. `Graph { graph, assign_l, reassign_l }` navigates the centroid graph: `assign_l` routes inserts; `reassign_l` sizes split-neighbor and dissolve-survivor search, raised internally to fit candidates and exclusions; `graph` is the build recipe (`degree` R, `slack`, `l_build`, `alpha`). `Exact` scans every live centroid and carries none of these. |
+| `reassign_neighbors` | Nearby postings scanned by LIRE's Equation 1/2 filters after a split (`≥ 1`). |
+| `two_means_iters` | Iterations for the capacity-constrained binary child fit (internally at least one). |
+| `routing` | How the clusterer finds nearest centroids. `Graph { graph, assign_l, reassign_l }` navigates the centroid graph: `assign_l` routes inserts and final NPA checks; `reassign_l` sizes split-neighbor discovery; `graph` is the build recipe (`degree` R, `slack`, `l_build`, `alpha`). `Exact` scans every live centroid. |
 | `metric` | Candidate-scoring metric for live and flushed search. Clustering and centroid-graph construction remain L2; a loaded index navigates that same saved graph with this search metric. |
 | `normalize_centroids` | L2-normalize warmup and child centroids (unit-sphere corpora). |
 | `num_threads`, `seed` | Worker pool for warmup/split k-means, routing, and graph build; RNG seed. |
@@ -574,10 +572,10 @@ routing, split, delete, and merge totals plus one event per structural change.
 The library exposes two stable, deliberately separate CSV writers:
 
 - **`<telemetry_csv>`** — one row per split, written by `write_csv`. Fields:
-  triggering insert index, retired cluster and size, neighbor count, points that
-  changed cluster, resulting live count, and 2-means/reassignment/total
-  latencies.
-- **Merge CSV** — one row per dissolve, written by `write_merges_csv`. Fields:
+  triggering insert index, retired cluster and size, neighbor count, local region
+  points, Equation 1/2 candidates, points that changed cluster, resulting live
+  count, and balanced-fit/reassignment/total latencies.
+- **Merge CSV** — one row per LIRE merge, written by `write_merges_csv`. Fields:
    operation index, retired cluster and its size, survivor count, points moved,
    live count after the batch retirement, and search/reassignment/attributed
    latencies.
@@ -588,9 +586,8 @@ and automatically derives `<stem>_merges.<ext>` beside it for merge events. The
 schemas stay separate so existing split analysis remains compatible.
 
 An event's `total_us` is **attributed algorithm time**, not full operation
-latency. For a split it is the parent's member-weighted k-means share plus that
-region's reassignment and excludes neighborhood search and shared graph
-publication. For a dissolve it is landing-site search plus reassignment and
+latency. For a split it is balanced-fit time plus final NPA routing and excludes
+shared graph publication. For a merge it is target search plus reassignment and
 excludes shared graph retirement. Cumulative `BuildTelemetry::split_us` and
 `merge_us` measure the complete prepare/commit passes; `routing_us` and
 `delete_us` are recorded separately.

--- a/diskann-graphivf/ONLINE.md
+++ b/diskann-graphivf/ONLINE.md
@@ -353,10 +353,14 @@ balanced fits run per parent and LIRE globally routes only filtered vectors.
    `merge_threshold` are considered emptiest-first, subject to the
    `min_clusters` floor. `merge_threshold = 0` (the default) disables merges.
 3. **Prepare LIRE merges.** Snapshot each admitted victim's remaining members.
-   Select the nearest surviving posting whose current plus already-planned merge
-   load remains at or below `split_threshold`; skip a victim when no compatible
-   target exists. Neighbor posting vectors require no check: deleting a centroid
-   cannot invalidate a vector already assigned to another live centroid.
+   In graph mode, search a bounded, progressively widened set of surviving
+   centroids, exactly rerank that set, and select the nearest posting whose
+   current plus already-planned merge load remains at or below
+   `split_threshold`. If the bounded candidates have no compatible target, use
+   one packed exact pass without a full sort; exact routing starts with that
+   pass. Skip a victim when no compatible target exists. Neighbor posting
+   vectors require no check: deleting a centroid cannot invalidate a vector
+   already assigned to another live centroid.
 4. **Commit removal and merges.** Filter each touched list once, resetting the
    deleted points to `UNASSIGNED`. Then retire the whole victim batch from the
    centroid graph and table. Detach each victim's remaining members and route

--- a/diskann-graphivf/ONLINE.md
+++ b/diskann-graphivf/ONLINE.md
@@ -36,12 +36,12 @@ partition state, [`search.rs`](src/online/search.rs) implements live queries,
 - **Search = route then scan.** A query navigates the centroid graph to its
   `nlist` nearest centroids, reads those lists from disk, and exhaustively scores
   the query against their members.
-- **Online build = stream, route, LIRE split/merge.** Points stream in and out:
+- **Online build = stream, route, LIRE split, local merge.** Points stream in and out:
   each insert is routed to its nearest centroid and appended; each delete removes
   the point from its list. When a cluster overflows `split_threshold` it is
   **split** and its neighbourhood locally **reassigned**. When one falls below
    `merge_threshold` it is **merged** — retired from the centroid graph and its
-   members globally rerouted for NPA. The centroid count grows with splits and
+   members locally scattered onto preselected survivors. The centroid count grows with splits and
    contracts with merges; it is not fixed up front.
 
 ```mermaid
@@ -225,24 +225,32 @@ partition. For a single streamed point `pid`:
    the affected region. An error after commit starts poisons the clusterer; see
    [State ownership and failure semantics](#3d-state-ownership-and-failure-semantics).
 
-This is the semantics of `batch_size: 1`. Inserts trigger split-reassign; deletes
-can trigger LIRE merges whose final NPA routes may cascade into splits. Larger
+This is the semantics of `batch_size: 1`. Inserts trigger LIRE split-reassign;
+deletes can trigger local-scatter merges but never split. Larger
 batches plan all initial splits together — see
 [Batched inserts](#3b-batched-inserts).
 
 
 ### 3. LIRE split and reassignment
 
-Online maintenance follows SPFresh's Lightweight Incremental RE-balancing
-(LIRE) protocol. One admitted parent `c` becomes two capacity-bounded children;
+The insert-driven split path follows SPFresh's Lightweight Incremental
+RE-balancing (LIRE) protocol. One admitted parent `c` becomes two children with
+capacity-constrained training assignments;
 the two necessary conditions from SPFresh §3.3 select only vectors that can
 possibly violate nearest-partition assignment (NPA), and a final global centroid
 route removes the false positives.
 
+The necessary-condition proof assumes an old globally nearest assignment.
+Graph routing is approximate, split filtering only visits the selected local
+region, and local-scatter merges can leave a point outside its global nearest
+posting. Consequently these checks do not promise exact global NPA for every
+point; they retain the configured routing and strict-distance placement rules.
+
 The algorithmic reference is SPFresh §3.2–§3.4
 ([SOSP'23 paper](https://arxiv.org/abs/2410.14452)). This in-memory Graph-IVF
-adaptation implements balanced split, both necessary conditions, final NPA
-checks, merge, and cascade convergence. It does not implement SPFresh's
+adaptation retains balanced split, both necessary conditions, final routing
+checks, and insert-driven split cascades. The merge path instead uses the
+Control local-scatter operator described below. It does not implement SPFresh's
 asynchronous Local Rebuilder, version map, replicas, or SSD Block Controller.
 
 **Prepare, without changing live state:**
@@ -352,32 +360,37 @@ balanced fits run per parent and LIRE globally routes only filtered vectors.
    list size without removing anything. Clusters projected below
    `merge_threshold` are considered emptiest-first, subject to the
    `min_clusters` floor. `merge_threshold = 0` (the default) disables merges.
-3. **Prepare LIRE merges.** Snapshot each admitted victim's remaining members.
-   In graph mode, search a bounded, progressively widened set of surviving
-   centroids, exactly rerank that set, and select the nearest posting whose
-   current plus already-planned merge load remains at or below
-   `split_threshold`. If the bounded candidates have no compatible target, use
-   one packed exact pass without a full sort; exact routing starts with that
-   pass. Skip a victim when no compatible target exists. Neighbor posting
-   vectors require no check: deleting a centroid cannot invalidate a vector
-   already assigned to another live centroid.
+3. **Prepare local merge candidates.** Snapshot each admitted victim's remaining
+   members. Query around its centroid for up to `reassign_neighbors` surviving
+   centroids, excluding every victim in the batch. If graph search returns too
+   few survivors, score and sort the live non-victim centroids exactly. The
+   selected set is fixed before mutation; there is no capacity reservation or
+   post-retirement per-member global route.
 4. **Commit removal and merges.** Filter each touched list once, resetting the
    deleted points to `UNASSIGNED`. Then retire the whole victim batch from the
-   centroid graph and table. Detach each victim's remaining members and route
-   them against the post-retirement global centroid set for the final NPA check.
+   centroid graph and table. Detach each victim's remaining members and use a
+   tiled GEMM to assign them to the nearest centroid in its saved candidate set.
+   Neighbor members stay in place.
 
-Capacity-compatible target selection happens **before** retirement, but final
-NPA routing happens **after** every victim is retired. Batch-wide victim
-exclusion prevents one victim from selecting another victim as its merge target.
+Candidate selection happens **before** retirement, and local scatter happens
+**after** every victim is retired. Batch-wide exclusion prevents points from
+landing on another victim. Assignment is exact within the saved candidate set,
+not a guarantee of globally nearest-centroid placement.
 
 A merge is a net **−1** to the live-cluster count, fits no new centroid, and
 consumes **no centroid id** — merges are free against the id budget
 (see [§4](#4-id-budget--termination)).
 
-**The cascade rule:** insert-driven and merge-reassignment overflows both run
-split-reassign to threshold equilibrium. LIRE's convergence argument applies:
-each split retires one centroid and publishes two, so live-centroid count grows
-by one and remains bounded by the finite vector/id budgets.
+**The deferred-overflow contract:** deletes never split, so local scatter may
+leave surviving postings above `split_threshold`. An insert reaching one of
+those postings selects it for a Treatment split. Once any insert starts a split,
+the existing LIRE cascade scans all live postings and must restore the global
+threshold before an uncapped operation returns successfully. An insert that
+does not split checks only its own destinations and leaves unrelated deferred
+overflow untouched. Resource exhaustion still fails an uncapped insert that
+cannot repair its destinations or finish a started cascade; explicit
+`max_clusters` continues to permit overfull postings. Search and flush may
+therefore observe deferred merge overflow.
 
 The `min_clusters` floor prevents the partition from collapsing entirely: merges
 are admitted emptiest-first until the live count would fall below `min_clusters`.
@@ -580,9 +593,9 @@ The library exposes two stable, deliberately separate CSV writers:
   changed cluster, resulting live count, balanced-fit/reassignment/total
   latencies, logical postings updated, local region points, Equation 1/2
   candidates, and an operation index. New fields are appended after the stable
-  legacy prefix. `operation_index` counts completed inserts plus deletes, so it
-  also identifies split cascades triggered by a delete/merge batch.
-- **Merge CSV** — one row per LIRE merge, written by `write_merges_csv`. Fields:
+  legacy prefix. `operation_index` counts completed inserts plus deletes and
+  identifies the insert batch that triggered the split cascade.
+- **Merge CSV** — one row per local merge, written by `write_merges_csv`. Fields:
    operation index, retired cluster and its size, survivor count, points moved,
    live count after the batch retirement, and search/reassignment/attributed
    latencies.

--- a/diskann-graphivf/ONLINE.md
+++ b/diskann-graphivf/ONLINE.md
@@ -576,9 +576,12 @@ routing, split, delete, and merge totals plus one event per structural change.
 The library exposes two stable, deliberately separate CSV writers:
 
 - **`<telemetry_csv>`** — one row per split, written by `write_csv`. Fields:
-  triggering insert index, retired cluster and size, neighbor count, local region
-  points, Equation 1/2 candidates, points that changed cluster, resulting live
-  count, and balanced-fit/reassignment/total latencies.
+  triggering insert index, retired cluster and size, neighbor count, points that
+  changed cluster, resulting live count, balanced-fit/reassignment/total
+  latencies, logical postings updated, local region points, Equation 1/2
+  candidates, and an operation index. New fields are appended after the stable
+  legacy prefix. `operation_index` counts completed inserts plus deletes, so it
+  also identifies split cascades triggered by a delete/merge batch.
 - **Merge CSV** — one row per LIRE merge, written by `write_merges_csv`. Fields:
    operation index, retired cluster and its size, survivor count, points moved,
    live count after the batch retirement, and search/reassignment/attributed

--- a/diskann-graphivf/src/centroids/exact.rs
+++ b/diskann-graphivf/src/centroids/exact.rs
@@ -189,6 +189,45 @@ impl DenseCentroids {
         (0..self.rows.len() as u32).filter(|&id| self.contains(id))
     }
 
+    /// The nearest packed live centroid accepted by `keep`.
+    ///
+    /// This is the low-allocation fallback for a graph search whose bounded
+    /// candidate set contains no admissible result. It walks only the packed
+    /// live rows, keeps one running best, and therefore avoids both the sparse
+    /// id map and a full candidate sort.
+    pub(crate) fn closest_where(
+        &self,
+        query: &[f32],
+        mut keep: impl FnMut(u32) -> bool,
+    ) -> Option<u32> {
+        debug_assert_eq!(query.len(), self.dim);
+        let mut best = None;
+        for (&id, centroid) in self.ids.iter().zip(self.vecs.chunks_exact(self.dim)) {
+            if !keep(id) {
+                continue;
+            }
+            let distance = query
+                .iter()
+                .zip(centroid)
+                .map(|(&left, &right)| {
+                    let delta = left - right;
+                    delta * delta
+                })
+                .sum::<f32>();
+            let replace = match best {
+                None => true,
+                Some((best_id, best_distance)) => distance
+                    .total_cmp(&best_distance)
+                    .then(id.cmp(&best_id))
+                    .is_lt(),
+            };
+            if replace {
+                best = Some((id, distance));
+            }
+        }
+        best.map(|(id, _)| id)
+    }
+
     /// Add centroid `id` with vector `vec`.
     ///
     /// # Panics
@@ -452,6 +491,27 @@ mod tests {
             .collect();
         scored.sort_unstable_by(|a, b| a.1.total_cmp(&b.1).then(a.0.cmp(&b.0)));
         scored
+    }
+
+    #[test]
+    fn closest_where_scans_packed_rows_and_breaks_ties_by_id() {
+        let centroids = Matrix::try_from(
+            vec![-1.0, 0.0, 1.0, 0.0, 4.0, 0.0, 8.0, 0.0].into_boxed_slice(),
+            4,
+            2,
+        )
+        .unwrap();
+        let mut dense = DenseCentroids::from_matrix(&centroids);
+
+        assert_eq!(dense.closest_where(&[0.0, 0.0], |_| true), Some(0));
+        assert_eq!(dense.closest_where(&[0.0, 0.0], |id| id != 0), Some(1));
+        dense.remove(1);
+        assert_eq!(
+            dense.closest_where(&[0.0, 0.0], |id| id != 0),
+            Some(2),
+            "retirement must not make the packed scan walk stale id slots"
+        );
+        assert_eq!(dense.closest_where(&[0.0, 0.0], |_| false), None);
     }
 
     /// Compare returned ids against the reference, tolerating a different

--- a/diskann-graphivf/src/centroids/exact.rs
+++ b/diskann-graphivf/src/centroids/exact.rs
@@ -189,45 +189,6 @@ impl DenseCentroids {
         (0..self.rows.len() as u32).filter(|&id| self.contains(id))
     }
 
-    /// The nearest packed live centroid accepted by `keep`.
-    ///
-    /// This is the low-allocation fallback for a graph search whose bounded
-    /// candidate set contains no admissible result. It walks only the packed
-    /// live rows, keeps one running best, and therefore avoids both the sparse
-    /// id map and a full candidate sort.
-    pub(crate) fn closest_where(
-        &self,
-        query: &[f32],
-        mut keep: impl FnMut(u32) -> bool,
-    ) -> Option<u32> {
-        debug_assert_eq!(query.len(), self.dim);
-        let mut best = None;
-        for (&id, centroid) in self.ids.iter().zip(self.vecs.chunks_exact(self.dim)) {
-            if !keep(id) {
-                continue;
-            }
-            let distance = query
-                .iter()
-                .zip(centroid)
-                .map(|(&left, &right)| {
-                    let delta = left - right;
-                    delta * delta
-                })
-                .sum::<f32>();
-            let replace = match best {
-                None => true,
-                Some((best_id, best_distance)) => distance
-                    .total_cmp(&best_distance)
-                    .then(id.cmp(&best_id))
-                    .is_lt(),
-            };
-            if replace {
-                best = Some((id, distance));
-            }
-        }
-        best.map(|(id, _)| id)
-    }
-
     /// Add centroid `id` with vector `vec`.
     ///
     /// # Panics
@@ -491,27 +452,6 @@ mod tests {
             .collect();
         scored.sort_unstable_by(|a, b| a.1.total_cmp(&b.1).then(a.0.cmp(&b.0)));
         scored
-    }
-
-    #[test]
-    fn closest_where_scans_packed_rows_and_breaks_ties_by_id() {
-        let centroids = Matrix::try_from(
-            vec![-1.0, 0.0, 1.0, 0.0, 4.0, 0.0, 8.0, 0.0].into_boxed_slice(),
-            4,
-            2,
-        )
-        .unwrap();
-        let mut dense = DenseCentroids::from_matrix(&centroids);
-
-        assert_eq!(dense.closest_where(&[0.0, 0.0], |_| true), Some(0));
-        assert_eq!(dense.closest_where(&[0.0, 0.0], |id| id != 0), Some(1));
-        dense.remove(1);
-        assert_eq!(
-            dense.closest_where(&[0.0, 0.0], |id| id != 0),
-            Some(2),
-            "retirement must not make the packed scan walk stale id slots"
-        );
-        assert_eq!(dense.closest_where(&[0.0, 0.0], |_| false), None);
     }
 
     /// Compare returned ids against the reference, tolerating a different

--- a/diskann-graphivf/src/lib.rs
+++ b/diskann-graphivf/src/lib.rs
@@ -20,8 +20,8 @@
 //!   obtain a fixed number of centroids, build a graph over them, assign every
 //!   corpus point to its nearest centroid, then stream the lists to disk.
 //! * **Online** ([`OnlineClusterer`]): accept insert and delete batches, route
-//!   inserts through the centroid graph, split overfull clusters with local
-//!   reassignment, and dissolve underfull clusters onto nearby survivors. The
+//!   inserts through the centroid graph and maintain overfull/underfull postings
+//!   with SPFresh-style LIRE split, merge, and NPA-filtered reassignment. The
 //!   live cluster count emerges from the stream. See `ONLINE.md` for the
 //!   algorithm.
 //!

--- a/diskann-graphivf/src/lib.rs
+++ b/diskann-graphivf/src/lib.rs
@@ -21,7 +21,8 @@
 //!   corpus point to its nearest centroid, then stream the lists to disk.
 //! * **Online** ([`OnlineClusterer`]): accept insert and delete batches, route
 //!   inserts through the centroid graph and maintain overfull/underfull postings
-//!   with SPFresh-style LIRE split, merge, and NPA-filtered reassignment. The
+//!   with SPFresh-style LIRE splits, NPA-filtered split reassignment, and
+//!   local-scatter merges. The
 //!   live cluster count emerges from the stream. See `ONLINE.md` for the
 //!   algorithm.
 //!

--- a/diskann-graphivf/src/online.rs
+++ b/diskann-graphivf/src/online.rs
@@ -86,6 +86,33 @@ const UNASSIGNED: u32 = storage::NOT_INDEXED;
 /// Points routed per parallel work unit in [`OnlineClusterer::insert_batch`].
 const ROUTE_CHUNK: usize = 256;
 
+/// Most non-victim candidates requested from the graph-first merge planner.
+///
+/// The result window includes victims that will be excluded. If it finds no
+/// capacity-compatible survivor, one packed exact pass preserves progress
+/// without restoring the old full candidate sort.
+const MERGE_GRAPH_MAX_SURVIVORS: usize = 1024;
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MergeTargetSource {
+    Graph,
+    ExactFallback,
+}
+
+struct MergeTarget {
+    id: u32,
+    #[cfg(test)]
+    source: MergeTargetSource,
+}
+
+#[derive(Default)]
+struct MergeSearchScratch {
+    ids: Vec<u32>,
+    distances: Vec<f32>,
+    candidates: Vec<(u32, f32)>,
+}
+
 /// Route one point to its nearest live centroid via the centroid graph.
 ///
 /// The centroid graph is mutated in place as clusters split and merge:
@@ -1044,6 +1071,7 @@ impl OnlineClusterer {
         let started = Instant::now();
         let victim_set: std::collections::HashSet<u32> = victims.iter().copied().collect();
         let mut planned_targets = std::collections::HashMap::<u32, usize>::new();
+        let mut search_scratch = MergeSearchScratch::default();
         let mut plans = Vec::new();
         for &id in victims {
             let anchor = self
@@ -1058,30 +1086,22 @@ impl OnlineClusterer {
                 .filter(|pid| !deleted.contains(pid))
                 .collect();
             let search_start = Instant::now();
-            let mut candidates: Vec<(u32, f32)> = self
-                .centroids
-                .iter_live()
-                .filter(|(candidate, _)| !victim_set.contains(candidate))
-                .map(|(candidate, vector)| (candidate, sq_l2(anchor, vector)))
-                .collect();
-            candidates.sort_unstable_by(|a, b| a.1.total_cmp(&b.1).then(a.0.cmp(&b.0)));
-            let target = candidates
-                .into_iter()
-                .map(|(candidate, _)| candidate)
-                .find(|candidate| {
-                    self.partition.list_len(*candidate)
-                        + planned_targets.get(candidate).copied().unwrap_or(0)
-                        + members.len()
-                        <= self.params.split_threshold
-                });
+            let target = self.find_merge_target(
+                anchor,
+                &victim_set,
+                members.len(),
+                &planned_targets,
+                MERGE_GRAPH_MAX_SURVIVORS,
+                &mut search_scratch,
+            )?;
             let Some(target) = target else {
                 continue;
             };
-            *planned_targets.entry(target).or_default() += members.len();
+            *planned_targets.entry(target.id).or_default() += members.len();
             plans.push(MergeVictimPlan {
                 id,
                 members,
-                target,
+                target: target.id,
                 search_us: search_start.elapsed().as_micros() as u64,
             });
         }
@@ -1089,6 +1109,110 @@ impl OnlineClusterer {
             victims: plans,
             started,
         })
+    }
+
+    /// Find a capacity-compatible survivor near `anchor`.
+    ///
+    /// Graph routing searches a bounded candidate set first. The survivor
+    /// budget doubles when the nearest candidates are victims or lack projected
+    /// capacity, and each returned set is exactly reranked. Exact routing, or a
+    /// graph search that exhausts the bounded budget, falls back to one packed
+    /// scan that keeps only the nearest feasible centroid.
+    fn find_merge_target(
+        &self,
+        anchor: &[f32],
+        victim_set: &std::collections::HashSet<u32>,
+        incoming: usize,
+        planned_targets: &std::collections::HashMap<u32, usize>,
+        max_graph_survivors: usize,
+        scratch: &mut MergeSearchScratch,
+    ) -> Result<Option<MergeTarget>> {
+        let survivor_count = self.centroids.live_count().saturating_sub(victim_set.len());
+        if survivor_count == 0 {
+            return Ok(None);
+        }
+
+        if self.params.routing.neighbor_beam(1).is_some() {
+            let survivor_cap = survivor_count.min(max_graph_survivors.max(1));
+            let mut survivor_budget = self.params.reassign_neighbors.min(survivor_cap).max(1);
+            loop {
+                let victim_allowance = victim_set.len().min(MERGE_GRAPH_MAX_SURVIVORS);
+                let search_k = victim_allowance
+                    .saturating_add(survivor_budget)
+                    .min(self.centroids.live_count());
+                let search_l = self
+                    .params
+                    .routing
+                    .neighbor_beam(search_k)
+                    .expect("graph routing has a merge search beam");
+                scratch.ids.clear();
+                scratch.ids.resize(search_k, 0);
+                scratch.distances.clear();
+                scratch.distances.resize(search_k, 0.0);
+                let found = self.centroids.search(
+                    &self.runtime,
+                    anchor,
+                    search_l,
+                    &mut scratch.ids,
+                    &mut scratch.distances,
+                )?;
+                scratch.ids.truncate(found);
+
+                scratch.candidates.clear();
+                for &candidate in &scratch.ids {
+                    if victim_set.contains(&candidate) || !self.centroids.is_live(candidate) {
+                        continue;
+                    }
+                    let vector = self
+                        .centroids
+                        .get(candidate)
+                        .expect("graph candidate is a live centroid");
+                    scratch.candidates.push((candidate, sq_l2(anchor, vector)));
+                }
+                scratch
+                    .candidates
+                    .sort_unstable_by(|a, b| a.1.total_cmp(&b.1).then(a.0.cmp(&b.0)));
+                if let Some(&(target, _)) = scratch.candidates.iter().find(|(candidate, _)| {
+                    self.merge_target_has_capacity(*candidate, incoming, planned_targets)
+                }) {
+                    return Ok(Some(MergeTarget {
+                        id: target,
+                        #[cfg(test)]
+                        source: MergeTargetSource::Graph,
+                    }));
+                }
+
+                if survivor_budget == survivor_cap {
+                    break;
+                }
+                survivor_budget = survivor_budget.saturating_mul(2).min(survivor_cap);
+            }
+        }
+
+        Ok(self
+            .centroids
+            .closest_live_where(anchor, |candidate| {
+                !victim_set.contains(&candidate)
+                    && self.merge_target_has_capacity(candidate, incoming, planned_targets)
+            })
+            .map(|id| MergeTarget {
+                id,
+                #[cfg(test)]
+                source: MergeTargetSource::ExactFallback,
+            }))
+    }
+
+    fn merge_target_has_capacity(
+        &self,
+        candidate: u32,
+        incoming: usize,
+        planned_targets: &std::collections::HashMap<u32, usize>,
+    ) -> bool {
+        self.partition
+            .list_len(candidate)
+            .saturating_add(planned_targets.get(&candidate).copied().unwrap_or(0))
+            .saturating_add(incoming)
+            <= self.params.split_threshold
     }
 
     /// Retire and globally reroute a prepared LIRE merge batch.

--- a/diskann-graphivf/src/online.rs
+++ b/diskann-graphivf/src/online.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-//! Online graph-IVF clustering with split, dissolve, and reassignment.
+//! Online graph-IVF clustering with LIRE split, merge, and reassignment.
 //!
 //! [`OnlineClusterer`] builds the IVF partition incrementally instead of in a
 //! single batch Lloyd pass. Points are routed to their nearest centroid via a
@@ -16,17 +16,14 @@
 //! validate and route the batch, select overflows from projected sizes, prepare
 //! every split against unchanged state, then commit the inserts and reassign
 //! each split region. A batch large enough to be worth the dispatch routes
-//! across the thread pool; reassignment is always a GEMM.
+//! across the thread pool; LIRE globally routes only possible NPA violations.
 //!
 //! Points can also be removed with
 //! [`delete_batch`](OnlineClusterer::delete_batch): select underflows from
-//! projected post-delete sizes and prepare survivor candidates first, then drop
-//! the deleted points and retire the selected clusters. Retiring *dissolves* a
-//! cluster — it leaves the centroid graph and its remaining members are
-//! scattered onto preselected survivors by the same GEMM the split path uses —
-//! so a split is `+1` live cluster and a merge is `-1`. Splits are insert-driven
-//! and merges are delete-driven, and neither triggers the other, so the two
-//! cannot cascade.
+//! projected post-delete sizes and prepare capacity-compatible merges first,
+//! then drop the deleted points and retire the selected clusters. Victim members
+//! receive a final global NPA route; any resulting overflow enters the same
+//! convergent split-reassign cascade as an insertion.
 //!
 //! Ordinary fallible work is completed before mutation. Structural changes go
 //! through a private registry that owns both the centroid table and graph, and
@@ -50,11 +47,10 @@
 use std::path::Path;
 use std::time::Instant;
 
-use diskann_disk::utils::compute_closest_centers;
 use diskann_providers::utils::{create_thread_pool, ParallelIteratorInPool, RayonThreadPool};
 use diskann_utils::views::{Matrix, MatrixView};
 use diskann_vector::distance::Metric as VectorMetric;
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::{rngs::StdRng, SeedableRng};
 use rayon::prelude::*;
 use tokio::runtime::Runtime;
 
@@ -62,13 +58,14 @@ use crate::{
     centroids::{self, AdjacencyCensus},
     cluster::{self, sq_l2},
     index::{with_suffix, CENTROIDS_SUFFIX, GRAPH_SUFFIX, LISTS_SUFFIX, META_SUFFIX},
-    params::{EmptyClusterPolicy, OnlineCentroidRouting, OnlineParams},
+    params::{OnlineCentroidRouting, OnlineParams},
     storage::{self, Layout},
     GraphIvfError, Result,
 };
 
 use diskann::{utils::VectorRepr, ANNError};
 
+mod lire;
 mod search;
 mod seed;
 mod state;
@@ -89,15 +86,9 @@ const UNASSIGNED: u32 = storage::NOT_INDEXED;
 /// Points routed per parallel work unit in [`OnlineClusterer::insert_batch`].
 const ROUTE_CHUNK: usize = 256;
 
-/// Maximum points gathered into one contiguous tile for a GEMM reassignment
-/// call. Reassigning a whole split region at once would need `|P| * dim` floats
-/// (gigabytes for a large `reassign_neighbors`), so points are streamed through
-/// a tile that bounds the scratch to `REASSIGN_TILE * dim` floats.
-const REASSIGN_TILE: usize = 4096;
-
 /// Route one point to its nearest live centroid via the centroid graph.
 ///
-/// The centroid graph is mutated in place as clusters split and dissolve:
+/// The centroid graph is mutated in place as clusters split and merge:
 /// retired slots are recycled, and the in-edges repaired around a departing
 /// centroid can leave a region thinly connected. A narrow beam can then
 /// occasionally exhaust its frontier without reaching a live centroid, so the
@@ -137,18 +128,10 @@ struct NeighborScratch {
 }
 
 #[derive(Default)]
-struct ReassignScratch {
-    centroid_vectors: Vec<f32>,
-    point_tile: Vec<f32>,
-    best: Vec<u32>,
-}
-
-#[derive(Default)]
 struct MaintenanceScratch {
     points: Vec<DetachedPoint>,
     candidates: Vec<u32>,
     neighbors: NeighborScratch,
-    reassign: ReassignScratch,
 }
 
 struct SplitParentPlan {
@@ -156,6 +139,8 @@ struct SplitParentPlan {
     members: Vec<u32>,
     neighbors: Vec<u32>,
     children: [Box<[f32]>; 2],
+    reassign_candidates: Vec<u32>,
+    region_points: usize,
     two_means_us: u64,
 }
 
@@ -168,7 +153,7 @@ struct SplitPlan {
 struct MergeVictimPlan {
     id: u32,
     members: Vec<u32>,
-    candidates: Vec<u32>,
+    target: u32,
     search_us: u64,
 }
 
@@ -177,8 +162,8 @@ struct MergePlan {
     started: Instant,
 }
 
-/// An incremental graph-IVF clusterer with insert-driven splits, delete-driven
-/// dissolves, and live in-memory search.
+/// An incremental graph-IVF clusterer with LIRE split/merge maintenance and
+/// live in-memory search.
 pub struct OnlineClusterer {
     /// The full corpus, preloaded; row `pid` is point `pid`.
     points: Matrix<f32>,
@@ -275,7 +260,7 @@ impl OnlineClusterer {
         }
         params.routing.validate()?;
         // Merging needs a hysteresis gap below the split threshold. Without
-        // one, a dissolve spills onto a neighbor, overflowing it; the split
+        // one, a merge spills onto a neighbor, overflowing it; the split
         // that follows produces two half-size children, either of which may
         // land back under the merge line.
         if params.merges_enabled() && 2 * params.merge_threshold > params.split_threshold {
@@ -420,12 +405,9 @@ impl OnlineClusterer {
     ///    read-only with respect to the centroid graph and a batch large enough
     ///    to be worth the dispatch runs across the whole thread pool.
     /// 2. **Split each overflow.** Every routed-to cluster that now overflows is
-    ///    bisected on its own by a local 2-means over its members, including the
-    ///    points this batch routed to it. Parents are independent of one
-    ///    another, so a cluster splits identically however many others
-    ///    overflowed in the same batch.
-    /// 3. **Reassign per split region.** Each split parent's neighborhood is
-    ///    then reassigned in turn, as a GEMM.
+    ///    bisected by a capacity-constrained binary fit.
+    /// 3. **LIRE reassign.** Necessary conditions filter possible NPA violations,
+    ///    which are globally routed; resulting overflows cascade to equilibrium.
     ///
     /// Routes are computed against the pre-batch partition, so a point that
     /// lands in a cluster which then splits is routed slightly stale; phase 3
@@ -573,11 +555,8 @@ impl OnlineClusterer {
     /// there is no tombstone to keep or consolidation pass to run. A deleted
     /// point's id becomes free and may be inserted again later.
     ///
-    /// Deleting never splits. A survivor that absorbs a dissolved cluster's
-    /// members can land above `split_threshold`, but it is left for the next
-    /// insert routed to it: keeping splits insert-driven and merges
-    /// delete-driven makes split/merge cascades structurally impossible rather
-    /// than merely bounded.
+    /// Merge reassignment can overflow a survivor, in which case LIRE runs the
+    /// same split-reassign cascade used by insertion until threshold equilibrium.
     ///
     /// # Errors
     ///
@@ -785,10 +764,9 @@ impl OnlineClusterer {
     /// Prepare every parent's split without changing centroid or partition
     /// state.
     ///
-    /// Each parent is bisected on its own by a local 2-means over its members,
-    /// exactly as a batch of one would be. Parents that overflow in the same
-    /// batch do not see one another, so a split is planned identically however
-    /// many others fired alongside it.
+    /// Each parent is bisected on its own by a capacity-constrained binary fit.
+    /// LIRE's two necessary conditions filter the parent-plus-neighbor region
+    /// before any structural update.
     ///
     /// `parents` must be sorted, live, hold at least two members each, and fit
     /// the id budget and cluster cap — [`insert_batch`](Self::insert_batch)
@@ -814,15 +792,58 @@ impl OnlineClusterer {
             if let Some(inserted) = incoming.get(&c) {
                 members.extend_from_slice(inserted);
             }
+            let old_centroid = self
+                .centroids
+                .get(c)
+                .expect("split parent is live")
+                .to_vec()
+                .into_boxed_slice();
             let neighbors = self.region_neighbors(c, s)?;
 
             let kmeans_start = Instant::now();
-            let children = self.two_means(&members, &mut rng_after)?;
+            let balanced = lire::balanced_two_means(
+                &self.points,
+                &members,
+                &mut rng_after,
+                self.params.two_means_iters,
+                self.params.split_threshold,
+                self.params.normalize_centroids,
+            )?;
+            let mut reassign_candidates = Vec::new();
+            for &pid in &members {
+                if lire::old_posting_may_move_elsewhere(
+                    self.points.row(pid as usize),
+                    &old_centroid,
+                    &balanced.children,
+                ) {
+                    reassign_candidates.push(pid);
+                }
+            }
+            for &neighbor in &neighbors {
+                for &pid in self.partition.members(neighbor) {
+                    if lire::neighbor_may_move_to_child(
+                        self.points.row(pid as usize),
+                        &old_centroid,
+                        &balanced.children,
+                    ) {
+                        reassign_candidates.push(pid);
+                    }
+                }
+            }
+            reassign_candidates.sort_unstable();
+            reassign_candidates.dedup();
+            let region_points = members.len()
+                + neighbors
+                    .iter()
+                    .map(|&neighbor| self.partition.list_len(neighbor))
+                    .sum::<usize>();
             parent_plans.push(SplitParentPlan {
                 id: c,
                 members,
                 neighbors,
-                children,
+                children: balanced.children,
+                reassign_candidates,
+                region_points,
                 two_means_us: kmeans_start.elapsed().as_micros() as u64,
             });
         }
@@ -834,54 +855,29 @@ impl OnlineClusterer {
         })
     }
 
-    /// Bisect `members` into two centroids, seeded with two distinct members
-    /// drawn from `rng`.
-    fn two_means(&self, members: &[u32], rng: &mut StdRng) -> Result<[Box<[f32]>; 2]> {
-        let dim = self.dim;
-        let m = members.len();
-        debug_assert!(m >= 2);
-
-        let mut buf = vec![0.0f32; m * dim];
-        for (i, &pid) in members.iter().enumerate() {
-            buf[i * dim..(i + 1) * dim].copy_from_slice(self.points.row(pid as usize));
-        }
-        let data = Matrix::try_from(buf.into_boxed_slice(), m, dim)
-            .map_err(|_| GraphIvfError::invalid("split sub-matrix shape mismatch"))?;
-
-        let a = rng.random_range(0..m);
-        let mut b = rng.random_range(0..m);
-        if b == a {
-            b = (a + 1) % m;
-        }
-        let mut seed = vec![0.0f32; 2 * dim];
-        seed[..dim].copy_from_slice(data.row(a));
-        seed[dim..].copy_from_slice(data.row(b));
-        let mut children = Matrix::try_from(seed.into_boxed_slice(), 2, dim)
-            .map_err(|_| GraphIvfError::invalid("split seed shape mismatch"))?;
-
-        let mut assigner = cluster::ExactAssigner::default();
-        cluster::lloyd(
-            data.as_view(),
-            &mut children,
-            &mut assigner,
-            self.params.two_means_iters.max(1),
-            EmptyClusterPolicy::PreserveOld,
-            self.params.normalize_centroids,
-            &self.pool,
-        )?;
-
-        Ok([
-            children.row(0).to_vec().into_boxed_slice(),
-            children.row(1).to_vec().into_boxed_slice(),
-        ])
-    }
-
     /// Publish a prepared split and reassign each affected region.
     ///
     /// The caller has already marked the clusterer poisoned. All preparation
     /// that can run against the old graph and partition is complete, but graph
-    /// publication and GEMM assignment remain fallible and irreversible.
+    /// publication and final NPA routing remain fallible and irreversible.
     fn commit_split(&mut self, plan: SplitPlan) -> Result<()> {
+        let mut pending = Some(plan);
+        while let Some(plan) = pending {
+            self.commit_split_once(plan)?;
+            let parents = self.select_live_split_parents();
+            pending = if parents.is_empty() {
+                None
+            } else {
+                Some(self.prepare_split(&parents, &std::collections::HashMap::new())?)
+            };
+        }
+        Ok(())
+    }
+
+    /// Publish one LIRE split round, apply the paper's final NPA check to the
+    /// necessary-condition candidates, and move only points whose assignment
+    /// changes.
+    fn commit_split_once(&mut self, plan: SplitPlan) -> Result<()> {
         let parent_ids: Vec<u32> = plan.parents.iter().map(|parent| parent.id).collect();
         let children: Vec<Box<[f32]>> = plan
             .parents
@@ -892,101 +888,151 @@ impl OnlineClusterer {
             .centroids
             .apply_split(&self.runtime, &parent_ids, children)?;
         let live_after = self.centroids.live_count();
-        let mut events = Vec::with_capacity(plan.parents.len());
-        let mut total_reassigned = 0u64;
 
-        // Reassign each split region in turn. The candidates are the parent's
-        // own two children plus the neighbors picked before the mutation, less
-        // any neighbor that was itself a parent of this batch and has since
-        // been retired — that region is covered by its own turn.
-        for (parent, born) in plan.parents.iter().zip(child_ids.chunks_exact(2)) {
-            let cluster_size = parent.members.len();
-
-            self.scratch.candidates.clear();
-            self.scratch.candidates.extend(
-                parent
-                    .neighbors
-                    .iter()
-                    .copied()
-                    .filter(|&c| self.centroids.is_live(c)),
-            );
-            let num_neighbors = self.scratch.candidates.len();
-            self.scratch.candidates.extend_from_slice(born);
-
-            // Candidate points: the parent's own members plus everything its
-            // surviving neighbors hold. The children's lists are still empty —
-            // no other region can have placed a point on them — so the k-means
-            // assignment is not applied separately; reassignment places every
-            // member against the neighbors too, which strictly refines it.
-            self.scratch.points.clear();
-            self.partition
-                .detach_members_into(parent.id, &mut self.scratch.points);
-            debug_assert!(self.scratch.points[..cluster_size]
-                .iter()
-                .map(|point| point.id)
-                .eq(parent.members.iter().copied()));
-            for i in 0..num_neighbors {
-                let cid = self.scratch.candidates[i];
-                self.partition
-                    .detach_members_into(cid, &mut self.scratch.points);
+        let mut candidate_pids: Vec<u32> = plan
+            .parents
+            .iter()
+            .flat_map(|parent| parent.reassign_candidates.iter().copied())
+            .collect();
+        candidate_pids.sort_unstable();
+        candidate_pids.dedup();
+        let mut unowned_candidates: std::collections::HashSet<u32> =
+            candidate_pids.iter().copied().collect();
+        let mut attributed_candidates = vec![0usize; plan.parents.len()];
+        for (index, parent) in plan.parents.iter().enumerate() {
+            for &pid in &parent.reassign_candidates {
+                attributed_candidates[index] += usize::from(unowned_candidates.remove(&pid));
             }
-
-            let reassign_start = Instant::now();
-            let num_reassigned = match self.reassign_scratch_points() {
-                Ok(count) => count,
-                Err(error) => {
-                    self.telemetry.total_splits += events.len() as u64;
-                    self.telemetry.total_reassigned += total_reassigned;
-                    self.telemetry.splits.extend(events);
-                    self.telemetry.split_us += plan.started.elapsed().as_micros() as u64;
-                    return Err(error);
-                }
-            };
-            let reassign_us = reassign_start.elapsed().as_micros() as u64;
-
-            total_reassigned += num_reassigned as u64;
-            events.push(SplitEvent {
-                insert_index: self.telemetry.total_inserts,
-                cluster: parent.id,
-                cluster_size,
-                num_neighbors,
-                num_reassigned,
-                live_after,
-                two_means_us: parent.two_means_us,
-                reassign_us,
-                total_us: parent.two_means_us + reassign_us,
-            });
         }
+        debug_assert!(unowned_candidates.is_empty());
+        let reassign_start = Instant::now();
+        let mut candidate_routes = vec![0u32; candidate_pids.len()];
+        self.route_batch(&candidate_pids, &mut candidate_routes)?;
+        let routed: std::collections::HashMap<u32, u32> = candidate_pids
+            .iter()
+            .copied()
+            .zip(candidate_routes)
+            .collect();
+
+        let mut destinations = std::collections::HashMap::<u32, u32>::new();
+        for (parent_index, parent) in plan.parents.iter().enumerate() {
+            for &pid in &parent.members {
+                let target = routed.get(&pid).copied().unwrap_or_else(|| {
+                    let point = self.points.row(pid as usize);
+                    let child = usize::from(
+                        cluster::sq_l2(point, &parent.children[1])
+                            < cluster::sq_l2(point, &parent.children[0]),
+                    );
+                    child_ids[2 * parent_index + child]
+                });
+                destinations.insert(pid, target);
+            }
+        }
+        for (&pid, &target) in &routed {
+            destinations.entry(pid).or_insert(target);
+        }
+        let mut destinations: Vec<(u32, u32)> = destinations.into_iter().collect();
+        destinations.sort_unstable_by_key(|&(pid, _)| pid);
+
+        let moved: std::collections::HashSet<u32> = destinations
+            .iter()
+            .filter_map(|&(pid, target)| (self.partition.assignment(pid) != target).then_some(pid))
+            .collect();
+        let num_reassigned = self.partition.relocate(&destinations);
+        debug_assert_eq!(num_reassigned, moved.len());
+        let reassign_us = reassign_start.elapsed().as_micros() as u64;
+
+        let mut attributed = vec![0usize; plan.parents.len()];
+        let mut remaining = moved;
+        for (index, parent) in plan.parents.iter().enumerate() {
+            for &pid in &parent.members {
+                attributed[index] += usize::from(remaining.remove(&pid));
+            }
+        }
+        for (index, parent) in plan.parents.iter().enumerate() {
+            for &pid in &parent.reassign_candidates {
+                attributed[index] += usize::from(remaining.remove(&pid));
+            }
+        }
+        debug_assert!(remaining.is_empty());
+        let work_units: Vec<usize> = plan
+            .parents
+            .iter()
+            .zip(&attributed_candidates)
+            .map(|(parent, candidates)| parent.members.len() + candidates)
+            .collect();
+        let total_work = work_units.iter().sum::<usize>().max(1);
+
+        let events = plan
+            .parents
+            .iter()
+            .zip(attributed)
+            .zip(attributed_candidates)
+            .zip(work_units)
+            .map(|(((parent, num_reassigned), npa_candidates), work)| {
+                let reassign_us = reassign_us * work as u64 / total_work as u64;
+                SplitEvent {
+                    insert_index: self.telemetry.total_inserts,
+                    cluster: parent.id,
+                    cluster_size: parent.members.len(),
+                    num_neighbors: parent.neighbors.len(),
+                    region_points: parent.region_points,
+                    npa_candidates,
+                    num_reassigned,
+                    live_after,
+                    two_means_us: parent.two_means_us,
+                    reassign_us,
+                    total_us: parent.two_means_us + reassign_us,
+                }
+            })
+            .collect::<Vec<_>>();
 
         self.rng = plan.rng_after;
         self.telemetry.total_splits += events.len() as u64;
-        self.telemetry.total_reassigned += total_reassigned;
+        self.telemetry.total_reassigned += num_reassigned as u64;
         self.telemetry.splits.extend(events);
         self.telemetry.split_us += plan.started.elapsed().as_micros() as u64;
         Ok(())
     }
 
-    /// Snapshot every merge victim before any structural mutation.
+    /// Admit every currently overfull live posting that fits the remaining id
+    /// and live-cluster budgets. LIRE repeats this after reassignment until no
+    /// cascading overflow remains.
+    fn select_live_split_parents(&self) -> Vec<u32> {
+        let mut parents: Vec<u32> = self
+            .centroids
+            .live_ids()
+            .filter(|&cid| self.partition.list_len(cid) > self.params.split_threshold)
+            .collect();
+        parents.sort_unstable_by(|&a, &b| {
+            self.partition
+                .list_len(b)
+                .cmp(&self.partition.list_len(a))
+                .then(a.cmp(&b))
+        });
+        let mut admitted = parents.len().min(self.centroids.alloc_budget() / 2);
+        if let Some(max_clusters) = self.params.max_clusters {
+            admitted = admitted.min(max_clusters.saturating_sub(self.centroids.live_count()));
+        }
+        parents.truncate(admitted);
+        parents.sort_unstable();
+        parents
+    }
+
+    /// Prepare the merge half of LIRE before any structural mutation.
     ///
-    /// The counterpart of a split, but deliberately not its mirror. A split
-    /// has to re-examine the neighbors' points because
-    /// it *fits* new centroids, and a point that was nearest its own centroid
-    /// may now be nearer a child. A merge fits nothing, and removing a centroid
-    /// cannot change a surviving point's nearest-among-survivors — so the
-    /// neighbors' members are provably already where they belong, and only the
-    /// victim's own points are re-placed. That is the whole operator: no
-    /// k-means and no new centroid.
+    /// Each underfull posting is appended to its nearest surviving posting,
+    /// provided the combined size does not exceed the split threshold. As proved
+    /// by LIRE's NPA argument, removing a centroid cannot invalidate vectors in
+    /// surviving postings, so only the retired posting's members are checked.
     ///
     /// Because nothing is fitted, a merge consumes no centroid id. Deletes are
     /// therefore free against the
     /// [`centroid_capacity`](OnlineParams::centroid_capacity) budget, which
     /// only splits draw down.
     ///
-    /// Candidate search runs before retirement so graph navigation remains
-    /// fallible but non-mutating. Every victim in the batch is explicitly
-    /// excluded from every result, including the exact fallback, so the saved
-    /// candidates remain live after the whole batch is retired. Placement then
-    /// runs only after all victims have left the graph and table.
+    /// Capacity-compatible target selection runs before retirement. Final NPA
+    /// routing runs only after all victims have left the graph and table.
     ///
     /// `victims` must be live, distinct, and leave at least one cluster
     /// standing; [`delete_batch`](Self::delete_batch) guarantees all of these.
@@ -997,69 +1043,55 @@ impl OnlineClusterer {
     ) -> Result<MergePlan> {
         let started = Instant::now();
         let victim_set: std::collections::HashSet<u32> = victims.iter().copied().collect();
-        let survivor_count = self.centroids.live_count().saturating_sub(victims.len());
-        let want = self.params.reassign_neighbors.min(survivor_count);
-        // Ignored under exact routing, which scans every live centroid.
-        let floor = want.saturating_add(victims.len()).max(1);
-        let search_l = self.params.routing.neighbor_beam(floor).unwrap_or(floor);
-        let victims = victims
-            .iter()
-            .map(|&id| {
-                let anchor = self.centroids.get(id).ok_or_else(|| {
-                    GraphIvfError::invalid(format!("merge victim {id} is not live"))
-                })?;
-                let search_start = Instant::now();
-                let mut ids = vec![0u32; want.saturating_add(victims.len()).max(1)];
-                let mut distances = vec![0.0f32; ids.len()];
-                let found = self.centroids.search(
-                    &self.runtime,
-                    anchor,
-                    search_l,
-                    &mut ids,
-                    &mut distances,
-                )?;
-                ids.truncate(found);
-                ids.retain(|candidate| {
-                    self.centroids.is_live(*candidate) && !victim_set.contains(candidate)
+        let mut planned_targets = std::collections::HashMap::<u32, usize>::new();
+        let mut plans = Vec::new();
+        for &id in victims {
+            let anchor = self
+                .centroids
+                .get(id)
+                .ok_or_else(|| GraphIvfError::invalid(format!("merge victim {id} is not live")))?;
+            let members: Vec<u32> = self
+                .partition
+                .members(id)
+                .iter()
+                .copied()
+                .filter(|pid| !deleted.contains(pid))
+                .collect();
+            let search_start = Instant::now();
+            let mut candidates: Vec<(u32, f32)> = self
+                .centroids
+                .iter_live()
+                .filter(|(candidate, _)| !victim_set.contains(candidate))
+                .map(|(candidate, vector)| (candidate, sq_l2(anchor, vector)))
+                .collect();
+            candidates.sort_unstable_by(|a, b| a.1.total_cmp(&b.1).then(a.0.cmp(&b.0)));
+            let target = candidates
+                .into_iter()
+                .map(|(candidate, _)| candidate)
+                .find(|candidate| {
+                    self.partition.list_len(*candidate)
+                        + planned_targets.get(candidate).copied().unwrap_or(0)
+                        + members.len()
+                        <= self.params.split_threshold
                 });
-                ids.truncate(want);
-                if ids.len() < want {
-                    let mut exact: Vec<(u32, f32)> = self
-                        .centroids
-                        .iter_live()
-                        .filter(|(candidate, _)| !victim_set.contains(candidate))
-                        .map(|(candidate, vector)| (candidate, sq_l2(anchor, vector)))
-                        .collect();
-                    exact.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
-                    ids = exact
-                        .into_iter()
-                        .take(want)
-                        .map(|(candidate, _)| candidate)
-                        .collect();
-                }
-                if ids.is_empty() {
-                    return Err(GraphIvfError::invalid(format!(
-                        "retiring cluster {id} found no surviving centroid"
-                    )));
-                }
-                Ok(MergeVictimPlan {
-                    id,
-                    members: self
-                        .partition
-                        .members(id)
-                        .iter()
-                        .copied()
-                        .filter(|pid| !deleted.contains(pid))
-                        .collect(),
-                    candidates: ids,
-                    search_us: search_start.elapsed().as_micros() as u64,
-                })
-            })
-            .collect::<Result<Vec<_>>>()?;
-        Ok(MergePlan { victims, started })
+            let Some(target) = target else {
+                continue;
+            };
+            *planned_targets.entry(target).or_default() += members.len();
+            plans.push(MergeVictimPlan {
+                id,
+                members,
+                target,
+                search_us: search_start.elapsed().as_micros() as u64,
+            });
+        }
+        Ok(MergePlan {
+            victims: plans,
+            started,
+        })
     }
 
-    /// Retire and scatter a prepared merge batch.
+    /// Retire and globally reroute a prepared LIRE merge batch.
     fn commit_merge(&mut self, plan: MergePlan) -> Result<()> {
         let victim_ids: Vec<u32> = plan.victims.iter().map(|victim| victim.id).collect();
 
@@ -1068,15 +1100,15 @@ impl OnlineClusterer {
         self.centroids.retire_all(&self.runtime, &victim_ids)?;
         let live_after = self.centroids.live_count();
 
-        // Scatter each victim's members over the survivors nearest its anchor.
+        // Route every victim member against the post-retirement centroid set.
+        // This is LIRE's final NPA check for merge; surviving postings need no
+        // scan because deleting a centroid cannot invalidate their assignments.
         let op_index = self.telemetry.total_inserts + self.telemetry.total_deletes;
         let mut events = Vec::with_capacity(plan.victims.len());
         let mut total_reassigned = 0u64;
         for victim in &plan.victims {
             self.scratch.candidates.clear();
-            self.scratch
-                .candidates
-                .extend_from_slice(&victim.candidates);
+            self.scratch.candidates.push(victim.target);
             self.scratch.points.clear();
             self.partition
                 .detach_members_into(victim.id, &mut self.scratch.points);
@@ -1088,16 +1120,16 @@ impl OnlineClusterer {
                 .eq(victim.members.iter().copied()));
 
             let reassign_start = Instant::now();
-            let num_reassigned = match self.reassign_scratch_points() {
-                Ok(count) => count,
-                Err(error) => {
-                    self.telemetry.total_merges += events.len() as u64;
-                    self.telemetry.total_merge_reassigned += total_reassigned;
-                    self.telemetry.merges.extend(events);
-                    self.telemetry.merge_us += plan.started.elapsed().as_micros() as u64;
-                    return Err(error);
-                }
-            };
+            let mut routes = vec![0u32; self.scratch.points.len()];
+            let pids: Vec<u32> = self.scratch.points.iter().map(|point| point.id).collect();
+            self.route_batch(&pids, &mut routes)?;
+            let num_reassigned = self
+                .scratch
+                .points
+                .drain(..)
+                .zip(routes)
+                .map(|(point, target)| usize::from(self.partition.attach_detached(point, target)))
+                .sum::<usize>();
             let reassign_us = reassign_start.elapsed().as_micros() as u64;
 
             total_reassigned += num_reassigned as u64;
@@ -1105,7 +1137,7 @@ impl OnlineClusterer {
                 op_index,
                 victim: victim.id,
                 victim_size: victim.members.len(),
-                num_neighbors: self.scratch.candidates.len(),
+                num_neighbors: 1,
                 num_reassigned,
                 live_after,
                 search_us: victim.search_us,
@@ -1118,69 +1150,15 @@ impl OnlineClusterer {
         self.telemetry.total_merge_reassigned += total_reassigned;
         self.telemetry.merges.extend(events);
         self.telemetry.merge_us += plan.started.elapsed().as_micros() as u64;
+
+        // Merge reassignment may overflow a different target posting. LIRE
+        // treats it like an insertion and cascades split-reassign to stability.
+        let parents = self.select_live_split_parents();
+        if !parents.is_empty() {
+            let split = self.prepare_split(&parents, &std::collections::HashMap::new())?;
+            self.commit_split(split)?;
+        }
         Ok(())
-    }
-
-    /// Reassign all currently detached scratch points to the nearest scratch
-    /// candidate, returning how many actually changed cluster.
-    ///
-    /// Distances are computed as `‖p‖² - 2p·c + ‖c‖²` over a `tile x |cands|`
-    /// GEMM instead of a scalar loop per point, which is what makes a large
-    /// `reassign_neighbors` affordable. Each point must already be detached;
-    /// candidate lists that are not part of the working region remain intact.
-    fn reassign_scratch_points(&mut self) -> Result<usize> {
-        let MaintenanceScratch {
-            points,
-            candidates,
-            reassign,
-            ..
-        } = &mut self.scratch;
-        if candidates.is_empty() || points.is_empty() {
-            return Ok(0);
-        }
-        let dim = self.dim;
-        let nc = candidates.len();
-
-        reassign.centroid_vectors.clear();
-        reassign.centroid_vectors.resize(nc * dim, 0.0);
-        for (i, &c) in candidates.iter().enumerate() {
-            reassign.centroid_vectors[i * dim..(i + 1) * dim]
-                .copy_from_slice(self.centroids.get(c).expect("candidate is live"));
-        }
-        let rows = REASSIGN_TILE.min(points.len());
-        reassign.point_tile.clear();
-        reassign.point_tile.resize(rows * dim, 0.0);
-        reassign.best.clear();
-        reassign.best.resize(rows, 0);
-
-        let mut num_reassigned = 0usize;
-        for chunk in points.chunks(rows) {
-            let n = chunk.len();
-            for (i, point) in chunk.iter().enumerate() {
-                reassign.point_tile[i * dim..(i + 1) * dim]
-                    .copy_from_slice(self.points.row(point.id as usize));
-            }
-            compute_closest_centers(
-                &reassign.point_tile[..n * dim],
-                n,
-                dim,
-                &reassign.centroid_vectors,
-                nc,
-                1,
-                &mut reassign.best[..n],
-                None,
-                None,
-                self.pool.as_ref(),
-            )?;
-            for (i, point) in chunk.iter().copied().enumerate() {
-                let cid = candidates[reassign.best[i] as usize];
-                if self.partition.attach_detached(point, cid) {
-                    num_reassigned += 1;
-                }
-            }
-        }
-
-        Ok(num_reassigned)
     }
 
     /// Restore any scratch points that remain detached after a failed

--- a/diskann-graphivf/src/online.rs
+++ b/diskann-graphivf/src/online.rs
@@ -3,7 +3,7 @@
  * Licensed under the MIT license.
  */
 
-//! Online graph-IVF clustering with LIRE split, merge, and reassignment.
+//! Online graph-IVF clustering with LIRE splits and local-scatter merges.
 //!
 //! [`OnlineClusterer`] builds the IVF partition incrementally instead of in a
 //! single batch Lloyd pass. Points are routed to their nearest centroid via a
@@ -20,10 +20,11 @@
 //!
 //! Points can also be removed with
 //! [`delete_batch`](OnlineClusterer::delete_batch): select underflows from
-//! projected post-delete sizes and prepare capacity-compatible merges first,
+//! projected post-delete sizes and prepare local survivor candidates first,
 //! then drop the deleted points and retire the selected clusters. Victim members
-//! receive a final global NPA route; any resulting overflow enters the same
-//! convergent split-reassign cascade as an insertion.
+//! are scattered onto those candidates by a GEMM. Deletes never split: any
+//! resulting overflow is deferred until an insert reaches it or starts a LIRE
+//! split cascade. An unrelated insert that does not split leaves it untouched.
 //!
 //! Ordinary fallible work is completed before mutation. Structural changes go
 //! through a private registry that owns both the centroid table and graph, and
@@ -47,6 +48,7 @@
 use std::path::Path;
 use std::time::Instant;
 
+use diskann_disk::utils::compute_closest_centers;
 use diskann_providers::utils::{create_thread_pool, ParallelIteratorInPool, RayonThreadPool};
 use diskann_utils::views::{Matrix, MatrixView};
 use diskann_vector::distance::Metric as VectorMetric;
@@ -86,39 +88,8 @@ const UNASSIGNED: u32 = storage::NOT_INDEXED;
 /// Points routed per parallel work unit in [`OnlineClusterer::insert_batch`].
 const ROUTE_CHUNK: usize = 256;
 
-/// Most non-victim candidates requested from the graph-first merge planner.
-///
-/// The result window includes victims that will be excluded. If it finds no
-/// capacity-compatible survivor, one packed exact pass preserves progress
-/// without restoring the old full candidate sort.
-const MERGE_GRAPH_MAX_SURVIVORS: usize = 1024;
-
-#[cfg(test)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum MergeTargetSource {
-    Graph,
-    ExactFallback,
-}
-
-struct MergeTarget {
-    id: u32,
-    #[cfg(test)]
-    source: MergeTargetSource,
-}
-
-#[derive(Default)]
-struct MergeSearchScratch {
-    ids: Vec<u32>,
-    distances: Vec<f32>,
-    candidates: Vec<(u32, f32)>,
-}
-
-struct MergeTargetContext<'a> {
-    excluded: &'a std::collections::HashSet<u32>,
-    deleted_counts: &'a std::collections::HashMap<u32, usize>,
-    planned_targets: &'a std::collections::HashMap<u32, usize>,
-    max_graph_survivors: usize,
-}
+/// Maximum points gathered into a contiguous tile for local GEMM reassignment.
+const REASSIGN_TILE: usize = 4096;
 
 /// Route one point to its nearest live centroid via the centroid graph.
 ///
@@ -162,10 +133,18 @@ struct NeighborScratch {
 }
 
 #[derive(Default)]
+struct ReassignScratch {
+    centroid_vectors: Vec<f32>,
+    point_tile: Vec<f32>,
+    best: Vec<u32>,
+}
+
+#[derive(Default)]
 struct MaintenanceScratch {
     points: Vec<DetachedPoint>,
     candidates: Vec<u32>,
     neighbors: NeighborScratch,
+    reassign: ReassignScratch,
 }
 
 struct SplitParentPlan {
@@ -188,7 +167,7 @@ struct SplitPlan {
 struct MergeVictimPlan {
     id: u32,
     members: Vec<u32>,
-    target: u32,
+    candidates: Vec<u32>,
     search_us: u64,
 }
 
@@ -197,7 +176,7 @@ struct MergePlan {
     started: Instant,
 }
 
-/// An incremental graph-IVF clusterer with LIRE split/merge maintenance and
+/// An incremental graph-IVF clusterer with LIRE splits, local-scatter merges and
 /// live in-memory search.
 pub struct OnlineClusterer {
     /// The full corpus, preloaded; row `pid` is point `pid`.
@@ -531,24 +510,29 @@ impl OnlineClusterer {
         self.telemetry.total_inserts += pids.len() as u64;
 
         match split {
-            Some(plan) => self.commit_split(plan),
-            None => Ok(()),
-        }?;
-        self.ensure_split_equilibrium()
+            Some(plan) => {
+                self.commit_split(plan)?;
+                self.ensure_split_equilibrium()
+            }
+            None => self.ensure_split_threshold(routes.iter().copied()),
+        }
     }
 
-    /// Reject a successful-looking uncapped mutation if resource exhaustion
-    /// prevented the split cascade from restoring the configured threshold.
-    /// Explicit `max_clusters` is different: its documented purpose is to cap
-    /// live clusters even when postings remain overfull.
+    /// A completed insert-driven cascade must restore the global threshold.
     fn ensure_split_equilibrium(&self) -> Result<()> {
+        self.ensure_split_threshold(self.centroids.live_ids())
+    }
+
+    /// Without a split, validate only this insert's destinations: a previous
+    /// local-scatter merge is allowed to leave unrelated postings overfull.
+    /// Resource exhaustion must still fail an uncapped insert that leaves one
+    /// of its own destinations overfull. An explicit cluster cap permits it.
+    fn ensure_split_threshold(&self, mut clusters: impl Iterator<Item = u32>) -> Result<()> {
         if self.params.max_clusters.is_some() {
             return Ok(());
         }
-        if let Some(blocked) = self
-            .centroids
-            .live_ids()
-            .find(|&cid| self.partition.list_len(cid) > self.params.split_threshold)
+        if let Some(blocked) =
+            clusters.find(|&cid| self.partition.list_len(cid) > self.params.split_threshold)
         {
             return Err(GraphIvfError::invalid(format!(
                 "centroid id budget exhausted before split equilibrium; \
@@ -615,8 +599,10 @@ impl OnlineClusterer {
     /// there is no tombstone to keep or consolidation pass to run. A deleted
     /// point's id becomes free and may be inserted again later.
     ///
-    /// Merge reassignment can overflow a survivor, in which case LIRE runs the
-    /// same split-reassign cascade used by insertion until threshold equilibrium.
+    /// Deletes never split. Local scatter can overflow a survivor; that overflow
+    /// is deferred until an insert reaches it or starts a LIRE split cascade.
+    /// An insert with no split checks only its own destinations, so an unrelated
+    /// deferred overflow does not poison an otherwise successful insertion.
     ///
     /// # Errors
     ///
@@ -685,7 +671,7 @@ impl OnlineClusterer {
             } else {
                 let deleted: std::collections::HashSet<u32> =
                     by_cluster.iter().map(|&(_, pid)| pid).collect();
-                Some(self.prepare_merge(&victims, &deleted, &deleted_counts)?)
+                Some(self.prepare_merge(&victims, &deleted)?)
             }
         } else {
             None
@@ -1178,20 +1164,28 @@ impl OnlineClusterer {
         parents
     }
 
-    /// Prepare the merge half of LIRE before any structural mutation.
+    /// Snapshot every merge victim before any structural mutation.
     ///
-    /// Each underfull posting is appended to its nearest surviving posting,
-    /// provided the combined size does not exceed the split threshold. As proved
-    /// by LIRE's NPA argument, removing a centroid cannot invalidate vectors in
-    /// surviving postings, so only the retired posting's members are checked.
+    /// The counterpart of a split, but deliberately not its mirror. A split
+    /// has to re-examine the neighbors' points because
+    /// it *fits* new centroids, and a point that was nearest its own centroid
+    /// may now be nearer a child. A merge fits nothing, and removing a centroid
+    /// cannot invalidate an already nearest surviving owner. This argument
+    /// assumes the old assignment was globally nearest; graph routing and a
+    /// limited local candidate set do not guarantee that premise. The local
+    /// merge operator leaves neighbor members in place and re-places only the
+    /// victim's own points: no k-means and no new centroid.
     ///
     /// Because nothing is fitted, a merge consumes no centroid id. Deletes are
     /// therefore free against the
     /// [`centroid_capacity`](OnlineParams::centroid_capacity) budget, which
     /// only splits draw down.
     ///
-    /// Capacity-compatible target selection runs before retirement. Final NPA
-    /// routing runs only after all victims have left the graph and table.
+    /// Candidate search runs before retirement so graph navigation remains
+    /// fallible but non-mutating. Every victim in the batch is explicitly
+    /// excluded from every result, including the exact fallback, so the saved
+    /// candidates remain live after the whole batch is retired. Placement then
+    /// runs only after all victims have left the graph and table.
     ///
     /// `victims` must be live, distinct, and leave at least one cluster
     /// standing; [`delete_batch`](Self::delete_batch) guarantees all of these.
@@ -1199,219 +1193,72 @@ impl OnlineClusterer {
         &self,
         victims: &[u32],
         deleted: &std::collections::HashSet<u32>,
-        deleted_counts: &std::collections::HashMap<u32, usize>,
     ) -> Result<MergePlan> {
         let started = Instant::now();
         let victim_set: std::collections::HashSet<u32> = victims.iter().copied().collect();
-        let mut planned_targets = std::collections::HashMap::<u32, usize>::new();
-        let mut search_scratch = MergeSearchScratch::default();
-        let mut plans = Vec::new();
-        let mut skipped = Vec::new();
-        for &id in victims {
-            let anchor = self
-                .centroids
-                .get(id)
-                .ok_or_else(|| GraphIvfError::invalid(format!("merge victim {id} is not live")))?;
-            let members: Vec<u32> = self
-                .partition
-                .members(id)
-                .iter()
-                .copied()
-                .filter(|pid| !deleted.contains(pid))
-                .collect();
-            let search_start = Instant::now();
-            let target = self.find_merge_target(
-                anchor,
-                members.len(),
-                MergeTargetContext {
-                    excluded: &victim_set,
-                    deleted_counts,
-                    planned_targets: &planned_targets,
-                    max_graph_survivors: MERGE_GRAPH_MAX_SURVIVORS,
-                },
-                &mut search_scratch,
-            )?;
-            let Some(target) = target else {
-                skipped.push((id, members));
-                continue;
-            };
-            *planned_targets.entry(target.id).or_default() += members.len();
-            plans.push(MergeVictimPlan {
-                id,
-                members,
-                target: target.id,
-                search_us: search_start.elapsed().as_micros() as u64,
-            });
-        }
-
-        // A victim rejected above remains live. It can therefore be a valid
-        // destination for another rejected victim, but the first pass excluded
-        // it together with the tentative victim set. Retry skipped victims
-        // greedily against the now-known retirement set. If a future skipped
-        // victim is selected as a target, protect it from retirement.
-        let mut retiring: std::collections::HashSet<u32> =
-            plans.iter().map(|victim| victim.id).collect();
-        let mut protected = std::collections::HashSet::new();
-        for (id, members) in skipped {
-            if protected.contains(&id) {
-                continue;
-            }
-            let mut excluded = retiring.clone();
-            excluded.insert(id);
-            let anchor = self
-                .centroids
-                .get(id)
-                .ok_or_else(|| GraphIvfError::invalid(format!("merge victim {id} is not live")))?;
-            let search_start = Instant::now();
-            let target = self.find_merge_target(
-                anchor,
-                members.len(),
-                MergeTargetContext {
-                    excluded: &excluded,
-                    deleted_counts,
-                    planned_targets: &planned_targets,
-                    max_graph_survivors: MERGE_GRAPH_MAX_SURVIVORS,
-                },
-                &mut search_scratch,
-            )?;
-            let Some(target) = target else {
-                continue;
-            };
-            retiring.insert(id);
-            protected.insert(target.id);
-            *planned_targets.entry(target.id).or_default() += members.len();
-            plans.push(MergeVictimPlan {
-                id,
-                members,
-                target: target.id,
-                search_us: search_start.elapsed().as_micros() as u64,
-            });
-        }
-        Ok(MergePlan {
-            victims: plans,
-            started,
-        })
-    }
-
-    /// Find a capacity-compatible survivor near `anchor`.
-    ///
-    /// Graph routing searches a bounded candidate set first. The survivor
-    /// budget doubles when the nearest candidates are victims or lack projected
-    /// capacity, and each returned set is exactly reranked. Exact routing, or a
-    /// graph search that exhausts the bounded budget, falls back to one packed
-    /// scan that keeps only the nearest feasible centroid.
-    fn find_merge_target(
-        &self,
-        anchor: &[f32],
-        incoming: usize,
-        context: MergeTargetContext<'_>,
-        scratch: &mut MergeSearchScratch,
-    ) -> Result<Option<MergeTarget>> {
-        let survivor_count = self
-            .centroids
-            .live_count()
-            .saturating_sub(context.excluded.len());
-        if survivor_count == 0 {
-            return Ok(None);
-        }
-
-        if self.params.routing.neighbor_beam(1).is_some() {
-            let survivor_cap = survivor_count.min(context.max_graph_survivors.max(1));
-            let mut survivor_budget = self.params.reassign_neighbors.min(survivor_cap).max(1);
-            loop {
-                let victim_allowance = context.excluded.len().min(MERGE_GRAPH_MAX_SURVIVORS);
-                let search_k = victim_allowance
-                    .saturating_add(survivor_budget)
-                    .min(self.centroids.live_count());
-                let search_l = self
-                    .params
-                    .routing
-                    .neighbor_beam(search_k)
-                    .expect("graph routing has a merge search beam");
-                scratch.ids.clear();
-                scratch.ids.resize(search_k, 0);
-                scratch.distances.clear();
-                scratch.distances.resize(search_k, 0.0);
+        let survivor_count = self.centroids.live_count().saturating_sub(victims.len());
+        let want = self.params.reassign_neighbors.min(survivor_count);
+        // Ignored under exact routing, which scans every live centroid.
+        let floor = want.saturating_add(victims.len()).max(1);
+        let search_l = self.params.routing.neighbor_beam(floor).unwrap_or(floor);
+        let victims = victims
+            .iter()
+            .map(|&id| {
+                let anchor = self.centroids.get(id).ok_or_else(|| {
+                    GraphIvfError::invalid(format!("merge victim {id} is not live"))
+                })?;
+                let search_start = Instant::now();
+                let mut ids = vec![0u32; want.saturating_add(victims.len()).max(1)];
+                let mut distances = vec![0.0f32; ids.len()];
                 let found = self.centroids.search(
                     &self.runtime,
                     anchor,
                     search_l,
-                    &mut scratch.ids,
-                    &mut scratch.distances,
+                    &mut ids,
+                    &mut distances,
                 )?;
-                scratch.ids.truncate(found);
-
-                scratch.candidates.clear();
-                for &candidate in &scratch.ids {
-                    if context.excluded.contains(&candidate) || !self.centroids.is_live(candidate) {
-                        continue;
-                    }
-                    let vector = self
+                ids.truncate(found);
+                ids.retain(|candidate| {
+                    self.centroids.is_live(*candidate) && !victim_set.contains(candidate)
+                });
+                ids.truncate(want);
+                if ids.len() < want {
+                    let mut exact: Vec<(u32, f32)> = self
                         .centroids
-                        .get(candidate)
-                        .expect("graph candidate is a live centroid");
-                    scratch.candidates.push((candidate, sq_l2(anchor, vector)));
+                        .iter_live()
+                        .filter(|(candidate, _)| !victim_set.contains(candidate))
+                        .map(|(candidate, vector)| (candidate, sq_l2(anchor, vector)))
+                        .collect();
+                    exact.sort_unstable_by(|a, b| a.1.total_cmp(&b.1));
+                    ids = exact
+                        .into_iter()
+                        .take(want)
+                        .map(|(candidate, _)| candidate)
+                        .collect();
                 }
-                scratch
-                    .candidates
-                    .sort_unstable_by(|a, b| a.1.total_cmp(&b.1).then(a.0.cmp(&b.0)));
-                if let Some(&(target, _)) = scratch.candidates.iter().find(|(candidate, _)| {
-                    self.merge_target_has_capacity(
-                        *candidate,
-                        incoming,
-                        context.deleted_counts,
-                        context.planned_targets,
-                    )
-                }) {
-                    return Ok(Some(MergeTarget {
-                        id: target,
-                        #[cfg(test)]
-                        source: MergeTargetSource::Graph,
-                    }));
+                if ids.is_empty() {
+                    return Err(GraphIvfError::invalid(format!(
+                        "retiring cluster {id} found no surviving centroid"
+                    )));
                 }
-
-                if survivor_budget == survivor_cap {
-                    break;
-                }
-                survivor_budget = survivor_budget.saturating_mul(2).min(survivor_cap);
-            }
-        }
-
-        Ok(self
-            .centroids
-            .closest_live_where(anchor, |candidate| {
-                !context.excluded.contains(&candidate)
-                    && self.merge_target_has_capacity(
-                        candidate,
-                        incoming,
-                        context.deleted_counts,
-                        context.planned_targets,
-                    )
+                Ok(MergeVictimPlan {
+                    id,
+                    members: self
+                        .partition
+                        .members(id)
+                        .iter()
+                        .copied()
+                        .filter(|pid| !deleted.contains(pid))
+                        .collect(),
+                    candidates: ids,
+                    search_us: search_start.elapsed().as_micros() as u64,
+                })
             })
-            .map(|id| MergeTarget {
-                id,
-                #[cfg(test)]
-                source: MergeTargetSource::ExactFallback,
-            }))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(MergePlan { victims, started })
     }
 
-    fn merge_target_has_capacity(
-        &self,
-        candidate: u32,
-        incoming: usize,
-        deleted_counts: &std::collections::HashMap<u32, usize>,
-        planned_targets: &std::collections::HashMap<u32, usize>,
-    ) -> bool {
-        let deleted_from_candidate = deleted_counts.get(&candidate).copied().unwrap_or(0);
-        self.partition
-            .list_len(candidate)
-            .saturating_sub(deleted_from_candidate)
-            .saturating_add(planned_targets.get(&candidate).copied().unwrap_or(0))
-            .saturating_add(incoming)
-            <= self.params.split_threshold
-    }
-
-    /// Retire and globally reroute a prepared LIRE merge batch.
+    /// Retire and scatter a prepared merge batch.
     fn commit_merge(&mut self, plan: MergePlan) -> Result<()> {
         let victim_ids: Vec<u32> = plan.victims.iter().map(|victim| victim.id).collect();
 
@@ -1420,15 +1267,15 @@ impl OnlineClusterer {
         self.centroids.retire_all(&self.runtime, &victim_ids)?;
         let live_after = self.centroids.live_count();
 
-        // Route every victim member against the post-retirement centroid set.
-        // This is LIRE's final NPA check for merge; surviving postings need no
-        // scan because deleting a centroid cannot invalidate their assignments.
+        // Scatter each victim's members over the survivors nearest its anchor.
         let op_index = self.telemetry.total_inserts + self.telemetry.total_deletes;
         let mut events = Vec::with_capacity(plan.victims.len());
         let mut total_reassigned = 0u64;
         for victim in &plan.victims {
             self.scratch.candidates.clear();
-            self.scratch.candidates.push(victim.target);
+            self.scratch
+                .candidates
+                .extend_from_slice(&victim.candidates);
             self.scratch.points.clear();
             self.partition
                 .detach_members_into(victim.id, &mut self.scratch.points);
@@ -1440,20 +1287,16 @@ impl OnlineClusterer {
                 .eq(victim.members.iter().copied()));
 
             let reassign_start = Instant::now();
-            let mut routes = vec![0u32; self.scratch.points.len()];
-            let pids: Vec<u32> = self.scratch.points.iter().map(|point| point.id).collect();
-            self.route_batch(&pids, &mut routes)?;
-            let mut destinations = Vec::with_capacity(self.scratch.points.len());
-            let num_reassigned = self.scratch.points.len();
-            for (point, routed) in self.scratch.points.drain(..).zip(routes) {
-                let pid = point.id;
-                self.partition.attach_detached(point, victim.target);
-                destinations.push((pid, routed));
-            }
-            // Materialize the capacity-safe merge target first, then perform
-            // the final global NPA moves. Any destination overflow enters the
-            // normal split cascade below.
-            self.partition.relocate(&destinations);
+            let num_reassigned = match self.reassign_scratch_points() {
+                Ok(count) => count,
+                Err(error) => {
+                    self.telemetry.total_merges += events.len() as u64;
+                    self.telemetry.total_merge_reassigned += total_reassigned;
+                    self.telemetry.merges.extend(events);
+                    self.telemetry.merge_us += plan.started.elapsed().as_micros() as u64;
+                    return Err(error);
+                }
+            };
             let reassign_us = reassign_start.elapsed().as_micros() as u64;
 
             total_reassigned += num_reassigned as u64;
@@ -1461,7 +1304,7 @@ impl OnlineClusterer {
                 op_index,
                 victim: victim.id,
                 victim_size: victim.members.len(),
-                num_neighbors: 1,
+                num_neighbors: self.scratch.candidates.len(),
                 num_reassigned,
                 live_after,
                 search_us: victim.search_us,
@@ -1474,15 +1317,73 @@ impl OnlineClusterer {
         self.telemetry.total_merge_reassigned += total_reassigned;
         self.telemetry.merges.extend(events);
         self.telemetry.merge_us += plan.started.elapsed().as_micros() as u64;
+        Ok(())
+    }
 
-        // Merge reassignment may overflow a different target posting. LIRE
-        // treats it like an insertion and cascades split-reassign to stability.
-        let parents = self.select_live_split_parents();
-        if !parents.is_empty() {
-            let split = self.prepare_split(&parents, &std::collections::HashMap::new())?;
-            self.commit_split(split)?;
+    /// Reassign all currently detached scratch points to the nearest scratch
+    /// candidate, returning how many actually changed cluster.
+    ///
+    /// Distances are computed as `‖p‖² - 2p·c + ‖c‖²` over a `tile x |cands|`
+    /// GEMM instead of a scalar loop per point, which is what makes a large
+    /// `reassign_neighbors` affordable. Each point must already be detached;
+    /// candidate lists that are not part of the working region remain intact.
+    fn reassign_scratch_points(&mut self) -> Result<usize> {
+        let MaintenanceScratch {
+            points,
+            candidates,
+            reassign,
+            ..
+        } = &mut self.scratch;
+        if candidates.is_empty() || points.is_empty() {
+            return Ok(0);
         }
-        self.ensure_split_equilibrium()
+        let dim = self.dim;
+        let nc = candidates.len();
+
+        reassign.centroid_vectors.clear();
+        reassign.centroid_vectors.resize(nc * dim, 0.0);
+        for (i, &c) in candidates.iter().enumerate() {
+            reassign.centroid_vectors[i * dim..(i + 1) * dim]
+                .copy_from_slice(self.centroids.get(c).expect("candidate is live"));
+        }
+        let rows = REASSIGN_TILE.min(points.len());
+        reassign.point_tile.clear();
+        reassign.point_tile.resize(rows * dim, 0.0);
+        reassign.best.clear();
+        reassign.best.resize(rows, 0);
+
+        let mut num_reassigned = 0usize;
+        for chunk in points.chunks(rows) {
+            let n = chunk.len();
+            for (i, point) in chunk.iter().enumerate() {
+                reassign.point_tile[i * dim..(i + 1) * dim]
+                    .copy_from_slice(self.points.row(point.id as usize));
+            }
+            compute_closest_centers(
+                &reassign.point_tile[..n * dim],
+                n,
+                dim,
+                &reassign.centroid_vectors,
+                nc,
+                1,
+                &mut reassign.best[..n],
+                None,
+                None,
+                self.pool.as_ref(),
+            )?;
+            for (i, point) in chunk.iter().copied().enumerate() {
+                let cid = candidates[reassign.best[i] as usize];
+                if self.partition.attach_detached(point, cid) {
+                    num_reassigned += 1;
+                }
+            }
+        }
+
+        // Only failed assignments may remain recovery candidates. Keeping
+        // completed points here could resurrect one after a later delete if
+        // an unrelated insertion then fails and invokes recovery.
+        points.clear();
+        Ok(num_reassigned)
     }
 
     /// Restore any scratch points that remain detached after a failed

--- a/diskann-graphivf/src/online.rs
+++ b/diskann-graphivf/src/online.rs
@@ -1135,6 +1135,7 @@ impl OnlineClusterer {
                     num_neighbors: parent.neighbors.len(),
                     region_points: parent.region_points,
                     npa_candidates,
+                    operation_index: self.telemetry.total_inserts + self.telemetry.total_deletes,
                     num_reassigned,
                     live_after,
                     clusters_updated: 0,

--- a/diskann-graphivf/src/online.rs
+++ b/diskann-graphivf/src/online.rs
@@ -113,6 +113,13 @@ struct MergeSearchScratch {
     candidates: Vec<(u32, f32)>,
 }
 
+struct MergeTargetContext<'a> {
+    excluded: &'a std::collections::HashSet<u32>,
+    deleted_counts: &'a std::collections::HashMap<u32, usize>,
+    planned_targets: &'a std::collections::HashMap<u32, usize>,
+    max_graph_survivors: usize,
+}
+
 /// Route one point to its nearest live centroid via the centroid graph.
 ///
 /// The centroid graph is mutated in place as clusters split and merge:
@@ -166,6 +173,7 @@ struct SplitParentPlan {
     members: Vec<u32>,
     neighbors: Vec<u32>,
     children: [Box<[f32]>; 2],
+    assignments: Vec<u8>,
     reassign_candidates: Vec<u32>,
     region_points: usize,
     two_means_us: u64,
@@ -488,12 +496,13 @@ impl OnlineClusterer {
         let split = if parents.is_empty() {
             None
         } else {
-            let parent_set: std::collections::HashSet<u32> = parents.iter().copied().collect();
             let mut incoming = std::collections::HashMap::<u32, Vec<u32>>::new();
             for (&pid, &cid) in pids.iter().zip(&routes) {
-                if parent_set.contains(&cid) {
-                    incoming.entry(cid).or_default().push(pid);
-                }
+                // Split-neighbor Equation 2 must see points routed to every
+                // posting in this batch, not only points routed to a parent.
+                // None are attached until commit, so they are otherwise absent
+                // from `partition.members(neighbor)`.
+                incoming.entry(cid).or_default().push(pid);
             }
             Some(self.prepare_split(&parents, &incoming)?)
         };
@@ -524,7 +533,31 @@ impl OnlineClusterer {
         match split {
             Some(plan) => self.commit_split(plan),
             None => Ok(()),
+        }?;
+        self.ensure_split_equilibrium()
+    }
+
+    /// Reject a successful-looking uncapped mutation if resource exhaustion
+    /// prevented the split cascade from restoring the configured threshold.
+    /// Explicit `max_clusters` is different: its documented purpose is to cap
+    /// live clusters even when postings remain overfull.
+    fn ensure_split_equilibrium(&self) -> Result<()> {
+        if self.params.max_clusters.is_some() {
+            return Ok(());
         }
+        if let Some(blocked) = self
+            .centroids
+            .live_ids()
+            .find(|&cid| self.partition.list_len(cid) > self.params.split_threshold)
+        {
+            return Err(GraphIvfError::invalid(format!(
+                "centroid id budget exhausted before split equilibrium; \
+                 posting {blocked} has {} points above threshold {}",
+                self.partition.list_len(blocked),
+                self.params.split_threshold
+            )));
+        }
+        Ok(())
     }
 
     /// Select overflowing routed-to clusters using their projected post-insert
@@ -621,6 +654,7 @@ impl OnlineClusterer {
         // their fallible candidate searches before removing a single point.
         let merge = if self.params.merges_enabled() {
             let mut victims = Vec::new();
+            let mut deleted_counts = std::collections::HashMap::<u32, usize>::new();
             let mut start = 0;
             while start < by_cluster.len() {
                 let cid = by_cluster[start].0;
@@ -628,7 +662,9 @@ impl OnlineClusterer {
                     .iter()
                     .position(|&(candidate, _)| candidate != cid)
                     .map_or(by_cluster.len(), |offset| start + offset);
-                if self.partition.list_len(cid) - (end - start) < self.params.merge_threshold {
+                let deleted = end - start;
+                deleted_counts.insert(cid, deleted);
+                if self.partition.list_len(cid) - deleted < self.params.merge_threshold {
                     victims.push(cid);
                 }
                 start = end;
@@ -639,10 +675,7 @@ impl OnlineClusterer {
                 .len()
                 .min(self.centroids.live_count().saturating_sub(floor));
             victims.sort_unstable_by_key(|&cid| {
-                let deleted = by_cluster
-                    .iter()
-                    .filter(|&&(candidate, _)| candidate == cid)
-                    .count();
+                let deleted = deleted_counts.get(&cid).copied().unwrap_or(0);
                 (self.partition.list_len(cid) - deleted, cid)
             });
             victims.truncate(admitted);
@@ -652,7 +685,7 @@ impl OnlineClusterer {
             } else {
                 let deleted: std::collections::HashSet<u32> =
                     by_cluster.iter().map(|&(_, pid)| pid).collect();
-                Some(self.prepare_merge(&victims, &deleted)?)
+                Some(self.prepare_merge(&victims, &deleted, &deleted_counts)?)
             }
         } else {
             None
@@ -856,19 +889,34 @@ impl OnlineClusterer {
                         reassign_candidates.push(pid);
                     }
                 }
+                if let Some(inserted) = incoming.get(&neighbor) {
+                    for &pid in inserted {
+                        if lire::neighbor_may_move_to_child(
+                            self.points.row(pid as usize),
+                            &old_centroid,
+                            &balanced.children,
+                        ) {
+                            reassign_candidates.push(pid);
+                        }
+                    }
+                }
             }
             reassign_candidates.sort_unstable();
             reassign_candidates.dedup();
             let region_points = members.len()
                 + neighbors
                     .iter()
-                    .map(|&neighbor| self.partition.list_len(neighbor))
+                    .map(|&neighbor| {
+                        self.partition.list_len(neighbor)
+                            + incoming.get(&neighbor).map_or(0, Vec::len)
+                    })
                     .sum::<usize>();
             parent_plans.push(SplitParentPlan {
                 id: c,
                 members,
                 neighbors,
                 children: balanced.children,
+                assignments: balanced.assignments,
                 reassign_candidates,
                 region_points,
                 two_means_us: kmeans_start.elapsed().as_micros() as u64,
@@ -975,20 +1023,60 @@ impl OnlineClusterer {
 
         let mut destinations = std::collections::HashMap::<u32, u32>::new();
         for (parent_index, parent) in plan.parents.iter().enumerate() {
-            for &pid in &parent.members {
-                let target = routed.get(&pid).copied().unwrap_or_else(|| {
-                    let point = self.points.row(pid as usize);
-                    let child = usize::from(
-                        cluster::sq_l2(point, &parent.children[1])
-                            < cluster::sq_l2(point, &parent.children[0]),
-                    );
-                    child_ids[2 * parent_index + child]
+            for (member_index, &pid) in parent.members.iter().enumerate() {
+                let point = self.points.row(pid as usize);
+                let distances = [
+                    cluster::sq_l2(point, &parent.children[0]),
+                    cluster::sq_l2(point, &parent.children[1]),
+                ];
+                // Preserve NPA by choosing the strictly nearer child. The
+                // constrained training assignment is needed for exact distance
+                // ties; otherwise identical points all choose child zero and
+                // immediately overflow it again.
+                let fitted = parent.assignments[member_index] as usize;
+                let local_child = match distances[0].total_cmp(&distances[1]) {
+                    std::cmp::Ordering::Less => 0,
+                    std::cmp::Ordering::Greater => 1,
+                    std::cmp::Ordering::Equal => fitted,
+                };
+                let local_target = child_ids[2 * parent_index + local_child];
+                let local_distance = distances[local_child];
+                let target = routed.get(&pid).copied().map_or(local_target, |global| {
+                    let global_distance = self
+                        .centroids
+                        .get(global)
+                        .map(|centroid| cluster::sq_l2(point, centroid))
+                        .unwrap_or(f32::INFINITY);
+                    if global_distance < local_distance {
+                        global
+                    } else {
+                        local_target
+                    }
                 });
                 destinations.insert(pid, target);
             }
         }
         for (&pid, &target) in &routed {
-            destinations.entry(pid).or_insert(target);
+            destinations.entry(pid).or_insert_with(|| {
+                let source = self.partition.assignment(pid);
+                let Some(source_centroid) = self.centroids.get(source) else {
+                    // Every retired-parent member was inserted above. This is
+                    // defensive for a partially prepared plan.
+                    return target;
+                };
+                let point = self.points.row(pid as usize);
+                let source_distance = cluster::sq_l2(point, source_centroid);
+                let target_distance = self
+                    .centroids
+                    .get(target)
+                    .map(|centroid| cluster::sq_l2(point, centroid))
+                    .unwrap_or(f32::INFINITY);
+                if target_distance < source_distance {
+                    target
+                } else {
+                    source
+                }
+            });
         }
         let mut destinations: Vec<(u32, u32)> = destinations.into_iter().collect();
         destinations.sort_unstable_by_key(|&(pid, _)| pid);
@@ -1110,12 +1198,14 @@ impl OnlineClusterer {
         &self,
         victims: &[u32],
         deleted: &std::collections::HashSet<u32>,
+        deleted_counts: &std::collections::HashMap<u32, usize>,
     ) -> Result<MergePlan> {
         let started = Instant::now();
         let victim_set: std::collections::HashSet<u32> = victims.iter().copied().collect();
         let mut planned_targets = std::collections::HashMap::<u32, usize>::new();
         let mut search_scratch = MergeSearchScratch::default();
         let mut plans = Vec::new();
+        let mut skipped = Vec::new();
         for &id in victims {
             let anchor = self
                 .centroids
@@ -1131,15 +1221,63 @@ impl OnlineClusterer {
             let search_start = Instant::now();
             let target = self.find_merge_target(
                 anchor,
-                &victim_set,
                 members.len(),
-                &planned_targets,
-                MERGE_GRAPH_MAX_SURVIVORS,
+                MergeTargetContext {
+                    excluded: &victim_set,
+                    deleted_counts,
+                    planned_targets: &planned_targets,
+                    max_graph_survivors: MERGE_GRAPH_MAX_SURVIVORS,
+                },
+                &mut search_scratch,
+            )?;
+            let Some(target) = target else {
+                skipped.push((id, members));
+                continue;
+            };
+            *planned_targets.entry(target.id).or_default() += members.len();
+            plans.push(MergeVictimPlan {
+                id,
+                members,
+                target: target.id,
+                search_us: search_start.elapsed().as_micros() as u64,
+            });
+        }
+
+        // A victim rejected above remains live. It can therefore be a valid
+        // destination for another rejected victim, but the first pass excluded
+        // it together with the tentative victim set. Retry skipped victims
+        // greedily against the now-known retirement set. If a future skipped
+        // victim is selected as a target, protect it from retirement.
+        let mut retiring: std::collections::HashSet<u32> =
+            plans.iter().map(|victim| victim.id).collect();
+        let mut protected = std::collections::HashSet::new();
+        for (id, members) in skipped {
+            if protected.contains(&id) {
+                continue;
+            }
+            let mut excluded = retiring.clone();
+            excluded.insert(id);
+            let anchor = self
+                .centroids
+                .get(id)
+                .ok_or_else(|| GraphIvfError::invalid(format!("merge victim {id} is not live")))?;
+            let search_start = Instant::now();
+            let target = self.find_merge_target(
+                anchor,
+                members.len(),
+                MergeTargetContext {
+                    excluded: &excluded,
+                    deleted_counts,
+                    planned_targets: &planned_targets,
+                    max_graph_survivors: MERGE_GRAPH_MAX_SURVIVORS,
+                },
                 &mut search_scratch,
             )?;
             let Some(target) = target else {
                 continue;
             };
+            retiring.insert(id);
+            protected.insert(target.id);
             *planned_targets.entry(target.id).or_default() += members.len();
             plans.push(MergeVictimPlan {
                 id,
@@ -1164,22 +1302,23 @@ impl OnlineClusterer {
     fn find_merge_target(
         &self,
         anchor: &[f32],
-        victim_set: &std::collections::HashSet<u32>,
         incoming: usize,
-        planned_targets: &std::collections::HashMap<u32, usize>,
-        max_graph_survivors: usize,
+        context: MergeTargetContext<'_>,
         scratch: &mut MergeSearchScratch,
     ) -> Result<Option<MergeTarget>> {
-        let survivor_count = self.centroids.live_count().saturating_sub(victim_set.len());
+        let survivor_count = self
+            .centroids
+            .live_count()
+            .saturating_sub(context.excluded.len());
         if survivor_count == 0 {
             return Ok(None);
         }
 
         if self.params.routing.neighbor_beam(1).is_some() {
-            let survivor_cap = survivor_count.min(max_graph_survivors.max(1));
+            let survivor_cap = survivor_count.min(context.max_graph_survivors.max(1));
             let mut survivor_budget = self.params.reassign_neighbors.min(survivor_cap).max(1);
             loop {
-                let victim_allowance = victim_set.len().min(MERGE_GRAPH_MAX_SURVIVORS);
+                let victim_allowance = context.excluded.len().min(MERGE_GRAPH_MAX_SURVIVORS);
                 let search_k = victim_allowance
                     .saturating_add(survivor_budget)
                     .min(self.centroids.live_count());
@@ -1203,7 +1342,7 @@ impl OnlineClusterer {
 
                 scratch.candidates.clear();
                 for &candidate in &scratch.ids {
-                    if victim_set.contains(&candidate) || !self.centroids.is_live(candidate) {
+                    if context.excluded.contains(&candidate) || !self.centroids.is_live(candidate) {
                         continue;
                     }
                     let vector = self
@@ -1216,7 +1355,12 @@ impl OnlineClusterer {
                     .candidates
                     .sort_unstable_by(|a, b| a.1.total_cmp(&b.1).then(a.0.cmp(&b.0)));
                 if let Some(&(target, _)) = scratch.candidates.iter().find(|(candidate, _)| {
-                    self.merge_target_has_capacity(*candidate, incoming, planned_targets)
+                    self.merge_target_has_capacity(
+                        *candidate,
+                        incoming,
+                        context.deleted_counts,
+                        context.planned_targets,
+                    )
                 }) {
                     return Ok(Some(MergeTarget {
                         id: target,
@@ -1235,8 +1379,13 @@ impl OnlineClusterer {
         Ok(self
             .centroids
             .closest_live_where(anchor, |candidate| {
-                !victim_set.contains(&candidate)
-                    && self.merge_target_has_capacity(candidate, incoming, planned_targets)
+                !context.excluded.contains(&candidate)
+                    && self.merge_target_has_capacity(
+                        candidate,
+                        incoming,
+                        context.deleted_counts,
+                        context.planned_targets,
+                    )
             })
             .map(|id| MergeTarget {
                 id,
@@ -1249,10 +1398,13 @@ impl OnlineClusterer {
         &self,
         candidate: u32,
         incoming: usize,
+        deleted_counts: &std::collections::HashMap<u32, usize>,
         planned_targets: &std::collections::HashMap<u32, usize>,
     ) -> bool {
+        let deleted_from_candidate = deleted_counts.get(&candidate).copied().unwrap_or(0);
         self.partition
             .list_len(candidate)
+            .saturating_sub(deleted_from_candidate)
             .saturating_add(planned_targets.get(&candidate).copied().unwrap_or(0))
             .saturating_add(incoming)
             <= self.params.split_threshold
@@ -1290,13 +1442,17 @@ impl OnlineClusterer {
             let mut routes = vec![0u32; self.scratch.points.len()];
             let pids: Vec<u32> = self.scratch.points.iter().map(|point| point.id).collect();
             self.route_batch(&pids, &mut routes)?;
-            let num_reassigned = self
-                .scratch
-                .points
-                .drain(..)
-                .zip(routes)
-                .map(|(point, target)| usize::from(self.partition.attach_detached(point, target)))
-                .sum::<usize>();
+            let mut destinations = Vec::with_capacity(self.scratch.points.len());
+            let num_reassigned = self.scratch.points.len();
+            for (point, routed) in self.scratch.points.drain(..).zip(routes) {
+                let pid = point.id;
+                self.partition.attach_detached(point, victim.target);
+                destinations.push((pid, routed));
+            }
+            // Materialize the capacity-safe merge target first, then perform
+            // the final global NPA moves. Any destination overflow enters the
+            // normal split cascade below.
+            self.partition.relocate(&destinations);
             let reassign_us = reassign_start.elapsed().as_micros() as u64;
 
             total_reassigned += num_reassigned as u64;
@@ -1325,7 +1481,7 @@ impl OnlineClusterer {
             let split = self.prepare_split(&parents, &std::collections::HashMap::new())?;
             self.commit_split(split)?;
         }
-        Ok(())
+        self.ensure_split_equilibrium()
     }
 
     /// Restore any scratch points that remain detached after a failed

--- a/diskann-graphivf/src/online/lire.rs
+++ b/diskann-graphivf/src/online/lire.rs
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
+ */
+
+//! Algorithmic core of SPFresh's Lightweight Incremental RE-balancing (LIRE).
+//!
+//! This module implements the paper's two necessary conditions for split
+//! reassignment and a capacity-balanced binary centroid fit. Storage versioning,
+//! asynchronous rebuild workers, and append-only SSD blocks belong to SPFresh's
+//! system layer and are intentionally outside the synchronous in-memory
+//! OnlineClusterer.
+
+use diskann_utils::views::Matrix;
+use rand::{rngs::StdRng, Rng};
+
+use crate::{cluster, GraphIvfError, Result};
+
+pub(super) struct BalancedSplit {
+    pub(super) children: [Box<[f32]>; 2],
+    #[cfg(test)]
+    pub(super) assignments: Vec<u8>,
+}
+
+pub(super) fn balanced_two_means(
+    points: &Matrix<f32>,
+    members: &[u32],
+    rng: &mut StdRng,
+    max_iters: usize,
+    split_threshold: usize,
+    normalize: bool,
+) -> Result<BalancedSplit> {
+    if members.len() < 2 {
+        return Err(GraphIvfError::invalid(
+            "balanced split requires at least two members",
+        ));
+    }
+    let dim = points.ncols();
+    let a = rng.random_range(0..members.len());
+    let b = members
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| *index != a)
+        .max_by(|(_, left), (_, right)| {
+            cluster::sq_l2(points.row(members[a] as usize), points.row(**left as usize)).total_cmp(
+                &cluster::sq_l2(
+                    points.row(members[a] as usize),
+                    points.row(**right as usize),
+                ),
+            )
+        })
+        .map(|(index, _)| index)
+        .expect("at least two members");
+    let mut children = [
+        points.row(members[a] as usize).to_vec().into_boxed_slice(),
+        points.row(members[b] as usize).to_vec().into_boxed_slice(),
+    ];
+    let mut assignments = vec![u8::MAX; members.len()];
+    let mut previous = vec![u8::MAX; members.len()];
+    let mut margins = Vec::with_capacity(members.len());
+    // Each child must fit the posting capacity and receive at least one quarter
+    // of the parent. SPFresh calls for an even, capacity-bounded split, while
+    // its referenced multi-constraint SPANN implementation is not public; this
+    // explicit 1:3 bound preserves geometry better than strict 1:1 and rules
+    // out degenerate tiny children.
+    let child_capacity = split_threshold.max(members.len().div_ceil(2));
+    let child_min = members.len().div_ceil(4);
+
+    for _ in 0..max_iters.max(1) {
+        margins.clear();
+        for (index, &pid) in members.iter().enumerate() {
+            let point = points.row(pid as usize);
+            margins.push((
+                index,
+                cluster::sq_l2(point, &children[0]) - cluster::sq_l2(point, &children[1]),
+            ));
+        }
+        margins.sort_unstable_by(|a, b| a.1.total_cmp(&b.1).then(a.0.cmp(&b.0)));
+        for &(index, margin) in &margins {
+            assignments[index] = u8::from(margin > 0.0);
+        }
+        let mut child0_len = assignments.iter().filter(|&&child| child == 0).count();
+        if child0_len > child_capacity {
+            // Move the child-0 points with the weakest preference for child 0.
+            for &(index, _) in margins[..child0_len]
+                .iter()
+                .rev()
+                .take(child0_len - child_capacity)
+            {
+                assignments[index] = 1;
+            }
+            child0_len = child_capacity;
+        }
+        let child1_len = members.len() - child0_len;
+        if child1_len > child_capacity {
+            // Move the child-1 points with the weakest preference for child 1.
+            for &(index, _) in margins[child0_len..]
+                .iter()
+                .take(child1_len - child_capacity)
+            {
+                assignments[index] = 0;
+            }
+        }
+        let child0_len = assignments.iter().filter(|&&child| child == 0).count();
+        if child0_len < child_min {
+            for &(index, _) in margins[child0_len..].iter().take(child_min - child0_len) {
+                assignments[index] = 0;
+            }
+        }
+        let child1_len = assignments.iter().filter(|&&child| child == 1).count();
+        if child1_len < child_min {
+            for &(index, _) in margins[..members.len() - child1_len]
+                .iter()
+                .rev()
+                .take(child_min - child1_len)
+            {
+                assignments[index] = 1;
+            }
+        }
+        if assignments == previous {
+            break;
+        }
+        previous.copy_from_slice(&assignments);
+
+        let mut sums = [vec![0.0f64; dim], vec![0.0f64; dim]];
+        let mut counts = [0usize; 2];
+        for (&pid, &assigned) in members.iter().zip(&assignments) {
+            let child = assigned as usize;
+            counts[child] += 1;
+            for (sum, &value) in sums[child].iter_mut().zip(points.row(pid as usize)) {
+                *sum += value as f64;
+            }
+        }
+        for child in 0..2 {
+            debug_assert!(counts[child] > 0);
+            let inv = 1.0 / counts[child] as f64;
+            for (value, &sum) in children[child].iter_mut().zip(&sums[child]) {
+                *value = (sum * inv) as f32;
+            }
+            if normalize {
+                cluster::normalize(&mut children[child]);
+            }
+        }
+    }
+
+    Ok(BalancedSplit {
+        children,
+        #[cfg(test)]
+        assignments,
+    })
+}
+
+pub(super) fn old_posting_may_move_elsewhere(
+    point: &[f32],
+    old: &[f32],
+    children: &[Box<[f32]>; 2],
+) -> bool {
+    let old_distance = cluster::sq_l2(point, old);
+    children
+        .iter()
+        .all(|child| old_distance <= cluster::sq_l2(point, child))
+}
+
+pub(super) fn neighbor_may_move_to_child(
+    point: &[f32],
+    old: &[f32],
+    children: &[Box<[f32]>; 2],
+) -> bool {
+    let old_distance = cluster::sq_l2(point, old);
+    children
+        .iter()
+        .any(|child| cluster::sq_l2(point, child) <= old_distance)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+
+    fn matrix(values: Vec<f32>, rows: usize, cols: usize) -> Matrix<f32> {
+        Matrix::try_from(values.into_boxed_slice(), rows, cols).unwrap()
+    }
+
+    #[test]
+    fn balanced_fit_keeps_training_buckets_within_one() {
+        let points = matrix(vec![0.0, 0.1, 0.2, 9.8, 9.9, 10.0, 10.1], 7, 1);
+        let members: Vec<u32> = (0..7).collect();
+        let mut rng = StdRng::seed_from_u64(4);
+        let split = balanced_two_means(&points, &members, &mut rng, 8, 4, false).unwrap();
+        let left = split
+            .assignments
+            .iter()
+            .filter(|&&child| child == 0)
+            .count();
+        let right = split.assignments.len() - left;
+        assert!(left.abs_diff(right) <= 1, "{left} vs {right}");
+        let mut centers = [split.children[0][0], split.children[1][0]];
+        centers.sort_by(f32::total_cmp);
+        assert!(centers[0] < 1.0 && centers[1] > 9.0);
+    }
+
+    #[test]
+    fn lire_conditions_select_only_possible_npa_violations() {
+        let children = [vec![-1.0].into_boxed_slice(), vec![1.0].into_boxed_slice()];
+        assert!(old_posting_may_move_elsewhere(&[0.0], &[0.0], &children));
+        assert!(!old_posting_may_move_elsewhere(&[0.9], &[0.0], &children));
+        assert!(neighbor_may_move_to_child(&[1.2], &[0.0], &children));
+        assert!(!neighbor_may_move_to_child(&[0.1], &[0.0], &children));
+    }
+
+    #[test]
+    fn balanced_fit_prevents_a_degenerate_tiny_child() {
+        let points = matrix(vec![0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 10.0], 8, 1);
+        let members: Vec<u32> = (0..8).collect();
+        let mut rng = StdRng::seed_from_u64(8);
+        let split = balanced_two_means(&points, &members, &mut rng, 8, 8, false).unwrap();
+        let left = split
+            .assignments
+            .iter()
+            .filter(|&&child| child == 0)
+            .count();
+        let right = split.assignments.len() - left;
+        assert!(left >= 2 && right >= 2, "{left} vs {right}");
+    }
+}

--- a/diskann-graphivf/src/online/lire.rs
+++ b/diskann-graphivf/src/online/lire.rs
@@ -18,7 +18,11 @@ use crate::{cluster, GraphIvfError, Result};
 
 pub(super) struct BalancedSplit {
     pub(super) children: [Box<[f32]>; 2],
-    #[cfg(test)]
+    /// Capacity-constrained training assignment, aligned with `members`.
+    ///
+    /// Final NPA placement normally selects the nearer child. This assignment
+    /// supplies its stable tie-break, preserving the fitter's balance when the
+    /// two child centroids are exactly equidistant (including duplicate data).
     pub(super) assignments: Vec<u8>,
 }
 
@@ -145,7 +149,6 @@ pub(super) fn balanced_two_means(
 
     Ok(BalancedSplit {
         children,
-        #[cfg(test)]
         assignments,
     })
 }

--- a/diskann-graphivf/src/online/search.rs
+++ b/diskann-graphivf/src/online/search.rs
@@ -195,18 +195,23 @@ impl<'a> OnlineSearcher<'a> {
                 params.nlist
             )));
         }
-        // Comparing against a distance rather than an id set counts a tie as
-        // correct instead of penalizing whichever tie-break the graph took.
+        // Compare ids first, then admit alternative tie-breaks with a tolerance.
+        // The exact scan and scalar distance use different accumulation paths,
+        // so a strict cutoff can classify an exact boundary result as a miss.
         let cutoff = self.cdist[params.nlist - 1];
+        let tolerance = 32.0 * f32::EPSILON * cutoff.abs().max(1.0);
+        let exact_ids: std::collections::HashSet<u32> =
+            self.cids[..params.nlist].iter().copied().collect();
 
         let found = self.select_centroids(query, params)?;
         let matched = self.cids[..found]
             .iter()
             .filter(|&&cid| {
-                clusterer
-                    .centroids
-                    .get(cid)
-                    .is_some_and(|c| sq_l2(query, c) <= cutoff)
+                exact_ids.contains(&cid)
+                    || clusterer
+                        .centroids
+                        .get(cid)
+                        .is_some_and(|centroid| sq_l2(query, centroid) <= cutoff + tolerance)
             })
             .count();
 

--- a/diskann-graphivf/src/online/state.rs
+++ b/diskann-graphivf/src/online/state.rs
@@ -221,6 +221,18 @@ impl CentroidRegistry {
         self.dense.search(ExactMetric::SqL2, query, ids, distances)
     }
 
+    /// The nearest packed live centroid accepted by `keep`.
+    ///
+    /// Used only after bounded graph candidates fail, or as the primary path
+    /// when exact routing is configured.
+    pub(super) fn closest_live_where(
+        &self,
+        query: &[f32],
+        keep: impl FnMut(u32) -> bool,
+    ) -> Option<u32> {
+        self.dense.closest_where(query, keep)
+    }
+
     /// Out-edge health of the centroid graph, or `None` when no graph is
     /// maintained.
     pub(super) fn adjacency_census(&self, runtime: &Runtime) -> Result<Option<AdjacencyCensus>> {

--- a/diskann-graphivf/src/online/state.rs
+++ b/diskann-graphivf/src/online/state.rs
@@ -378,4 +378,32 @@ impl IvfPartition {
             });
         }
     }
+
+    /// Move selected currently assigned points to new centroids in one pass per
+    /// touched source list. Entries whose target equals their current centroid
+    /// are ignored.
+    pub(super) fn relocate(&mut self, destinations: &[(u32, u32)]) -> usize {
+        let mut moves = Vec::with_capacity(destinations.len());
+        let mut touched = Vec::new();
+        for &(pid, target) in destinations {
+            let source = self.assignment(pid);
+            if source == target {
+                continue;
+            }
+            debug_assert_ne!(source, UNASSIGNED);
+            moves.push((pid, source, target));
+            touched.push(source);
+            self.assignments[pid as usize] = UNASSIGNED;
+        }
+        touched.sort_unstable();
+        touched.dedup();
+        for source in touched {
+            let assignments = &self.assignments;
+            self.lists[source as usize].retain(|&pid| assignments[pid as usize] != UNASSIGNED);
+        }
+        for &(pid, _, target) in &moves {
+            self.attach_new(pid, target);
+        }
+        moves.len()
+    }
 }

--- a/diskann-graphivf/src/online/state.rs
+++ b/diskann-graphivf/src/online/state.rs
@@ -221,18 +221,6 @@ impl CentroidRegistry {
         self.dense.search(ExactMetric::SqL2, query, ids, distances)
     }
 
-    /// The nearest packed live centroid accepted by `keep`.
-    ///
-    /// Used only after bounded graph candidates fail, or as the primary path
-    /// when exact routing is configured.
-    pub(super) fn closest_live_where(
-        &self,
-        query: &[f32],
-        keep: impl FnMut(u32) -> bool,
-    ) -> Option<u32> {
-        self.dense.closest_where(query, keep)
-    }
-
     /// Out-edge health of the centroid graph, or `None` when no graph is
     /// maintained.
     pub(super) fn adjacency_census(&self, runtime: &Runtime) -> Result<Option<AdjacencyCensus>> {

--- a/diskann-graphivf/src/online/telemetry.rs
+++ b/diskann-graphivf/src/online/telemetry.rs
@@ -21,11 +21,17 @@ pub struct SplitEvent {
     pub cluster_size: usize,
     /// Live neighbor clusters drawn into reassignment, excluding the children.
     pub num_neighbors: usize,
+    /// Points in the parent posting plus the nearby postings examined by LIRE.
+    pub region_points: usize,
+    /// Deduplicated points surviving LIRE's two necessary-condition filters and
+    /// sent to the final global NPA check, attributed once within the batch.
+    pub npa_candidates: usize,
     /// Points that actually changed cluster during reassignment.
     pub num_reassigned: usize,
     /// Live centroid count immediately after the batch's splits.
     pub live_after: usize,
-    /// Wall-clock of this parent's 2-means, microseconds.
+    /// Wall-clock of this parent's balanced fit and condition filtering,
+    /// microseconds.
     pub two_means_us: u64,
     /// Wall-clock of this parent's reassignment pass, microseconds.
     pub reassign_us: u64,
@@ -35,20 +41,20 @@ pub struct SplitEvent {
     pub total_us: u64,
 }
 
-/// One cluster-dissolve event recorded during a delete.
+/// One LIRE merge event recorded during a delete.
 ///
-/// A merge retires one underfull centroid and scatters only that centroid's
-/// remaining members onto survivors. A batched delete emits one event per
+/// A merge retires one underfull centroid and globally routes only that
+/// centroid's remaining members. A batched delete emits one event per
 /// retirement; all events from the batch share `op_index` and `live_after`.
 #[derive(Debug, Clone, Copy)]
 pub struct MergeEvent {
     /// Total operations (inserts plus deletes) completed when this merge fired.
     pub op_index: u64,
-    /// The underfull centroid that was dissolved and retired.
+    /// The underfull centroid that was merged and retired.
     pub victim: u32,
-    /// Points the victim still held when it was dissolved.
+    /// Points the victim still held when it was merged.
     pub victim_size: usize,
-    /// Surviving clusters offered as landing sites.
+    /// Landing-site count; LIRE records one capacity-compatible merge target.
     pub num_neighbors: usize,
     /// Points that actually changed cluster.
     pub num_reassigned: usize,
@@ -106,17 +112,19 @@ impl BuildTelemetry {
         use std::fmt::Write as _;
         let mut out = String::with_capacity(64 + self.splits.len() * 48);
         out.push_str(
-            "insert_index,cluster,cluster_size,num_neighbors,num_reassigned,\
+            "insert_index,cluster,cluster_size,num_neighbors,region_points,npa_candidates,num_reassigned,\
              live_after,two_means_us,reassign_us,total_us\n",
         );
         for event in &self.splits {
             let _ = writeln!(
                 out,
-                "{},{},{},{},{},{},{},{},{}",
+                "{},{},{},{},{},{},{},{},{},{},{}",
                 event.insert_index,
                 event.cluster,
                 event.cluster_size,
                 event.num_neighbors,
+                event.region_points,
+                event.npa_candidates,
                 event.num_reassigned,
                 event.live_after,
                 event.two_means_us,

--- a/diskann-graphivf/src/online/telemetry.rs
+++ b/diskann-graphivf/src/online/telemetry.rs
@@ -117,8 +117,8 @@ impl BuildTelemetry {
         use std::fmt::Write as _;
         let mut out = String::with_capacity(64 + self.splits.len() * 48);
         out.push_str(
-            "insert_index,cluster,cluster_size,num_neighbors,region_points,npa_candidates,num_reassigned,\
-             live_after,two_means_us,reassign_us,total_us,clusters_updated\n",
+            "insert_index,cluster,cluster_size,num_neighbors,num_reassigned,\
+             live_after,two_means_us,reassign_us,total_us,clusters_updated,region_points,npa_candidates\n",
         );
         for event in &self.splits {
             let _ = writeln!(
@@ -128,14 +128,14 @@ impl BuildTelemetry {
                 event.cluster,
                 event.cluster_size,
                 event.num_neighbors,
-                event.region_points,
-                event.npa_candidates,
                 event.num_reassigned,
                 event.live_after,
                 event.two_means_us,
                 event.reassign_us,
                 event.total_us,
                 event.clusters_updated,
+                event.region_points,
+                event.npa_candidates,
             );
         }
         std::fs::write(path, out)

--- a/diskann-graphivf/src/online/telemetry.rs
+++ b/diskann-graphivf/src/online/telemetry.rs
@@ -26,6 +26,11 @@ pub struct SplitEvent {
     /// Deduplicated points surviving LIRE's two necessary-condition filters and
     /// sent to the final global NPA check, attributed once within the batch.
     pub npa_candidates: usize,
+    /// Total completed inserts plus deletes at the update-batch boundary that
+    /// triggered this split. Unlike `insert_index`, this also advances for
+    /// delete-triggered cascade splits and therefore identifies the maintenance
+    /// batch unambiguously.
+    pub operation_index: u64,
     /// Points that actually changed cluster during reassignment.
     pub num_reassigned: usize,
     /// Live centroid count immediately after the batch's splits.
@@ -118,12 +123,12 @@ impl BuildTelemetry {
         let mut out = String::with_capacity(64 + self.splits.len() * 48);
         out.push_str(
             "insert_index,cluster,cluster_size,num_neighbors,num_reassigned,\
-             live_after,two_means_us,reassign_us,total_us,clusters_updated,region_points,npa_candidates\n",
+             live_after,two_means_us,reassign_us,total_us,clusters_updated,region_points,npa_candidates,operation_index\n",
         );
         for event in &self.splits {
             let _ = writeln!(
                 out,
-                "{},{},{},{},{},{},{},{},{},{},{},{}",
+                "{},{},{},{},{},{},{},{},{},{},{},{},{}",
                 event.insert_index,
                 event.cluster,
                 event.cluster_size,
@@ -136,6 +141,7 @@ impl BuildTelemetry {
                 event.clusters_updated,
                 event.region_points,
                 event.npa_candidates,
+                event.operation_index,
             );
         }
         std::fs::write(path, out)

--- a/diskann-graphivf/src/online/telemetry.rs
+++ b/diskann-graphivf/src/online/telemetry.rs
@@ -27,9 +27,8 @@ pub struct SplitEvent {
     /// sent to the final global NPA check, attributed once within the batch.
     pub npa_candidates: usize,
     /// Total completed inserts plus deletes at the update-batch boundary that
-    /// triggered this split. Unlike `insert_index`, this also advances for
-    /// delete-triggered cascade splits and therefore identifies the maintenance
-    /// batch unambiguously.
+    /// triggered this split. It includes earlier deletes as well as inserts and
+    /// identifies the insert-driven maintenance batch.
     pub operation_index: u64,
     /// Points that actually changed cluster during reassignment.
     pub num_reassigned: usize,
@@ -51,9 +50,9 @@ pub struct SplitEvent {
     pub total_us: u64,
 }
 
-/// One LIRE merge event recorded during a delete.
+/// One local-scatter merge event recorded during a delete.
 ///
-/// A merge retires one underfull centroid and globally routes only that
+/// A merge retires one underfull centroid and locally reassigns only that
 /// centroid's remaining members. A batched delete emits one event per
 /// retirement; all events from the batch share `op_index` and `live_after`.
 #[derive(Debug, Clone, Copy)]
@@ -64,7 +63,7 @@ pub struct MergeEvent {
     pub victim: u32,
     /// Points the victim still held when it was merged.
     pub victim_size: usize,
-    /// Landing-site count; LIRE records one capacity-compatible merge target.
+    /// Number of surviving centroid candidates used for local reassignment.
     pub num_neighbors: usize,
     /// Points that actually changed cluster.
     pub num_reassigned: usize,

--- a/diskann-graphivf/src/online/tests.rs
+++ b/diskann-graphivf/src/online/tests.rs
@@ -788,6 +788,157 @@ fn underflow_retires_the_cluster_and_scatters_it_onto_survivors() {
 }
 
 #[test]
+fn graph_merge_target_excludes_batch_victims() {
+    let (points, initial) = four_groups(5);
+    let mut c = OnlineClusterer::new(points, initial, merge_params(8, 10_000, 3)).unwrap();
+    c.insert_batch(&(0..20u32).collect::<Vec<_>>()).unwrap();
+
+    let victims = std::collections::HashSet::from([0, 1]);
+    let mut scratch = MergeSearchScratch::default();
+    let target = c
+        .find_merge_target(
+            c.centroids.get(0).unwrap(),
+            &victims,
+            2,
+            &std::collections::HashMap::new(),
+            MERGE_GRAPH_MAX_SURVIVORS,
+            &mut scratch,
+        )
+        .unwrap()
+        .unwrap();
+
+    assert!(!victims.contains(&target.id));
+    assert_eq!(target.source, MergeTargetSource::Graph);
+}
+
+#[test]
+fn graph_merge_target_widens_to_a_farther_capacity_safe_survivor() {
+    let points = mat(vec![0.0; 20], 20, 1);
+    let initial = mat(vec![0.0, 1.0, 2.0, 100.0], 4, 1);
+    let mut p = merge_params(8, 5, 2);
+    p.reassign_neighbors = 1;
+    let mut c = OnlineClusterer::new(points, initial, p).unwrap();
+
+    for pid in 0..5 {
+        c.partition.attach_new(pid, 1);
+    }
+    for pid in 5..10 {
+        c.partition.attach_new(pid, 2);
+    }
+    c.partition.attach_new(10, 3);
+
+    let victims = std::collections::HashSet::from([0]);
+    let mut scratch = MergeSearchScratch::default();
+    let target = c
+        .find_merge_target(
+            c.centroids.get(0).unwrap(),
+            &victims,
+            1,
+            &std::collections::HashMap::new(),
+            MERGE_GRAPH_MAX_SURVIVORS,
+            &mut scratch,
+        )
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(target.id, 3, "the only posting with projected capacity");
+    assert_eq!(target.source, MergeTargetSource::Graph);
+}
+
+#[test]
+fn graph_merge_target_uses_exact_fallback_after_the_bounded_search() {
+    let points = mat(vec![0.0; 20], 20, 1);
+    let initial = mat(vec![0.0, 1.0, 2.0, 100.0], 4, 1);
+    let mut p = merge_params(8, 5, 2);
+    p.reassign_neighbors = 1;
+    let mut c = OnlineClusterer::new(points, initial, p).unwrap();
+
+    for pid in 0..5 {
+        c.partition.attach_new(pid, 1);
+    }
+    for pid in 5..10 {
+        c.partition.attach_new(pid, 2);
+    }
+    c.partition.attach_new(10, 3);
+
+    let victims = std::collections::HashSet::from([0]);
+    let mut scratch = MergeSearchScratch::default();
+    let target = c
+        .find_merge_target(
+            c.centroids.get(0).unwrap(),
+            &victims,
+            1,
+            &std::collections::HashMap::new(),
+            2,
+            &mut scratch,
+        )
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(target.id, 3, "the only posting with projected capacity");
+    assert_eq!(target.source, MergeTargetSource::ExactFallback);
+}
+
+#[test]
+fn exact_merge_target_uses_the_nearest_capacity_safe_survivor() {
+    let (points, initial) = four_groups(5);
+    let mut p = merge_params(8, 6, 3);
+    p.routing = OnlineCentroidRouting::Exact;
+    let mut c = OnlineClusterer::new(points, initial, p).unwrap();
+    for pid in 5..10 {
+        c.partition.attach_new(pid, 1);
+    }
+
+    let victims = std::collections::HashSet::from([0]);
+    let mut scratch = MergeSearchScratch::default();
+    let target = c
+        .find_merge_target(
+            c.centroids.get(0).unwrap(),
+            &victims,
+            2,
+            &std::collections::HashMap::new(),
+            MERGE_GRAPH_MAX_SURVIVORS,
+            &mut scratch,
+        )
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(target.id, 2, "cluster 1 lacks capacity, so cluster 2 wins");
+    assert_eq!(target.source, MergeTargetSource::ExactFallback);
+}
+
+#[test]
+fn merge_target_respects_capacity_reserved_by_earlier_victims() {
+    let (points, initial) = four_groups(5);
+    let mut p = merge_params(8, 6, 3);
+    p.routing = OnlineCentroidRouting::Exact;
+    let mut c = OnlineClusterer::new(points, initial, p).unwrap();
+    for pid in 5..8 {
+        c.partition.attach_new(pid, 1);
+    }
+
+    let victims = std::collections::HashSet::from([0]);
+    let planned_targets = std::collections::HashMap::from([(1, 2)]);
+    let mut scratch = MergeSearchScratch::default();
+    let target = c
+        .find_merge_target(
+            c.centroids.get(0).unwrap(),
+            &victims,
+            2,
+            &planned_targets,
+            MERGE_GRAPH_MAX_SURVIVORS,
+            &mut scratch,
+        )
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        target.id, 2,
+        "the nearer target is full after the earlier reservation"
+    );
+}
+
+#[test]
 fn retiring_adjacent_clusters_never_lands_a_point_on_a_retired_cell() {
     // Groups 0 and 1 are each other's nearest neighbors and both starve in
     // the same batch. Retiring the whole batch before placing any point is

--- a/diskann-graphivf/src/online/tests.rs
+++ b/diskann-graphivf/src/online/tests.rs
@@ -156,6 +156,49 @@ fn assert_live_invariants(c: &OnlineClusterer, live: &[u32]) {
     }
 }
 
+/// Every live point is assigned to its globally nearest live centroid.
+fn assert_npa(c: &OnlineClusterer, live: &[u32]) {
+    for &pid in live {
+        let assigned = c.partition.assignment(pid);
+        let assigned_distance = sqd(
+            c.points.row(pid as usize),
+            c.centroids
+                .get(assigned)
+                .expect("assigned centroid is live"),
+        );
+        let best = c
+            .centroids
+            .iter_live()
+            .map(|(_, centroid)| sqd(c.points.row(pid as usize), centroid))
+            .fold(f64::INFINITY, f64::min);
+        assert!(
+            assigned_distance <= best + 1e-5,
+            "point {pid} violates NPA: assigned={assigned_distance} best={best}"
+        );
+    }
+}
+
+#[test]
+fn lire_split_reaches_npa_and_threshold_equilibrium() {
+    let mut rng = StdRng::seed_from_u64(71);
+    let (n, dim) = (400usize, 4usize);
+    let values = (0..n * dim)
+        .map(|_| rng.random_range(-10.0f32..10.0))
+        .collect();
+    let points = mat(values, n, dim);
+    let mut p = params(128, 24);
+    p.max_clusters = None;
+    p.centroid_capacity = 4 * n;
+    p.routing = OnlineCentroidRouting::Exact;
+    let initial = mat(points.row(0).to_vec(), 1, dim);
+    let mut c = OnlineClusterer::new(points, initial, p).unwrap();
+    c.insert_batch(&(0..n as u32).collect::<Vec<_>>()).unwrap();
+
+    assert_invariants(&c, n);
+    assert!(c.cluster_sizes().into_iter().all(|size| size <= 24));
+    assert_npa(&c, &(0..n as u32).collect::<Vec<_>>());
+}
+
 #[test]
 fn no_split_matches_nearest_centroid() {
     // High threshold => no splits; pure online assignment with fixed
@@ -486,7 +529,8 @@ fn telemetry_records_splits_and_reassignments() {
         assert!(e.insert_index >= 1 && e.insert_index <= n as u64);
         prev = e.insert_index;
         assert!(e.cluster_size >= 2);
-        assert!(e.num_reassigned >= e.cluster_size); // all of C always moves
+        assert!(e.npa_candidates <= e.region_points);
+        assert!(e.num_reassigned <= e.region_points);
         reassigned_sum += e.num_reassigned as u64;
     }
     assert_eq!(reassigned_sum, t.total_reassigned);
@@ -740,6 +784,7 @@ fn underflow_retires_the_cluster_and_scatters_it_onto_survivors() {
         e.num_reassigned, 2,
         "only the victim's own members are re-placed"
     );
+    assert_npa(&c, &live);
 }
 
 #[test]
@@ -848,12 +893,17 @@ fn churn_keeps_the_centroid_graph_and_registry_in_sync() {
     c.insert_batch(&(0..n as u32).collect::<Vec<_>>()).unwrap();
     assert_graph_matches_registry(&c);
 
-    // Recycle a sixth of the corpus at a time. Deleting a contiguous id range
-    // starves whole regions at once, which is the case that retires spatially
-    // adjacent centroids together; reinserting the same ids then splits those
-    // regions back apart and reuses the slots just freed.
-    for round in 0..6u32 {
-        let victims: Vec<u32> = (round * 100..round * 100 + 100).collect();
+    // Recycle one whole current posting at a time. Selecting from current
+    // membership guarantees a merge even when a new split policy changes how
+    // contiguous pid ranges are distributed.
+    for _ in 0..6 {
+        let victim = c
+            .centroids
+            .live_ids()
+            .max_by_key(|&cid| c.partition.list_len(cid))
+            .unwrap();
+        let victims = c.partition.members(victim).to_vec();
+        assert!(!victims.is_empty());
         c.delete_batch(&victims).unwrap();
         assert_graph_matches_registry(&c);
         c.insert_batch(&victims).unwrap();

--- a/diskann-graphivf/src/online/tests.rs
+++ b/diskann-graphivf/src/online/tests.rs
@@ -811,169 +811,59 @@ fn underflow_retires_the_cluster_and_scatters_it_onto_survivors() {
 }
 
 #[test]
-fn graph_merge_target_excludes_batch_victims() {
+fn merge_plan_excludes_all_batch_victims_from_local_candidates() {
     let (points, initial) = four_groups(5);
     let mut c = OnlineClusterer::new(points, initial, merge_params(8, 10_000, 3)).unwrap();
     c.insert_batch(&(0..20u32).collect::<Vec<_>>()).unwrap();
 
-    let victims = std::collections::HashSet::from([0, 1]);
-    let mut scratch = MergeSearchScratch::default();
-    let target = c
-        .find_merge_target(
-            c.centroids.get(0).unwrap(),
-            2,
-            MergeTargetContext {
-                excluded: &victims,
-                deleted_counts: &std::collections::HashMap::new(),
-                planned_targets: &std::collections::HashMap::new(),
-                max_graph_survivors: MERGE_GRAPH_MAX_SURVIVORS,
-            },
-            &mut scratch,
-        )
-        .unwrap()
-        .unwrap();
+    let victims = [0, 1];
+    let deleted = std::collections::HashSet::from([0, 1, 2, 5, 6, 7]);
+    let plan = c.prepare_merge(&victims, &deleted).unwrap();
 
-    assert!(!victims.contains(&target.id));
-    assert_eq!(target.source, MergeTargetSource::Graph);
+    assert_eq!(plan.victims.len(), 2);
+    for victim in plan.victims {
+        assert_eq!(victim.members.len(), 2);
+        assert_eq!(victim.candidates.len(), 2);
+        assert!(victim.candidates.iter().all(|cid| !victims.contains(cid)));
+    }
 }
 
 #[test]
-fn graph_merge_target_widens_to_a_farther_capacity_safe_survivor() {
-    let points = mat(vec![0.0; 20], 20, 1);
-    let initial = mat(vec![0.0, 1.0, 2.0, 100.0], 4, 1);
-    let mut p = merge_params(8, 5, 2);
+fn merge_scatter_uses_saved_local_candidates_instead_of_global_routing() {
+    let points = mat(vec![0.0, 0.1, 0.2, 1.0, 100.0, 100.1], 6, 1);
+    let initial = mat(vec![0.0, 1.0, 100.0], 3, 1);
+    let mut p = merge_params(8, 4, 2);
+    p.routing = OnlineCentroidRouting::Exact;
     p.reassign_neighbors = 1;
     let mut c = OnlineClusterer::new(points, initial, p).unwrap();
-
-    for pid in 0..5 {
-        c.partition.attach_new(pid, 1);
-    }
-    for pid in 5..10 {
-        c.partition.attach_new(pid, 2);
-    }
-    c.partition.attach_new(10, 3);
-
-    let victims = std::collections::HashSet::from([0]);
-    let mut scratch = MergeSearchScratch::default();
-    let target = c
-        .find_merge_target(
-            c.centroids.get(0).unwrap(),
-            1,
-            MergeTargetContext {
-                excluded: &victims,
-                deleted_counts: &std::collections::HashMap::new(),
-                planned_targets: &std::collections::HashMap::new(),
-                max_graph_survivors: MERGE_GRAPH_MAX_SURVIVORS,
-            },
-            &mut scratch,
-        )
-        .unwrap()
+    c.insert_batch(&(0..6).collect::<Vec<_>>()).unwrap();
+    let plan = c
+        .prepare_merge(&[0], &std::collections::HashSet::new())
         .unwrap();
+    assert_eq!(plan.victims[0].candidates, [1]);
 
-    assert_eq!(target.id, 3, "the only posting with projected capacity");
-    assert_eq!(target.source, MergeTargetSource::Graph);
-}
-
-#[test]
-fn graph_merge_target_uses_exact_fallback_after_the_bounded_search() {
-    let points = mat(vec![0.0; 20], 20, 1);
-    let initial = mat(vec![0.0, 1.0, 2.0, 100.0], 4, 1);
-    let mut p = merge_params(8, 5, 2);
-    p.reassign_neighbors = 1;
-    let mut c = OnlineClusterer::new(points, initial, p).unwrap();
-
-    for pid in 0..5 {
-        c.partition.attach_new(pid, 1);
+    // Once a plan exists, members use its candidate set, even if another live
+    // centroid would win globally. This pins the local-scatter kernel itself.
+    let plan = MergePlan {
+        victims: vec![MergeVictimPlan {
+            id: 0,
+            members: c.partition.members(0).to_vec(),
+            candidates: vec![2],
+            search_us: 0,
+        }],
+        started: Instant::now(),
+    };
+    c.begin_commit();
+    let result = c.commit_merge(plan);
+    c.finish_commit(&result);
+    assert!(result.is_ok());
+    assert!(!c.is_poisoned());
+    for pid in 0..3 {
+        assert_eq!(c.partition.assignment(pid), 2);
     }
-    for pid in 5..10 {
-        c.partition.attach_new(pid, 2);
-    }
-    c.partition.attach_new(10, 3);
-
-    let victims = std::collections::HashSet::from([0]);
-    let mut scratch = MergeSearchScratch::default();
-    let target = c
-        .find_merge_target(
-            c.centroids.get(0).unwrap(),
-            1,
-            MergeTargetContext {
-                excluded: &victims,
-                deleted_counts: &std::collections::HashMap::new(),
-                planned_targets: &std::collections::HashMap::new(),
-                max_graph_survivors: 2,
-            },
-            &mut scratch,
-        )
-        .unwrap()
-        .unwrap();
-
-    assert_eq!(target.id, 3, "the only posting with projected capacity");
-    assert_eq!(target.source, MergeTargetSource::ExactFallback);
-}
-
-#[test]
-fn exact_merge_target_uses_the_nearest_capacity_safe_survivor() {
-    let (points, initial) = four_groups(5);
-    let mut p = merge_params(8, 6, 3);
-    p.routing = OnlineCentroidRouting::Exact;
-    let mut c = OnlineClusterer::new(points, initial, p).unwrap();
-    for pid in 5..10 {
-        c.partition.attach_new(pid, 1);
-    }
-
-    let victims = std::collections::HashSet::from([0]);
-    let mut scratch = MergeSearchScratch::default();
-    let target = c
-        .find_merge_target(
-            c.centroids.get(0).unwrap(),
-            2,
-            MergeTargetContext {
-                excluded: &victims,
-                deleted_counts: &std::collections::HashMap::new(),
-                planned_targets: &std::collections::HashMap::new(),
-                max_graph_survivors: MERGE_GRAPH_MAX_SURVIVORS,
-            },
-            &mut scratch,
-        )
-        .unwrap()
-        .unwrap();
-
-    assert_eq!(target.id, 2, "cluster 1 lacks capacity, so cluster 2 wins");
-    assert_eq!(target.source, MergeTargetSource::ExactFallback);
-}
-
-#[test]
-fn merge_target_respects_capacity_reserved_by_earlier_victims() {
-    let (points, initial) = four_groups(5);
-    let mut p = merge_params(8, 6, 3);
-    p.routing = OnlineCentroidRouting::Exact;
-    let mut c = OnlineClusterer::new(points, initial, p).unwrap();
-    for pid in 5..8 {
-        c.partition.attach_new(pid, 1);
-    }
-
-    let victims = std::collections::HashSet::from([0]);
-    let planned_targets = std::collections::HashMap::from([(1, 2)]);
-    let mut scratch = MergeSearchScratch::default();
-    let target = c
-        .find_merge_target(
-            c.centroids.get(0).unwrap(),
-            2,
-            MergeTargetContext {
-                excluded: &victims,
-                deleted_counts: &std::collections::HashMap::new(),
-                planned_targets: &planned_targets,
-                max_graph_survivors: MERGE_GRAPH_MAX_SURVIVORS,
-            },
-            &mut scratch,
-        )
-        .unwrap()
-        .unwrap();
-
-    assert_eq!(
-        target.id, 2,
-        "the nearer target is full after the earlier reservation"
-    );
+    assert_eq!(c.telemetry().merges[0].num_neighbors, 1);
+    assert_eq!(c.telemetry().total_splits, 0);
+    assert_live_invariants(&c, &(0..6).collect::<Vec<_>>());
 }
 
 #[test]
@@ -1468,7 +1358,7 @@ fn co_split_routes_candidates_across_all_new_children() {
 }
 
 #[test]
-fn merge_capacity_accounts_for_deletes_in_the_same_batch() {
+fn merge_scatter_omits_points_deleted_in_the_same_batch() {
     let points = mat((0..15).map(|x| x as f32).collect(), 15, 1);
     let initial = mat(vec![0.0, 1.0, 100.0], 3, 1);
     let mut p = merge_params(8, 6, 3);
@@ -1492,7 +1382,7 @@ fn merge_capacity_accounts_for_deletes_in_the_same_batch() {
 }
 
 #[test]
-fn underfull_victims_can_merge_with_each_other_when_other_survivors_are_full() {
+fn local_merges_retire_all_admitted_victims_even_when_survivors_are_full() {
     let points = mat(vec![0.0, 0.1, 1.0, 1.1, 100.0, 100.1, 100.2, 100.3], 8, 1);
     let initial = mat(vec![0.0, 1.0, 100.0], 3, 1);
     let mut p = merge_params(8, 4, 2);
@@ -1512,30 +1402,115 @@ fn underfull_victims_can_merge_with_each_other_when_other_survivors_are_full() {
 
     c.delete_batch(&[0, 2]).unwrap();
 
-    assert_eq!(c.telemetry().total_merges, 1);
-    assert_eq!(c.num_clusters(), 2);
+    assert_eq!(c.telemetry().total_merges, 2);
+    assert_eq!(c.num_clusters(), 1);
     assert_live_invariants(&c, &[1, 3, 4, 5, 6, 7]);
-    assert!(c.cluster_sizes().into_iter().all(|size| size <= 4));
+    assert_eq!(c.cluster_sizes(), vec![6]);
+    assert_eq!(c.telemetry().total_splits, 0);
+    assert!(!c.is_poisoned());
 }
 
-#[test]
-fn merge_preserves_capacity_when_npa_prefers_a_full_posting() {
-    let points = mat(vec![0.0, 0.1, 1.0, 1.1, 1.2, 1.3, 100.0], 7, 1);
+/// A successful local merge leaves cluster 1 overfull while cluster 2 has room.
+fn merged_overflow(capacity: usize) -> OnlineClusterer {
+    let points = mat(
+        vec![
+            0.0, 0.1, 1.0, 1.1, 1.2, 1.3, 100.0, 100.1, 1.4, 100.2, 100.3, 100.4,
+        ],
+        12,
+        1,
+    );
     let initial = mat(vec![0.0, 1.0, 100.0], 3, 1);
     let mut p = merge_params(8, 4, 2);
     p.max_clusters = None;
     p.routing = OnlineCentroidRouting::Exact;
-    p.centroid_capacity = 3;
+    p.centroid_capacity = capacity;
     let mut c = OnlineClusterer::new(points, initial, p).unwrap();
-    c.partition.attach_new(0, 0);
-    c.partition.attach_new(1, 0);
-    for pid in 2..6 {
-        c.partition.attach_new(pid, 1);
-    }
-    c.partition.attach_new(6, 2);
+    c.insert_batch(&(0..7).collect::<Vec<_>>()).unwrap();
 
-    assert!(c.delete_batch(&[0]).is_err());
+    let result = c.delete_batch(&[0]);
+    assert!(result.is_ok());
+    assert!(!c.is_poisoned());
+    assert_eq!(c.partition.list_len(1), 5);
+    assert_eq!(c.telemetry().total_splits, 0);
+    assert_eq!(c.telemetry().total_merges, 1);
+    assert_live_invariants(&c, &(1..7).collect::<Vec<_>>());
+    c
+}
+
+#[test]
+fn local_merge_overflow_succeeds_without_centroid_id_budget() {
+    let c = merged_overflow(3);
+    assert_eq!(c.centroids.alloc_budget(), 0);
+    assert_eq!(c.num_clusters(), 2);
+}
+
+#[test]
+fn unrelated_insert_leaves_deferred_merge_overflow_usable() {
+    let mut c = merged_overflow(3);
+
+    let result = c.insert_batch(&[7]);
+    assert!(result.is_ok());
+    assert!(!c.is_poisoned());
+    assert_eq!(c.partition.assignment(7), 2);
+    assert_eq!(c.partition.list_len(1), 5);
+    assert_eq!(c.telemetry().total_splits, 0);
+    assert_live_invariants(&c, &(1..8).collect::<Vec<_>>());
+    assert!(c.searcher().is_ok());
+}
+
+#[test]
+fn insert_into_deferred_merge_overflow_runs_lire_split_cascade() {
+    let mut c = merged_overflow(32);
+
+    let result = c.insert_batch(&[8]);
+    assert!(result.is_ok());
+    assert!(!c.is_poisoned());
+    assert!(c.telemetry().total_splits > 0);
+    assert!(c.cluster_sizes().into_iter().all(|size| size <= 4));
+    assert_live_invariants(&c, &[1, 2, 3, 4, 5, 6, 8]);
+}
+
+#[test]
+fn any_started_insert_cascade_also_repairs_unrelated_merge_overflow() {
+    let mut c = merged_overflow(64);
+
+    // This insert initially overflows cluster 2, not the deferred cluster 1.
+    let result = c.insert_batch(&[7, 9, 10, 11]);
+    assert!(result.is_ok());
+    assert!(!c.is_poisoned());
+    assert!(c.telemetry().total_splits >= 2);
+    assert!(c.cluster_sizes().into_iter().all(|size| size <= 4));
+    assert_live_invariants(&c, &[1, 2, 3, 4, 5, 6, 7, 9, 10, 11]);
+}
+
+#[test]
+fn insert_into_deferred_merge_overflow_still_reports_exhausted_budget() {
+    let mut c = merged_overflow(3);
+
+    let result = c.insert_batch(&[8]);
+    assert!(result.is_err());
     assert!(c.is_poisoned());
+    assert_eq!(c.telemetry().total_splits, 0);
+    assert_live_invariants(&c, &[1, 2, 3, 4, 5, 6, 8]);
+    assert!(c.searcher().is_err());
+}
+
+#[test]
+fn failed_insert_does_not_restore_a_previously_merged_then_deleted_point() {
+    let mut c = merged_overflow(3);
+    assert!(c.scratch.points.is_empty());
+
+    // Point 1 was scattered by the successful merge, then explicitly deleted.
+    // The next insert cannot split because the centroid id budget is exhausted.
+    c.delete_batch(&[1]).unwrap();
+    assert_eq!(c.partition.assignment(1), UNASSIGNED);
+    assert_eq!(c.telemetry().total_merges, 1);
+
+    let result = c.insert_batch(&[8]);
+    assert!(result.is_err());
+    assert!(c.is_poisoned());
+    assert_eq!(c.partition.assignment(1), UNASSIGNED);
+    assert_live_invariants(&c, &[2, 3, 4, 5, 6, 8]);
 }
 
 #[test]

--- a/diskann-graphivf/src/online/tests.rs
+++ b/diskann-graphivf/src/online/tests.rs
@@ -574,7 +574,7 @@ fn telemetry_records_splits_and_reassignments() {
     assert_eq!(
         lines[0],
         "insert_index,cluster,cluster_size,num_neighbors,num_reassigned,\
-         live_after,two_means_us,reassign_us,total_us,clusters_updated,region_points,npa_candidates"
+         live_after,two_means_us,reassign_us,total_us,clusters_updated,region_points,npa_candidates,operation_index"
     );
     assert_eq!(lines.len(), 1 + t.splits.len());
     let _ = std::fs::remove_dir_all(&dir);

--- a/diskann-graphivf/src/online/tests.rs
+++ b/diskann-graphivf/src/online/tests.rs
@@ -571,7 +571,11 @@ fn telemetry_records_splits_and_reassignments() {
     t.write_csv(&csv).unwrap();
     let text = std::fs::read_to_string(&csv).unwrap();
     let lines: Vec<&str> = text.lines().collect();
-    assert!(lines[0].starts_with("insert_index,cluster,cluster_size"));
+    assert_eq!(
+        lines[0],
+        "insert_index,cluster,cluster_size,num_neighbors,num_reassigned,\
+         live_after,two_means_us,reassign_us,total_us,clusters_updated,region_points,npa_candidates"
+    );
     assert_eq!(lines.len(), 1 + t.splits.len());
     let _ = std::fs::remove_dir_all(&dir);
 }
@@ -817,10 +821,13 @@ fn graph_merge_target_excludes_batch_victims() {
     let target = c
         .find_merge_target(
             c.centroids.get(0).unwrap(),
-            &victims,
             2,
-            &std::collections::HashMap::new(),
-            MERGE_GRAPH_MAX_SURVIVORS,
+            MergeTargetContext {
+                excluded: &victims,
+                deleted_counts: &std::collections::HashMap::new(),
+                planned_targets: &std::collections::HashMap::new(),
+                max_graph_survivors: MERGE_GRAPH_MAX_SURVIVORS,
+            },
             &mut scratch,
         )
         .unwrap()
@@ -851,10 +858,13 @@ fn graph_merge_target_widens_to_a_farther_capacity_safe_survivor() {
     let target = c
         .find_merge_target(
             c.centroids.get(0).unwrap(),
-            &victims,
             1,
-            &std::collections::HashMap::new(),
-            MERGE_GRAPH_MAX_SURVIVORS,
+            MergeTargetContext {
+                excluded: &victims,
+                deleted_counts: &std::collections::HashMap::new(),
+                planned_targets: &std::collections::HashMap::new(),
+                max_graph_survivors: MERGE_GRAPH_MAX_SURVIVORS,
+            },
             &mut scratch,
         )
         .unwrap()
@@ -885,10 +895,13 @@ fn graph_merge_target_uses_exact_fallback_after_the_bounded_search() {
     let target = c
         .find_merge_target(
             c.centroids.get(0).unwrap(),
-            &victims,
             1,
-            &std::collections::HashMap::new(),
-            2,
+            MergeTargetContext {
+                excluded: &victims,
+                deleted_counts: &std::collections::HashMap::new(),
+                planned_targets: &std::collections::HashMap::new(),
+                max_graph_survivors: 2,
+            },
             &mut scratch,
         )
         .unwrap()
@@ -913,10 +926,13 @@ fn exact_merge_target_uses_the_nearest_capacity_safe_survivor() {
     let target = c
         .find_merge_target(
             c.centroids.get(0).unwrap(),
-            &victims,
             2,
-            &std::collections::HashMap::new(),
-            MERGE_GRAPH_MAX_SURVIVORS,
+            MergeTargetContext {
+                excluded: &victims,
+                deleted_counts: &std::collections::HashMap::new(),
+                planned_targets: &std::collections::HashMap::new(),
+                max_graph_survivors: MERGE_GRAPH_MAX_SURVIVORS,
+            },
             &mut scratch,
         )
         .unwrap()
@@ -942,10 +958,13 @@ fn merge_target_respects_capacity_reserved_by_earlier_victims() {
     let target = c
         .find_merge_target(
             c.centroids.get(0).unwrap(),
-            &victims,
             2,
-            &planned_targets,
-            MERGE_GRAPH_MAX_SURVIVORS,
+            MergeTargetContext {
+                excluded: &victims,
+                deleted_counts: &std::collections::HashMap::new(),
+                planned_targets: &planned_targets,
+                max_graph_survivors: MERGE_GRAPH_MAX_SURVIVORS,
+            },
             &mut scratch,
         )
         .unwrap()
@@ -1392,4 +1411,143 @@ fn warmup_rejects_bad_config() {
         iters: 5,
     };
     assert!(OnlineClusterer::with_seed(points, seed, params(8, 10)).is_err());
+}
+
+#[test]
+fn balanced_split_commit_preserves_capacity_on_identical_points() {
+    let points = mat(vec![0.0; 9], 9, 1);
+    let initial = mat(vec![0.0], 1, 1);
+    let mut p = params(32, 4);
+    p.routing = OnlineCentroidRouting::Exact;
+    p.max_clusters = None;
+    p.centroid_capacity = 64;
+    let mut c = OnlineClusterer::new(points, initial, p).unwrap();
+
+    c.insert_batch(&(0..9).collect::<Vec<_>>()).unwrap();
+
+    assert_invariants(&c, 9);
+    assert!(c.cluster_sizes().into_iter().all(|size| size <= 4));
+}
+
+#[test]
+fn split_rechecks_points_routed_to_a_neighbor_in_the_same_batch() {
+    let points = mat(vec![0.0, 0.0, 4.8, 4.8, 0.0, 5.2], 6, 1);
+    let initial = mat(vec![0.0, 10.0], 2, 1);
+    let mut p = params(10, 4);
+    p.routing = OnlineCentroidRouting::Exact;
+    p.reassign_neighbors = 8;
+    p.centroid_capacity = 32;
+    let mut c = OnlineClusterer::new(points, initial, p).unwrap();
+    c.insert_batch(&(0..4).collect::<Vec<_>>()).unwrap();
+
+    c.insert_batch(&[4, 5]).unwrap();
+
+    assert_live_invariants(&c, &(0..6).collect::<Vec<_>>());
+    assert_npa(&c, &(0..6).collect::<Vec<_>>());
+}
+
+#[test]
+fn co_split_routes_candidates_across_all_new_children() {
+    let points = mat(
+        vec![0.0, 0.0, 4.8, 4.8, 10.0, 10.0, 20.0, 20.0, 0.0, 5.2],
+        10,
+        1,
+    );
+    let initial = mat(vec![0.0, 10.0], 2, 1);
+    let mut p = params(10, 4);
+    p.routing = OnlineCentroidRouting::Exact;
+    p.reassign_neighbors = 8;
+    p.centroid_capacity = 32;
+    let mut c = OnlineClusterer::new(points, initial, p).unwrap();
+    c.insert_batch(&(0..8).collect::<Vec<_>>()).unwrap();
+
+    c.insert_batch(&[8, 9]).unwrap();
+
+    assert_live_invariants(&c, &(0..10).collect::<Vec<_>>());
+    assert_npa(&c, &(0..10).collect::<Vec<_>>());
+}
+
+#[test]
+fn merge_capacity_accounts_for_deletes_in_the_same_batch() {
+    let points = mat((0..15).map(|x| x as f32).collect(), 15, 1);
+    let initial = mat(vec![0.0, 1.0, 100.0], 3, 1);
+    let mut p = merge_params(8, 6, 3);
+    p.routing = OnlineCentroidRouting::Exact;
+    p.centroid_capacity = 16;
+    let mut c = OnlineClusterer::new(points, initial, p).unwrap();
+    for pid in 0..3 {
+        c.partition.attach_new(pid, 0);
+    }
+    for pid in 3..9 {
+        c.partition.attach_new(pid, 1);
+    }
+    for pid in 9..15 {
+        c.partition.attach_new(pid, 2);
+    }
+
+    c.delete_batch(&[0, 3, 4]).unwrap();
+
+    assert_eq!(c.telemetry().total_merges, 1);
+    assert_eq!(c.num_clusters(), 2);
+}
+
+#[test]
+fn underfull_victims_can_merge_with_each_other_when_other_survivors_are_full() {
+    let points = mat(vec![0.0, 0.1, 1.0, 1.1, 100.0, 100.1, 100.2, 100.3], 8, 1);
+    let initial = mat(vec![0.0, 1.0, 100.0], 3, 1);
+    let mut p = merge_params(8, 4, 2);
+    p.max_clusters = None;
+    p.routing = OnlineCentroidRouting::Exact;
+    p.centroid_capacity = 16;
+    let mut c = OnlineClusterer::new(points, initial, p).unwrap();
+    for pid in 0..2 {
+        c.partition.attach_new(pid, 0);
+    }
+    for pid in 2..4 {
+        c.partition.attach_new(pid, 1);
+    }
+    for pid in 4..8 {
+        c.partition.attach_new(pid, 2);
+    }
+
+    c.delete_batch(&[0, 2]).unwrap();
+
+    assert_eq!(c.telemetry().total_merges, 1);
+    assert_eq!(c.num_clusters(), 2);
+    assert_live_invariants(&c, &[1, 3, 4, 5, 6, 7]);
+    assert!(c.cluster_sizes().into_iter().all(|size| size <= 4));
+}
+
+#[test]
+fn merge_preserves_capacity_when_npa_prefers_a_full_posting() {
+    let points = mat(vec![0.0, 0.1, 1.0, 1.1, 1.2, 1.3, 100.0], 7, 1);
+    let initial = mat(vec![0.0, 1.0, 100.0], 3, 1);
+    let mut p = merge_params(8, 4, 2);
+    p.max_clusters = None;
+    p.routing = OnlineCentroidRouting::Exact;
+    p.centroid_capacity = 3;
+    let mut c = OnlineClusterer::new(points, initial, p).unwrap();
+    c.partition.attach_new(0, 0);
+    c.partition.attach_new(1, 0);
+    for pid in 2..6 {
+        c.partition.attach_new(pid, 1);
+    }
+    c.partition.attach_new(6, 2);
+
+    assert!(c.delete_batch(&[0]).is_err());
+    assert!(c.is_poisoned());
+}
+
+#[test]
+fn id_budget_exhaustion_is_reported_instead_of_leaving_overflow() {
+    let points = mat((0..6).map(|x| x as f32).collect(), 6, 1);
+    let initial = mat(vec![0.0], 1, 1);
+    let mut p = params(10, 2);
+    p.max_clusters = None;
+    p.routing = OnlineCentroidRouting::Exact;
+    p.centroid_capacity = 1;
+    let mut c = OnlineClusterer::new(points, initial, p).unwrap();
+
+    assert!(c.insert_batch(&(0..6).collect::<Vec<_>>()).is_err());
+    assert!(c.is_poisoned());
 }

--- a/diskann-graphivf/src/params.rs
+++ b/diskann-graphivf/src/params.rs
@@ -135,8 +135,8 @@ pub enum AssignMethod {
 /// How the index finds the centroids nearest to a vector.
 ///
 /// This is a single index-wide choice: it governs every centroid lookup the
-/// index performs — routing points on insert, locating neighbors when a cluster
-/// splits or is dissolved, and selecting the clusters a query probes. Keeping it
+/// index performs — routing points on insert/NPA checks, locating neighbors when
+/// a cluster splits, and selecting the clusters a query probes. Keeping it
 /// to one setting means the clusters a query probes are found the same way the
 /// points in them were routed, so the two can never disagree about what
 /// "nearest" means.
@@ -251,7 +251,7 @@ impl CentroidRouting {
 /// Centroid routing for an online build.
 ///
 /// Distinct from [`CentroidRouting`] because a streaming build also searches
-/// the centroids when a cluster splits or dissolves, which a batch build never
+/// the centroids when a cluster splits or merges, which a batch build never
 /// does, so the `Graph` variant carries one more beam width.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum OnlineCentroidRouting {
@@ -261,7 +261,7 @@ pub enum OnlineCentroidRouting {
         graph: GraphParams,
         /// Search-list size used to route each inserted point.
         assign_l: usize,
-        /// Search-list size for split-neighbor and dissolve-survivor selection.
+        /// Search-list size for split-neighbor discovery.
         /// Raised internally to fit the requested candidates and exclusions.
         reassign_l: usize,
     },
@@ -300,7 +300,7 @@ impl OnlineCentroidRouting {
         }
     }
 
-    /// Beam width for split-neighbor and dissolve-survivor selection, floored to
+    /// Beam width for split-neighbor discovery, floored to
     /// return at least `want` candidates. `None` in exact mode.
     pub(crate) fn neighbor_beam(self, want: usize) -> Option<usize> {
         match self {
@@ -438,10 +438,8 @@ pub struct OnlineParams {
     /// A cluster is split once it holds strictly more than this many points.
     /// Must be `>= 2`.
     pub split_threshold: usize,
-    /// Number of nearest centroid clusters (besides the two children) drawn in
-    /// as reassignment candidates when a cluster is split, and the maximum
-    /// survivor landing sites considered when a cluster is dissolved. Must be
-    /// `>= 1`.
+    /// Number of nearby postings scanned by LIRE's necessary-condition filters
+    /// when a cluster splits. Must be `>= 1`.
     ///
     /// A candidate *count*, so it applies whichever routing mode is in use.
     pub reassign_neighbors: usize,
@@ -451,9 +449,9 @@ pub struct OnlineParams {
     /// disables merging entirely: deletes still remove points, but the
     /// partition only ever gains clusters.
     ///
-    /// Retiring dissolves the cluster: it is removed from the centroid graph
-    /// and its members are scattered onto their nearest survivors. No centroid
-    /// is fitted and no id is consumed, so deletes are free against the
+    /// Retiring merges the posting into a capacity-compatible survivor, then
+    /// globally routes its members for final NPA compliance. No centroid is
+    /// fitted and no id is consumed, so merges are free against the
     /// [`centroid_capacity`](Self::centroid_capacity) budget.
     ///
     /// Must leave a hysteresis gap below

--- a/diskann-graphivf/src/params.rs
+++ b/diskann-graphivf/src/params.rs
@@ -435,11 +435,13 @@ pub struct OnlineParams {
     /// live-cluster count. Splitting stops when the slots are exhausted,
     /// whatever [`max_clusters`](Self::max_clusters) says.
     pub centroid_capacity: usize,
-    /// A cluster is split once it holds strictly more than this many points.
-    /// Must be `>= 2`.
+    /// Insert-driven splits start above this many points. A local-scatter merge
+    /// can leave a posting overfull until an insert reaches it or starts a split
+    /// cascade. Must be `>= 2`.
     pub split_threshold: usize,
     /// Number of nearby postings scanned by LIRE's necessary-condition filters
-    /// when a cluster splits. Must be `>= 1`.
+    /// when a cluster splits, and survivor candidates for local merge scatter.
+    /// Must be `>= 1`.
     ///
     /// A candidate *count*, so it applies whichever routing mode is in use.
     pub reassign_neighbors: usize,
@@ -449,9 +451,10 @@ pub struct OnlineParams {
     /// disables merging entirely: deletes still remove points, but the
     /// partition only ever gains clusters.
     ///
-    /// Retiring merges the posting into a capacity-compatible survivor, then
-    /// globally routes its members for final NPA compliance. No centroid is
-    /// fitted and no id is consumed, so merges are free against the
+    /// Retiring scatters the posting over preselected nearby survivors using
+    /// local exact assignment. Deletes do not trigger splits even if a survivor
+    /// overflows. No centroid is fitted and no id is consumed, so merges are
+    /// free against the
     /// [`centroid_capacity`](Self::centroid_capacity) budget.
     ///
     /// Must leave a hysteresis gap below


### PR DESCRIPTION
## What this implements

This draft adds LIRE split maintenance while retaining the original Control
local-scatter merge behavior. The comparison base is
`u/adkrishnan/graph-ivf` at `90cb5cafc75199d407873141b3029610e33f653d`;
the revised treatment head is `eef08a2d034fcd2118f87a87372afe92ca668ac2`.

- Fit each overflowing parent with a capacity-constrained binary fit. Filter
  parent and nearby points using the LIRE necessary conditions, including
  same-batch arrivals to neighbor postings. Route the deduplicated candidates
  through the configured live-centroid router, retain local-child/source
  distance guards, and move only changed assignments.
- Keep insert-driven split cascades. Graph routing remains approximate and
  the filter region is local, so this is not an unconditional global exact-NPA
  guarantee.
- Restore Control merge candidate selection and local GEMM reassignment.
  Exclude the whole victim batch before retirement. Remove capacity target
  reservations, per-member global merge routing and delete-triggered split
  cascades.
- A delete can leave overfull survivor postings. Inserts that start a split
  retain the global cascade/guard; inserts without a split check only their
  own destinations. An explicit cluster cap retains its existing exception.
  Uncapped resource-exhausted updates still fail instead of silently claiming
  successful repair.
- Clear successful local-reassignment scratch so a later failed insertion
  cannot resurrect a point that was already merged and then deleted. Preserve
  the existing commit-failure poison and pending-point recovery behavior.

No dependencies are added. Split telemetry retains the appended
`region_points`, `npa_candidates` and `operation_index` fields. Public
`SplitEvent` struct literals require the fields introduced by this draft;
CSV consumers should select columns by header. `clusters_updated` is logical
posting activity, not SSD writes. The centroid-recall diagnostic correction
from the earlier draft remains; it does not change normal top-k selection.

## Validation

- `cargo fmt --all` passed.
- `cargo test -p diskann-graphivf --locked`: 97 unit and 11 integration tests passed.
- `cargo clippy --workspace --all-targets --locked -- -D warnings` passed.
- `git diff --check` passed.

Regression coverage includes balanced duplicate-vector splits, same-batch
neighbor arrivals, local merge candidate semantics, whole-batch victim
exclusion, deferred merge overflow followed by related/unrelated inserts,
resource exhaustion, and the stale-scratch deletion recovery case.

## Quick experiment against original Control

Both Control `90cb5caf` and Treatment `eef08a2d` were run fresh on the original
MSTuring30M runbook stages 1–258 with the same first 100 queries. The prefix
contains 65 insert, 64 delete and 129 search stages. Each final index was
then measured by a separate single-threaded Load sweep. This is one run
per arm, not ABBA or a statistical-significance claim.

| Metric | Control | Treatment | Treatment / Control - 1 |
| --- | ---: | ---: | ---: |
| Process wall | 551.895 s | 447.071 s | -18.99% |
| Insert + delete stages | 406.665 s | 308.731 s | -24.08% |
| Split + merge timer | 374.465 s | 269.981 s | -27.90% |
| Split timer | 333.415 s | 227.765 s | -31.69% |
| Merge timer | 41.050 s | 42.216 s | +2.84% |
| Replay peak RSS | 22.934 GiB | 22.970 GiB | +0.16% |
| Replay peak private committed | 25.049 GiB | 25.091 GiB | +0.17% |
| Independent Load/search peak RSS | 152.35 MiB | 157.28 MiB | +3.23% |
| Independent Load/search peak private committed | 140.84 MiB | 238.88 MiB | +69.61% |

At matched 2%/4% actual scan, all 258 paired Recall@50 targets were bracketed
and positive. The mean improvement was +2.889 percentage points overall and
+2.057 pp after deletes. At 90%/95% recall on the final disk index, bytes/query
changed by -15.71%/-9.76% and mean latency by -17.28%/-12.04%. These values
use interpolation between adjacent measured points, without extrapolation.

Both final indexes have 1,416,288 live points. Final overfull postings are
122 for Control and zero for Treatment. Treatment has deferred overflow
during deletes; the final insertion repairs it. Final state alone must not
be interpreted as a strict post-delete capacity guarantee.

All four measured processes exited zero and remained Normal in every sample,
with no priority/sampling/sampler violations and gaps below five seconds.
Input/profile/output/GT/telemetry auditing passed 56,268 checks. Eleven
rank-100 GT tail padding anomalies were preserved byte-for-byte and lie
outside every consumed Recall@10/50 prefix and consecutive tie extension.

The builder holds the full stored corpus plus its FP32 copy. Load/search
memory includes centroid data, graph, metadata, queries, GT and scratch;
it is not an idle index-only footprint. The identical warm-cache protocol
does not include system file cache in process RSS. No full-RAM ANN baseline
was measured, and these results do not demonstrate a memory reduction.

The earlier `287b086f` comparison is a separate revision experiment and is
not the baseline for the table above. Local reports and slides remain
outside the source commit.
