### PR TITLE
Restore the ability to have `Owned` computers.

### DIFF
--- a/diskann-benchmark/src/exhaustive/product.rs
+++ b/diskann-benchmark/src/exhaustive/product.rs
@@ -373,7 +373,7 @@ mod imp {
             query: &[f32],
         ) -> anyhow::Result<Self::Computer<'a>> {
             Ok(diskann_providers::model::pq::distance::QueryComputer::new(
-                &store.quantizer,
+                (&store.quantizer).into(),
                 self.measure.into(),
                 query,
                 None,

--- a/diskann-providers/src/model/graph/provider/async_/experimental/multi_pq_async.rs
+++ b/diskann-providers/src/model/graph/provider/async_/experimental/multi_pq_async.rs
@@ -13,7 +13,10 @@ use diskann_vector::{DistanceFunction, PreprocessedDistanceFunction, distance::M
 use rand::{Rng, SeedableRng, rngs::StdRng};
 
 use crate::{
-    model::{FixedChunkPQTable, pq::distance::multi},
+    model::{
+        FixedChunkPQTable,
+        pq::distance::{Shared, multi},
+    },
     utils::BridgeErr,
 };
 
@@ -71,8 +74,10 @@ impl TestMultiPQProviderAsync {
 
     pub fn multi_table(&self) -> Result<MultiTable<'_>, multi::EqualVersionsError> {
         match &self.table_old {
-            None => Ok(MultiTable::one(&self.table_new, 1)),
-            Some(table_old) => MultiTable::two(&self.table_new, table_old, 2, 1),
+            None => Ok(MultiTable::one(Shared::Ref(&self.table_new), 1)),
+            Some(table_old) => {
+                MultiTable::two(Shared::Ref(&self.table_new), Shared::Ref(table_old), 2, 1)
+            }
         }
     }
 

--- a/diskann-providers/src/model/graph/provider/async_/fast_memory_quant_vector_provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/fast_memory_quant_vector_provider.rs
@@ -24,7 +24,7 @@ use crate::{
     common::IgnoreLockPoison,
     model::{
         distance::common::distance_table_pool,
-        pq::{self, FixedChunkPQTable},
+        pq::{self, FixedChunkPQTable, distance::Shared},
     },
     storage::{self, AsyncIndexMetadata, AsyncQuantLoadContext, LoadWith, SaveWith, bin},
     utils::{BridgeErr, PQPathNames},
@@ -104,7 +104,7 @@ impl FastMemoryQuantVectorProviderAsync {
         T: VectorRepr,
     {
         QueryComputer::new(
-            &self.pq_chunk_table,
+            Shared::Ref(&self.pq_chunk_table),
             self.metric,
             &T::as_f32(query).into_ann_result()?,
             Some(self.vec_pool.clone()),
@@ -113,7 +113,7 @@ impl FastMemoryQuantVectorProviderAsync {
 
     /// Create a distance computer for the underlying schema.
     pub fn distance_computer(&self) -> DistanceComputer<'_> {
-        DistanceComputer::new(&self.pq_chunk_table, self.metric)
+        DistanceComputer::new(Shared::Ref(&self.pq_chunk_table), self.metric)
     }
 
     /// Return an "immutable" slice over the PQ data at index `i`.

--- a/diskann-providers/src/model/graph/provider/async_/memory_quant_vector_provider.rs
+++ b/diskann-providers/src/model/graph/provider/async_/memory_quant_vector_provider.rs
@@ -25,7 +25,7 @@ use crate::utils::BridgeErr;
 use crate::{
     model::{
         distance::common::distance_table_pool,
-        pq::{self, FixedChunkPQTable},
+        pq::{self, FixedChunkPQTable, distance::Shared},
     },
     storage::{self, AsyncIndexMetadata, AsyncQuantLoadContext, LoadWith, SaveWith, bin},
     utils::PQPathNames,
@@ -90,7 +90,7 @@ impl MemoryQuantVectorProviderAsync {
         T: VectorRepr,
     {
         QueryComputer::new(
-            &self.pq_chunk_table,
+            Shared::Ref(&self.pq_chunk_table),
             self.metric,
             &T::as_f32(query).into_ann_result()?,
             Some(self.vec_pool.clone()),
@@ -99,7 +99,7 @@ impl MemoryQuantVectorProviderAsync {
 
     /// Create a distance computer for the underlying schema.
     pub fn distance_computer(&self) -> DistanceComputer<'_> {
-        DistanceComputer::new(&self.pq_chunk_table, self.metric)
+        DistanceComputer::new(Shared::Ref(&self.pq_chunk_table), self.metric)
     }
 
     /// Return an immutable, reference counted guard over the data as position `i`.

--- a/diskann-providers/src/model/pq/distance/cosine.rs
+++ b/diskann-providers/src/model/pq/distance/cosine.rs
@@ -6,7 +6,7 @@
 use diskann::ANNResult;
 use diskann_vector::PreprocessedDistanceFunction;
 
-use crate::model::pq::fixed_chunk_pq_table::FixedChunkPQTable;
+use crate::model::pq::{distance::Shared, fixed_chunk_pq_table::FixedChunkPQTable};
 
 ////////////
 // Cosine //
@@ -19,18 +19,18 @@ pub struct DirectCosine<'a> {
     query: Vec<f32>,
 
     /// The parent table for the pivots and other meta-data regarding the PQ Schema.
-    parent: &'a FixedChunkPQTable,
+    parent: Shared<'a, FixedChunkPQTable>,
 }
 
 impl<'a> DirectCosine<'a> {
     /// Caller must ensure `query.len() == parent.get_dim()` (validated by `QueryComputer::new`).
-    pub(crate) fn new(parent: &'a FixedChunkPQTable, query: &[f32]) -> ANNResult<Self> {
+    pub(crate) fn new(parent: Shared<'a, FixedChunkPQTable>, query: &[f32]) -> ANNResult<Self> {
         let mut object = Self::new_unpopulated(parent);
         object.populate(query)?;
         Ok(object)
     }
 
-    fn new_unpopulated(parent: &'a FixedChunkPQTable) -> Self {
+    fn new_unpopulated(parent: Shared<'a, FixedChunkPQTable>) -> Self {
         Self {
             query: vec![0.0f32; parent.get_dim()],
             parent,
@@ -102,7 +102,7 @@ mod tests {
                     // DirectCosine
                     test_utils::test_cosine_inner(
                         |table: &FixedChunkPQTable, query: &[f32]| {
-                            DirectCosine::new(table, query).unwrap()
+                            DirectCosine::new(Shared::Ref(table), query).unwrap()
                         },
                         &table,
                         num_trials,
@@ -127,7 +127,7 @@ mod tests {
 
         let table = test_utils::seed_pivot_table(config);
         let query = vec![0.0; config.dim];
-        let computer = DirectCosine::new(&table, &query).unwrap();
+        let computer = DirectCosine::new(Shared::Ref(&table), &query).unwrap();
 
         let code = vec![0, 0, 0, 0];
         computer.evaluate_similarity(&code);
@@ -145,7 +145,7 @@ mod tests {
 
         let table = test_utils::seed_pivot_table(config);
         let query = vec![0.0; config.dim];
-        let computer = DirectCosine::new(&table, &query).unwrap();
+        let computer = DirectCosine::new(Shared::Ref(&table), &query).unwrap();
 
         // Entry `4` is out-of-bounds.
         let code = vec![0, 4, 0];

--- a/diskann-providers/src/model/pq/distance/dynamic.rs
+++ b/diskann-providers/src/model/pq/distance/dynamic.rs
@@ -10,7 +10,7 @@ use diskann_utils::{lazy_format, object_pool::ObjectPool};
 use diskann_vector::{DistanceFunction, PreprocessedDistanceFunction, distance::Metric};
 
 // Concrete implementations
-use super::{cosine::DirectCosine, innerproduct::TableIP, l2::TableL2};
+use super::{Shared, cosine::DirectCosine, innerproduct::TableIP, l2::TableL2};
 use crate::model::pq::fixed_chunk_pq_table::FixedChunkPQTable;
 
 /// A quantized computation that works for multiple distance functions.
@@ -62,7 +62,7 @@ impl<'a> QueryComputer<'a> {
     /// Even though PQ does not necessarily preserve the norms of compressed vectors, using L2
     /// for Cosine Normalized seems to work well enough in practice to work as a temporary fix.
     pub fn new(
-        table: &'a FixedChunkPQTable,
+        table: Shared<'a, FixedChunkPQTable>,
         metric: Metric,
         query: &[f32],
         pool: Option<Arc<ObjectPool<Vec<f32>>>>,
@@ -146,7 +146,7 @@ impl VTable {
 /// Internally, a mini v-table is kept to invoke the correct distance function.
 #[derive(Debug)]
 pub struct DistanceComputer<'a> {
-    table: &'a FixedChunkPQTable,
+    table: Shared<'a, FixedChunkPQTable>,
     vtable: VTable,
 }
 
@@ -164,7 +164,7 @@ impl<'a> DistanceComputer<'a> {
     /// * `Metric::Cosine`
     /// * `Metric::CosineNormalized`
     ///
-    pub fn new(table: &'a FixedChunkPQTable, distance: Metric) -> Self {
+    pub fn new(table: Shared<'a, FixedChunkPQTable>, distance: Metric) -> Self {
         Self {
             table,
             vtable: VTable::new(distance),
@@ -191,7 +191,7 @@ impl DistanceFunction<&[f32], &[u8], f32> for DistanceComputer<'_> {
             "{}",
             INVALID_PQ_DIMENSION
         );
-        (self.vtable.distance_fn)(self.table, fp, q)
+        (self.vtable.distance_fn)(&self.table, fp, q)
     }
 }
 
@@ -202,7 +202,7 @@ impl DistanceFunction<&[u8], &[u8], f32> for DistanceComputer<'_> {
         let num_pq_chunks = self.table.get_num_chunks();
         assert_eq!(q0.len(), num_pq_chunks, "{}", INVALID_PQ_DIMENSION);
         assert_eq!(q1.len(), num_pq_chunks, "{}", INVALID_PQ_DIMENSION);
-        (self.vtable.distance_fn_qq)(self.table, q0, q1)
+        (self.vtable.distance_fn_qq)(&self.table, q0, q1)
     }
 }
 
@@ -265,7 +265,7 @@ mod tests {
 
                     test_utils::test_l2_inner(
                         |table: &FixedChunkPQTable, query: &[f32]| {
-                            QueryComputer::new(table, Metric::L2, query, None).unwrap()
+                            QueryComputer::new(Shared::Ref(table), Metric::L2, query, None).unwrap()
                         },
                         &table,
                         num_trials,
@@ -276,7 +276,7 @@ mod tests {
 
                     test_utils::test_l2_inner(
                         |table: &FixedChunkPQTable, query: &[f32]| PreprocessedWrapper {
-                            table: DistanceComputer::new(table, Metric::L2),
+                            table: DistanceComputer::new(Shared::Ref(table), Metric::L2),
                             query: query.to_vec(),
                         },
                         &table,
@@ -321,7 +321,13 @@ mod tests {
 
                     test_utils::test_ip_inner(
                         |table: &FixedChunkPQTable, query: &[f32]| {
-                            QueryComputer::new(table, Metric::InnerProduct, query, None).unwrap()
+                            QueryComputer::new(
+                                Shared::Ref(table),
+                                Metric::InnerProduct,
+                                query,
+                                None,
+                            )
+                            .unwrap()
                         },
                         &table,
                         num_trials,
@@ -332,7 +338,7 @@ mod tests {
 
                     test_utils::test_ip_inner(
                         |table: &FixedChunkPQTable, query: &[f32]| PreprocessedWrapper {
-                            table: DistanceComputer::new(table, Metric::InnerProduct),
+                            table: DistanceComputer::new(Shared::Ref(table), Metric::InnerProduct),
                             query: query.to_vec(),
                         },
                         &table,
@@ -376,7 +382,8 @@ mod tests {
 
                     test_utils::test_cosine_inner(
                         |table: &FixedChunkPQTable, query: &[f32]| {
-                            QueryComputer::new(table, Metric::Cosine, query, None).unwrap()
+                            QueryComputer::new(Shared::Ref(table), Metric::Cosine, query, None)
+                                .unwrap()
                         },
                         &table,
                         num_trials,
@@ -387,7 +394,7 @@ mod tests {
 
                     test_utils::test_cosine_inner(
                         |table: &FixedChunkPQTable, query: &[f32]| PreprocessedWrapper {
-                            table: DistanceComputer::new(table, Metric::Cosine),
+                            table: DistanceComputer::new(Shared::Ref(table), Metric::Cosine),
                             query: query.to_vec(),
                         },
                         &table,
@@ -443,18 +450,18 @@ mod tests {
                 config.start_value,
             );
 
-            let squared_l2 = DistanceComputer::new(&table, Metric::L2);
+            let squared_l2 = DistanceComputer::new(Shared::Ref(&table), Metric::L2);
             let expected: f32 = SquaredL2::evaluate(&*v0, &*v1);
             assert_eq!(squared_l2.evaluate_similarity(&*code0, &*code1), expected);
 
-            let inner_product = DistanceComputer::new(&table, Metric::InnerProduct);
+            let inner_product = DistanceComputer::new(Shared::Ref(&table), Metric::InnerProduct);
             let expected: f32 = InnerProduct::evaluate(&*v0, &*v1);
             assert_eq!(
                 inner_product.evaluate_similarity(&*code0, &*code1),
                 expected,
             );
 
-            let cosine = DistanceComputer::new(&table, Metric::Cosine);
+            let cosine = DistanceComputer::new(Shared::Ref(&table), Metric::Cosine);
             let sim: f32 = cosine.evaluate_similarity(&*code0, &*code1);
             assert!(0.0 <= sim);
             assert!(sim <= 2.0);
@@ -465,7 +472,8 @@ mod tests {
             normalize(&mut v0);
             normalize(&mut v1);
 
-            let cosine_normalized = DistanceComputer::new(&table, Metric::CosineNormalized);
+            let cosine_normalized =
+                DistanceComputer::new(Shared::Ref(&table), Metric::CosineNormalized);
             let expected: f32 = CosineNormalized::evaluate(&*v0, &*v1);
             assert_relative_eq!(
                 cosine_normalized.evaluate_similarity(&*code0, &*code1),
@@ -485,7 +493,8 @@ mod tests {
         };
         let table = test_utils::seed_pivot_table(config);
         let short_query = vec![0.0f32; config.dim - 1];
-        let _ = QueryComputer::new(&table, Metric::L2, &short_query, None).unwrap_err();
+        let _ =
+            QueryComputer::new(Shared::Ref(&table), Metric::L2, &short_query, None).unwrap_err();
     }
 
     #[test]
@@ -498,7 +507,7 @@ mod tests {
             start_value: 0.0,
         };
         let table = test_utils::seed_pivot_table(config);
-        let computer = DistanceComputer::new(&table, Metric::L2);
+        let computer = DistanceComputer::new(Shared::Ref(&table), Metric::L2);
         let short_fp = vec![0.0f32; config.dim - 1];
         let code = vec![0u8; config.pq_chunks];
         let _ = computer.evaluate_similarity(short_fp.as_slice(), code.as_slice());

--- a/diskann-providers/src/model/pq/distance/innerproduct.rs
+++ b/diskann-providers/src/model/pq/distance/innerproduct.rs
@@ -10,7 +10,10 @@ use diskann_utils::object_pool::{self, ObjectPool, PoolOption};
 use diskann_vector::PreprocessedDistanceFunction;
 
 use super::common::get_lookup_table_size;
-use crate::model::pq::fixed_chunk_pq_table::{FixedChunkPQTable, pq_dist_lookup_single};
+use crate::model::pq::{
+    distance::Shared,
+    fixed_chunk_pq_table::{FixedChunkPQTable, pq_dist_lookup_single},
+};
 
 ////////
 // IP //
@@ -38,13 +41,13 @@ pub struct TableIP<'a> {
     num_centers: usize,
 
     /// The parent table for the pivots and other meta-data regarding the PQ Schema.
-    parent: &'a FixedChunkPQTable,
+    parent: Shared<'a, FixedChunkPQTable>,
 }
 
 impl<'a> TableIP<'a> {
     /// Caller must ensure `query.len() == parent.get_dim()` (validated by `QueryComputer::new`).
     pub(crate) fn new(
-        parent: &'a FixedChunkPQTable,
+        parent: Shared<'a, FixedChunkPQTable>,
         query: &[f32],
         pool: Option<Arc<ObjectPool<Vec<f32>>>>,
     ) -> ANNResult<Self> {
@@ -54,10 +57,10 @@ impl<'a> TableIP<'a> {
     }
 
     fn new_unpopulated(
-        parent: &'a FixedChunkPQTable,
+        parent: Shared<'a, FixedChunkPQTable>,
         pool: Option<Arc<ObjectPool<Vec<f32>>>>,
     ) -> Self {
-        let vec_size = get_lookup_table_size(parent);
+        let vec_size = get_lookup_table_size(&parent);
         Self {
             lookup_table: match pool {
                 Some(p) => PoolOption::pooled(&p, object_pool::Undef::new(vec_size)),
@@ -135,7 +138,7 @@ mod tests {
                     // Basic `TableIP`
                     test_utils::test_ip_inner(
                         |table: &FixedChunkPQTable, query: &[f32]| {
-                            TableIP::new(table, query, None).unwrap()
+                            TableIP::new(Shared::Ref(table), query, None).unwrap()
                         },
                         &table,
                         num_trials,
@@ -160,7 +163,7 @@ mod tests {
 
         let table = test_utils::seed_pivot_table(config);
         let query = vec![0.0; config.dim];
-        let computer = TableIP::new(&table, &query, None).unwrap();
+        let computer = TableIP::new(Shared::Ref(&table), &query, None).unwrap();
 
         let code = vec![0, 0, 0, 0];
         computer.evaluate_similarity(&code);
@@ -178,7 +181,7 @@ mod tests {
 
         let table = test_utils::seed_pivot_table(config);
         let query = vec![0.0; config.dim];
-        let computer = TableIP::new(&table, &query, None).unwrap();
+        let computer = TableIP::new(Shared::Ref(&table), &query, None).unwrap();
 
         // Entry `4` is out-of-bounds.
         let code = vec![0, 4, 0];

--- a/diskann-providers/src/model/pq/distance/l2.rs
+++ b/diskann-providers/src/model/pq/distance/l2.rs
@@ -10,7 +10,10 @@ use diskann_utils::object_pool::{self, ObjectPool, PoolOption};
 use diskann_vector::PreprocessedDistanceFunction;
 
 use super::common::get_lookup_table_size;
-use crate::model::pq::fixed_chunk_pq_table::{FixedChunkPQTable, pq_dist_lookup_single};
+use crate::model::pq::{
+    distance::Shared,
+    fixed_chunk_pq_table::{FixedChunkPQTable, pq_dist_lookup_single},
+};
 
 ////////
 // L2 //
@@ -39,13 +42,13 @@ pub struct TableL2<'a> {
     num_centers: usize,
 
     /// The parent table for the pivots and other metadata regarding the PQ Schema.
-    parent: &'a FixedChunkPQTable,
+    parent: Shared<'a, FixedChunkPQTable>,
 }
 
 impl<'a> TableL2<'a> {
     /// Caller must ensure `query.len() == parent.get_dim()` (validated by `QueryComputer::new`).
     pub(crate) fn new(
-        parent: &'a FixedChunkPQTable,
+        parent: Shared<'a, FixedChunkPQTable>,
         query: &[f32],
         pool: Option<Arc<ObjectPool<Vec<f32>>>>,
     ) -> ANNResult<Self> {
@@ -55,10 +58,10 @@ impl<'a> TableL2<'a> {
     }
 
     fn new_unpopulated(
-        parent: &'a FixedChunkPQTable,
+        parent: Shared<'a, FixedChunkPQTable>,
         pool: Option<Arc<ObjectPool<Vec<f32>>>>,
     ) -> Self {
-        let vec_size = get_lookup_table_size(parent);
+        let vec_size = get_lookup_table_size(&parent);
         Self {
             lookup_table: match pool {
                 Some(p) => PoolOption::pooled(&p, object_pool::Undef::new(vec_size)),
@@ -136,7 +139,7 @@ mod tests {
                     // Basic `TableL2`
                     test_utils::test_l2_inner(
                         |table: &FixedChunkPQTable, query: &[f32]| {
-                            TableL2::new(table, query, None).unwrap()
+                            TableL2::new(Shared::Ref(table), query, None).unwrap()
                         },
                         &table,
                         num_trials,
@@ -161,7 +164,7 @@ mod tests {
 
         let table = test_utils::seed_pivot_table(config);
         let query = vec![0.0; config.dim];
-        let computer = TableL2::new(&table, &query, None).unwrap();
+        let computer = TableL2::new(Shared::Ref(&table), &query, None).unwrap();
 
         let code = vec![0, 0, 0, 0];
         computer.evaluate_similarity(&code);
@@ -179,7 +182,7 @@ mod tests {
 
         let table = test_utils::seed_pivot_table(config);
         let query = vec![0.0; config.dim];
-        let computer = TableL2::new(&table, &query, None).unwrap();
+        let computer = TableL2::new(Shared::Ref(&table), &query, None).unwrap();
 
         // Entry `4` is out-of-bounds.
         let code = vec![0, 4, 0];

--- a/diskann-providers/src/model/pq/distance/mod.rs
+++ b/diskann-providers/src/model/pq/distance/mod.rs
@@ -11,8 +11,74 @@ pub mod l2;
 
 pub mod multi;
 
+/// A light-weight [`std::borrow::Cow`] whose owned state is a [`std::sync::Arc`].
+#[derive(Debug)]
+pub enum Shared<'a, T> {
+    Arc(std::sync::Arc<T>),
+    Ref(&'a T),
+}
+
+impl<T> Clone for Shared<'_, T> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Arc(arc) => Shared::Arc(arc.clone()),
+            Self::Ref(r) => Shared::Ref(r),
+        }
+    }
+}
+
+impl<'a, T> From<&'a T> for Shared<'a, T> {
+    fn from(r: &'a T) -> Self {
+        Self::Ref(r)
+    }
+}
+
+impl<'a, T> std::ops::Deref for Shared<'a, T> {
+    type Target = T;
+    fn deref(&self) -> &T {
+        match self {
+            Self::Arc(arc) => arc,
+            Self::Ref(r) => r,
+        }
+    }
+}
+
 // Exports
 pub use dynamic::{DistanceComputer, QueryComputer};
 
 #[cfg(test)]
 pub(crate) mod test_utils;
+
+///////////
+// Tests //
+///////////
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::{assert_matches, sync::Arc};
+
+    fn assert_is_async_friendly<T>(_: &T)
+    where
+        T: Send + Sync + 'static,
+    {
+    }
+
+    #[test]
+    fn test_shared() {
+        let s = Arc::new("a string");
+
+        let mut shared = Shared::<'static, &'static str>::Arc(s.clone());
+        assert_is_async_friendly(&shared);
+
+        assert_eq!(shared.as_ptr(), s.as_ptr());
+        assert_eq!(*s, "a string");
+
+        let static_str = &"a static str";
+        shared = static_str.into();
+
+        assert_eq!(*shared, "a static str");
+        assert_matches!(shared, Shared::Ref(_));
+    }
+}

--- a/diskann-providers/src/model/pq/distance/mod.rs
+++ b/diskann-providers/src/model/pq/distance/mod.rs
@@ -72,7 +72,7 @@ mod tests {
         let mut shared = Shared::<'static, &'static str>::Arc(s.clone());
         assert_is_async_friendly(&shared);
 
-        assert_eq!(shared.as_ptr(), s.as_ptr());
+        assert_matches!(&shared, Shared::Arc(arc) if Arc::ptr_eq(arc, &s));
         assert_eq!(*s, "a string");
 
         let static_str = &"a static str";

--- a/diskann-providers/src/model/pq/distance/multi.rs
+++ b/diskann-providers/src/model/pq/distance/multi.rs
@@ -8,7 +8,7 @@ use diskann_utils::Reborrow;
 use diskann_vector::{DistanceFunction, PreprocessedDistanceFunction, distance::Metric};
 use thiserror::Error;
 
-use super::{QueryComputer, dynamic::VTable};
+use super::{QueryComputer, Shared, dynamic::VTable};
 use crate::model::FixedChunkPQTable;
 
 pub trait PQVersion: Eq + Copy {}
@@ -94,15 +94,15 @@ where
 {
     /// Only one table is present with an associated version.
     One {
-        table: &'a FixedChunkPQTable,
+        table: Shared<'a, FixedChunkPQTable>,
         version: I,
     },
     /// Two tables are present, an incoming "new" table and an outgoing "old" table.
     /// The versions of these tables are recorded respectively in `new_version` and
     /// `old_version`.
     Two {
-        new: &'a FixedChunkPQTable,
-        old: &'a FixedChunkPQTable,
+        new: Shared<'a, FixedChunkPQTable>,
+        old: Shared<'a, FixedChunkPQTable>,
         new_version: I,
         old_version: I,
     },
@@ -117,7 +117,7 @@ where
     I: PQVersion,
 {
     /// Construct a new `MultiTable` containing a single `FixedChunkPQTable`.
-    pub fn one(table: &'a FixedChunkPQTable, version: I) -> Self {
+    pub fn one(table: Shared<'a, FixedChunkPQTable>, version: I) -> Self {
         Self::One { table, version }
     }
 
@@ -125,8 +125,8 @@ where
     ///
     /// Returns an `Err` if the two provided versions are equal.
     pub fn two(
-        new: &'a FixedChunkPQTable,
-        old: &'a FixedChunkPQTable,
+        new: Shared<'a, FixedChunkPQTable>,
+        old: Shared<'a, FixedChunkPQTable>,
         new_version: I,
         old_version: I,
     ) -> Result<Self, EqualVersionsError> {
@@ -517,7 +517,7 @@ mod tests {
         let new = test_utils::seed_pivot_table(config);
         let old = test_utils::seed_pivot_table(config);
 
-        let result = MultiTable::two(&new, &old, 0, 0);
+        let result = MultiTable::two(Shared::Ref(&new), Shared::Ref(&old), 0, 0);
         assert!(
             matches!(result, Err(EqualVersionsError)),
             "MultiTable should now allow construction of the Two variant with equal versions"
@@ -622,7 +622,7 @@ mod tests {
 
         let version: usize = 0x625b215f82f38008;
 
-        let multi_table = MultiTable::one(&table, version);
+        let multi_table = MultiTable::one(Shared::Ref(&table), version);
         let (n, o) = multi_table.versions();
         assert_eq!(*n, version);
         assert!(o.is_none());
@@ -794,7 +794,13 @@ mod tests {
         let new_version: usize = 0x5a2b92a731766613;
         let old_version: usize = 0x2fab58c9c8b73841;
 
-        let multi_table = MultiTable::two(&new, &old, new_version, old_version).unwrap();
+        let multi_table = MultiTable::two(
+            Shared::Ref(&new),
+            Shared::Ref(&old),
+            new_version,
+            old_version,
+        )
+        .unwrap();
         let (n, o) = multi_table.versions();
         assert_eq!(*n, new_version);
         assert_eq!(*o.unwrap(), old_version);
@@ -912,7 +918,7 @@ mod tests {
         };
 
         let create = |version: usize, query: &[f32]| {
-            let schema = MultiTable::one(&table, version);
+            let schema = MultiTable::one(Shared::Ref(&table), version);
             MultiQueryComputer::new(schema, metric, query).unwrap()
         };
         test_query_computer_multi_with_one(
@@ -1037,7 +1043,13 @@ mod tests {
         let num_trials = 20;
 
         let create = |new_version: usize, old_version: usize, query: &[f32]| {
-            let schema = MultiTable::two(&new, &old, new_version, old_version).unwrap();
+            let schema = MultiTable::two(
+                Shared::Ref(&new),
+                Shared::Ref(&old),
+                new_version,
+                old_version,
+            )
+            .unwrap();
             MultiQueryComputer::new(schema, metric, query).unwrap()
         };
 


### PR DESCRIPTION
Turns out #1247 was a little premature - we still have some code that is dependent on using `Arc<FixedChunkPQTable>`. Until a full replacement for PQ is in place, this is a stop-gap to enabled reference counted computers.

The main idea is to introduce
```rust
struct Shared<'a, T> {
    Arc(Arc<T>),
    Ref(&'a T),
}
```
as the container for the `FixedChunkPQTable`. Types that need to use `Arc` can use `Shared<'static, T>`. Existing code can continue to use `Shared::Ref`.