### PR TITLE
Allow access to the inner accessor in `BetaAccessor`.

### DIFF
--- a/diskann-providers/src/model/graph/provider/layers/betafilter.rs
+++ b/diskann-providers/src/model/graph/provider/layers/betafilter.rs
@@ -159,6 +159,16 @@ where
     filter: Filter<Inner::Id>,
 }
 
+impl<Inner> BetaAccessor<Inner>
+where
+    Inner: HasId,
+{
+    /// Return a mutable reference to the inner accessor.
+    pub fn inner(&mut self) -> &mut Inner {
+        &mut self.inner
+    }
+}
+
 struct Filter<I> {
     labels: Arc<dyn QueryLabelProvider<I>>,
     beta: f32,


### PR DESCRIPTION
Needed for enabling tunneling into the inner accessor for custom metric reporting. We aren't really exposing any additional members since `Unwrap` already allows direct access to the inner accessor.