### PR TITLE
DiskANN 0.58.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "diskann"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -457,7 +457,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -496,7 +496,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-core"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "diskann",
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-runner"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -527,7 +527,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-benchmark-simd"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "diskann-benchmark-runner",
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-bftree"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bf-tree",
  "bytemuck",
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-disk"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "approx",
@@ -621,7 +621,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-inmem"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -645,7 +645,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-label-filter"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "bf-tree",
@@ -668,7 +668,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-linalg"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "approx",
  "cfg-if",
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-providers"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "approx",
  "arc-swap",
@@ -716,7 +716,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-quantization"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -737,7 +737,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-record"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -747,7 +747,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-tools"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "anyhow",
  "bincode",
@@ -780,7 +780,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-utils"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -796,7 +796,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-vector"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "approx",
  "bytemuck",
@@ -811,7 +811,7 @@ dependencies = [
 
 [[package]]
 name = "diskann-wide"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bytemuck",
  "cfg-if",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ default-members = [
 exclude = ["vectorset"]
 
 [workspace.package]
-version = "0.57.0" # Obeying semver
+version = "0.58.0" # Obeying semver
 description = "DiskANN3 is a composable library for bringing scalable, accurate and cost-effective vector indexing to multiple databases."
 authors = ["Microsoft"]
 repository = "https://github.com/microsoft/DiskANN"
@@ -52,24 +52,24 @@ undocumented_unsafe_blocks = "warn"
 
 [workspace.dependencies]
 # Base And Numerics
-diskann-wide = { path = "diskann-wide", version = "0.57.0" }
-diskann-vector = { path = "diskann-vector", version = "0.57.0" }
-diskann-linalg = { path = "diskann-linalg", version = "0.57.0" }
-diskann-utils = { path = "diskann-utils", default-features = false, version = "0.57.0" }
-diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.57.0" }
+diskann-wide = { path = "diskann-wide", version = "0.58.0" }
+diskann-vector = { path = "diskann-vector", version = "0.58.0" }
+diskann-linalg = { path = "diskann-linalg", version = "0.58.0" }
+diskann-utils = { path = "diskann-utils", default-features = false, version = "0.58.0" }
+diskann-quantization = { path = "diskann-quantization", default-features = false, version = "0.58.0" }
 # Algorithm
-diskann = { path = "diskann", version = "0.57.0" }
+diskann = { path = "diskann", version = "0.58.0" }
 # Providers
-diskann-providers = { path = "diskann-providers", default-features = false, version = "0.57.0" }
-diskann-inmem = { path = "diskann-inmem", default-features = false, version = "0.57.0" }
-diskann-disk = { path = "diskann-disk", version = "0.57.0" }
-diskann-label-filter = { path = "diskann-label-filter", version = "0.57.0" }
+diskann-providers = { path = "diskann-providers", default-features = false, version = "0.58.0" }
+diskann-inmem = { path = "diskann-inmem", default-features = false, version = "0.58.0" }
+diskann-disk = { path = "diskann-disk", version = "0.58.0" }
+diskann-label-filter = { path = "diskann-label-filter", version = "0.58.0" }
 # Infra
-diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.57.0" }
-diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.57.0" }
-diskann-tools = { path = "diskann-tools", version = "0.57.0" }
-diskann-bftree = { path = "diskann-bftree", version = "0.57.0" }
-diskann-record = { path = "diskann-record", version = "0.57.0" }
+diskann-benchmark-runner = { path = "diskann-benchmark-runner", version = "0.58.0" }
+diskann-benchmark-core = { path = "diskann-benchmark-core", version = "0.58.0" }
+diskann-tools = { path = "diskann-tools", version = "0.58.0" }
+diskann-bftree = { path = "diskann-bftree", version = "0.58.0" }
+diskann-record = { path = "diskann-record", version = "0.58.0" }
 
 # External dependencies (shared versions)
 anyhow = "1.0.98"


### PR DESCRIPTION
# Breaking Changes since 0.57.0
• Restored support for reference-counted (`Arc`) PQ distance tables via a new internal `Shared<'a, FixedChunkPQTable>` enum, unblocking code paths that still depend on owned/shared tables ahead of a full PQ replacement. (#1382)

## What's Changed
* Restore the ability to have `Owned` computers. by @hildebrandmw in https://github.com/microsoft/DiskANN/pull/1382

**Full Changelog**: https://github.com/microsoft/DiskANN/compare/v0.57.0...v0.58.0