### PR TITLE
Fix inplace deletion for providers that reclaim vector data

### DIFF
--- a/diskann-garnet/src/ffi_tests.rs
+++ b/diskann-garnet/src/ffi_tests.rs
@@ -176,6 +176,51 @@ mod tests {
     }
 
     #[test]
+    fn remove_reclaims_data_and_preserves_graph() {
+        let store = Store::new();
+        let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);
+
+        for (id, vector) in [(10, [1.0, 0.0]), (20, [0.0, 1.0]), (30, [1.0, 1.0])] {
+            assert_eq!(
+                insert_f32_vector(&ctx, index_ptr, id, &vector),
+                InsertResult::Success
+            );
+        }
+
+        let id = 20u32;
+        let id_bytes = bytemuck::bytes_of(&id);
+        let iid_bytes = store
+            .get(ctx.term(Term::IntMap).get(), id_bytes)
+            .expect("missing internal ID mapping");
+        assert!(
+            store
+                .get(ctx.term(Term::Neighbors).get(), &iid_bytes)
+                .is_some()
+        );
+
+        // SAFETY: The index and ID buffers remain valid throughout the call.
+        assert!(unsafe { remove(ctx.get(), index_ptr, id_bytes.as_ptr(), id_bytes.len()) });
+
+        for term in [Term::Vector, Term::Neighbors, Term::ExtMap] {
+            assert!(store.get(ctx.term(term).get(), &iid_bytes).is_none());
+        }
+        assert!(store.get(ctx.term(Term::IntMap).get(), id_bytes).is_none());
+
+        let (ids, _) = do_search(&ctx, index_ptr, &[0.0, 1.0], 3, None);
+        assert_eq!(ids, [30, 10]);
+
+        assert_eq!(
+            insert_f32_vector(&ctx, index_ptr, id, &[2.0, 0.0]),
+            InsertResult::Success
+        );
+        let (ids, _) = do_search(&ctx, index_ptr, &[2.0, 0.0], 3, None);
+        assert_eq!(ids, [20, 10, 30]);
+
+        // SAFETY: This is the only call dropping the index.
+        unsafe { drop_index(ctx.get(), index_ptr) };
+    }
+
+    #[test]
     fn update_vector_attributes() {
         let store = Store::new();
         let (index_ptr, ctx) = create_test_index(&store, VectorQuantType::NoQuant);

--- a/diskann-garnet/src/provider.rs
+++ b/diskann-garnet/src/provider.rs
@@ -1099,11 +1099,10 @@ impl<T: VectorRepr> Delete for GarnetProvider<T> {
             .callbacks
             .delete_iid(&context.term(Term::Attributes), id);
 
-        // TODO: inplace_delete needs access to neighbors. Delete these once that bug is fixed.
-        // See https://github.com/microsoft/DiskANN/issues/1153.
-        // ok &= self
-        //     .callbacks
-        //     .delete_iid(&context.term(Term::Neighbors), id);
+        // Neighbors may not exist if graph insertion did not complete.
+        let _: bool = self
+            .callbacks
+            .delete_iid(&context.term(Term::Neighbors), id);
 
         ok &= self.callbacks.delete_iid(&context.term(Term::Vector), id);
 
@@ -2048,7 +2047,7 @@ mod tests {
             config::{self, defaults::GRAPH_SLACK_FACTOR},
             search,
         },
-        provider::{Delete, SetElement},
+        provider::{DataProvider, Delete, SetElement},
     };
     use diskann_providers::index::wrapped_async::DiskANNIndex;
     use diskann_vector::distance::Metric;
@@ -2079,11 +2078,25 @@ mod tests {
 
         let id = GarnetId::from(bytemuck::bytes_of(&0));
 
-        let res = provider.set_element(&ctx, &id, &[0f32, 0f32]).await;
-        assert!(res.is_ok());
+        provider
+            .set_element(&ctx, &id, &[0f32, 0f32])
+            .await
+            .unwrap();
+        let iid = provider.to_internal_id(&ctx, &id).unwrap();
+        let iid_bytes = bytemuck::bytes_of(&iid);
 
-        let res = provider.delete(&ctx, &id).await;
-        assert!(res.is_ok());
+        // Setting an element does not create its graph adjacency list.
+        assert!(
+            store
+                .get(ctx.term(Term::Neighbors).get(), iid_bytes)
+                .is_none()
+        );
+        provider.delete(&ctx, &id).await.unwrap();
+
+        for term in [Term::Vector, Term::Neighbors, Term::ExtMap] {
+            assert!(store.get(ctx.term(term).get(), iid_bytes).is_none());
+        }
+        assert!(store.get(ctx.term(Term::IntMap).get(), &id).is_none());
     }
 
     fn create_2d_f32_index(

--- a/diskann/src/graph/index.rs
+++ b/diskann/src/graph/index.rs
@@ -1172,13 +1172,17 @@ where
         id: DP::InternalId,
         l_value: usize,
         k_value: usize,
-        v: S::DeleteElementGuard,
+        ids_to_delete: &HashSet<DP::InternalId>,
     ) -> impl SendFuture<ANNResult<InplaceDeleteWorkList<DP::InternalId>>>
     where
         S: InplaceDeleteStrategy<DP> + Sync,
         DP: Delete,
     {
         async move {
+            let v = strategy
+                .get_delete_element(&self.data_provider, context, id)
+                .await
+                .into_ann_result()?;
             let search_strategy = strategy.search_strategy();
             let mut search_accessor = search_strategy
                 .search_accessor(&self.data_provider, context, v.reborrow())
@@ -1197,14 +1201,17 @@ where
 
             let mut output = vec![Neighbor::<DP::InternalId>::default(); l_value];
 
-            // NOTE: We rely on `post_process` to remove deleted items from the results
-            // placed into the output.
+            // The batch is still live during preparation, so exclude it explicitly.
+            // The post-processor removes items deleted by earlier operations.
             let num_results = strategy
                 .search_post_processor()
                 .post_process(
                     &mut search_accessor,
                     v.reborrow(),
-                    scratch.best.iter(),
+                    scratch
+                        .best
+                        .iter()
+                        .filter(|neighbor| !ids_to_delete.contains(neighbor.id())),
                     &mut neighbor::BackInserter::new(output.as_mut_slice()),
                 )
                 .await
@@ -1356,32 +1363,37 @@ where
             let max_minibatch_par = self.config.max_minibatch_par();
             let chunk_iter = async_tools::arc_chunks(ids, max_minibatch_par);
             for chunk in chunk_iter {
-                // Convert external ids in chunk to internal ids. We do this first as `inplace_delete_inner` may actually
-                // delete the mapping.
+                // Capture the mappings before deletion and prepare each internal ID once.
                 let mut ids_to_delete = HashSet::with_capacity(chunk.len());
+                let mut delete_targets = Vec::with_capacity(chunk.len());
                 for i in 0..chunk.len() {
                     let vector_id = self
                         .data_provider
                         .to_internal_id(context, chunk.get(i))
                         .escalate("id translation for `inplace_delete` must succeed")?;
-                    ids_to_delete.insert(vector_id);
+                    if ids_to_delete.insert(vector_id) {
+                        delete_targets.push((i, vector_id));
+                    }
                 }
+                let ids_to_delete = Arc::new(ids_to_delete);
 
                 // compute edge updates for each inplace delete, running in parallel
-                let handles: Vec<_> = (0..chunk.len())
-                    .map(|i| {
+                let handles: Vec<_> = delete_targets
+                    .iter()
+                    .map(|&(_, vector_id)| {
                         let self_clone = Arc::clone(self);
-                        let chunk_clone = chunk.clone();
                         let context_clone = context.clone();
                         let strategy_clone = strategy.clone();
+                        let ids_to_delete_clone = ids_to_delete.clone();
                         let future = async move {
                             self_clone
                                 .inplace_delete_inner(
                                     &strategy_clone,
                                     &context_clone,
-                                    chunk_clone.get(i),
+                                    vector_id,
                                     num_to_replace,
                                     &inplace_delete_method,
+                                    &ids_to_delete_clone,
                                 )
                                 .await
                         };
@@ -1401,34 +1413,66 @@ where
                     edge_collection.push(res);
                 }
 
-                // check for errors and collect ids to modify in one hashset
+                let mut prepared_edges = Vec::with_capacity(delete_targets.len());
+                for output in edge_collection {
+                    // Every preparation task has finished, so an error leaves the batch live.
+                    prepared_edges.push(output??);
+                }
+
                 let mut ids_to_modify = HashSet::<DP::InternalId>::with_capacity(
                     self.pruned_degree() * 2 * chunk.len(),
                 );
-                let mut edge_hashmaps = Vec::with_capacity(chunk.len());
+                let mut edge_hashmaps = Vec::with_capacity(delete_targets.len());
+                let mut deleted_ids = HashSet::with_capacity(delete_targets.len());
+                let mut delete_error = None;
 
-                for output in edge_collection {
-                    match output {
-                        Ok(Ok(edges)) => {
-                            for neighbor in edges.keys() {
-                                ids_to_modify.insert(*neighbor);
+                let prune_strategy = strategy.prune_strategy();
+                let mut accessor = prune_strategy
+                    .prune_accessor(&self.data_provider, context, 0)
+                    .into_ann_result()?;
+                for (&(i, vector_id), edges) in delete_targets.iter().zip(prepared_edges) {
+                    let deleted = if delete_error.is_none() {
+                        match self
+                            .delete_with_empty_adjacency(
+                                context,
+                                chunk.get(i),
+                                vector_id,
+                                &mut accessor.neighbors(),
+                            )
+                            .await
+                        {
+                            Ok(()) => true,
+                            Err(error) => {
+                                delete_error = Some(error);
+                                false
                             }
+                        }
+                    } else {
+                        false
+                    };
+                    let status = if deleted {
+                        Some(ElementStatus::Deleted)
+                    } else {
+                        self.data_provider
+                            .status_by_internal_id(context, vector_id)
+                            .await
+                            .ok()
+                    };
+                    match status {
+                        Some(ElementStatus::Deleted) => {
+                            deleted_ids.insert(vector_id);
+                            ids_to_modify.extend(edges.keys().copied());
                             edge_hashmaps.push(edges);
                         }
-                        Ok(Err(ann_error)) => {
-                            tracked_error!(
-                                "inplace_delete returned error in multi_inplace_delete: {}",
-                                ann_error
-                            );
+                        Some(ElementStatus::Valid) => {
+                            // Preparation excluded this target, but it may now survive a
+                            // partial batch. Remove its edges to completed deletions too.
+                            ids_to_modify.insert(vector_id);
                         }
-                        Err(err) => {
-                            tracked_error!(
-                                "Tokio spawned task has a join error in multi_inplace_delete: {}",
-                                err
-                            );
-                        }
+                        None => {}
                     }
                 }
+                let ids_to_delete = Arc::new(deleted_ids);
 
                 // next, insert and prune, adding the option to remove all the deleted neighbors
                 // at each prune. this runs in parallel and respects the max_minibatch_par
@@ -1438,7 +1482,6 @@ where
                     .min(max_minibatch_par);
 
                 let edges_to_add = Arc::new(Mutex::new(ids_to_modify.into_iter()));
-                let ids_to_delete = Arc::new(ids_to_delete);
                 let edge_hashmaps = Arc::new(edge_hashmaps);
 
                 let mut tasks = JoinSet::new();
@@ -1494,24 +1537,28 @@ where
                     });
                 }
 
-                // Wait for all tasks to complete.
+                // Join every repair before returning an error, leaving no tasks in flight.
+                let mut repair_error = None;
                 while let Some(result) = tasks.join_next().await {
-                    if let Err(_e) = result {
-                        tracked_error!("Tokio task JoinError in multi_inplace_delete");
-                    } else if let Ok(Err(e)) = result {
-                        tracked_error!("Error in add_edge_and_prune: {}", e);
+                    let result = result
+                        .map_err(|error| {
+                            ANNError::new(error).context("joining inplace-delete repair task")
+                        })
+                        .and_then(|result| result);
+                    if let Err(error) = result {
+                        repair_error.get_or_insert(error);
                     }
                 }
-
-                // finally, drop each deleted neighbor's edges, this can run sequentially
-                let prune_strategy = strategy.prune_strategy();
-                let mut accessor = prune_strategy
-                    .prune_accessor(&self.data_provider, context, 0)
-                    .into_ann_result()?;
-
-                for vector_id in ids_to_delete.iter() {
-                    self.drop_adj_list(&mut accessor.neighbors(), *vector_id)
-                        .await?;
+                if let Some(error) = delete_error {
+                    return Err(match repair_error {
+                        Some(repair_error) => error.context(format!(
+                            "repairing completed deletions also failed: {repair_error}"
+                        )),
+                        None => error,
+                    });
+                }
+                if let Some(error) = repair_error {
+                    return Err(error);
                 }
             }
 
@@ -1542,23 +1589,26 @@ where
                 .to_internal_id(context, id)
                 .escalate("id translation for `inplace_delete` must succeed")?;
 
+            let mut delete_set = HashSet::with_capacity(1);
+            delete_set.insert(vector_id);
             let edges_to_add = self
                 .inplace_delete_inner(
                     &strategy,
                     context,
-                    id,
+                    vector_id,
                     num_to_replace,
                     &inplace_delete_method,
+                    &delete_set,
                 )
                 .await?;
-
-            let mut delete_set = HashSet::with_capacity(1);
-            delete_set.insert(vector_id);
             let prune_strategy = strategy.prune_strategy();
 
             let mut accessor = prune_strategy
                 .prune_accessor(self.provider(), context, self.max_occlusion_size())
                 .into_ann_result()?;
+
+            self.delete_with_empty_adjacency(context, id, vector_id, &mut accessor.neighbors())
+                .await?;
 
             let mut prune_scratch = prune::Scratch::new();
 
@@ -1573,70 +1623,88 @@ where
                 .await?
             }
 
-            self.drop_adj_list(&mut accessor.neighbors(), vector_id)
-                .await?;
-
             Ok(())
         }
     }
 
-    /// To assist with multi_delete, this function computes the edge updates for an
-    /// inplace delete, but returns them instead of immediately adding them to the index
+    /// Clear adjacency while the target is still accessible, restoring it if deletion fails.
+    /// No target data is accessed after a successful provider deletion.
+    fn delete_with_empty_adjacency<NA>(
+        &self,
+        context: &DP::Context,
+        id: &DP::ExternalId,
+        vector_id: DP::InternalId,
+        accessor: &mut NA,
+    ) -> impl SendFuture<ANNResult<()>>
+    where
+        DP: Delete,
+        NA: NeighborAccessorMut<Id = DP::InternalId>,
+    {
+        async move {
+            let mut neighbors = AdjacencyList::new();
+            accessor.get_neighbors(vector_id, &mut neighbors).await?;
+            self.drop_adj_list(accessor, vector_id).await?;
+
+            if let Err(error) = self
+                .data_provider
+                .delete(context, id)
+                .await
+                .escalate("`inplace_delete` requires a successful delete")
+            {
+                // A failed delete can still release the ID; do not recreate its adjacency.
+                if self
+                    .data_provider
+                    .status_by_internal_id(context, vector_id)
+                    .await
+                    .is_ok_and(|status| status.is_valid())
+                    && let Err(restore_error) = accessor.set_neighbors(vector_id, &neighbors).await
+                {
+                    return Err(error.context(format!(
+                        "restoring adjacency after failed deletion also failed: {restore_error}"
+                    )));
+                }
+                return Err(error);
+            }
+            Ok(())
+        }
+    }
+
+    /// Compute repair edges while all targets are still accessible. The caller must wait
+    /// for every preparation in a batch before deleting any target.
     fn inplace_delete_inner<'a, S>(
         &'a self,
         strategy: &'a S,
         context: &'a DP::Context,
-        id: &'a DP::ExternalId,
+        vector_id: DP::InternalId,
         num_to_replace: usize,
         inplace_delete_method: &'a InplaceDeleteMethod,
+        ids_to_delete: &'a HashSet<DP::InternalId>,
     ) -> impl SendFuture<ANNResult<HashMap<DP::InternalId, Vec<DP::InternalId>>>>
     where
         S: InplaceDeleteStrategy<DP> + Sync,
         DP: Delete,
     {
         async move {
-            let vector_id = self
-                .data_provider
-                .to_internal_id(context, id)
-                .escalate("id translation for `inplace_delete` must succeed")?;
-
-            // For VisitedAndTopK, we must capture the delete element *before* erasing
-            // the vector data, since it uses the deleted vector as a search query.
-            // This is necessary in hard-delete providers.
-            let delete_element = match inplace_delete_method {
-                InplaceDeleteMethod::VisitedAndTopK { .. } => Some(
-                    strategy
-                        .get_delete_element(&self.data_provider, context, vector_id)
-                        .await
-                        .into_ann_result()?,
-                ),
-                _ => None,
-            };
-
-            self.data_provider
-                .delete(context, id)
-                .await
-                .escalate("`inplace_delete` requires a successful delete")?;
-
             let prune_strategy = strategy.prune_strategy();
             let mut accessor = prune_strategy
                 .prune_accessor(&self.data_provider, context, self.max_occlusion_size())
                 .into_ann_result()?;
 
             let InplaceDeleteWorkList {
-                replace_candidates,
-                in_neighbors,
+                mut replace_candidates,
+                mut in_neighbors,
             } = match inplace_delete_method {
                 InplaceDeleteMethod::VisitedAndTopK {
                     k_value: k,
                     l_value: l,
                 } => {
-                    // delete_element is always Some for VisitedAndTopK (set above).
-                    let Some(v) = delete_element else {
-                        unreachable!("delete_element is set for VisitedAndTopK");
-                    };
                     self.get_candidates_using_visited_and_topk(
-                        strategy, context, vector_id, *l, *k, v,
+                        strategy,
+                        context,
+                        vector_id,
+                        *l,
+                        *k,
+                        ids_to_delete,
                     )
                     .await?
                 }
@@ -1658,11 +1726,16 @@ where
 
             // fetch the filtered adjacency list of `p`.
             let PartitionedNeighbors {
-                undeleted: adjacency_list,
+                undeleted: mut adjacency_list,
                 ..
             } = self
                 .get_undeleted_neighbors(context, &mut accessor.neighbors(), vector_id)
                 .await?;
+
+            // Filter before ranking so other batch targets cannot consume replacement slots.
+            replace_candidates.retain(|id| !ids_to_delete.contains(id));
+            in_neighbors.retain(|id| !ids_to_delete.contains(id));
+            adjacency_list.retain(|id| !ids_to_delete.contains(id));
 
             // This is the total union of elements that we consider for neighbors.
             // It's possible there is some repitition, but implementations of `Fill` should

--- a/diskann/src/graph/test/cases/helpers.rs
+++ b/diskann/src/graph/test/cases/helpers.rs
@@ -29,6 +29,15 @@ pub(super) fn setup_2d_square(
     adjacency_lists: Vec<AdjacencyList<u32>>,
     pruned_degree: usize,
 ) -> Arc<DiskANNIndex<Provider>> {
+    setup_2d_square_with_config(adjacency_lists, pruned_degree, 1, |config| config)
+}
+
+pub(super) fn setup_2d_square_with_config(
+    adjacency_lists: Vec<AdjacencyList<u32>>,
+    pruned_degree: usize,
+    max_minibatch_par: usize,
+    configure: impl FnOnce(test_provider::Config) -> test_provider::Config,
+) -> Arc<DiskANNIndex<Provider>> {
     let vectors = Grid::Two.data(2);
     let num_points = vectors.nrows();
     let dim = vectors.ncols();
@@ -67,14 +76,21 @@ pub(super) fn setup_2d_square(
         .enumerate()
         .map(|(id, (row, adj))| (id as u32, row.to_vec(), adj));
 
-    let provider =
-        Provider::new_from(provider_config, iter::once((start_id, start_adj)), points).unwrap();
+    let provider = Provider::new_from(
+        configure(provider_config),
+        iter::once((start_id, start_adj)),
+        points,
+    )
+    .unwrap();
 
-    let index_config = graph::config::Builder::new(
+    let index_config = graph::config::Builder::new_with(
         pruned_degree,
         graph::config::MaxDegree::same(),
         10,
         Metric::L2.into(),
+        |builder| {
+            builder.max_minibatch_par(max_minibatch_par);
+        },
     )
     .build()
     .unwrap();

--- a/diskann/src/graph/test/cases/inplace_delete.rs
+++ b/diskann/src/graph/test/cases/inplace_delete.rs
@@ -17,6 +17,7 @@ use crate::{
 
 use super::helpers::{
     generate_2d_square_adjacency_list, setup_2d_square, setup_2d_square_using_synthetics_grid,
+    setup_2d_square_with_config,
 };
 
 fn inplace_delete_setup() -> Arc<DiskANNIndex<test_provider::Provider>> {
@@ -174,6 +175,221 @@ async fn multi_inplace_delete_visited_and_topk() {
         l_value: 10,
     })
     .await;
+}
+
+fn delete_methods(k_value: usize) -> [InplaceDeleteMethod; 3] {
+    [
+        InplaceDeleteMethod::OneHop,
+        InplaceDeleteMethod::TwoHopAndOneHop,
+        InplaceDeleteMethod::VisitedAndTopK {
+            k_value,
+            l_value: 10,
+        },
+    ]
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn inplace_delete_with_hard_deletes() {
+    for method in delete_methods(4) {
+        let index = setup_2d_square_with_config(
+            generate_2d_square_adjacency_list(),
+            4,
+            1,
+            test_provider::Config::with_hard_deletes,
+        );
+        let ctx = test_provider::Context::new();
+
+        index
+            .inplace_delete(test_provider::Strategy::new(), &ctx, &3, 3, method)
+            .await
+            .unwrap_or_else(|err| panic!("hard delete failed for {method:?}: {err}"));
+
+        assert!(!index.provider().all_internal_ids().contains(&3));
+        validate_graph_rebuild_for_simple_graph_after_3_delete(&mut index.provider().neighbors())
+            .await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multi_inplace_delete_with_hard_deletes() {
+    for method in delete_methods(4) {
+        let index = setup_2d_square_with_config(
+            generate_2d_square_adjacency_list(),
+            4,
+            2,
+            test_provider::Config::with_hard_deletes,
+        );
+        let ctx = test_provider::Context::new();
+
+        index
+            .multi_inplace_delete(
+                test_provider::Strategy::new(),
+                &ctx,
+                Arc::new([2, 3]),
+                3,
+                method,
+            )
+            .await
+            .unwrap_or_else(|err| panic!("hard delete failed for {method:?}: {err}"));
+
+        let remaining = index.provider().all_internal_ids();
+        assert!(!remaining.contains(&2));
+        assert!(!remaining.contains(&3));
+        validate_graph_after_2_and_3_delete(&mut index.provider().neighbors()).await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn rejected_inplace_delete_preserves_graph() {
+    for method in delete_methods(4) {
+        let index = setup_2d_square_with_config(
+            generate_2d_square_adjacency_list(),
+            4,
+            1,
+            test_provider::Config::with_hard_deletes,
+        );
+        let ctx = test_provider::Context::new();
+        let before = index.provider().dump_neighbors(true);
+
+        let error = index
+            .inplace_delete(test_provider::Strategy::new(), &ctx, &4, 3, method)
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("cannot delete start point 4"));
+        assert_eq!(index.provider().dump_neighbors(true), before, "{method:?}");
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multi_inplace_delete_deduplicates_ids() {
+    for method in delete_methods(4) {
+        let index = setup_2d_square_with_config(
+            generate_2d_square_adjacency_list(),
+            4,
+            4,
+            test_provider::Config::with_hard_deletes,
+        );
+        let ctx = test_provider::Context::new();
+
+        index
+            .multi_inplace_delete(
+                test_provider::Strategy::new(),
+                &ctx,
+                Arc::new([2, 3, 2, 3]),
+                3,
+                method,
+            )
+            .await
+            .unwrap_or_else(|err| panic!("duplicate deletes failed for {method:?}: {err}"));
+
+        assert_eq!(index.provider().delete_calls.value(), 2, "{method:?}");
+        validate_graph_after_2_and_3_delete(&mut index.provider().neighbors()).await;
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multi_inplace_delete_prefers_live_replacements() {
+    for method in delete_methods(2) {
+        let provider_config = test_provider::Config::new(
+            Metric::L2,
+            4,
+            test_provider::StartPoint::new(4, vec![20.0]),
+        )
+        .unwrap()
+        .with_hard_deletes();
+        let provider = test_provider::Provider::new_from(
+            provider_config,
+            [(4, AdjacencyList::from_iter_untrusted([3, 1]))],
+            [
+                (0, vec![0.0], AdjacencyList::from_iter_untrusted([3])),
+                (1, vec![10.0], AdjacencyList::from_iter_untrusted([4])),
+                (2, vec![0.1], AdjacencyList::from_iter_untrusted([1])),
+                (
+                    3,
+                    vec![0.2],
+                    AdjacencyList::from_iter_untrusted([0, 2, 1, 4]),
+                ),
+            ],
+        )
+        .unwrap();
+        let config = graph::config::Builder::new_with(
+            4,
+            graph::config::MaxDegree::same(),
+            10,
+            Metric::L2.into(),
+            |builder| {
+                builder.max_minibatch_par(2);
+            },
+        )
+        .build()
+        .unwrap();
+        let index = Arc::new(DiskANNIndex::new(config, provider, None));
+        let ctx = test_provider::Context::new();
+
+        // Vertex 2 is closer than every live replacement for vertex 0, but it is
+        // also being deleted. It must not consume a top-k or replacement slot.
+        index
+            .multi_inplace_delete(
+                test_provider::Strategy::new(),
+                &ctx,
+                Arc::new([3, 2]),
+                1,
+                method,
+            )
+            .await
+            .unwrap_or_else(|err| panic!("replacement selection failed for {method:?}: {err}"));
+
+        index.provider().is_consistent().unwrap();
+        let mut list = AdjacencyList::new();
+        index
+            .provider()
+            .neighbors()
+            .get_neighbors(0, &mut list)
+            .await
+            .unwrap();
+        assert!(
+            list.contains(1),
+            "vertex 0 needs live replacement 1 for {method:?}"
+        );
+        assert!(!list.contains(2));
+        assert!(!list.contains(3));
+    }
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multi_inplace_delete_prunes_after_hard_deletes() {
+    for method in delete_methods(4) {
+        let index = setup_2d_square_with_config(
+            generate_2d_square_adjacency_list(),
+            1,
+            2,
+            test_provider::Config::with_hard_deletes,
+        );
+        let ctx = test_provider::Context::new();
+
+        index
+            .multi_inplace_delete(
+                test_provider::Strategy::new(),
+                &ctx,
+                Arc::new([2, 3]),
+                1,
+                method,
+            )
+            .await
+            .unwrap_or_else(|err| panic!("pruning failed for {method:?}: {err}"));
+
+        index.provider().is_consistent().unwrap();
+        let mut list = AdjacencyList::new();
+        index
+            .provider()
+            .neighbors()
+            .get_neighbors(4, &mut list)
+            .await
+            .unwrap();
+        assert_eq!(list.len(), 1, "start point must be pruned for {method:?}");
+        assert!(list.contains(0) || list.contains(1));
+    }
 }
 
 async fn validate_graph_rebuild_for_simple_graph_after_3_delete<N>(neighbors: &mut N)
@@ -390,4 +606,37 @@ async fn multi_inplace_delete_wider_topology() {
         reachable, 7,
         "6 surviving data nodes + start should be reachable"
     );
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn multi_inplace_delete_repairs_completed_deletions_after_rejection() {
+    for method in delete_methods(4) {
+        let index = setup_2d_square_with_config(
+            generate_2d_square_adjacency_list(),
+            4,
+            2,
+            test_provider::Config::with_hard_deletes,
+        );
+        let ctx = test_provider::Context::new();
+
+        // Vertex 3 is deleted successfully before the start point rejects deletion.
+        let error = index
+            .multi_inplace_delete(
+                test_provider::Strategy::new(),
+                &ctx,
+                Arc::new([3, 4]),
+                3,
+                method,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("cannot delete start point 4"));
+        let remaining = index.provider().all_internal_ids();
+        assert!(!remaining.contains(&3));
+        assert!(remaining.contains(&4));
+        index.provider().is_consistent().unwrap();
+        validate_graph_rebuild_for_simple_graph_after_3_delete(&mut index.provider().neighbors())
+            .await;
+    }
 }

--- a/diskann/src/graph/test/provider.rs
+++ b/diskann/src/graph/test/provider.rs
@@ -12,7 +12,7 @@ use std::{
     sync::Arc,
 };
 
-use dashmap::{DashMap, mapref::entry::Entry};
+use dashmap::{DashMap, DashSet, mapref::entry::Entry};
 use diskann_utils::views::Matrix;
 use diskann_vector::{PreprocessedDistanceFunction, distance::Metric};
 use thiserror::Error;
@@ -97,6 +97,7 @@ pub struct Config {
     max_degree: NonZeroUsize,
     dim: NonZeroUsize,
     metric: Metric,
+    hard_deletes: bool,
 }
 
 impl Config {
@@ -157,7 +158,15 @@ impl Config {
             max_degree,
             dim,
             metric,
+            hard_deletes: false,
         })
+    }
+
+    /// Remove vectors and adjacency lists immediately, keeping only deletion status.
+    #[cfg(test)]
+    pub(crate) fn with_hard_deletes(mut self) -> Self {
+        self.hard_deletes = true;
+        self
     }
 }
 
@@ -186,7 +195,7 @@ convert_error!(ConfigError);
 /// * All calls to [`provider::NeighborAccessorMut::set_neighbors`] do not contain duplicates.
 /// * All calls to [`provider::NeighborAccessorMut::append_vector`] do not contain duplicates
 ///   and are disjoint with the current adjacency list.
-/// * Vectors can be marked as deleted, but their data remains accessible.
+/// * By default, vectors can be marked as deleted, but their data remains accessible.
 /// * Vectors that are deleted but not [`provider::Delete::release`]d cannot be overwritten.
 /// * Attempting to retrieve and ID that is not present is an error.
 /// * All attempts to mutate the graph via [`provider::NeighborAccessorMut`] must be preceeded
@@ -196,9 +205,11 @@ convert_error!(ConfigError);
 #[derive(Debug)]
 pub struct Provider {
     terms: DashMap<u32, Term>,
+    hard_deleted: DashSet<u32>,
     config: Config,
 
     // Counters
+    pub(crate) delete_calls: Counter,
     pub(crate) get_vector: Counter,
     pub(crate) set_vector: Counter,
     pub(crate) get_neighbors: Counter,
@@ -213,7 +224,9 @@ impl Provider {
     pub fn new(config: Config) -> Self {
         let this = Self {
             terms: DashMap::new(),
+            hard_deleted: DashSet::new(),
             config,
+            delete_calls: Counter::new(),
             get_vector: Counter::new(),
             set_vector: Counter::new(),
             get_neighbors: Counter::new(),
@@ -388,14 +401,14 @@ impl Provider {
         Ok(())
     }
 
-    /// Return `true` if `id` is present in the provider but marked as deleted.
+    /// Return whether the ID has been deleted, including hard-deleted IDs.
     ///
-    /// If `id` is present but not marked deleted, returns `false`.
-    ///
-    /// An error is returned if `id` is not present in the provider.
+    /// An error is returned for unknown or released IDs.
     fn is_deleted(&self, id: u32) -> Result<bool, InvalidId> {
         if let Some(term) = self.terms.get(&id) {
             Ok(term.is_deleted())
+        } else if self.hard_deleted.contains(&id) {
+            Ok(true)
         } else {
             Err(InvalidId::Internal(id))
         }
@@ -698,13 +711,19 @@ impl provider::Delete for Provider {
         _context: &Self::Context,
         gid: &Self::ExternalId,
     ) -> Result<(), Self::Error> {
+        self.delete_calls.increment();
         if self.is_start_point(*gid) {
             return Err(InvalidId::IsStartPoint(*gid));
         }
 
         match self.terms.entry(*gid) {
             Entry::Occupied(mut occupied) => {
-                occupied.get_mut().mark_deleted();
+                if self.config.hard_deletes {
+                    self.hard_deleted.insert(*gid);
+                    occupied.remove();
+                } else {
+                    occupied.get_mut().mark_deleted();
+                }
                 Ok(())
             }
             Entry::Vacant(_) => Err(InvalidId::External(*gid)),

--- a/diskann/src/provider.rs
+++ b/diskann/src/provider.rs
@@ -158,10 +158,10 @@ pub trait DataProvider: Sized + Send + Sync + 'static {
 pub trait Delete: DataProvider {
     /// Delete an item by external ID.
     ///
-    /// Note that internal vector IDs may still be reachable. In the context of a graph
-    /// index, this is equivalent to a "soft" delete where the deleted ID should no longer
-    /// be returned as the result of search methods, but may still be accessed by its
-    /// private ID during graph node expansion.
+    /// Implementations may immediately remove all data associated with the item, including
+    /// its adjacency list. Callers must read any data they need before deleting the item.
+    /// Internal IDs may still be reachable through incoming graph edges, so accessors must
+    /// handle references to deleted items.
     fn delete(
         &self,
         context: &Self::Context,


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/microsoft/DiskANN/blob/main/CONTRIBUTING.md
-->
- [ ] Does this PR have a descriptive title that could go in our release notes?
- [ ] Does this PR add any new dependencies?
- [ ] Does this PR modify any existing APIs?
- [ ] Is the change to the API backwards compatible?
- [ ] Should this result in any changes to our documentation, either updating existing docs or adding new ones?

#### Reference Issues/PRs

Fixes #1153.

#### What does this implement/fix? Briefly explain your changes.

`inplace_delete` previously read and cleared a target's adjacency after calling the provider's delete method, so providers could not immediately reclaim all of its data. Prepare candidate searches and repair edges while the targets are still accessible, then clear target adjacency before deletion and repair only surviving nodes. Batched deletion waits for all preparation tasks, excludes the whole batch before candidate truncation, and deduplicates IDs within each chunk.

If a provider rejects deletion while the target remains valid, restore its adjacency. Finish repairs for completed deletions before returning a later batch error. Enable Garnet neighbor-record cleanup, including the case where graph insertion has not yet created a neighbor record, and clarify the provider deletion contract. Public signatures and dependencies are unchanged.

#### Any other comments?

Validation on Windows with the repository-pinned Rust 1.97.1:

- `cargo fmt --all --check` passed.
- `cargo clippy --workspace --all-targets -- -D warnings` passed.
- Coverage-instrumented library suites passed: 331 `diskann`, 48 `diskann-garnet`, and 89 `diskann-inmem` tests (468 total).
- Local LCOV reports 404/415 changed executable lines covered (97.35%); core deletion implementation coverage is 121/131 changed executable lines (92.37%). CI remains authoritative for Codecov.
- New regressions cover all three deletion methods, physical vector/adjacency removal, real multi-ID batches, duplicate IDs, limited replacement budgets, pruning, rejected deletions, partial batch failures, and Garnet search/reinsertion after deletion. The initial hard-delete regressions fail on the original implementation.

Batch deletion remains non-atomic when a provider operation fails.
